### PR TITLE
Port Craft sidebar conversation row component

### DIFF
--- a/.beans/ai-nexus-aopx--design-openclaw-style-autonomous-agent-system-for.md
+++ b/.beans/ai-nexus-aopx--design-openclaw-style-autonomous-agent-system-for.md
@@ -1,0 +1,10 @@
+---
+# ai-nexus-aopx
+title: Design OpenClaw-style autonomous agent system for ai-nexus
+status: in-progress
+type: feature
+created_at: 2026-03-22T02:32:13Z
+updated_at: 2026-03-22T02:32:13Z
+---
+
+Brainstorm and design an autonomous AI agent architecture inspired by OpenClaw — allowing agents to take real actions (shell commands, file ops, API calls, messaging), not just chat. Includes agent identity, tool/skill system, scheduler, multi-channel support, and governance.

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { EntityRow } from "@/components/ui/entity-row";
+import { cn } from "@/lib/utils";
+
+interface ConversationSidebarItemProps {
+	id: string;
+	title: string;
+	updatedAt: string;
+	showSeparator: boolean;
+}
+
+function formatConversationAge(updatedAt: string) {
+	const date = new Date(updatedAt);
+
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	const diffMs = date.getTime() - Date.now();
+	const divisions = [
+		{ amount: 60, unit: "second" },
+		{ amount: 60, unit: "minute" },
+		{ amount: 24, unit: "hour" },
+		{ amount: 7, unit: "day" },
+	] as const;
+	let duration = Math.round(diffMs / 1000);
+
+	for (const division of divisions) {
+		if (Math.abs(duration) < division.amount) {
+			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+				duration,
+				division.unit,
+			);
+		}
+
+		duration = Math.round(duration / division.amount);
+	}
+
+	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+		duration,
+		"week",
+	);
+}
+
+export function ConversationSidebarItem({
+	id,
+	title,
+	updatedAt,
+	showSeparator,
+}: ConversationSidebarItemProps) {
+	const pathname = usePathname();
+	const href = `/c/${id}`;
+	const isSelected = pathname === href;
+	const age = formatConversationAge(updatedAt);
+
+	return (
+		<EntityRow
+			asChild
+			showSeparator={showSeparator}
+			isSelected={isSelected}
+			icon={
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
+			}
+			title={title}
+			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
+			titleTrailing={
+				age ? (
+					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+						{age}
+					</span>
+				) : undefined
+			}
+		>
+			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+		</EntityRow>
+	);
+}

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { Calligraph } from "calligraph";
-import Image from "next/image";
-import Link from "next/link";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -24,22 +20,14 @@ export function NavChats() {
 		<SidebarGroup>
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu>
-				{conversations.map((conversation) => (
-					<SidebarMenuItem key={conversation.id}>
-						<SidebarMenuButton asChild tooltip={conversation.title}>
-							{/* Using link for soft navigation. */}
-							<Link href={`/c/${conversation.id}`}>
-								<Image
-									src="/bars-rotate-fade.svg"
-									width={15}
-									height={15}
-									alt="Animated Loader"
-									unoptimized // Recommended for some animated SVGs to prevent caching issues
-								/>
-								<Calligraph>{conversation.title}</Calligraph>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+				{conversations.map((conversation, index) => (
+					<ConversationSidebarItem
+						key={conversation.id}
+						id={conversation.id}
+						title={conversation.title}
+						updatedAt={conversation.updated_at}
+						showSeparator={index > 0}
+					/>
 				))}
 			</SidebarMenu>
 		</SidebarGroup>

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+export interface EntityRowProps {
+	icon?: React.ReactNode;
+	title: React.ReactNode;
+	titleClassName?: string;
+	titleTrailing?: React.ReactNode;
+	badges?: React.ReactNode;
+	trailing?: React.ReactNode;
+	children?: React.ReactNode;
+	isSelected?: boolean;
+	showSeparator?: boolean;
+	className?: string;
+	separatorClassName?: string;
+	asChild?: boolean;
+}
+
+export function EntityRow({
+	icon,
+	title,
+	titleClassName,
+	titleTrailing,
+	badges,
+	trailing,
+	children,
+	isSelected = false,
+	showSeparator = false,
+	className,
+	separatorClassName = "pl-[38px] pr-4",
+	asChild = false,
+}: EntityRowProps) {
+	const Comp = asChild ? ("div" as const) : ("button" as const);
+
+	return (
+		<div className={className} data-selected={isSelected || undefined}>
+			{showSeparator && (
+				<div className={separatorClassName}>
+					<Separator />
+				</div>
+			)}
+			<div className="relative group select-none pl-2 mr-2">
+				{isSelected && (
+					<div className="absolute left-0 inset-y-0 w-[2px] bg-accent" />
+				)}
+				<Comp
+					className={cn(
+						"flex w-full items-start gap-2 pl-2 pr-4 py-3 text-left text-sm outline-none rounded-[8px]",
+						"transition-[background-color] duration-75",
+						isSelected ? "bg-foreground/3" : "hover:bg-foreground/2",
+					)}
+				>
+					<div className="flex flex-col gap-1.5 min-w-0 flex-1">
+						{titleTrailing ? (
+							<div className="flex items-center gap-[10px] w-full min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div className={cn("font-sans truncate min-w-0", titleClassName)}>
+									{title}
+								</div>
+								<div className="shrink-0 ml-auto relative -mr-1">
+									{titleTrailing}
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div
+									className={cn(
+										"font-medium font-sans line-clamp-2 min-w-0 -mb-[2px]",
+										titleClassName,
+									)}
+								>
+									{title}
+								</div>
+							</div>
+						)}
+						{(badges || trailing) && (
+							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
+								{icon && (
+									<div
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										aria-hidden="true"
+									>
+										{icon}
+									</div>
+								)}
+								{badges && (
+									<div className="flex-1 flex items-center gap-1 min-w-0 overflow-x-auto scrollbar-hide">
+										{badges}
+									</div>
+								)}
+								{trailing && (
+									<div className="shrink-0 flex items-center gap-1 ml-auto">
+										{trailing}
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</Comp>
+				{children}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Ports the Craft-style sidebar conversation row, replacing the previous basic `SidebarMenuItem` + `SidebarMenuButton` + `<Link>` implementation with a more polished, design-system aligned component hierarchy.

### What changed

- **New `EntityRow` component** (`frontend/components/ui/entity-row.tsx`) — A reusable, generic row primitive for sidebar entities. Supports:
  - Configurable icon, title, trailing content, and badges slots
  - Active/selected state with left accent indicator (`bg-accent` bar)
  - Separator rendering between items
  - `asChild` pattern (renders as `<div>` for composition, `<button>` by default)
  - Hover/selected background transitions
  - Proper text truncation and `min-w-0` flex containment to prevent overflow

- **New `ConversationSidebarItem` component** (`frontend/components/conversation-sidebar-item.tsx`) — A specialized wrapper around `EntityRow` for chat conversations. Features:
  - Route-aware active state via `usePathname()` comparison
  - Relative time display ("3 minutes ago", "2 hours ago", etc.) using `Intl.RelativeTimeFormat` with smart unit escalation (seconds → minutes → hours → days → weeks)
  - Chat bubble SVG icon
  - Full-area `<Link>` overlay for Next.js soft navigation

- **Simplified `NavChats`** (`frontend/components/nav-chats.tsx`) — Replaced inline conversation rendering with the new `ConversationSidebarItem`. Removed unused imports (`Calligraph`, `Image`, `Link`, `SidebarMenuButton`, `SidebarMenuItem`) and the animated loader SVG placeholder.

### Architecture notes

`EntityRow` is intentionally generic — it will serve as the base for other sidebar row types (agents, projects, etc.) beyond conversations. The slot-based API (`icon`, `title`, `titleTrailing`, `badges`, `trailing`) follows the same pattern established in the Craft design system.

## Test plan

- [ ] Verify sidebar conversation list renders correctly with conversation titles
- [ ] Confirm active conversation has left accent bar and `bg-foreground/3` background
- [ ] Check relative time labels display correctly (recent = "X minutes ago", older = "X days ago")
- [ ] Verify hover state shows `bg-foreground/2` on non-selected rows
- [ ] Confirm separator lines appear between conversation items (not before the first)
- [ ] Test clicking a conversation navigates correctly via soft navigation
- [ ] Verify text truncation on long conversation titles (no overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reusable sidebar entity row primitive and adopt it for rendering conversation items in the chats navigation.

New Features:
- Add a generic EntityRow UI component for consistent, slot-based sidebar entity rows.
- Add a ConversationSidebarItem component that wraps EntityRow with chat-specific behavior, including active-state handling and relative updated time display.

Enhancements:
- Refactor NavChats to render conversations via the new ConversationSidebarItem and remove legacy sidebar item markup and unused assets.