### PR TITLE
feat(frontend): adopt Craft theme foundation and port top bar sidebar trigger

### DIFF
--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -20,6 +20,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { TopBarButton } from "@/components/ui/top-bar-button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
@@ -253,16 +254,15 @@ function SidebarTrigger({
 	className,
 	onClick,
 	...props
-}: React.ComponentProps<typeof Button>) {
+}: React.ComponentProps<typeof TopBarButton>) {
 	const { toggleSidebar } = useSidebar();
 
 	return (
-		<Button
+		<TopBarButton
 			data-sidebar="trigger"
 			data-slot="sidebar-trigger"
-			variant="ghost"
-			size="icon-sm"
-			className={cn(className)}
+			aria-label="Toggle Sidebar"
+			className={cn("[&_svg]:size-4", className)}
 			onClick={(event) => {
 				onClick?.(event);
 				toggleSidebar();
@@ -271,7 +271,7 @@ function SidebarTrigger({
 		>
 			<IconLayoutSidebar />
 			<span className="sr-only">Toggle Sidebar</span>
-		</Button>
+		</TopBarButton>
 	);
 }
 

--- a/frontend/components/ui/top-bar-button.tsx
+++ b/frontend/components/ui/top-bar-button.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type TopBarButtonProps = React.ComponentProps<"button"> & {
+	isActive?: boolean;
+};
+
+export const TopBarButton = React.forwardRef<
+	HTMLButtonElement,
+	TopBarButtonProps
+>(({ children, className, disabled, isActive, ...props }, ref) => {
+	return (
+		<button
+			ref={ref}
+			type="button"
+			disabled={disabled}
+			className={cn(
+				"flex h-7 w-7 items-center justify-center rounded-[6px] transition-colors duration-100",
+				"hover:bg-foreground/5 focus:outline-none focus-visible:ring-0",
+				"disabled:pointer-events-none disabled:opacity-30",
+				isActive && "bg-foreground/5",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</button>
+	);
+});
+
+TopBarButton.displayName = "TopBarButton";


### PR DESCRIPTION
## Summary
This branch brings the Craft theme foundation into the frontend and ports Craft's top bar button into AI Nexus for the sidebar trigger. The visible component change is small, but the branch also includes the larger global token groundwork the trigger now sits on.

## What Changed
- added `frontend/components/ui/top-bar-button.tsx`
  - ports the Craft `TopBarButton` component into AI Nexus
- updated `frontend/components/ui/sidebar.tsx`
  - switched `SidebarTrigger` from the shared `Button` to `TopBarButton`
  - preserved sidebar toggle behavior while changing the chrome of the trigger
- overhauled `frontend/app/globals.css`
  - adopts the Craft theme foundation token system
  - introduces the semantic 6-color base (`background`, `foreground`, `accent`, `info`, `success`, `destructive`)
  - refreshes derived sidebar/shadow/theme utility tokens used by the frontend shell

## What Users Will Notice
- the sidebar toggle in the top bar now uses the Craft button styling
- broader frontend visuals can shift because the branch also includes the Craft theme/token foundation work

## Manual Testing

### Setup
- run the frontend locally
- open the main app routes that render the sidebar/header

### Test Steps
1. Open the main conversation page and confirm the sidebar trigger renders as the new compact top bar button.
2. Click the trigger and verify the sidebar still expands/collapses correctly.
3. Use `Cmd/Ctrl+B` and verify the sidebar toggle keyboard shortcut still works.
4. Tab to the trigger and verify it is reachable and still operable via keyboard.
5. Open the dashboard route and verify the trigger styling/behavior there as well.
6. Check light and dark mode for obvious sidebar/header contrast regressions.

### Edge Cases
- verify mobile sheet sidebar behavior still works when the trigger is used on narrow screens
- verify hover/focus states remain visible enough for keyboard use

## Automated Testing

### Commands
```bash
cd frontend && bun run typecheck
cd frontend && bun run build
```

### Coverage Gaps
- `typecheck` currently fails due to pre-existing missing modules:
  - `use-stick-to-bottom`
  - `calligraph`
- `build` currently fails for the same missing-module issues
- I did not add or change linting in this PR
- broad visual regression coverage is still manual because `globals.css` has a large blast radius

## Checklist
- [x] Self-reviewed
- [ ] Tests pass locally
- [ ] Types check