### PR TITLE
feat(frontend): port Craft sidebar controls and conversation chrome

### DIFF
--- a/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
+++ b/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
@@ -1,0 +1,143 @@
+# Craft Sidebar Migration — Next Steps Plan
+
+## Goal
+Continue the Craft Agents migration in **tiny, review-friendly PRs** that keep scope narrow and visual diffs easy to understand.
+
+## Working Rules
+- Prefer **small, isolated frontend-only PRs**.
+- Stay on one surface area until it feels coherent.
+- Avoid bundling behavior, data-flow, and styling changes together unless necessary.
+- For ACP coding/planning runs, explicitly use **`openai-codex/gpt-5.4` with `xhigh` thinking** unless we decide otherwise.
+- Human review happens after each slice; do not assume a long stacked migration branch is the default.
+
+## Current State
+Recently completed sidebar/theme work includes:
+- Craft-style theme/token foundation
+- Craft-style top bar button
+- Craft-style conversation sidebar rows
+- Craft-style chats section header
+
+This gives us a solid sidebar visual base to keep iterating on.
+
+## Plan of Attack
+
+### Phase 1 — Finish the Sidebar Surface
+Focus on the sidebar until it feels visually coherent.
+
+#### 1. New Conversation button
+**Why next:**
+- highly visible
+- still sidebar-local
+- likely styling-first
+- easy to review as a standalone PR
+
+**Target outcome:**
+- button treatment matches the newer Craft-inspired sidebar language
+- no backend or routing changes beyond existing behavior
+
+#### 2. Sidebar spacing / rhythm polish
+**Possible scope:**
+- spacing between section header and conversation rows
+- vertical rhythm around separators
+- sidebar content padding and grouping
+
+**Why:**
+- useful if the sidebar looks close but still slightly off after the previous PRs
+- remains low-risk and visual-only
+
+#### 3. Sidebar empty state
+**Why:**
+- self-contained
+- improves UX for new/empty accounts
+- good presentational follow-up before touching the chat panel
+
+**Target outcome:**
+- empty sidebar/chat-list area feels intentional and consistent with Craft
+
+#### 4. Row interaction polish (only if needed)
+**Possible scope:**
+- hover/selected contrast
+- keyboard focus styling
+- timestamp alignment/overflow edge cases
+
+**Why:**
+- only worth doing if review feedback or visual inspection says current rows need refinement
+
+### Phase 2 — Move Inward to the Main Panel
+Once the sidebar feels coherent, start on the least risky main-panel surfaces.
+
+#### 5. Chat empty state / welcome state
+**Why first:**
+- mostly presentational
+- easier than message rendering or composer work
+- visible win without dragging in streaming logic
+
+#### 6. Main panel chrome / lightweight layout polish
+**Possible scope:**
+- headers
+- framing containers
+- subtle spacing and token alignment
+
+**Why:**
+- helps bridge the visual language from sidebar to content area
+
+### Phase 3 — Higher-Risk Surfaces (Do Later)
+These should only happen after the low-risk presentational layers are in place.
+
+#### 7. Message cards / message presentation
+**Risks:**
+- content rendering differences
+- tool/result states
+- assistant/user role styling
+- streaming edge cases
+
+#### 8. Input composer
+**Risks:**
+- autosize
+- keyboard behavior
+- attachments
+- submit/disabled/loading states
+
+#### 9. Model selector
+**Risks:**
+- state wiring
+- interaction complexity
+- command/dialog behavior
+
+## Recommended Immediate Next Step
+Create a **small planning/research pass** for the next PR focused on:
+
+> **Port the Craft-style New Conversation button**
+
+That pass should answer:
+- exact Craft source reference
+- exact local files to change
+- whether this should be a local override or shared primitive
+- risk of accidental layout/behavior changes
+- smallest reviewable implementation path
+
+## PR Sequencing Recommendation
+1. Theme/tokens + sidebar rows + section header ✅
+2. New Conversation button
+3. Sidebar spacing/polish
+4. Sidebar empty state
+5. Main-panel empty state
+6. Main-panel chrome polish
+7. Message cards
+8. Composer
+9. Model selector
+
+## Anti-Goals
+For the next few PRs, avoid:
+- backend changes
+- API contract changes
+- broad routing changes
+- mixing multiple UI surfaces into one PR
+- turning a visual PR into a behavior/refactor swamp
+
+## Success Criteria
+This plan is working if:
+- each PR has a clear single-surface story
+- diffs stay easy to review
+- visual progress is obvious after each merge
+- we avoid giant tangled migration branches

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { EntityRow } from "@/components/ui/entity-row";
+import { cn } from "@/lib/utils";
+
+interface ConversationSidebarItemProps {
+	id: string;
+	title: string;
+	updatedAt: string;
+	showSeparator: boolean;
+}
+
+function formatConversationAge(updatedAt: string) {
+	const date = new Date(updatedAt);
+
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	const diffMs = date.getTime() - Date.now();
+	const divisions = [
+		{ amount: 60, unit: "second" },
+		{ amount: 60, unit: "minute" },
+		{ amount: 24, unit: "hour" },
+		{ amount: 7, unit: "day" },
+	] as const;
+	let duration = Math.round(diffMs / 1000);
+
+	for (const division of divisions) {
+		if (Math.abs(duration) < division.amount) {
+			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+				duration,
+				division.unit,
+			);
+		}
+
+		duration = Math.round(duration / division.amount);
+	}
+
+	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+		duration,
+		"week",
+	);
+}
+
+export function ConversationSidebarItem({
+	id,
+	title,
+	updatedAt,
+	showSeparator,
+}: ConversationSidebarItemProps) {
+	const pathname = usePathname();
+	const href = `/c/${id}`;
+	const isSelected = pathname === href;
+	const age = formatConversationAge(updatedAt);
+
+	return (
+		<EntityRow
+			asChild
+			showSeparator={showSeparator}
+			isSelected={isSelected}
+			icon={
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
+			}
+			title={title}
+			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
+			titleTrailing={
+				age ? (
+					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+						{age}
+					</span>
+				) : undefined
+			}
+		>
+			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+		</EntityRow>
+	);
+}

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { Calligraph } from "calligraph";
-import Image from "next/image";
-import Link from "next/link";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -24,22 +20,14 @@ export function NavChats() {
 		<SidebarGroup>
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu>
-				{conversations.map((conversation) => (
-					<SidebarMenuItem key={conversation.id}>
-						<SidebarMenuButton asChild tooltip={conversation.title}>
-							{/* Using link for soft navigation. */}
-							<Link href={`/c/${conversation.id}`}>
-								<Image
-									src="/bars-rotate-fade.svg"
-									width={15}
-									height={15}
-									alt="Animated Loader"
-									unoptimized // Recommended for some animated SVGs to prevent caching issues
-								/>
-								<Calligraph>{conversation.title}</Calligraph>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+				{conversations.map((conversation, index) => (
+					<ConversationSidebarItem
+						key={conversation.id}
+						id={conversation.id}
+						title={conversation.title}
+						updatedAt={conversation.updated_at}
+						showSeparator={index > 0}
+					/>
 				))}
 			</SidebarMenu>
 		</SidebarGroup>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,10 +1,12 @@
 "use client";
+import { IconPencilPlus } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
 	SidebarContent,
+	SidebarHeader,
 	SidebarInset,
 	SidebarMenuButton,
 	SidebarMenuItem,
@@ -32,14 +34,18 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							className="cursor-pointer"
-							onClick={handleNewConversation}
-						>
-							<span>New Conversation</span>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+					<SidebarHeader className="pb-1">
+						<SidebarMenuItem>
+							<SidebarMenuButton
+								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] text-[13px] shadow-minimal hover:bg-background active:bg-background"
+								onClick={handleNewConversation}
+								type="button"
+							>
+								<IconPencilPlus />
+								<span>New Conversation</span>
+							</SidebarMenuButton>
+						</SidebarMenuItem>
+					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>
 			</Sidebar>

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+export interface EntityRowProps {
+	icon?: React.ReactNode;
+	title: React.ReactNode;
+	titleClassName?: string;
+	titleTrailing?: React.ReactNode;
+	badges?: React.ReactNode;
+	trailing?: React.ReactNode;
+	children?: React.ReactNode;
+	isSelected?: boolean;
+	showSeparator?: boolean;
+	className?: string;
+	separatorClassName?: string;
+	asChild?: boolean;
+}
+
+export function EntityRow({
+	icon,
+	title,
+	titleClassName,
+	titleTrailing,
+	badges,
+	trailing,
+	children,
+	isSelected = false,
+	showSeparator = false,
+	className,
+	separatorClassName = "pl-[38px] pr-4",
+	asChild = false,
+}: EntityRowProps) {
+	const Comp = asChild ? ("div" as const) : ("button" as const);
+
+	return (
+		<div className={className} data-selected={isSelected || undefined}>
+			{showSeparator && (
+				<div className={separatorClassName}>
+					<Separator />
+				</div>
+			)}
+			<div className="relative group select-none pl-2 mr-2">
+				{isSelected && (
+					<div className="absolute left-0 inset-y-0 w-[2px] bg-accent" />
+				)}
+				<Comp
+					className={cn(
+						"flex w-full items-start gap-2 pl-2 pr-4 py-3 text-left text-sm outline-none rounded-[8px]",
+						"transition-[background-color] duration-75",
+						isSelected ? "bg-foreground/3" : "hover:bg-foreground/2",
+					)}
+				>
+					<div className="flex flex-col gap-1.5 min-w-0 flex-1">
+						{titleTrailing ? (
+							<div className="flex items-center gap-[10px] w-full min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div className={cn("font-sans truncate min-w-0", titleClassName)}>
+									{title}
+								</div>
+								<div className="shrink-0 ml-auto relative -mr-1">
+									{titleTrailing}
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div
+									className={cn(
+										"font-medium font-sans line-clamp-2 min-w-0 -mb-[2px]",
+										titleClassName,
+									)}
+								>
+									{title}
+								</div>
+							</div>
+						)}
+						{(badges || trailing) && (
+							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
+								{icon && (
+									<div
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										aria-hidden="true"
+									>
+										{icon}
+									</div>
+								)}
+								{badges && (
+									<div className="flex-1 flex items-center gap-1 min-w-0 overflow-x-auto scrollbar-hide">
+										{badges}
+									</div>
+								)}
+								{trailing && (
+									<div className="shrink-0 flex items-center gap-1 ml-auto">
+										{trailing}
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</Comp>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -403,7 +403,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/45 h-6 px-3 text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- continue the Craft-inspired AI Nexus migration with a tiny New Conversation button pass on top of the sidebar/theme work
- carry forward the Craft-style sidebar rows, section header, top-bar control, and theme token foundation in one reviewable branch
- add a short repo-local plan doc that captures the intended tiny-PR migration sequence

## Technical Changes
- update `frontend/app/globals.css` with the Craft-style theme/runtime token foundation and supporting toast/chrome styling
- add reusable Craft-style sidebar primitives:
  - `frontend/components/ui/entity-row.tsx`
  - `frontend/components/ui/top-bar-button.tsx`
- add `frontend/components/conversation-sidebar-item.tsx` and wire `frontend/components/nav-chats.tsx` to use the richer conversation rows
- update `frontend/components/ui/sidebar.tsx` so the sidebar trigger and chats section header match the Craft treatment
- update `frontend/components/new-sidebar.tsx` so the New Conversation button becomes a Craft-style top-of-sidebar control while preserving existing `/` navigation behavior
- add `docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md` to document the tiny, review-friendly migration plan

## User Impact
- the app sidebar gets a clearer Craft-inspired structure and visual hierarchy
- conversation rows now show richer layout and relative timestamps
- the chats section header is subtler and more in line with Craft
- the New Conversation button now reads as a more intentional top-of-sidebar primary action
- no backend or API changes

## Manual Testing
1. Start the app and sign in with a user that has at least 2 conversations.
2. Open `/` and confirm the sidebar renders with:
   - New Conversation button at the top
   - `Your Chats` section header
   - conversation rows with icons, separators, and timestamps
3. Click New Conversation and confirm it still navigates to `/`.
4. Click a conversation row and confirm navigation to `/c/<conversationId>` plus selected-state highlight.
5. Open `/c/<conversationId>` directly and verify the matching row is selected.
6. Confirm valid `updated_at` values render as relative times and invalid timestamps do not break rendering.
7. Toggle the sidebar on desktop and mobile widths and confirm layout remains clean.

## Automated Checks
- `bunx --bun @biomejs/biome check frontend/components/new-sidebar.tsx`
- `bun run typecheck` (from `frontend/`)

## Notes / Risk Areas
- `frontend/app/globals.css` remains the broadest risk surface because it changes global theme/runtime tokens.
- Root Biome config excludes parts of `frontend/components/ui/**`, so not every touched UI primitive is covered by normal Biome validation.
- This branch is intentionally stacked on top of the earlier Craft sidebar/theme work rather than being only the final button commit.

## Summary by Sourcery

Refresh the chat sidebar UI with Craft-inspired conversation rows and New Conversation control while introducing reusable sidebar primitives and documenting the next migration steps.

New Features:
- Introduce a reusable EntityRow UI primitive for sidebar-like list items.
- Add a ConversationSidebarItem component to render richer conversation entries with icons and relative timestamps.

Enhancements:
- Update the chat sidebar to use ConversationSidebarItem for improved layout, selection state, and visual hierarchy.
- Restyle the New Conversation control as a prominent top-of-sidebar action with iconography and refined treatment.
- Adjust the sidebar section header styling to better match the Craft-inspired visual language.

Documentation:
- Add a migration plan document outlining the phased Craft sidebar and main-panel UI refresh strategy.