### PR TITLE
feat(frontend): calibrate sidebar top chrome, tooltip, and motion

### DIFF
--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -44,12 +44,12 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 				</SidebarContent>
 			</Sidebar>
 			<SidebarInset>
-				<header className="flex h-16 shrink-0 items-center gap-2">
-					<div className="flex items-center gap-2 px-4">
-						<SidebarTrigger className="-ml-1 cursor-pointer" />
+				<header className="flex h-14 shrink-0 items-center">
+					<div className="flex items-center gap-1.5 px-3 py-2">
+						<SidebarTrigger className="-ml-0.5 cursor-pointer" />
 						<Separator
 							orientation="vertical"
-							className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+							className="bg-border/60 mr-1 data-vertical:h-3.5 data-vertical:self-auto"
 						/>
 					</div>
 				</header>

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -30,6 +30,8 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_MOTION_CLASS =
+	"duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none";
 
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
@@ -217,7 +219,8 @@ function Sidebar({
 			<div
 				data-slot="sidebar-gap"
 				className={cn(
-					"transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent",
+					"relative w-(--sidebar-width) bg-transparent transition-[width]",
+					SIDEBAR_MOTION_CLASS,
 					"group-data-[collapsible=offcanvas]:w-0",
 					"group-data-[side=right]:rotate-180",
 					variant === "floating" || variant === "inset"
@@ -229,7 +232,8 @@ function Sidebar({
 				data-slot="sidebar-container"
 				data-side={side}
 				className={cn(
-					"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+					"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+					SIDEBAR_MOTION_CLASS,
 					// Adjust the padding for floating and inset variants.
 					variant === "floating" || variant === "inset"
 						? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -287,7 +291,8 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(
-				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 transition-[background-color,transform] after:transition-colors group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+				SIDEBAR_MOTION_CLASS,
 				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
 				"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
 				"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
@@ -305,7 +310,8 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 		<main
 			data-slot="sidebar-inset"
 			className={cn(
-				"bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col",
+				"bg-background relative flex w-full flex-1 flex-col transition-[margin,border-radius,box-shadow] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+				SIDEBAR_MOTION_CLASS,
 				className,
 			)}
 			{...props}
@@ -403,7 +409,8 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] focus-visible:ring-2 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-4 [&>svg]:shrink-0",
+				SIDEBAR_MOTION_CLASS,
 				className,
 			)}
 			{...props}
@@ -423,7 +430,8 @@ function SidebarGroupAction({
 			data-slot="sidebar-group-action"
 			data-sidebar="group-action"
 			className={cn(
-				"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-[background-color,color,opacity,transform] focus-visible:ring-2 group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+				SIDEBAR_MOTION_CLASS,
 				className,
 			)}
 			{...props}
@@ -468,7 +476,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	"ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-lg px-3 py-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium peer/menu-button flex w-full items-center overflow-hidden outline-hidden group/menu-button disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+	`ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-lg px-3 py-2 text-left text-sm transition-[width,height,padding,background-color,color,box-shadow] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium peer/menu-button flex w-full items-center overflow-hidden outline-hidden group/menu-button disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0 ${SIDEBAR_MOTION_CLASS}`,
 	{
 		variants: {
 			variant: {
@@ -555,7 +563,8 @@ function SidebarMenuAction({
 			data-slot="sidebar-menu-action"
 			data-sidebar="menu-action"
 			className={cn(
-				"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-2 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-[background-color,color,opacity,transform] peer-data-[size=default]/menu-button:top-2 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+				SIDEBAR_MOTION_CLASS,
 				showOnHover &&
 					"peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 aria-expanded:opacity-100 md:opacity-0",
 				className,

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -6,13 +6,17 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 function TooltipProvider({
-	delayDuration = 0,
+	delayDuration = 450,
+	skipDelayDuration = 120,
+	disableHoverableContent = true,
 	...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
 	return (
 		<TooltipPrimitive.Provider
 			data-slot="tooltip-provider"
 			delayDuration={delayDuration}
+			skipDelayDuration={skipDelayDuration}
+			disableHoverableContent={disableHoverableContent}
 			{...props}
 		/>
 	);
@@ -36,7 +40,7 @@ function TooltipTrigger({
 
 function TooltipContent({
 	className,
-	sideOffset = 0,
+	sideOffset = 8,
 	children,
 	...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -46,13 +50,12 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-2xl px-3 py-1.5 text-xs **:data-[slot=kbd]:rounded-4xl bg-foreground text-background z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)",
+					"z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) overflow-hidden rounded-[10px] border border-border/60 bg-background/90 px-2.5 py-1.5 text-[11px] font-medium text-foreground shadow-[0_10px_30px_rgba(15,23,42,0.12)] backdrop-blur-sm",
 					className,
 				)}
 				{...props}
 			>
 				{children}
-				<TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground z-50 translate-y-[calc(-50%_-_2px)]" />
 			</TooltipPrimitive.Content>
 		</TooltipPrimitive.Portal>
 	);

--- a/frontend/components/ui/top-bar-button.tsx
+++ b/frontend/components/ui/top-bar-button.tsx
@@ -16,10 +16,10 @@ export const TopBarButton = React.forwardRef<
 			type="button"
 			disabled={disabled}
 			className={cn(
-				"flex h-7 w-7 items-center justify-center rounded-[6px] transition-colors duration-100",
-				"hover:bg-foreground/5 focus:outline-none focus-visible:ring-0",
+				"text-foreground/70 flex h-8 w-8 items-center justify-center rounded-[8px] transition-[background-color,color,box-shadow] duration-150 ease-out motion-reduce:transition-none",
+				"hover:bg-foreground/[0.045] hover:text-foreground active:bg-foreground/[0.06] focus:outline-none focus-visible:ring-0",
 				"disabled:pointer-events-none disabled:opacity-30",
-				isActive && "bg-foreground/5",
+				isActive && "bg-foreground/[0.055] text-foreground",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
This slice tunes the remaining Craft-parity chrome around the sidebar shell without dragging in any row primitive or metadata work. It makes the top bar feel quieter, makes collapsed-sidebar tooltips more restrained, and smooths the motion on the sidebar surfaces that already move today.

## What Changed
- Tightened the `NewSidebar` header chrome in `frontend/components/new-sidebar.tsx` by reducing the header height/padding and softening the divider treatment.
- Calibrated the trigger styling in `frontend/components/ui/top-bar-button.tsx` with a slightly roomier hit target and quieter hover/active states.
- Reworked shared tooltip defaults in `frontend/components/ui/tooltip.tsx` to add a delayed open, skip-delay behavior, non-hoverable content, more offset, and a calmer bordered surface without the arrow.
- Added a shared motion timing curve in `frontend/components/ui/sidebar.tsx` and applied it to the sidebar gap, container, rail, inset, labels, menu buttons, and action affordances so collapse/open transitions feel less abrupt.

## What Users Will Notice
- The top-left sidebar chrome feels lighter and less visually noisy.
- Tooltips in collapsed sidebar mode wait a beat before appearing and read more like subtle Craft-style labels than loud callouts.
- Sidebar open/close transitions and adjacent chrome shifts feel smoother instead of snapping.

No conversation freshness/search/status/row-action/backend behavior changed in this PR.

## Manual Testing

### Setup
- Run the frontend locally.
- Sign in to an account that can access the main app shell.

### Test Steps
1. Open any authenticated page that renders `NewSidebar` (for example, the main chat shell or an existing conversation).
2. Check the top-left header area and confirm the trigger/divider chrome feels slimmer and quieter than before.
3. Toggle the sidebar open/closed from the trigger and confirm the sidebar shell and inset shift smoothly without abrupt jumps.
4. Collapse the sidebar on desktop and hover a conversation row long enough to trigger a tooltip.
5. Confirm the tooltip appears after a short delay, uses the calmer surface styling, and disappears cleanly when the pointer leaves.

### Edge Cases
- While the sidebar is expanded, confirm the conversation-row tooltips remain hidden.
- On mobile, confirm tooltip behavior stays suppressed as before.
- With reduced-motion preferences enabled, confirm transitions do not become forced animations.

## Automated Testing

### Commands
- `cd frontend && bun run typecheck`
- `cd frontend && bun run build`

### Coverage Gaps
- I did not add automated browser coverage for tooltip timing, hover restraint, or the subjective motion polish in this slice.

## Checklist
- [x] Self-reviewed
- [x] Tests pass locally
- [x] Types check

## Summary by Sourcery

Polish the sidebar shell chrome, tooltip behavior, and top-bar trigger styling for a calmer, smoother sidebar experience.

New Features:
- Introduce shared sidebar motion timing used across the sidebar gap, container, rail, inset, labels, menu buttons, and actions for consistent open/close transitions.

Enhancements:
- Refine NewSidebar header layout with reduced height, tighter spacing, and softer divider styling to make the top-left chrome visually quieter.
- Adjust top-bar button sizing and visual states for a roomier hit target and subtler hover/active treatments.
- Retune tooltip defaults with delayed open, non-hoverable content, increased offset, and a calmer bordered surface without an arrow for collapsed-sidebar labels.