### PR TITLE
Polish sidebar empty and loading states

### DIFF
--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,23 +1,78 @@
 "use client";
 
 import { Calligraph } from "calligraph";
+import { MessageSquareDashed } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import {
 	SidebarGroup,
+	SidebarGroupContent,
 	SidebarGroupLabel,
 	SidebarMenu,
 	SidebarMenuButton,
 	SidebarMenuItem,
+	SidebarMenuSkeleton,
 } from "@/components/ui/sidebar";
 import useGetConversations from "@/hooks/get-conversations";
+
+function NavChatsLoading() {
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<div className="bg-sidebar-accent/35 rounded-xl border border-dashed px-3 py-3">
+					<div className="mb-3 space-y-1">
+						<p className="text-sidebar-foreground text-sm font-medium">
+							Loading conversations
+						</p>
+						<p className="text-sidebar-foreground/65 text-xs leading-5">
+							Recent chats will appear here in a moment.
+						</p>
+					</div>
+					<div className="space-y-1">
+						<SidebarMenuSkeleton showIcon />
+						<SidebarMenuSkeleton showIcon />
+						<SidebarMenuSkeleton showIcon />
+					</div>
+				</div>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
+function NavChatsEmpty() {
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<div className="bg-sidebar-accent/25 rounded-xl border border-dashed px-3 py-4">
+					<div className="mb-3 flex size-8 items-center justify-center rounded-lg border bg-background/80">
+						<MessageSquareDashed className="size-4 text-sidebar-foreground/70" />
+					</div>
+					<p className="text-sidebar-foreground text-sm font-medium">
+						No conversations yet
+					</p>
+					<p className="text-sidebar-foreground/65 mt-1 text-xs leading-5">
+						Start a new conversation to pin your recent work here.
+					</p>
+				</div>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
 
 // TODO: This needs to take in conversations/chats.
 export function NavChats() {
 	// Get the conversations for the current user.
-	const { data: conversations } = useGetConversations();
-	// If there are no conversations, return null.
-	if (!conversations || conversations.length === 0) return null;
+	const { data: conversations, isPending } = useGetConversations();
+
+	if (isPending) {
+		return <NavChatsLoading />;
+	}
+
+	if (!conversations || conversations.length === 0) {
+		return <NavChatsEmpty />;
+	}
 
 	// If there are conversations, render the sidebar group and menu.
 	return (


### PR DESCRIPTION
## Summary
- replace the sidebar chat list null state with a compact loading surface while conversations are fetching
- add a restrained empty state for accounts with no conversations yet
- keep existing conversation row behavior unchanged to limit risk

## Testing
- bun run typecheck
- bunx --bun @biomejs/biome lint frontend/components/nav-chats.tsx

## Summary by Sourcery

Polish the sidebar chats section by introducing dedicated loading and empty states while preserving existing conversation list behavior.

New Features:
- Add a compact loading state for the sidebar chat list while conversations are being fetched.
- Add a minimal empty state for users with no existing conversations in the sidebar.

Enhancements:
- Integrate new sidebar layout primitives and icon usage to improve the visual presentation of the chats section.