### PR TITLE
feat(chat): refine main chat pane chrome

### DIFF
--- a/frontend/app/(app)/c/[conversationId]/page.tsx
+++ b/frontend/app/(app)/c/[conversationId]/page.tsx
@@ -57,10 +57,7 @@ export default async function ConversationPage({
 	const messages = await response.json();
 
 	return (
-		<div>
-			<h1 className="flex-1 items-center text-center">
-				Conversation {conversationId}
-			</h1>
+		<div className="flex h-[calc(100dvh-4rem)] min-h-0 flex-col">
 			<ChatContainer
 				key={conversationId}
 				conversationId={conversationId}

--- a/frontend/app/(app)/page.tsx
+++ b/frontend/app/(app)/page.tsx
@@ -11,7 +11,7 @@ export default async function ConversationPage() {
 	const uuid: string = crypto.randomUUID();
 
 	return (
-		<div>
+		<div className="flex h-[calc(100dvh-4rem)] min-h-0 flex-col">
 			<ChatContainer key={uuid} conversationId={uuid} />
 		</div>
 	);

--- a/frontend/features/chat/ChatView.tsx
+++ b/frontend/features/chat/ChatView.tsx
@@ -25,13 +25,13 @@ import type { AgnoMessage } from "@/lib/types";
 import {
 	Conversation,
 	ConversationContent,
+	ConversationEmptyState,
 } from "../../components/ai-elements/conversation";
 import { Loader } from "../../components/ai-elements/loader";
 import type { PromptInputMessage } from "../../components/ai-elements/prompt-input";
 import {
 	PromptInput,
 	PromptInputFooter,
-	PromptInputProvider,
 	PromptInputSubmit,
 	PromptInputTextarea,
 } from "../../components/ai-elements/prompt-input";
@@ -87,16 +87,34 @@ const ChatView = ({
 	const [selectedModel, setSelectedModel] = useState("gemini-3-flash-preview");
 
 	return (
-		<div className="overflow-hidden sm:max-w-[80%] lg:max-w-[60%] xl:max-w-[50%] mx-auto">
-			<div className="h-[90vh] flex flex-col overflow-hidden">
-				<Conversation className="flex-1 overflow-y-auto" resize="smooth">
-					<ConversationContent>
+		<div className="mx-auto flex h-full min-h-0 w-full max-w-6xl flex-1 flex-col px-4 pb-4 md:px-6 md:pb-6">
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[28px] border border-foreground/8 bg-background-elevated/90 shadow-modal-small backdrop-blur-sm">
+				<div className="border-b border-foreground/8 px-5 py-4 sm:px-6">
+					<p className="text-[11px] font-medium uppercase tracking-[0.18em] text-foreground/45">
+						AI Nexus
+					</p>
+					<h1 className="mt-1 font-medium text-base tracking-tight text-foreground">
+						Chat
+					</h1>
+					<p className="mt-1 text-muted-foreground text-sm">
+						Stay focused on the conversation.
+					</p>
+				</div>
+				<Conversation
+					className="min-h-0 flex-1 overflow-y-auto"
+					resize="smooth"
+				>
+					<ConversationContent className="mx-auto flex w-full max-w-3xl flex-1 gap-6 px-5 py-6 sm:px-6">
 						{chatHistory.length === 0 ? (
-							<div className="text-center my-auto font-semibold mt-8">
-								<p className="text-3xl mt-4 bg-linear-to-r from-blue-600 via-purple-600 to-pink-600 bg-clip-text text-transparent animate-gradient">
-									What can we build together?
-								</p>
-							</div>
+							<ConversationEmptyState
+								className="min-h-[40vh] gap-4"
+								description="Ask about your memories, explore an idea, or pick up where you left off."
+								title="Start a conversation"
+							>
+								<div className="flex size-12 items-center justify-center rounded-full border border-foreground/10 bg-background shadow-minimal">
+									<div className="size-2 rounded-full bg-accent" />
+								</div>
+							</ConversationEmptyState>
 						) : (
 							<>
 								{chatHistory.map((message, index) => (
@@ -121,54 +139,59 @@ const ChatView = ({
 					</ConversationContent>
 					<ChatScrollAnchor track={chatHistory.length} />
 				</Conversation>
-				<PromptInput onSubmit={onSendMessage} className="px-2 pb-2">
-					<PromptInputTextarea
-						placeholder="Ask anything about your memories or search the web..."
-						className="pr-16 bg-white min-h-12.5"
-						onChange={onUpdateMessage}
-						value={message.content}
-					/>
-
-					<PromptInputFooter>
-						<ModelSelector open={open} onOpenChange={setOpen}>
-							<ModelSelectorTrigger asChild>
-								<Button variant="outline">
-									<ModelSelectorLogo provider="google" />
-									{selectedModel}
-								</Button>
-							</ModelSelectorTrigger>
-
-							<ModelSelectorContent>
-								<ModelSelectorInput placeholder="Search models..." />
-								<ModelSelectorList>
-									<ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
-
-									<ModelSelectorGroup heading="Google">
-										<ModelSelectorItem
-											value="gemini-3-flash-preview"
-											onSelect={() => {
-												setSelectedModel("gemini-3-flash-preview");
-												setOpen(false);
-											}}
-										>
-											<ModelSelectorLogo provider="google" />
-											<ModelSelectorName>
-												Gemini 3 Flash Preview
-											</ModelSelectorName>
-										</ModelSelectorItem>
-									</ModelSelectorGroup>
-
-									<ModelSelectorSeparator />
-								</ModelSelectorList>
-							</ModelSelectorContent>
-						</ModelSelector>
-						<PromptInputSubmit
-							disabled={message.content.length === 0}
-							className="absolute bottom-1 right-1 cursor-pointer"
-							status={isLoading ? "streaming" : "ready"}
+				<div className="border-t border-foreground/8 bg-background/80 px-3 py-3 sm:px-4">
+					<PromptInput
+						onSubmit={onSendMessage}
+						className="mx-auto w-full max-w-3xl"
+					>
+						<PromptInputTextarea
+							placeholder="Ask anything about your memories or search the web..."
+							className="min-h-12.5 pr-16"
+							onChange={onUpdateMessage}
+							value={message.content}
 						/>
-					</PromptInputFooter>
-				</PromptInput>
+
+						<PromptInputFooter>
+							<ModelSelector open={open} onOpenChange={setOpen}>
+								<ModelSelectorTrigger asChild>
+									<Button variant="outline">
+										<ModelSelectorLogo provider="google" />
+										{selectedModel}
+									</Button>
+								</ModelSelectorTrigger>
+
+								<ModelSelectorContent>
+									<ModelSelectorInput placeholder="Search models..." />
+									<ModelSelectorList>
+										<ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
+
+										<ModelSelectorGroup heading="Google">
+											<ModelSelectorItem
+												value="gemini-3-flash-preview"
+												onSelect={() => {
+													setSelectedModel("gemini-3-flash-preview");
+													setOpen(false);
+												}}
+											>
+												<ModelSelectorLogo provider="google" />
+												<ModelSelectorName>
+													Gemini 3 Flash Preview
+												</ModelSelectorName>
+											</ModelSelectorItem>
+										</ModelSelectorGroup>
+
+										<ModelSelectorSeparator />
+									</ModelSelectorList>
+								</ModelSelectorContent>
+							</ModelSelector>
+							<PromptInputSubmit
+								disabled={message.content.length === 0}
+								className="absolute bottom-1 right-1 cursor-pointer"
+								status={isLoading ? "streaming" : "ready"}
+							/>
+						</PromptInputFooter>
+					</PromptInput>
+				</div>
 			</div>
 		</div>
 	);

--- a/frontend/features/chat/ChatView.tsx
+++ b/frontend/features/chat/ChatView.tsx
@@ -110,11 +110,12 @@ const ChatView = ({
 								className="min-h-[40vh] gap-4"
 								description="Ask about your memories, explore an idea, or pick up where you left off."
 								title="Start a conversation"
-							>
-								<div className="flex size-12 items-center justify-center rounded-full border border-foreground/10 bg-background shadow-minimal">
-									<div className="size-2 rounded-full bg-accent" />
-								</div>
-							</ConversationEmptyState>
+								icon={
+									<div className="flex size-12 items-center justify-center rounded-full border border-foreground/10 bg-background shadow-minimal">
+										<div className="size-2 rounded-full bg-accent" />
+									</div>
+								}
+							/>
 						) : (
 							<>
 								{chatHistory.map((message, index) => (


### PR DESCRIPTION
## Summary
This PR tackles the next Craft-parity slice after the sidebar baseline: the main chat pane chrome. It removes the debuggy route-ID heading, gives both `/` and `/c/[conversationId]` the same full-height shell, and tightens the shared `ChatView` into a calmer, cleaner product surface.

## What Changed
### Route shell cleanup
- `frontend/app/(app)/page.tsx`
  - wraps the root chat route in a full-height flex container so the chat pane consistently fills the main app area
- `frontend/app/(app)/c/[conversationId]/page.tsx`
  - applies the same full-height shell to existing conversations
  - removes the old `Conversation {conversationId}` heading that leaked internal route state into the UI

### Main chat pane chrome refresh
- `frontend/features/chat/ChatView.tsx`
  - replaces the old `90vh`-style layout with a full-height, centered card shell
  - adds restrained top chrome (`AI Nexus`, `Chat`, supporting copy)
  - tightens message content width and spacing for a cleaner reading column
  - moves the composer into a dedicated bordered footer section
  - removes the forced white textarea background so the input inherits app styling cleanly

### Empty-state cleanup
- `frontend/features/chat/ChatView.tsx`
  - replaces the flashy gradient empty state with the shared `ConversationEmptyState`
  - fixes the empty-state rendering so the title/description text and icon all appear together

## What Users Will Notice
- opening an existing conversation no longer shows a raw `Conversation <uuid>` heading
- both `/` and `/c/[conversationId]` now feel like the same product surface instead of two slightly different layouts
- the main chat area has a calmer card shell, clearer top/bottom framing, and a less flashy empty state
- the composer/model selector flow behaves the same; this PR is presentation cleanup, not a workflow change

## Manual Testing

### Setup
1. Configure env files if needed:
   - `backend/.env` with required auth/API secrets
   - `frontend/.env` with `NEXT_PUBLIC_API_URL=http://localhost:8000`
2. Start the app with either:
   - `bun run dev`
   - or `bun run dev:backend` and `bun run frontend:dev`
3. Sign in so protected routes `/` and `/c/[conversationId]` are reachable.

### Test Steps
1. Open `/`.
   - Confirm the chat pane fills the main area below the app shell.
   - Confirm the new header copy appears.
   - Confirm the composer sits inside the bottom section of the card.
   - Confirm the empty state shows both the icon and the `Start a conversation` copy.
2. Send a first message from `/`.
   - Confirm the URL transitions to `/c/<generated-id>` without a layout jump.
   - Confirm the same card chrome persists during and after streaming.
3. Open an existing conversation at `/c/[conversationId]`.
   - Confirm the old `Conversation <id>` heading is gone.
   - Confirm existing messages render inside the same card shell.
4. Use a longer conversation.
   - Confirm only the message area scrolls.
   - Confirm the composer/footer stays fixed within the card.
5. Click **New Session** in the sidebar from an existing conversation.
   - Confirm you return to `/` and get a fresh empty chat shell with the same chrome.
6. Open the model selector.
   - Confirm it is not clipped by the new rounded/overflow-hidden container.
7. Smoke test at a narrower width.
   - Confirm no horizontal overflow and that composer controls remain usable.

### Edge Cases
- Open a bogus `/c/<id>` route and confirm existing 404 behavior still works.
- If backend/model env is unavailable, at minimum verify `/`, `/c/[conversationId]`, sidebar navigation, and existing-conversation rendering.

## Automated Testing

### Commands
- `bun --cwd frontend build`
- `bun --cwd frontend typecheck`
- `bunx biome check frontend/features/chat/ChatView.tsx`

### Coverage Gaps
- There is no checked-in frontend E2E/unit harness covering this surface.
- Scroll containment, route transition smoothness, responsive behavior, and model-selector overlay behavior are still manual-only checks.
- This PR does not change APIs, backend behavior, or conversation data freshness.

## Checklist
- [x] Self-reviewed
- [x] Types check
- [x] Targeted build/static checks pass locally
- [ ] Frontend E2E coverage exists for this surface

## Summary by Sourcery

Unify the main chat pane layout across root and conversation routes with a full-height card-style shell and updated chrome.

New Features:
- Introduce a centered, full-height chat card with branded header and footer chrome in the main chat view.

Bug Fixes:
- Remove the raw conversation ID heading from conversation routes to avoid exposing internal route state in the UI.

Enhancements:
- Replace the previous gradient empty state with the shared ConversationEmptyState component for a calmer, consistent experience.
- Constrain chat content to a readable column and keep the composer in a dedicated, fixed footer section.
- Ensure the model selector and scrolling behavior work cleanly within the new rounded, overflow-hidden container.