### PR TITLE
feat(sidebar): align Craft session rows and New Session button

### DIFF
--- a/docs/craft-button-guidelines.md
+++ b/docs/craft-button-guidelines.md
@@ -1,0 +1,36 @@
+# Craft-Style Button Rules
+
+Use these rules for any button intended to match the compact Craft-like control style used for the New Session action.
+
+- Keep geometry tight: prefer compact height, small horizontal padding, and rounded corners that read like a menu row instead of a large CTA.
+- Default state should be quiet: use a low-contrast background and a light shadow so the button is visible without looking filled or loud.
+- Do not introduce heavy borders: avoid full-strength strokes, dark outlines, or separator-like edge noise unless a border is functionally required.
+- Hover, active, and pressed states should shift slightly: adjust background, shadow, or inset treatment by a small step instead of switching to saturated colors.
+- Focus must be obvious: keep `cursor-pointer`, preserve keyboard focus visibility, and use a restrained but clear focus ring that does not change layout.
+- Icon and label must scan fast: use a small icon, consistent gap, medium-weight label, and avoid oversized glyphs or wide spacing.
+- Keep label copy short: this style works best with 1 to 3 words and no secondary helper text inside the button.
+- Match row rhythm: align button height, radius, and padding with adjacent sidebar rows or menu items so it feels native to the surface.
+
+## Good
+
+```tsx
+<button
+  className="inline-flex h-8 items-center gap-2 rounded-lg bg-neutral-100/90 px-3 text-sm font-medium text-neutral-900 shadow-sm transition-[background-color,box-shadow] hover:bg-neutral-100 hover:shadow active:bg-neutral-200/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400/60 cursor-pointer"
+>
+  <Plus className="size-4" />
+  <span>New Session</span>
+</button>
+```
+
+Why this works: compact height, quiet baseline fill, light shadow, small icon gap, and state changes that stay within the same tonal range.
+
+## Bad
+
+```tsx
+<button className="inline-flex h-11 items-center gap-3 rounded-2xl border border-neutral-300 bg-white px-5 text-sm font-semibold text-blue-600 shadow-md hover:bg-blue-600 hover:text-white">
+  <Plus className="size-5" />
+  <span>Create a New Session</span>
+</button>
+```
+
+Why this fails: too tall, too much border and shadow weight, oversized spacing, and hover state jumps to a different color story.

--- a/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
+++ b/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
@@ -1,0 +1,143 @@
+# Craft Sidebar Migration — Next Steps Plan
+
+## Goal
+Continue the Craft Agents migration in **tiny, review-friendly PRs** that keep scope narrow and visual diffs easy to understand.
+
+## Working Rules
+- Prefer **small, isolated frontend-only PRs**.
+- Stay on one surface area until it feels coherent.
+- Avoid bundling behavior, data-flow, and styling changes together unless necessary.
+- For ACP coding/planning runs, explicitly use **`openai-codex/gpt-5.4` with `xhigh` thinking** unless we decide otherwise.
+- Human review happens after each slice; do not assume a long stacked migration branch is the default.
+
+## Current State
+Recently completed sidebar/theme work includes:
+- Craft-style theme/token foundation
+- Craft-style top bar button
+- Craft-style conversation sidebar rows
+- Craft-style chats section header
+
+This gives us a solid sidebar visual base to keep iterating on.
+
+## Plan of Attack
+
+### Phase 1 — Finish the Sidebar Surface
+Focus on the sidebar until it feels visually coherent.
+
+#### 1. New Conversation button
+**Why next:**
+- highly visible
+- still sidebar-local
+- likely styling-first
+- easy to review as a standalone PR
+
+**Target outcome:**
+- button treatment matches the newer Craft-inspired sidebar language
+- no backend or routing changes beyond existing behavior
+
+#### 2. Sidebar spacing / rhythm polish
+**Possible scope:**
+- spacing between section header and conversation rows
+- vertical rhythm around separators
+- sidebar content padding and grouping
+
+**Why:**
+- useful if the sidebar looks close but still slightly off after the previous PRs
+- remains low-risk and visual-only
+
+#### 3. Sidebar empty state
+**Why:**
+- self-contained
+- improves UX for new/empty accounts
+- good presentational follow-up before touching the chat panel
+
+**Target outcome:**
+- empty sidebar/chat-list area feels intentional and consistent with Craft
+
+#### 4. Row interaction polish (only if needed)
+**Possible scope:**
+- hover/selected contrast
+- keyboard focus styling
+- timestamp alignment/overflow edge cases
+
+**Why:**
+- only worth doing if review feedback or visual inspection says current rows need refinement
+
+### Phase 2 — Move Inward to the Main Panel
+Once the sidebar feels coherent, start on the least risky main-panel surfaces.
+
+#### 5. Chat empty state / welcome state
+**Why first:**
+- mostly presentational
+- easier than message rendering or composer work
+- visible win without dragging in streaming logic
+
+#### 6. Main panel chrome / lightweight layout polish
+**Possible scope:**
+- headers
+- framing containers
+- subtle spacing and token alignment
+
+**Why:**
+- helps bridge the visual language from sidebar to content area
+
+### Phase 3 — Higher-Risk Surfaces (Do Later)
+These should only happen after the low-risk presentational layers are in place.
+
+#### 7. Message cards / message presentation
+**Risks:**
+- content rendering differences
+- tool/result states
+- assistant/user role styling
+- streaming edge cases
+
+#### 8. Input composer
+**Risks:**
+- autosize
+- keyboard behavior
+- attachments
+- submit/disabled/loading states
+
+#### 9. Model selector
+**Risks:**
+- state wiring
+- interaction complexity
+- command/dialog behavior
+
+## Recommended Immediate Next Step
+Create a **small planning/research pass** for the next PR focused on:
+
+> **Port the Craft-style New Conversation button**
+
+That pass should answer:
+- exact Craft source reference
+- exact local files to change
+- whether this should be a local override or shared primitive
+- risk of accidental layout/behavior changes
+- smallest reviewable implementation path
+
+## PR Sequencing Recommendation
+1. Theme/tokens + sidebar rows + section header ✅
+2. New Conversation button
+3. Sidebar spacing/polish
+4. Sidebar empty state
+5. Main-panel empty state
+6. Main-panel chrome polish
+7. Message cards
+8. Composer
+9. Model selector
+
+## Anti-Goals
+For the next few PRs, avoid:
+- backend changes
+- API contract changes
+- broad routing changes
+- mixing multiple UI surfaces into one PR
+- turning a visual PR into a behavior/refactor swamp
+
+## Success Criteria
+This plan is working if:
+- each PR has a clear single-surface story
+- diffs stay easy to review
+- visual progress is obvious after each merge
+- we avoid giant tangled migration branches

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { EntityRow } from "@/components/ui/entity-row";
+import { cn } from "@/lib/utils";
+
+interface ConversationSidebarItemProps {
+	id: string;
+	title: string;
+	updatedAt: string;
+	showSeparator: boolean;
+}
+
+function formatConversationAge(updatedAt: string) {
+	const date = new Date(updatedAt);
+
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	const diffMs = date.getTime() - Date.now();
+	const divisions = [
+		{ amount: 60, unit: "second" },
+		{ amount: 60, unit: "minute" },
+		{ amount: 24, unit: "hour" },
+		{ amount: 7, unit: "day" },
+	] as const;
+	let duration = Math.round(diffMs / 1000);
+
+	for (const division of divisions) {
+		if (Math.abs(duration) < division.amount) {
+			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+				duration,
+				division.unit,
+			);
+		}
+
+		duration = Math.round(duration / division.amount);
+	}
+
+	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+		duration,
+		"week",
+	);
+}
+
+export function ConversationSidebarItem({
+	id,
+	title,
+	updatedAt,
+	showSeparator,
+}: ConversationSidebarItemProps) {
+	const pathname = usePathname();
+	const href = `/c/${id}`;
+	const isSelected = pathname === href;
+	const age = formatConversationAge(updatedAt);
+
+	return (
+		<EntityRow
+			asChild
+			showSeparator={showSeparator}
+			isSelected={isSelected}
+			icon={
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
+			}
+			title={title}
+			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
+			titleTrailing={
+				age ? (
+					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+						{age}
+					</span>
+				) : undefined
+			}
+		>
+			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+		</EntityRow>
+	);
+}

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -19,43 +19,41 @@ function formatConversationAge(updatedAt: string) {
 		return null;
 	}
 
-	const diffMs = date.getTime() - Date.now();
-	const divisions = [
-		{ amount: 60, unit: "second" },
-		{ amount: 60, unit: "minute" },
-		{ amount: 24, unit: "hour" },
-		{ amount: 7, unit: "day" },
-	] as const;
-	let duration = Math.round(diffMs / 1000);
-
-	for (const division of divisions) {
-		if (Math.abs(duration) < division.amount) {
-			return new Intl.RelativeTimeFormat("en", {
-				numeric: "auto",
-			}).format(duration, division.unit);
-		}
-
-		duration = Math.round(duration / division.amount);
-	}
-
-	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
-		duration,
-		"week",
+	const diffSeconds = Math.max(
+		0,
+		Math.floor((Date.now() - date.getTime()) / 1000),
 	);
-}
 
-function conversationTone(seed: string) {
-	let hash = 0;
-	for (let i = 0; i < seed.length; i++) {
-		hash = (hash * 31 + seed.charCodeAt(i)) % 360;
+	if (diffSeconds < 60) {
+		return `${diffSeconds}s`;
 	}
 
-	const hue = Math.abs(hash);
-	return {
-		bg: `hsl(${hue} 90% 96%)`,
-		fg: `hsl(${hue} 70% 42%)`,
-		border: `hsl(${hue} 55% 78%)`,
-	};
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	if (diffMinutes < 60) {
+		return `${diffMinutes}m`;
+	}
+
+	const diffHours = Math.floor(diffMinutes / 60);
+	if (diffHours < 24) {
+		return `${diffHours}h`;
+	}
+
+	const diffDays = Math.floor(diffHours / 24);
+	if (diffDays < 7) {
+		return `${diffDays}d`;
+	}
+
+	const diffWeeks = Math.floor(diffDays / 7);
+	if (diffWeeks < 5) {
+		return `${diffWeeks}w`;
+	}
+
+	const diffMonths = Math.floor(diffDays / 30);
+	if (diffMonths < 12) {
+		return `${diffMonths}mo`;
+	}
+
+	return `${Math.floor(diffDays / 365)}y`;
 }
 
 export function ConversationSidebarItem({
@@ -68,7 +66,6 @@ export function ConversationSidebarItem({
 	const href = `/c/${id}`;
 	const isSelected = pathname === href;
 	const age = formatConversationAge(updatedAt);
-	const { bg, fg, border } = conversationTone(id);
 
 	return (
 		<EntityRow
@@ -76,22 +73,16 @@ export function ConversationSidebarItem({
 			showSeparator={showSeparator}
 			isSelected={isSelected}
 			icon={
-				<span
-					className="grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full border"
-					style={{ backgroundColor: bg, borderColor: border }}
-					aria-hidden="true"
-				>
-					<span
-						className="h-1.5 w-1.5 rounded-full"
-						style={{ backgroundColor: fg }}
-					/>
-				</span>
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
 			}
-			title={
-				<span className={cn("truncate", isSelected && "font-medium")}>
-					{title}
-				</span>
-			}
+			title={title}
 			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
 			titleTrailing={
 				age ? (

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { EntityRow } from "@/components/ui/entity-row";
-import { cn } from "@/lib/utils";
+import { SidebarMenuItem } from "@/components/ui/sidebar";
 
 interface ConversationSidebarItemProps {
 	id: string;
@@ -68,35 +68,27 @@ export function ConversationSidebarItem({
 	const age = formatConversationAge(updatedAt);
 
 	return (
-		<EntityRow
-			asChild
-			showSeparator={showSeparator}
-			isSelected={isSelected}
-			icon={
-				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
-					<g transform="translate(1.748, 0.7832)">
-						<path
-							fillRule="nonzero"
-							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
-						/>
-					</g>
-				</svg>
-			}
-			title={title}
-			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
-			titleTrailing={
-				age ? (
-					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
-						{age}
-					</span>
-				) : undefined
-			}
-		>
-			<Link
-				href={href}
-				className="absolute inset-0 rounded-[8px]"
-				aria-label={title}
-			/>
-		</EntityRow>
+		<SidebarMenuItem>
+			<EntityRow
+				asChild
+				showSeparator={showSeparator}
+				isSelected={isSelected}
+				title={title}
+				titleClassName="text-[13px]"
+				titleTrailing={
+					age ? (
+						<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+							{age}
+						</span>
+					) : undefined
+				}
+			>
+				<Link
+					href={href}
+					className="absolute inset-0 rounded-[8px]"
+					aria-label={title}
+				/>
+			</EntityRow>
+		</SidebarMenuItem>
 	);
 }

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -30,10 +30,9 @@ function formatConversationAge(updatedAt: string) {
 
 	for (const division of divisions) {
 		if (Math.abs(duration) < division.amount) {
-			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
-				duration,
-				division.unit,
-			);
+			return new Intl.RelativeTimeFormat("en", {
+				numeric: "auto",
+			}).format(duration, division.unit);
 		}
 
 		duration = Math.round(duration / division.amount);
@@ -43,6 +42,20 @@ function formatConversationAge(updatedAt: string) {
 		duration,
 		"week",
 	);
+}
+
+function conversationTone(seed: string) {
+	let hash = 0;
+	for (let i = 0; i < seed.length; i++) {
+		hash = (hash * 31 + seed.charCodeAt(i)) % 360;
+	}
+
+	const hue = Math.abs(hash);
+	return {
+		bg: `hsl(${hue} 90% 96%)`,
+		fg: `hsl(${hue} 70% 42%)`,
+		border: `hsl(${hue} 55% 78%)`,
+	};
 }
 
 export function ConversationSidebarItem({
@@ -55,6 +68,7 @@ export function ConversationSidebarItem({
 	const href = `/c/${id}`;
 	const isSelected = pathname === href;
 	const age = formatConversationAge(updatedAt);
+	const { bg, fg, border } = conversationTone(id);
 
 	return (
 		<EntityRow
@@ -62,16 +76,22 @@ export function ConversationSidebarItem({
 			showSeparator={showSeparator}
 			isSelected={isSelected}
 			icon={
-				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
-					<g transform="translate(1.748, 0.7832)">
-						<path
-							fillRule="nonzero"
-							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
-						/>
-					</g>
-				</svg>
+				<span
+					className="grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full border"
+					style={{ backgroundColor: bg, borderColor: border }}
+					aria-hidden="true"
+				>
+					<span
+						className="h-1.5 w-1.5 rounded-full"
+						style={{ backgroundColor: fg }}
+					/>
+				</span>
 			}
-			title={title}
+			title={
+				<span className={cn("truncate", isSelected && "font-medium")}>
+					{title}
+				</span>
+			}
 			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
 			titleTrailing={
 				age ? (
@@ -81,7 +101,11 @@ export function ConversationSidebarItem({
 				) : undefined
 			}
 		>
-			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+			<Link
+				href={href}
+				className="absolute inset-0 rounded-[8px]"
+				aria-label={title}
+			/>
 		</EntityRow>
 	);
 }

--- a/frontend/components/icons/SquarePenRounded.tsx
+++ b/frontend/components/icons/SquarePenRounded.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+/**
+ * Custom SquarePen icon with extra-rounded square corners,
+ * copied from craft-agents-oss.
+ */
+export function SquarePenRounded(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+			{...props}
+		>
+			<path d="M12 3H7a4 4 0 0 0-4 4v10a4 4 0 0 0 4 4h10a4 4 0 0 0 4-4v-5" />
+			<path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />
+		</svg>
+	);
+}

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
 } from "@/components/ui/sidebar";
-import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -17,9 +17,9 @@ export function NavChats() {
 
 	// If there are conversations, render the sidebar group and menu.
 	return (
-		<SidebarGroup>
+		<SidebarGroup className="pt-1">
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
-			<SidebarMenu>
+			<SidebarMenu className="gap-0">
 				{conversations.map((conversation, index) => (
 					<ConversationSidebarItem
 						key={conversation.id}

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -67,7 +67,9 @@ function formatDateGroupLabel(date: Date) {
 	}).format(date);
 }
 
-function buildConversationGroups(conversations: Conversation[]): ConversationGroup[] {
+function buildConversationGroups(
+	conversations: Conversation[],
+): ConversationGroup[] {
 	const sortedConversations = [...conversations].sort(
 		(left, right) =>
 			getConversationTimestamp(right) - getConversationTimestamp(left),

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { Calligraph } from "calligraph";
-import Image from "next/image";
-import Link from "next/link";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -24,22 +20,14 @@ export function NavChats() {
 		<SidebarGroup>
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu>
-				{conversations.map((conversation) => (
-					<SidebarMenuItem key={conversation.id}>
-						<SidebarMenuButton asChild tooltip={conversation.title}>
-							{/* Using link for soft navigation. */}
-							<Link href={`/c/${conversation.id}`}>
-								<Image
-									src="/bars-rotate-fade.svg"
-									width={15}
-									height={15}
-									alt="Animated Loader"
-									unoptimized // Recommended for some animated SVGs to prevent caching issues
-								/>
-								<Calligraph>{conversation.title}</Calligraph>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+				{conversations.map((conversation, index) => (
+					<ConversationSidebarItem
+						key={conversation.id}
+						id={conversation.id}
+						title={conversation.title}
+						updatedAt={conversation.updated_at}
+						showSeparator={index > 0}
+					/>
 				))}
 			</SidebarMenu>
 		</SidebarGroup>

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import {
 	SidebarGroup,
@@ -7,28 +9,230 @@ import {
 	SidebarMenu,
 } from "@/components/ui/sidebar";
 import useGetConversations from "@/hooks/get-conversations";
+import type { Conversation } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const COLLAPSED_GROUPS_STORAGE_KEY = "nav-chats-collapsed-groups";
+
+type ConversationGroup = {
+	key: string;
+	label: string;
+	items: Conversation[];
+};
+
+function getConversationDate(value: string) {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getConversationTimestamp(conversation: Conversation) {
+	const date =
+		getConversationDate(conversation.updated_at) ??
+		getConversationDate(conversation.created_at);
+
+	return date?.getTime() ?? 0;
+}
+
+function getLocalDayKey(date: Date) {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+
+	return `${year}-${month}-${day}`;
+}
+
+function isSameLocalDay(left: Date, right: Date) {
+	return (
+		left.getFullYear() === right.getFullYear() &&
+		left.getMonth() === right.getMonth() &&
+		left.getDate() === right.getDate()
+	);
+}
+
+function formatDateGroupLabel(date: Date) {
+	const now = new Date();
+	if (isSameLocalDay(date, now)) {
+		return "Today";
+	}
+
+	const yesterday = new Date(now);
+	yesterday.setDate(now.getDate() - 1);
+	if (isSameLocalDay(date, yesterday)) {
+		return "Yesterday";
+	}
+
+	return new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+	}).format(date);
+}
+
+function buildConversationGroups(conversations: Conversation[]): ConversationGroup[] {
+	const sortedConversations = [...conversations].sort(
+		(left, right) =>
+			getConversationTimestamp(right) - getConversationTimestamp(left),
+	);
+
+	const groups = new Map<string, ConversationGroup>();
+	for (const conversation of sortedConversations) {
+		const date =
+			getConversationDate(conversation.updated_at) ??
+			getConversationDate(conversation.created_at) ??
+			new Date(0);
+		const key = getLocalDayKey(date);
+
+		if (!groups.has(key)) {
+			groups.set(key, {
+				key,
+				label: formatDateGroupLabel(date),
+				items: [],
+			});
+		}
+
+		groups.get(key)?.items.push(conversation);
+	}
+
+	return [...groups.values()];
+}
+
+function CollapsibleGroupHeader({
+	label,
+	isCollapsed,
+	itemCount,
+	onToggle,
+}: {
+	label: string;
+	isCollapsed: boolean;
+	itemCount: number;
+	onToggle: () => void;
+}) {
+	return (
+		<li>
+			<button
+				type="button"
+				onClick={onToggle}
+				className="w-full py-2 px-4 flex items-center gap-1.5 cursor-pointer group/header relative"
+			>
+				<div className="absolute inset-y-0.5 left-2 right-2 rounded-[6px] group-hover/header:bg-foreground/2 transition-colors pointer-events-none" />
+				<ChevronRight
+					className={cn(
+						"h-3 w-3 text-muted-foreground/60 transition-transform relative",
+						!isCollapsed && "rotate-90",
+					)}
+				/>
+				<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground relative">
+					{label}
+					{isCollapsed ? (
+						<>
+							{" · "}
+							<span className="text-muted-foreground/50">{itemCount}</span>
+						</>
+					) : null}
+				</span>
+			</button>
+		</li>
+	);
+}
+
+function SectionHeader({ label }: { label: string }) {
+	return (
+		<li className="px-4 py-2">
+			<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+				{label}
+			</span>
+		</li>
+	);
+}
 
 // TODO: This needs to take in conversations/chats.
 export function NavChats() {
 	// Get the conversations for the current user.
 	const { data: conversations } = useGetConversations();
+	const groups = useMemo(
+		() => buildConversationGroups(conversations ?? []),
+		[conversations],
+	);
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
+		if (typeof window === "undefined") {
+			return new Set();
+		}
+
+		try {
+			const storedGroups = window.localStorage.getItem(
+				COLLAPSED_GROUPS_STORAGE_KEY,
+			);
+			if (!storedGroups) {
+				return new Set();
+			}
+
+			const parsedGroups = JSON.parse(storedGroups);
+			return new Set(Array.isArray(parsedGroups) ? parsedGroups : []);
+		} catch {
+			return new Set();
+		}
+	});
+
+	useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		window.localStorage.setItem(
+			COLLAPSED_GROUPS_STORAGE_KEY,
+			JSON.stringify([...collapsedGroups]),
+		);
+	}, [collapsedGroups]);
+
 	// If there are no conversations, return null.
 	if (!conversations || conversations.length === 0) return null;
+
+	const toggleGroupCollapse = (groupKey: string) => {
+		setCollapsedGroups((currentGroups) => {
+			const nextGroups = new Set(currentGroups);
+			if (nextGroups.has(groupKey)) {
+				nextGroups.delete(groupKey);
+			} else {
+				nextGroups.add(groupKey);
+			}
+			return nextGroups;
+		});
+	};
 
 	// If there are conversations, render the sidebar group and menu.
 	return (
 		<SidebarGroup className="pt-1">
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu className="gap-0">
-				{conversations.map((conversation, index) => (
-					<ConversationSidebarItem
-						key={conversation.id}
-						id={conversation.id}
-						title={conversation.title}
-						updatedAt={conversation.updated_at}
-						showSeparator={index > 0}
-					/>
-				))}
+				{groups.map((group) => {
+					const isCollapsible = groups.length > 1;
+					const isCollapsed = collapsedGroups.has(group.key);
+
+					return (
+						<Fragment key={group.key}>
+							{isCollapsible ? (
+								<CollapsibleGroupHeader
+									label={group.label}
+									isCollapsed={isCollapsed}
+									itemCount={group.items.length}
+									onToggle={() => toggleGroupCollapse(group.key)}
+								/>
+							) : (
+								<SectionHeader label={group.label} />
+							)}
+							{isCollapsible && isCollapsed
+								? null
+								: group.items.map((conversation, index) => (
+										<ConversationSidebarItem
+											key={conversation.id}
+											id={conversation.id}
+											title={conversation.title}
+											updatedAt={conversation.updated_at}
+											showSeparator={index > 0}
+										/>
+									))}
+						</Fragment>
+					);
+				})}
 			</SidebarMenu>
 		</SidebarGroup>
 	);

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { IconPencilPlus } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
@@ -8,16 +9,15 @@ import {
 	SidebarContent,
 	SidebarHeader,
 	SidebarInset,
-	SidebarMenuButton,
-	SidebarMenuItem,
 	SidebarProvider,
 	SidebarTrigger,
 } from "./ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 /**
  * Application sidebar layout wrapper.
  *
- * Renders the sidebar with a "New Conversation" button and conversation history,
+ * Renders the sidebar with a "New Session" button and conversation history,
  * alongside the main content area with a sidebar toggle and header.
  *
  * @param children - The page content to render in the main area.
@@ -34,17 +34,23 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarHeader className="pt-2 pb-2">
-						<SidebarMenuItem>
-							<SidebarMenuButton
-								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] gap-2 text-[13px] shadow-minimal hover:bg-background active:bg-background"
-								onClick={handleNewConversation}
-								type="button"
-							>
-								<IconPencilPlus />
-								<span>New Conversation</span>
-							</SidebarMenuButton>
-						</SidebarMenuItem>
+					<SidebarHeader className="px-2 pb-2 shrink-0">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div>
+									<button
+										type="button"
+										onClick={handleNewConversation}
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										aria-label="New Session"
+									>
+										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />
+										New Session
+									</button>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent side="right">⌘N</TooltipContent>
+						</Tooltip>
 					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -41,7 +41,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 									<button
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="inline-flex items-center w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
 										aria-label="New Session"
 									>
 										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -34,10 +34,10 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarHeader className="pb-1">
+					<SidebarHeader className="pt-2 pb-2">
 						<SidebarMenuItem>
 							<SidebarMenuButton
-								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] text-[13px] shadow-minimal hover:bg-background active:bg-background"
+								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] gap-2 text-[13px] shadow-minimal hover:bg-background active:bg-background"
 								onClick={handleNewConversation}
 								type="button"
 							>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,10 +1,12 @@
 "use client";
+import { IconPencilPlus } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
 	SidebarContent,
+	SidebarHeader,
 	SidebarInset,
 	SidebarMenuButton,
 	SidebarMenuItem,
@@ -32,14 +34,18 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							className="cursor-pointer"
-							onClick={handleNewConversation}
-						>
-							<span>New Conversation</span>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+					<SidebarHeader className="pb-1">
+						<SidebarMenuItem>
+							<SidebarMenuButton
+								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] text-[13px] shadow-minimal hover:bg-background active:bg-background"
+								onClick={handleNewConversation}
+								type="button"
+							>
+								<IconPencilPlus />
+								<span>New Conversation</span>
+							</SidebarMenuButton>
+						</SidebarMenuItem>
+					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>
 			</Sidebar>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
-import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -39,16 +38,15 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<Button
-										variant="ghost"
+									<button
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none hover:bg-foreground/3 transition-colors focus-visible:ring-0 focus-visible:border-transparent"
+										className="inline-flex items-center justify-start gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 w-full py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none text-foreground/85 font-normal hover:bg-foreground/3"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</Button>
+									</button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
+import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -38,15 +39,16 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<button
+									<Button
+										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="inline-flex items-center justify-start gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 w-full py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none text-foreground/85 font-normal hover:bg-foreground/3"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</button>
+									</Button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { SquarePenRounded } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
+import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
 import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { IconPencilPlus } from "@tabler/icons-react";
+import { SquarePenRounded } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
+import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -38,15 +39,16 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<button
+									<Button
+										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="inline-flex items-center w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
 										aria-label="New Session"
 									>
-										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />
+										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</button>
+									</Button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -43,7 +43,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none cursor-pointer"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -43,7 +43,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none hover:bg-foreground/3 transition-colors focus-visible:ring-0 focus-visible:border-transparent"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -57,7 +57,7 @@ export function EntityRow({
 						{titleTrailing ? (
 							<div className="flex items-center gap-[10px] w-full min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}
 									</div>
 								)}
@@ -71,7 +71,7 @@ export function EntityRow({
 						) : (
 							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}
 									</div>
 								)}
@@ -89,7 +89,7 @@ export function EntityRow({
 							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
 								{icon && (
 									<div
-										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5 invisible"
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
 										aria-hidden="true"
 									>
 										{icon}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -57,7 +57,7 @@ export function EntityRow({
 						{titleTrailing ? (
 							<div className="flex items-center gap-[10px] w-full min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
 										{icon}
 									</div>
 								)}
@@ -71,7 +71,7 @@ export function EntityRow({
 						) : (
 							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
 										{icon}
 									</div>
 								)}
@@ -89,7 +89,7 @@ export function EntityRow({
 							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
 								{icon && (
 									<div
-										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5 invisible"
 										aria-hidden="true"
 									>
 										{icon}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+export interface EntityRowProps {
+	icon?: React.ReactNode;
+	title: React.ReactNode;
+	titleClassName?: string;
+	titleTrailing?: React.ReactNode;
+	badges?: React.ReactNode;
+	trailing?: React.ReactNode;
+	children?: React.ReactNode;
+	isSelected?: boolean;
+	showSeparator?: boolean;
+	className?: string;
+	separatorClassName?: string;
+	asChild?: boolean;
+}
+
+export function EntityRow({
+	icon,
+	title,
+	titleClassName,
+	titleTrailing,
+	badges,
+	trailing,
+	children,
+	isSelected = false,
+	showSeparator = false,
+	className,
+	separatorClassName = "pl-[38px] pr-4",
+	asChild = false,
+}: EntityRowProps) {
+	const Comp = asChild ? ("div" as const) : ("button" as const);
+
+	return (
+		<div className={className} data-selected={isSelected || undefined}>
+			{showSeparator && (
+				<div className={separatorClassName}>
+					<Separator />
+				</div>
+			)}
+			<div className="relative group select-none pl-2 mr-2">
+				{isSelected && (
+					<div className="absolute left-0 inset-y-0 w-[2px] bg-accent" />
+				)}
+				<Comp
+					className={cn(
+						"flex w-full items-start gap-2 pl-2 pr-4 py-3 text-left text-sm outline-none rounded-[8px]",
+						"transition-[background-color] duration-75",
+						isSelected ? "bg-foreground/3" : "hover:bg-foreground/2",
+					)}
+				>
+					<div className="flex flex-col gap-1.5 min-w-0 flex-1">
+						{titleTrailing ? (
+							<div className="flex items-center gap-[10px] w-full min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div className={cn("font-sans truncate min-w-0", titleClassName)}>
+									{title}
+								</div>
+								<div className="shrink-0 ml-auto relative -mr-1">
+									{titleTrailing}
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div
+									className={cn(
+										"font-medium font-sans line-clamp-2 min-w-0 -mb-[2px]",
+										titleClassName,
+									)}
+								>
+									{title}
+								</div>
+							</div>
+						)}
+						{(badges || trailing) && (
+							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
+								{icon && (
+									<div
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										aria-hidden="true"
+									>
+										{icon}
+									</div>
+								)}
+								{badges && (
+									<div className="flex-1 flex items-center gap-1 min-w-0 overflow-x-auto scrollbar-hide">
+										{badges}
+									</div>
+								)}
+								{trailing && (
+									<div className="shrink-0 flex items-center gap-1 ml-auto">
+										{trailing}
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</Comp>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -69,7 +69,12 @@ export function EntityRow({
 								</div>
 							</div>
 						) : (
-							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+							<div
+								className={cn(
+									"flex items-center gap-[10px] w-full min-w-0",
+									icon && "pr-6",
+								)}
+							>
 								{icon && (
 									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -403,7 +403,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/45 h-6 px-3 text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 				className,
 			)}
 			{...props}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -385,7 +385,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="sidebar-group"
 			data-sidebar="group"
-			className={cn("p-2 relative flex w-full min-w-0 flex-col", className)}
+			className={cn("relative flex w-full min-w-0 flex-col px-2 pt-1 pb-1", className)}
 			{...props}
 		/>
 	);
@@ -403,7 +403,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/45 h-6 px-3 text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/45 h-5 px-2.5 pb-[5px] pt-[3px] text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- continue the Craft sidebar migration with a tighter, more exact port of the visible sidebar surface
- align the **New Session** button with Craft’s AppShell treatment
- move chat rows closer to Craft’s **Sessions** list behavior, including date-grouped sections and collapsible groups
- document the Craft button rules we want to keep using for future polish

## What changed
### New Session button
- matched the Craft AppShell button markup/classes more closely
- switched to the Craft-style `SquarePenRounded` icon component
- fixed hover/focus/pointer behavior so the control behaves like a real Craft button instead of a local approximation

### Chat/session rows
- tightened `EntityRow` to better match Craft row density and spacing
- updated `ConversationSidebarItem` to match Craft session-row feel more closely instead of using invented icon treatment
- grouped chats by date (`Today`, `Yesterday`, then dated groups)
- added collapsible date sections so the chat list behaves more like Craft’s Sessions surface
- kept AI Nexus’s simpler data model and navigation behavior intact

### Docs / planning
- added `docs/craft-button-guidelines.md` to encode the Craft button rules we distilled during implementation
- added `docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md` to keep the migration staged and reviewable

## Files changed
- `docs/craft-button-guidelines.md`
- `docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md`
- `frontend/components/conversation-sidebar-item.tsx`
- `frontend/components/icons/SquarePenRounded.tsx`
- `frontend/components/nav-chats.tsx`
- `frontend/components/new-sidebar.tsx`
- `frontend/components/ui/entity-row.tsx`
- `frontend/components/ui/sidebar.tsx`

## Why this matters
The earlier sidebar work got us into the right neighborhood, but the visible controls still drifted from Craft in the details that actually sell the effect: button geometry, row rhythm, and the Sessions-list grouping/collapse behavior. This PR makes the sidebar read much closer to Craft instead of “Craft-ish”.

## Testing
### Manual
1. Open the app with several conversations spanning multiple dates.
2. Confirm the **New Session** button matches Craft’s compact treatment and shows the correct pointer/hover behavior.
3. Confirm chat rows appear in date groups such as `Today` / `Yesterday` / dated buckets.
4. Collapse and expand date groups and verify the list state behaves correctly.
5. Open a conversation and verify selected-row styling still works.

### Automated
- `bunx biome format frontend/components/nav-chats.tsx --write`

## Coverage gaps
- no full frontend test suite was run in this pass
- this PR only ports the sidebar surface; the richer Craft state icon system still has limits because AI Nexus does not yet expose the same session-state model

## User impact
- sidebar feels significantly closer to Craft in the surfaces users see constantly
- no backend or routing contract changes
- lower-risk visual iteration that keeps the migration in small reviewable slices