### PR TITLE
feat(sidebar): port Craft-style session list, search, and new session button

### DIFF
--- a/docs/craft-button-guidelines.md
+++ b/docs/craft-button-guidelines.md
@@ -1,0 +1,36 @@
+# Craft-Style Button Rules
+
+Use these rules for any button intended to match the compact Craft-like control style used for the New Session action.
+
+- Keep geometry tight: prefer compact height, small horizontal padding, and rounded corners that read like a menu row instead of a large CTA.
+- Default state should be quiet: use a low-contrast background and a light shadow so the button is visible without looking filled or loud.
+- Do not introduce heavy borders: avoid full-strength strokes, dark outlines, or separator-like edge noise unless a border is functionally required.
+- Hover, active, and pressed states should shift slightly: adjust background, shadow, or inset treatment by a small step instead of switching to saturated colors.
+- Focus must be obvious: keep `cursor-pointer`, preserve keyboard focus visibility, and use a restrained but clear focus ring that does not change layout.
+- Icon and label must scan fast: use a small icon, consistent gap, medium-weight label, and avoid oversized glyphs or wide spacing.
+- Keep label copy short: this style works best with 1 to 3 words and no secondary helper text inside the button.
+- Match row rhythm: align button height, radius, and padding with adjacent sidebar rows or menu items so it feels native to the surface.
+
+## Good
+
+```tsx
+<button
+  className="inline-flex h-8 items-center gap-2 rounded-lg bg-neutral-100/90 px-3 text-sm font-medium text-neutral-900 shadow-sm transition-[background-color,box-shadow] hover:bg-neutral-100 hover:shadow active:bg-neutral-200/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400/60 cursor-pointer"
+>
+  <Plus className="size-4" />
+  <span>New Session</span>
+</button>
+```
+
+Why this works: compact height, quiet baseline fill, light shadow, small icon gap, and state changes that stay within the same tonal range.
+
+## Bad
+
+```tsx
+<button className="inline-flex h-11 items-center gap-3 rounded-2xl border border-neutral-300 bg-white px-5 text-sm font-semibold text-blue-600 shadow-md hover:bg-blue-600 hover:text-white">
+  <Plus className="size-5" />
+  <span>Create a New Session</span>
+</button>
+```
+
+Why this fails: too tall, too much border and shadow weight, oversized spacing, and hover state jumps to a different color story.

--- a/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
+++ b/docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md
@@ -1,0 +1,143 @@
+# Craft Sidebar Migration — Next Steps Plan
+
+## Goal
+Continue the Craft Agents migration in **tiny, review-friendly PRs** that keep scope narrow and visual diffs easy to understand.
+
+## Working Rules
+- Prefer **small, isolated frontend-only PRs**.
+- Stay on one surface area until it feels coherent.
+- Avoid bundling behavior, data-flow, and styling changes together unless necessary.
+- For ACP coding/planning runs, explicitly use **`openai-codex/gpt-5.4` with `xhigh` thinking** unless we decide otherwise.
+- Human review happens after each slice; do not assume a long stacked migration branch is the default.
+
+## Current State
+Recently completed sidebar/theme work includes:
+- Craft-style theme/token foundation
+- Craft-style top bar button
+- Craft-style conversation sidebar rows
+- Craft-style chats section header
+
+This gives us a solid sidebar visual base to keep iterating on.
+
+## Plan of Attack
+
+### Phase 1 — Finish the Sidebar Surface
+Focus on the sidebar until it feels visually coherent.
+
+#### 1. New Conversation button
+**Why next:**
+- highly visible
+- still sidebar-local
+- likely styling-first
+- easy to review as a standalone PR
+
+**Target outcome:**
+- button treatment matches the newer Craft-inspired sidebar language
+- no backend or routing changes beyond existing behavior
+
+#### 2. Sidebar spacing / rhythm polish
+**Possible scope:**
+- spacing between section header and conversation rows
+- vertical rhythm around separators
+- sidebar content padding and grouping
+
+**Why:**
+- useful if the sidebar looks close but still slightly off after the previous PRs
+- remains low-risk and visual-only
+
+#### 3. Sidebar empty state
+**Why:**
+- self-contained
+- improves UX for new/empty accounts
+- good presentational follow-up before touching the chat panel
+
+**Target outcome:**
+- empty sidebar/chat-list area feels intentional and consistent with Craft
+
+#### 4. Row interaction polish (only if needed)
+**Possible scope:**
+- hover/selected contrast
+- keyboard focus styling
+- timestamp alignment/overflow edge cases
+
+**Why:**
+- only worth doing if review feedback or visual inspection says current rows need refinement
+
+### Phase 2 — Move Inward to the Main Panel
+Once the sidebar feels coherent, start on the least risky main-panel surfaces.
+
+#### 5. Chat empty state / welcome state
+**Why first:**
+- mostly presentational
+- easier than message rendering or composer work
+- visible win without dragging in streaming logic
+
+#### 6. Main panel chrome / lightweight layout polish
+**Possible scope:**
+- headers
+- framing containers
+- subtle spacing and token alignment
+
+**Why:**
+- helps bridge the visual language from sidebar to content area
+
+### Phase 3 — Higher-Risk Surfaces (Do Later)
+These should only happen after the low-risk presentational layers are in place.
+
+#### 7. Message cards / message presentation
+**Risks:**
+- content rendering differences
+- tool/result states
+- assistant/user role styling
+- streaming edge cases
+
+#### 8. Input composer
+**Risks:**
+- autosize
+- keyboard behavior
+- attachments
+- submit/disabled/loading states
+
+#### 9. Model selector
+**Risks:**
+- state wiring
+- interaction complexity
+- command/dialog behavior
+
+## Recommended Immediate Next Step
+Create a **small planning/research pass** for the next PR focused on:
+
+> **Port the Craft-style New Conversation button**
+
+That pass should answer:
+- exact Craft source reference
+- exact local files to change
+- whether this should be a local override or shared primitive
+- risk of accidental layout/behavior changes
+- smallest reviewable implementation path
+
+## PR Sequencing Recommendation
+1. Theme/tokens + sidebar rows + section header ✅
+2. New Conversation button
+3. Sidebar spacing/polish
+4. Sidebar empty state
+5. Main-panel empty state
+6. Main-panel chrome polish
+7. Message cards
+8. Composer
+9. Model selector
+
+## Anti-Goals
+For the next few PRs, avoid:
+- backend changes
+- API contract changes
+- broad routing changes
+- mixing multiple UI surfaces into one PR
+- turning a visual PR into a behavior/refactor swamp
+
+## Success Criteria
+This plan is working if:
+- each PR has a clear single-surface story
+- diffs stay easy to review
+- visual progress is obvious after each merge
+- we avoid giant tangled migration branches

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,10 @@
+# AI Nexus Frontend Configuration
+# Copy this file to .env.local (or set these in Vercel).
+
+# Backend API base URL
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Optional dev / preview login shortcut.
+# Only exposed on the login page in local dev or non-production Vercel environments.
+TEST_USER_EMAIL=
+TEST_USER_PASSWORD=

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,10 +1,34 @@
 import { LoginForm } from "@/components/login-form";
 
+function getTestUserCredentials() {
+	const isLocalDev = process.env.NODE_ENV === "development";
+	const isNonProductionVercel =
+		Boolean(process.env.VERCEL_ENV) && process.env.VERCEL_ENV !== "production";
+	const shouldExposeTestUser = isLocalDev || isNonProductionVercel;
+
+	if (!shouldExposeTestUser) {
+		return {
+			testUserEmail: undefined,
+			testUserPassword: undefined,
+		};
+	}
+
+	return {
+		testUserEmail: process.env.TEST_USER_EMAIL,
+		testUserPassword: process.env.TEST_USER_PASSWORD,
+	};
+}
+
 export default function Page() {
+	const { testUserEmail, testUserPassword } = getTestUserCredentials();
+
 	return (
 		<div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
 			<div className="w-full max-w-sm">
-				<LoginForm />
+				<LoginForm
+					testUserEmail={testUserEmail}
+					testUserPassword={testUserPassword}
+				/>
 			</div>
 		</div>
 	);

--- a/frontend/components/conversation-search-header.tsx
+++ b/frontend/components/conversation-search-header.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+
+interface ConversationSearchHeaderProps {
+	searchQuery: string;
+	onSearchChange: (query: string) => void;
+	onSearchClose: () => void;
+	resultCount: number;
+}
+
+export function ConversationSearchHeader({
+	searchQuery,
+	onSearchChange,
+	onSearchClose,
+	resultCount,
+}: ConversationSearchHeaderProps) {
+	const isSearchActive = searchQuery.trim().length >= 2;
+
+	return (
+		<div className="shrink-0 px-2 pt-2 pb-1.5 border-b border-border/50">
+			<div className="relative rounded-[8px] shadow-minimal bg-muted/50 has-[:focus-visible]:bg-background">
+				<Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+				<input
+					type="text"
+					value={searchQuery}
+					onChange={(event) => onSearchChange(event.target.value)}
+					placeholder="Search session titles..."
+					className="w-full h-8 pl-8 pr-8 text-sm bg-transparent border-0 rounded-[8px] outline-none focus-visible:ring-0 focus-visible:outline-none placeholder:text-muted-foreground/50"
+				/>
+				{searchQuery ? (
+					<button
+						type="button"
+						onClick={onSearchClose}
+						className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 hover:bg-foreground/10 rounded cursor-pointer"
+						title="Close search"
+					>
+						<X className="h-3.5 w-3.5 text-muted-foreground" />
+					</button>
+				) : null}
+			</div>
+
+			{isSearchActive ? (
+				<div className="px-2 pt-2.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+					<span>{resultCount} results</span>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { EntityRow } from "@/components/ui/entity-row";
+import { cn } from "@/lib/utils";
+
+interface ConversationSidebarItemProps {
+	id: string;
+	title: string;
+	updatedAt: string;
+	showSeparator: boolean;
+}
+
+function formatConversationAge(updatedAt: string) {
+	const date = new Date(updatedAt);
+
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	const diffMs = date.getTime() - Date.now();
+	const divisions = [
+		{ amount: 60, unit: "second" },
+		{ amount: 60, unit: "minute" },
+		{ amount: 24, unit: "hour" },
+		{ amount: 7, unit: "day" },
+	] as const;
+	let duration = Math.round(diffMs / 1000);
+
+	for (const division of divisions) {
+		if (Math.abs(duration) < division.amount) {
+			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+				duration,
+				division.unit,
+			);
+		}
+
+		duration = Math.round(duration / division.amount);
+	}
+
+	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
+		duration,
+		"week",
+	);
+}
+
+export function ConversationSidebarItem({
+	id,
+	title,
+	updatedAt,
+	showSeparator,
+}: ConversationSidebarItemProps) {
+	const pathname = usePathname();
+	const href = `/c/${id}`;
+	const isSelected = pathname === href;
+	const age = formatConversationAge(updatedAt);
+
+	return (
+		<EntityRow
+			asChild
+			showSeparator={showSeparator}
+			isSelected={isSelected}
+			icon={
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
+			}
+			title={title}
+			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
+			titleTrailing={
+				age ? (
+					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+						{age}
+					</span>
+				) : undefined
+			}
+		>
+			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+		</EntityRow>
+	);
+}

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -19,43 +19,41 @@ function formatConversationAge(updatedAt: string) {
 		return null;
 	}
 
-	const diffMs = date.getTime() - Date.now();
-	const divisions = [
-		{ amount: 60, unit: "second" },
-		{ amount: 60, unit: "minute" },
-		{ amount: 24, unit: "hour" },
-		{ amount: 7, unit: "day" },
-	] as const;
-	let duration = Math.round(diffMs / 1000);
-
-	for (const division of divisions) {
-		if (Math.abs(duration) < division.amount) {
-			return new Intl.RelativeTimeFormat("en", {
-				numeric: "auto",
-			}).format(duration, division.unit);
-		}
-
-		duration = Math.round(duration / division.amount);
-	}
-
-	return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
-		duration,
-		"week",
+	const diffSeconds = Math.max(
+		0,
+		Math.floor((Date.now() - date.getTime()) / 1000),
 	);
-}
 
-function conversationTone(seed: string) {
-	let hash = 0;
-	for (let i = 0; i < seed.length; i++) {
-		hash = (hash * 31 + seed.charCodeAt(i)) % 360;
+	if (diffSeconds < 60) {
+		return `${diffSeconds}s`;
 	}
 
-	const hue = Math.abs(hash);
-	return {
-		bg: `hsl(${hue} 90% 96%)`,
-		fg: `hsl(${hue} 70% 42%)`,
-		border: `hsl(${hue} 55% 78%)`,
-	};
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	if (diffMinutes < 60) {
+		return `${diffMinutes}m`;
+	}
+
+	const diffHours = Math.floor(diffMinutes / 60);
+	if (diffHours < 24) {
+		return `${diffHours}h`;
+	}
+
+	const diffDays = Math.floor(diffHours / 24);
+	if (diffDays < 7) {
+		return `${diffDays}d`;
+	}
+
+	const diffWeeks = Math.floor(diffDays / 7);
+	if (diffWeeks < 5) {
+		return `${diffWeeks}w`;
+	}
+
+	const diffMonths = Math.floor(diffDays / 30);
+	if (diffMonths < 12) {
+		return `${diffMonths}mo`;
+	}
+
+	return `${Math.floor(diffDays / 365)}y`;
 }
 
 export function ConversationSidebarItem({
@@ -68,7 +66,6 @@ export function ConversationSidebarItem({
 	const href = `/c/${id}`;
 	const isSelected = pathname === href;
 	const age = formatConversationAge(updatedAt);
-	const { bg, fg, border } = conversationTone(id);
 
 	return (
 		<EntityRow
@@ -76,22 +73,16 @@ export function ConversationSidebarItem({
 			showSeparator={showSeparator}
 			isSelected={isSelected}
 			icon={
-				<span
-					className="grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full border"
-					style={{ backgroundColor: bg, borderColor: border }}
-					aria-hidden="true"
-				>
-					<span
-						className="h-1.5 w-1.5 rounded-full"
-						style={{ backgroundColor: fg }}
-					/>
-				</span>
+				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
+					<g transform="translate(1.748, 0.7832)">
+						<path
+							fillRule="nonzero"
+							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+						/>
+					</g>
+				</svg>
 			}
-			title={
-				<span className={cn("truncate", isSelected && "font-medium")}>
-					{title}
-				</span>
-			}
+			title={title}
 			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
 			titleTrailing={
 				age ? (

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { EntityRow } from "@/components/ui/entity-row";
-import { cn } from "@/lib/utils";
+import { SidebarMenuItem } from "@/components/ui/sidebar";
 
 interface ConversationSidebarItemProps {
 	id: string;
@@ -68,35 +68,27 @@ export function ConversationSidebarItem({
 	const age = formatConversationAge(updatedAt);
 
 	return (
-		<EntityRow
-			asChild
-			showSeparator={showSeparator}
-			isSelected={isSelected}
-			icon={
-				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
-					<g transform="translate(1.748, 0.7832)">
-						<path
-							fillRule="nonzero"
-							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
-						/>
-					</g>
-				</svg>
-			}
-			title={title}
-			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
-			titleTrailing={
-				age ? (
-					<span className="text-[11px] text-foreground/40 whitespace-nowrap">
-						{age}
-					</span>
-				) : undefined
-			}
-		>
-			<Link
-				href={href}
-				className="absolute inset-0 rounded-[8px]"
-				aria-label={title}
-			/>
-		</EntityRow>
+		<SidebarMenuItem>
+			<EntityRow
+				asChild
+				showSeparator={showSeparator}
+				isSelected={isSelected}
+				title={title}
+				titleClassName="text-[13px]"
+				titleTrailing={
+					age ? (
+						<span className="text-[11px] text-foreground/40 whitespace-nowrap">
+							{age}
+						</span>
+					) : undefined
+				}
+			>
+				<Link
+					href={href}
+					className="absolute inset-0 rounded-[8px]"
+					aria-label={title}
+				/>
+			</EntityRow>
+		</SidebarMenuItem>
 	);
 }

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -1,13 +1,28 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import {
+	Circle,
+	ExternalLink,
+	FolderOpen,
+	Link2,
+	MoreHorizontal,
+} from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { type ReactNode, useMemo, useState } from "react";
 import { EntityRow } from "@/components/ui/entity-row";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 
 interface ConversationSidebarItemProps {
 	id: string;
-	title: string;
+	title: ReactNode;
+	ariaLabel: string;
 	updatedAt: string;
 	showSeparator: boolean;
 }
@@ -56,12 +71,121 @@ function formatConversationAge(updatedAt: string) {
 	return `${Math.floor(diffDays / 365)}y`;
 }
 
+function ConversationStatusIcon() {
+	return (
+		<div className="flex items-center justify-center text-muted-foreground/75">
+			<Circle className="h-3.5 w-3.5" strokeWidth={1.5} />
+		</div>
+	);
+}
+
+function ConversationRowMenu({
+	href,
+	label,
+	age,
+}: {
+	href: string;
+	label: string;
+	age: string | null;
+}) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const absoluteHref = useMemo(() => {
+		if (typeof window === "undefined") {
+			return href;
+		}
+
+		return new URL(href, window.location.origin).toString();
+	}, [href]);
+
+	const openInNewTab = () => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		window.open(href, "_blank", "noopener,noreferrer");
+	};
+
+	const copyLink = async () => {
+		if (typeof navigator === "undefined" || !navigator.clipboard) {
+			return;
+		}
+
+		await navigator.clipboard.writeText(absoluteHref);
+	};
+
+	return (
+		<>
+			{age ? (
+				<span
+					className={open ? "invisible" : "group-hover:invisible text-[11px] text-foreground/40 whitespace-nowrap"}
+				>
+					{age}
+				</span>
+			) : null}
+			<div
+				className={open ? "absolute inset-0 flex items-center justify-end opacity-100" : "absolute inset-0 flex items-center justify-end opacity-0 group-hover:opacity-100"}
+			>
+				<DropdownMenu onOpenChange={setOpen}>
+					<DropdownMenuTrigger asChild>
+						<div
+							className="p-1 rounded-[6px] hover:bg-foreground/10 data-[state=open]:bg-foreground/10 cursor-pointer"
+							onClick={(event) => event.stopPropagation()}
+							onMouseDown={(event) => event.stopPropagation()}
+							onKeyDown={(event) => {
+								event.stopPropagation();
+							}}
+							role="button"
+							tabIndex={0}
+							aria-label={`Open actions for ${label}`}
+						>
+							<MoreHorizontal className="h-3.5 w-3.5 text-muted-foreground" />
+						</div>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-44">
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								router.push(href);
+							}}
+						>
+							<FolderOpen className="h-4 w-4" />
+							Open
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								openInNewTab();
+							}}
+						>
+							<ExternalLink className="h-4 w-4" />
+							Open in New Tab
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								void copyLink();
+							}}
+						>
+							<Link2 className="h-4 w-4" />
+							Copy Link
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		</>
+	);
+}
+
 export function ConversationSidebarItem({
 	id,
 	title,
+	ariaLabel,
 	updatedAt,
 	showSeparator,
 }: ConversationSidebarItemProps) {
+	const router = useRouter();
 	const pathname = usePathname();
 	const href = `/c/${id}`;
 	const isSelected = pathname === href;
@@ -70,25 +194,16 @@ export function ConversationSidebarItem({
 	return (
 		<SidebarMenuItem>
 			<EntityRow
-				asChild
+				icon={<ConversationStatusIcon />}
 				showSeparator={showSeparator}
 				isSelected={isSelected}
+				onClick={() => router.push(href)}
 				title={title}
 				titleClassName="text-[13px]"
 				titleTrailing={
-					age ? (
-						<span className="text-[11px] text-foreground/40 whitespace-nowrap">
-							{age}
-						</span>
-					) : undefined
+					<ConversationRowMenu href={href} label={ariaLabel} age={age} />
 				}
-			>
-				<Link
-					href={href}
-					className="absolute inset-0 rounded-[8px]"
-					aria-label={title}
-				/>
-			</EntityRow>
+			/>
 		</SidebarMenuItem>
 	);
 }

--- a/frontend/components/conversation-sidebar-item.tsx
+++ b/frontend/components/conversation-sidebar-item.tsx
@@ -30,10 +30,9 @@ function formatConversationAge(updatedAt: string) {
 
 	for (const division of divisions) {
 		if (Math.abs(duration) < division.amount) {
-			return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(
-				duration,
-				division.unit,
-			);
+			return new Intl.RelativeTimeFormat("en", {
+				numeric: "auto",
+			}).format(duration, division.unit);
 		}
 
 		duration = Math.round(duration / division.amount);
@@ -43,6 +42,20 @@ function formatConversationAge(updatedAt: string) {
 		duration,
 		"week",
 	);
+}
+
+function conversationTone(seed: string) {
+	let hash = 0;
+	for (let i = 0; i < seed.length; i++) {
+		hash = (hash * 31 + seed.charCodeAt(i)) % 360;
+	}
+
+	const hue = Math.abs(hash);
+	return {
+		bg: `hsl(${hue} 90% 96%)`,
+		fg: `hsl(${hue} 70% 42%)`,
+		border: `hsl(${hue} 55% 78%)`,
+	};
 }
 
 export function ConversationSidebarItem({
@@ -55,6 +68,7 @@ export function ConversationSidebarItem({
 	const href = `/c/${id}`;
 	const isSelected = pathname === href;
 	const age = formatConversationAge(updatedAt);
+	const { bg, fg, border } = conversationTone(id);
 
 	return (
 		<EntityRow
@@ -62,16 +76,22 @@ export function ConversationSidebarItem({
 			showSeparator={showSeparator}
 			isSelected={isSelected}
 			icon={
-				<svg viewBox="0 0 25 24" fill="currentColor" aria-hidden="true">
-					<g transform="translate(1.748, 0.7832)">
-						<path
-							fillRule="nonzero"
-							d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
-						/>
-					</g>
-				</svg>
+				<span
+					className="grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full border"
+					style={{ backgroundColor: bg, borderColor: border }}
+					aria-hidden="true"
+				>
+					<span
+						className="h-1.5 w-1.5 rounded-full"
+						style={{ backgroundColor: fg }}
+					/>
+				</span>
 			}
-			title={title}
+			title={
+				<span className={cn("truncate", isSelected && "font-medium")}>
+					{title}
+				</span>
+			}
 			titleClassName={cn("text-[13px]", isSelected && "font-medium")}
 			titleTrailing={
 				age ? (
@@ -81,7 +101,11 @@ export function ConversationSidebarItem({
 				) : undefined
 			}
 		>
-			<Link href={href} className="absolute inset-0 rounded-[8px]" aria-label={title} />
+			<Link
+				href={href}
+				className="absolute inset-0 rounded-[8px]"
+				aria-label={title}
+			/>
 		</EntityRow>
 	);
 }

--- a/frontend/components/icons/SquarePenRounded.tsx
+++ b/frontend/components/icons/SquarePenRounded.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+/**
+ * Custom SquarePen icon with extra-rounded square corners,
+ * copied from craft-agents-oss.
+ */
+export function SquarePenRounded(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+			{...props}
+		>
+			<path d="M12 3H7a4 4 0 0 0-4 4v10a4 4 0 0 0 4 4h10a4 4 0 0 0 4-4v-5" />
+			<path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z" />
+		</svg>
+	);
+}

--- a/frontend/components/login-form.tsx
+++ b/frontend/components/login-form.tsx
@@ -22,10 +22,22 @@ import { API_BASE_URL, API_ENDPOINTS } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 
+interface LoginFormProps extends React.ComponentProps<"div"> {
+	testUserEmail?: string;
+	testUserPassword?: string;
+}
+
+type LoginCredentials = {
+	email: string;
+	password: string;
+};
+
 export function LoginForm({
 	className,
+	testUserEmail,
+	testUserPassword,
 	...props
-}: React.ComponentProps<"div">) {
+}: LoginFormProps) {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	// Error message.
@@ -34,41 +46,70 @@ export function LoginForm({
 	const [isLoading, setIsLoading] = useState(false);
 	// Get the router.
 	const router = useRouter();
+	const canUseTestUser = Boolean(testUserEmail && testUserPassword);
+
+	const submitLogin = async ({ email, password }: LoginCredentials) => {
+		setIsLoading(true);
+
+		try {
+			// TODO: This inline fetch needs to be moved to a custom hook.
+			// TODO: Especially now that we also use this in the signup form.
+			const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({ username: email, password }),
+				credentials: "include",
+			});
+
+			// Handle errors.
+			// TODO: This same code is used on both the login and signup forms, which means it should be moved to a shared function.
+			if (!response.ok) {
+				let nextErrorMessage = "Unable to log in with those credentials.";
+
+				try {
+					const error = await response.json();
+					if (typeof error?.detail === "string") {
+						nextErrorMessage = error.detail;
+					}
+				} catch {
+					// Ignore JSON parse failures and keep the generic message.
+				}
+
+				setErrorMessage(nextErrorMessage);
+				return;
+			}
+
+			// Reset the error message.
+			// We do it here, so the Alert component doesn't jump unnecessarily every time we press the submit button.
+			setErrorMessage("");
+
+			// Redirect to the homepage.
+			router.push("/");
+		} catch {
+			setErrorMessage("Unable to reach the login service.");
+		} finally {
+			setIsLoading(false);
+		}
+	};
 
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		// Stops the page from refreshing.
 		event.preventDefault();
+		await submitLogin({ email, password });
+	};
 
-		// Disable the button while submitting.
-		setIsLoading(true);
-
-		// TODO: This inline fetch needs to be moved to a custom hook.
-		// TODO: Especially now that we also use this in the signup form.
-		const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-			},
-			body: new URLSearchParams({ username: email, password: password }),
-			credentials: "include",
-		});
-
-		// Handle errors.
-		// TODO: This same code is used on both the login and signup forms, which means it should be moved to a shared function.
-		if (!response.ok) {
-			const error = await response.json();
-			setErrorMessage(error.detail);
-			// Enable the button again.
-			setIsLoading(false);
+	const handleTestUserLogin = async () => {
+		if (!testUserEmail || !testUserPassword) {
 			return;
 		}
 
-		// Reset the error message.
-		// We do it here, so the Alert component doesn't jump unnecessarily every time we press the submit button.
-		setErrorMessage("");
-
-		// Redirect to the homepage.
-		router.push("/");
+		setEmail(testUserEmail);
+		await submitLogin({
+			email: testUserEmail,
+			password: testUserPassword,
+		});
 	};
 
 	return (
@@ -129,6 +170,21 @@ export function LoginForm({
 								<Button type="submit" disabled={isLoading}>
 									Login
 								</Button>
+								{canUseTestUser && (
+									<>
+										<Button
+											variant="outline"
+											type="button"
+											onClick={handleTestUserLogin}
+											disabled={isLoading}
+										>
+											Test User
+										</Button>
+										<FieldDescription className="text-center text-xs">
+											Dev-only shortcut for the shared test account.
+										</FieldDescription>
+									</>
+								)}
 								{/* TODO: Link to login with Google. */}
 								<Button variant="outline" type="button" disabled={isLoading}>
 									Login with Google

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
 } from "@/components/ui/sidebar";
-import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -17,9 +17,9 @@ export function NavChats() {
 
 	// If there are conversations, render the sidebar group and menu.
 	return (
-		<SidebarGroup>
+		<SidebarGroup className="pt-1">
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
-			<SidebarMenu>
+			<SidebarMenu className="gap-0">
 				{conversations.map((conversation, index) => (
 					<ConversationSidebarItem
 						key={conversation.id}

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { ChevronRight } from "lucide-react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Inbox, Search, ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Fragment, type ReactNode, useEffect, useMemo, useState } from "react";
+import { ConversationSearchHeader } from "@/components/conversation-search-header";
 import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
-import {
-	SidebarGroup,
-	SidebarGroupLabel,
-	SidebarMenu,
-} from "@/components/ui/sidebar";
 import useGetConversations from "@/hooks/get-conversations";
 import type { Conversation } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -97,6 +94,56 @@ function buildConversationGroups(
 	return [...groups.values()];
 }
 
+function highlightMatch(text: string, query: string): React.ReactNode {
+	const trimmedQuery = query.trim();
+	if (!trimmedQuery) {
+		return text;
+	}
+
+	const lowerText = text.toLowerCase();
+	const lowerQuery = trimmedQuery.toLowerCase();
+	const index = lowerText.indexOf(lowerQuery);
+
+	if (index === -1) {
+		return text;
+	}
+
+	const before = text.slice(0, index);
+	const match = text.slice(index, index + trimmedQuery.length);
+	const after = text.slice(index + trimmedQuery.length);
+
+	return (
+		<>
+			{before}
+			<span className="bg-yellow-300/25 rounded-[3px] px-[1px]">{match}</span>
+			{highlightMatch(after, trimmedQuery)}
+		</>
+	);
+}
+
+function filterConversationGroups(
+	groups: ConversationGroup[],
+	searchQuery: string,
+): ConversationGroup[] {
+	const trimmedQuery = searchQuery.trim().toLowerCase();
+	if (trimmedQuery.length < 2) {
+		return groups;
+	}
+
+	return groups
+		.map((group) => ({
+			...group,
+			items: group.items.filter((conversation) =>
+				conversation.title.toLowerCase().includes(trimmedQuery),
+			),
+		}))
+		.filter((group) => group.items.length > 0);
+}
+
+function countGroupItems(groups: ConversationGroup[]) {
+	return groups.reduce((total, group) => total + group.items.length, 0);
+}
+
 function CollapsibleGroupHeader({
 	label,
 	isCollapsed,
@@ -146,13 +193,57 @@ function SectionHeader({ label }: { label: string }) {
 	);
 }
 
-// TODO: This needs to take in conversations/chats.
+function ConversationsEmptyState({
+	icon,
+	title,
+	description,
+	buttonLabel,
+	onAction,
+}: {
+	icon: ReactNode;
+	title: string;
+	description: string;
+	buttonLabel?: string;
+	onAction?: () => void;
+}) {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
+			<div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-foreground/[0.03] text-muted-foreground/70 shadow-minimal">
+				{icon}
+			</div>
+			<h3 className="mt-4 text-sm font-medium text-foreground">{title}</h3>
+			<p className="mt-1.5 max-w-[220px] text-xs leading-5 text-muted-foreground">
+				{description}
+			</p>
+			{buttonLabel && onAction ? (
+				<button
+					type="button"
+					onClick={onAction}
+					className="mt-4 inline-flex items-center h-7 px-3 text-xs font-medium rounded-[8px] bg-background shadow-minimal hover:bg-foreground/[0.03] transition-colors"
+				>
+					{buttonLabel}
+				</button>
+			) : null}
+		</div>
+	);
+}
+
 export function NavChats() {
-	// Get the conversations for the current user.
-	const { data: conversations } = useGetConversations();
+	const router = useRouter();
+	const { data: conversations, isLoading } = useGetConversations();
+	const [searchQuery, setSearchQuery] = useState("");
 	const groups = useMemo(
 		() => buildConversationGroups(conversations ?? []),
 		[conversations],
+	);
+	const filteredGroups = useMemo(
+		() => filterConversationGroups(groups, searchQuery),
+		[groups, searchQuery],
+	);
+	const isSearchActive = searchQuery.trim().length >= 2;
+	const resultCount = useMemo(
+		() => countGroupItems(filteredGroups),
+		[filteredGroups],
 	);
 	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
 		if (typeof window === "undefined") {
@@ -185,9 +276,6 @@ export function NavChats() {
 		);
 	}, [collapsedGroups]);
 
-	// If there are no conversations, return null.
-	if (!conversations || conversations.length === 0) return null;
-
 	const toggleGroupCollapse = (groupKey: string) => {
 		setCollapsedGroups((currentGroups) => {
 			const nextGroups = new Set(currentGroups);
@@ -200,42 +288,69 @@ export function NavChats() {
 		});
 	};
 
-	// If there are conversations, render the sidebar group and menu.
 	return (
-		<SidebarGroup className="pt-1">
-			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
-			<SidebarMenu className="gap-0">
-				{groups.map((group) => {
-					const isCollapsible = groups.length > 1;
-					const isCollapsed = collapsedGroups.has(group.key);
+		<div className="flex min-h-0 flex-1 flex-col">
+			<ConversationSearchHeader
+				searchQuery={searchQuery}
+				onSearchChange={setSearchQuery}
+				onSearchClose={() => setSearchQuery("")}
+				resultCount={resultCount}
+			/>
+			{isLoading ? null : !conversations || conversations.length === 0 ? (
+				<ConversationsEmptyState
+					icon={<Inbox className="h-4 w-4" />}
+					title="No sessions yet"
+					description="Sessions with your agent appear here. Start one to get going."
+					buttonLabel="New Session"
+					onAction={() => router.push("/")}
+				/>
+			) : isSearchActive && resultCount === 0 ? (
+				<ConversationsEmptyState
+					icon={<Search className="h-4 w-4" />}
+					title="No matching sessions"
+					description="Try a different title fragment. Search lights up once you have at least two characters."
+				/>
+			) : (
+				<div className="pt-1">
+					<ul className="flex w-full min-w-0 flex-col gap-0">
+						{filteredGroups.map((group) => {
+							const isCollapsible = !isSearchActive && filteredGroups.length > 1;
+							const isCollapsed = !isSearchActive && collapsedGroups.has(group.key);
 
-					return (
-						<Fragment key={group.key}>
-							{isCollapsible ? (
-								<CollapsibleGroupHeader
-									label={group.label}
-									isCollapsed={isCollapsed}
-									itemCount={group.items.length}
-									onToggle={() => toggleGroupCollapse(group.key)}
-								/>
-							) : (
-								<SectionHeader label={group.label} />
-							)}
-							{isCollapsible && isCollapsed
-								? null
-								: group.items.map((conversation, index) => (
-										<ConversationSidebarItem
-											key={conversation.id}
-											id={conversation.id}
-											title={conversation.title}
-											updatedAt={conversation.updated_at}
-											showSeparator={index > 0}
+							return (
+								<Fragment key={group.key}>
+									{isCollapsible ? (
+										<CollapsibleGroupHeader
+											label={group.label}
+											isCollapsed={isCollapsed}
+											itemCount={group.items.length}
+											onToggle={() => toggleGroupCollapse(group.key)}
 										/>
-									))}
-						</Fragment>
-					);
-				})}
-			</SidebarMenu>
-		</SidebarGroup>
+									) : (
+										<SectionHeader label={group.label} />
+									)}
+									{isCollapsed
+										? null
+										: group.items.map((conversation, index) => (
+												<ConversationSidebarItem
+													key={conversation.id}
+													id={conversation.id}
+													title={
+														isSearchActive
+															? highlightMatch(conversation.title, searchQuery)
+															: conversation.title
+													}
+													ariaLabel={conversation.title}
+													updatedAt={conversation.updated_at}
+													showSeparator={index > 0}
+												/>
+											))}
+								</Fragment>
+							);
+						})}
+					</ul>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -67,7 +67,9 @@ function formatDateGroupLabel(date: Date) {
 	}).format(date);
 }
 
-function buildConversationGroups(conversations: Conversation[]): ConversationGroup[] {
+function buildConversationGroups(
+	conversations: Conversation[],
+): ConversationGroup[] {
 	const sortedConversations = [...conversations].sort(
 		(left, right) =>
 			getConversationTimestamp(right) - getConversationTimestamp(left),

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { Calligraph } from "calligraph";
-import Image from "next/image";
-import Link from "next/link";
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import useGetConversations from "@/hooks/get-conversations";
 
 // TODO: This needs to take in conversations/chats.
@@ -24,22 +20,14 @@ export function NavChats() {
 		<SidebarGroup>
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu>
-				{conversations.map((conversation) => (
-					<SidebarMenuItem key={conversation.id}>
-						<SidebarMenuButton asChild tooltip={conversation.title}>
-							{/* Using link for soft navigation. */}
-							<Link href={`/c/${conversation.id}`}>
-								<Image
-									src="/bars-rotate-fade.svg"
-									width={15}
-									height={15}
-									alt="Animated Loader"
-									unoptimized // Recommended for some animated SVGs to prevent caching issues
-								/>
-								<Calligraph>{conversation.title}</Calligraph>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+				{conversations.map((conversation, index) => (
+					<ConversationSidebarItem
+						key={conversation.id}
+						id={conversation.id}
+						title={conversation.title}
+						updatedAt={conversation.updated_at}
+						showSeparator={index > 0}
+					/>
 				))}
 			</SidebarMenu>
 		</SidebarGroup>

--- a/frontend/components/nav-chats.tsx
+++ b/frontend/components/nav-chats.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { ConversationSidebarItem } from "@/components/conversation-sidebar-item";
 import {
 	SidebarGroup,
@@ -7,28 +9,230 @@ import {
 	SidebarMenu,
 } from "@/components/ui/sidebar";
 import useGetConversations from "@/hooks/get-conversations";
+import type { Conversation } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const COLLAPSED_GROUPS_STORAGE_KEY = "nav-chats-collapsed-groups";
+
+type ConversationGroup = {
+	key: string;
+	label: string;
+	items: Conversation[];
+};
+
+function getConversationDate(value: string) {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getConversationTimestamp(conversation: Conversation) {
+	const date =
+		getConversationDate(conversation.updated_at) ??
+		getConversationDate(conversation.created_at);
+
+	return date?.getTime() ?? 0;
+}
+
+function getLocalDayKey(date: Date) {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+
+	return `${year}-${month}-${day}`;
+}
+
+function isSameLocalDay(left: Date, right: Date) {
+	return (
+		left.getFullYear() === right.getFullYear() &&
+		left.getMonth() === right.getMonth() &&
+		left.getDate() === right.getDate()
+	);
+}
+
+function formatDateGroupLabel(date: Date) {
+	const now = new Date();
+	if (isSameLocalDay(date, now)) {
+		return "Today";
+	}
+
+	const yesterday = new Date(now);
+	yesterday.setDate(now.getDate() - 1);
+	if (isSameLocalDay(date, yesterday)) {
+		return "Yesterday";
+	}
+
+	return new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+	}).format(date);
+}
+
+function buildConversationGroups(conversations: Conversation[]): ConversationGroup[] {
+	const sortedConversations = [...conversations].sort(
+		(left, right) =>
+			getConversationTimestamp(right) - getConversationTimestamp(left),
+	);
+
+	const groups = new Map<string, ConversationGroup>();
+	for (const conversation of sortedConversations) {
+		const date =
+			getConversationDate(conversation.updated_at) ??
+			getConversationDate(conversation.created_at) ??
+			new Date(0);
+		const key = getLocalDayKey(date);
+
+		if (!groups.has(key)) {
+			groups.set(key, {
+				key,
+				label: formatDateGroupLabel(date),
+				items: [],
+			});
+		}
+
+		groups.get(key)?.items.push(conversation);
+	}
+
+	return [...groups.values()];
+}
+
+function CollapsibleGroupHeader({
+	label,
+	isCollapsed,
+	itemCount,
+	onToggle,
+}: {
+	label: string;
+	isCollapsed: boolean;
+	itemCount: number;
+	onToggle: () => void;
+}) {
+	return (
+		<li>
+			<button
+				type="button"
+				onClick={onToggle}
+				className="w-full py-2 px-4 flex items-center gap-1.5 cursor-pointer group/header relative"
+			>
+				<div className="absolute inset-y-0.5 left-2 right-2 rounded-[6px] group-hover/header:bg-foreground/2 transition-colors pointer-events-none" />
+				<ChevronRight
+					className={cn(
+						"h-3 w-3 text-muted-foreground/60 transition-transform relative",
+						!isCollapsed && "rotate-90",
+					)}
+				/>
+				<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground relative">
+					{label}
+					{isCollapsed ? (
+						<>
+							{" · "}
+							<span className="text-muted-foreground/50">{itemCount}</span>
+						</>
+					) : null}
+				</span>
+			</button>
+		</li>
+	);
+}
+
+function SectionHeader({ label }: { label: string }) {
+	return (
+		<li className="px-4 py-2">
+			<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+				{label}
+			</span>
+		</li>
+	);
+}
 
 // TODO: This needs to take in conversations/chats.
 export function NavChats() {
 	// Get the conversations for the current user.
 	const { data: conversations } = useGetConversations();
+	const groups = useMemo(
+		() => buildConversationGroups(conversations ?? []),
+		[conversations],
+	);
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
+		if (typeof window === "undefined") {
+			return new Set();
+		}
+
+		try {
+			const storedGroups = window.localStorage.getItem(
+				COLLAPSED_GROUPS_STORAGE_KEY,
+			);
+			if (!storedGroups) {
+				return new Set();
+			}
+
+			const parsedGroups = JSON.parse(storedGroups);
+			return new Set(Array.isArray(parsedGroups) ? parsedGroups : []);
+		} catch {
+			return new Set();
+		}
+	});
+
+	useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		window.localStorage.setItem(
+			COLLAPSED_GROUPS_STORAGE_KEY,
+			JSON.stringify([...collapsedGroups]),
+		);
+	}, [collapsedGroups]);
+
 	// If there are no conversations, return null.
 	if (!conversations || conversations.length === 0) return null;
+
+	const toggleGroupCollapse = (groupKey: string) => {
+		setCollapsedGroups((currentGroups) => {
+			const nextGroups = new Set(currentGroups);
+			if (nextGroups.has(groupKey)) {
+				nextGroups.delete(groupKey);
+			} else {
+				nextGroups.add(groupKey);
+			}
+			return nextGroups;
+		});
+	};
 
 	// If there are conversations, render the sidebar group and menu.
 	return (
 		<SidebarGroup className="pt-1">
 			<SidebarGroupLabel>Your Chats</SidebarGroupLabel>
 			<SidebarMenu className="gap-0">
-				{conversations.map((conversation, index) => (
-					<ConversationSidebarItem
-						key={conversation.id}
-						id={conversation.id}
-						title={conversation.title}
-						updatedAt={conversation.updated_at}
-						showSeparator={index > 0}
-					/>
-				))}
+				{groups.map((group) => {
+					const isCollapsible = groups.length > 1;
+					const isCollapsed = collapsedGroups.has(group.key);
+
+					return (
+						<Fragment key={group.key}>
+							{isCollapsible ? (
+								<CollapsibleGroupHeader
+									label={group.label}
+									isCollapsed={isCollapsed}
+									itemCount={group.items.length}
+									onToggle={() => toggleGroupCollapse(group.key)}
+								/>
+							) : (
+								<SectionHeader label={group.label} />
+							)}
+							{isCollapsible && isCollapsed
+								? null
+								: group.items.map((conversation, index) => (
+										<ConversationSidebarItem
+											key={conversation.id}
+											id={conversation.id}
+											title={conversation.title}
+											updatedAt={conversation.updated_at}
+											showSeparator={index > 0}
+										/>
+									))}
+						</Fragment>
+					);
+				})}
 			</SidebarMenu>
 		</SidebarGroup>
 	);

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { IconPencilPlus } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
@@ -8,16 +9,15 @@ import {
 	SidebarContent,
 	SidebarHeader,
 	SidebarInset,
-	SidebarMenuButton,
-	SidebarMenuItem,
 	SidebarProvider,
 	SidebarTrigger,
 } from "./ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 /**
  * Application sidebar layout wrapper.
  *
- * Renders the sidebar with a "New Conversation" button and conversation history,
+ * Renders the sidebar with a "New Session" button and conversation history,
  * alongside the main content area with a sidebar toggle and header.
  *
  * @param children - The page content to render in the main area.
@@ -34,17 +34,23 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarHeader className="pt-2 pb-2">
-						<SidebarMenuItem>
-							<SidebarMenuButton
-								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] gap-2 text-[13px] shadow-minimal hover:bg-background active:bg-background"
-								onClick={handleNewConversation}
-								type="button"
-							>
-								<IconPencilPlus />
-								<span>New Conversation</span>
-							</SidebarMenuButton>
-						</SidebarMenuItem>
+					<SidebarHeader className="px-2 pb-2 shrink-0">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div>
+									<button
+										type="button"
+										onClick={handleNewConversation}
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										aria-label="New Session"
+									>
+										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />
+										New Session
+									</button>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent side="right">⌘N</TooltipContent>
+						</Tooltip>
 					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -41,7 +41,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 									<button
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="inline-flex items-center w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
 										aria-label="New Session"
 									>
 										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -34,10 +34,10 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarHeader className="pb-1">
+					<SidebarHeader className="pt-2 pb-2">
 						<SidebarMenuItem>
 							<SidebarMenuButton
-								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] text-[13px] shadow-minimal hover:bg-background active:bg-background"
+								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] gap-2 text-[13px] shadow-minimal hover:bg-background active:bg-background"
 								onClick={handleNewConversation}
 								type="button"
 							>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,10 +1,12 @@
 "use client";
+import { IconPencilPlus } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
 	SidebarContent,
+	SidebarHeader,
 	SidebarInset,
 	SidebarMenuButton,
 	SidebarMenuItem,
@@ -32,14 +34,18 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 		<SidebarProvider>
 			<Sidebar variant="inset">
 				<SidebarContent>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							className="cursor-pointer"
-							onClick={handleNewConversation}
-						>
-							<span>New Conversation</span>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
+					<SidebarHeader className="pb-1">
+						<SidebarMenuItem>
+							<SidebarMenuButton
+								className="h-auto cursor-pointer justify-start rounded-[6px] bg-background px-2 py-[7px] text-[13px] shadow-minimal hover:bg-background active:bg-background"
+								onClick={handleNewConversation}
+								type="button"
+							>
+								<IconPencilPlus />
+								<span>New Conversation</span>
+							</SidebarMenuButton>
+						</SidebarMenuItem>
+					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>
 			</Sidebar>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
-import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -39,16 +38,15 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<Button
-										variant="ghost"
+									<button
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none hover:bg-foreground/3 transition-colors focus-visible:ring-0 focus-visible:border-transparent"
+										className="inline-flex items-center justify-start gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 w-full py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none text-foreground/85 font-normal hover:bg-foreground/3"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</Button>
+									</button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -34,26 +34,26 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 	return (
 		<SidebarProvider>
 			<Sidebar variant="inset">
+				<SidebarHeader className="px-2 pb-2 shrink-0">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<div>
+								<Button
+									variant="ghost"
+									type="button"
+									onClick={handleNewConversation}
+									className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+									aria-label="New Session"
+								>
+									<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
+									New Session
+								</Button>
+							</div>
+						</TooltipTrigger>
+						<TooltipContent side="right">⌘N</TooltipContent>
+					</Tooltip>
+				</SidebarHeader>
 				<SidebarContent>
-					<SidebarHeader className="px-2 pb-2 shrink-0">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div>
-									<Button
-										variant="ghost"
-										type="button"
-										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none cursor-pointer"
-										aria-label="New Session"
-									>
-										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
-										New Session
-									</Button>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent side="right">⌘N</TooltipContent>
-						</Tooltip>
-					</SidebarHeader>
 					<NavChats />
 				</SidebarContent>
 			</Sidebar>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
+import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -38,15 +39,16 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<button
+									<Button
+										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="inline-flex items-center justify-start gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 w-full py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none text-foreground/85 font-normal hover:bg-foreground/3"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</button>
+									</Button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { SquarePenRounded } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
+import { SquarePenRounded } from "./icons/SquarePenRounded";
 import { NavChats } from "./nav-chats";
 import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { IconPencilPlus } from "@tabler/icons-react";
+import { SquarePenRounded } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { NavChats } from "./nav-chats";
+import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import {
 	Sidebar,
@@ -38,15 +39,16 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div>
-									<button
+									<Button
+										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="inline-flex items-center w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
 										aria-label="New Session"
 									>
-										<IconPencilPlus className="h-3.5 w-3.5 shrink-0" />
+										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />
 										New Session
-									</button>
+									</Button>
 								</div>
 							</TooltipTrigger>
 							<TooltipContent side="right">⌘N</TooltipContent>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -43,7 +43,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background border-0 transition-colors hover:bg-foreground/3 focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-transparent focus-visible:outline-none cursor-pointer"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -43,7 +43,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }) {
 										variant="ghost"
 										type="button"
 										onClick={handleNewConversation}
-										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] font-normal rounded-[6px] shadow-minimal bg-background"
+										className="w-full justify-start gap-2 py-[7px] px-2 text-[13px] rounded-[6px] shadow-minimal bg-background border-none hover:bg-foreground/3 transition-colors focus-visible:ring-0 focus-visible:border-transparent"
 										aria-label="New Session"
 									>
 										<SquarePenRounded className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -57,7 +57,7 @@ export function EntityRow({
 						{titleTrailing ? (
 							<div className="flex items-center gap-[10px] w-full min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}
 									</div>
 								)}
@@ -71,7 +71,7 @@ export function EntityRow({
 						) : (
 							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}
 									</div>
 								)}
@@ -89,7 +89,7 @@ export function EntityRow({
 							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
 								{icon && (
 									<div
-										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5 invisible"
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
 										aria-hidden="true"
 									>
 										{icon}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -17,6 +17,7 @@ export interface EntityRowProps {
 	className?: string;
 	separatorClassName?: string;
 	asChild?: boolean;
+	onClick?: () => void;
 }
 
 export function EntityRow({
@@ -32,6 +33,7 @@ export function EntityRow({
 	className,
 	separatorClassName = "pl-[38px] pr-4",
 	asChild = false,
+	onClick,
 }: EntityRowProps) {
 	const Comp = asChild ? ("div" as const) : ("button" as const);
 
@@ -47,6 +49,8 @@ export function EntityRow({
 					<div className="absolute left-0 inset-y-0 w-[2px] bg-accent" />
 				)}
 				<Comp
+					type={asChild ? undefined : "button"}
+					onClick={onClick}
 					className={cn(
 						"flex w-full items-start gap-2 pl-2 pr-4 py-3 text-left text-sm outline-none rounded-[8px]",
 						"transition-[background-color] duration-75",

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -57,7 +57,7 @@ export function EntityRow({
 						{titleTrailing ? (
 							<div className="flex items-center gap-[10px] w-full min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
 										{icon}
 									</div>
 								)}
@@ -71,7 +71,7 @@ export function EntityRow({
 						) : (
 							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
 								{icon && (
-									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5">
 										{icon}
 									</div>
 								)}
@@ -89,7 +89,7 @@ export function EntityRow({
 							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
 								{icon && (
 									<div
-										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3.5 [&>*]:h-3.5 invisible"
 										aria-hidden="true"
 									>
 										{icon}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+export interface EntityRowProps {
+	icon?: React.ReactNode;
+	title: React.ReactNode;
+	titleClassName?: string;
+	titleTrailing?: React.ReactNode;
+	badges?: React.ReactNode;
+	trailing?: React.ReactNode;
+	children?: React.ReactNode;
+	isSelected?: boolean;
+	showSeparator?: boolean;
+	className?: string;
+	separatorClassName?: string;
+	asChild?: boolean;
+}
+
+export function EntityRow({
+	icon,
+	title,
+	titleClassName,
+	titleTrailing,
+	badges,
+	trailing,
+	children,
+	isSelected = false,
+	showSeparator = false,
+	className,
+	separatorClassName = "pl-[38px] pr-4",
+	asChild = false,
+}: EntityRowProps) {
+	const Comp = asChild ? ("div" as const) : ("button" as const);
+
+	return (
+		<div className={className} data-selected={isSelected || undefined}>
+			{showSeparator && (
+				<div className={separatorClassName}>
+					<Separator />
+				</div>
+			)}
+			<div className="relative group select-none pl-2 mr-2">
+				{isSelected && (
+					<div className="absolute left-0 inset-y-0 w-[2px] bg-accent" />
+				)}
+				<Comp
+					className={cn(
+						"flex w-full items-start gap-2 pl-2 pr-4 py-3 text-left text-sm outline-none rounded-[8px]",
+						"transition-[background-color] duration-75",
+						isSelected ? "bg-foreground/3" : "hover:bg-foreground/2",
+					)}
+				>
+					<div className="flex flex-col gap-1.5 min-w-0 flex-1">
+						{titleTrailing ? (
+							<div className="flex items-center gap-[10px] w-full min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div className={cn("font-sans truncate min-w-0", titleClassName)}>
+									{title}
+								</div>
+								<div className="shrink-0 ml-auto relative -mr-1">
+									{titleTrailing}
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+								{icon && (
+									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
+										{icon}
+									</div>
+								)}
+								<div
+									className={cn(
+										"font-medium font-sans line-clamp-2 min-w-0 -mb-[2px]",
+										titleClassName,
+									)}
+								>
+									{title}
+								</div>
+							</div>
+						)}
+						{(badges || trailing) && (
+							<div className="flex items-center gap-[10px] text-xs text-foreground/70 w-full -mb-[2px] min-w-0">
+								{icon && (
+									<div
+										className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3 invisible"
+										aria-hidden="true"
+									>
+										{icon}
+									</div>
+								)}
+								{badges && (
+									<div className="flex-1 flex items-center gap-1 min-w-0 overflow-x-auto scrollbar-hide">
+										{badges}
+									</div>
+								)}
+								{trailing && (
+									<div className="shrink-0 flex items-center gap-1 ml-auto">
+										{trailing}
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</Comp>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/frontend/components/ui/entity-row.tsx
+++ b/frontend/components/ui/entity-row.tsx
@@ -69,7 +69,12 @@ export function EntityRow({
 								</div>
 							</div>
 						) : (
-							<div className="flex items-center gap-[10px] w-full pr-6 min-w-0">
+							<div
+								className={cn(
+									"flex items-center gap-[10px] w-full min-w-0",
+									icon && "pr-6",
+								)}
+							>
 								{icon && (
 									<div className="shrink-0 flex items-center gap-[10px] [&>*]:w-3 [&>*]:h-3">
 										{icon}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -403,7 +403,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/45 h-6 px-3 text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 				className,
 			)}
 			{...props}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -385,7 +385,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="sidebar-group"
 			data-sidebar="group"
-			className={cn("p-2 relative flex w-full min-w-0 flex-col", className)}
+			className={cn("relative flex w-full min-w-0 flex-col px-2 pt-1 pb-1", className)}
 			{...props}
 		/>
 	);
@@ -403,7 +403,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"text-sidebar-foreground/45 h-6 px-3 text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+				"text-sidebar-foreground/45 h-5 px-2.5 pb-[5px] pt-[3px] text-[10px] font-medium uppercase tracking-[0.16em] transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 [&>svg]:size-3.5 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
This ports AI Nexus's left sidebar closer to Craft's session navigator by replacing the old flat chat list with a grouped session list, a Craft-style New Session header button, and a reusable entity row primitive.

Because this branch is stacked on the existing PR #35 Craft baseline, this PR includes the baseline sidebar foundation plus the follow-up search and row-actions pass.

## What Changed
- Reworked the sidebar header and session list UI
  - `frontend/components/new-sidebar.tsx`
  - `frontend/components/nav-chats.tsx`
  - `frontend/components/conversation-search-header.tsx`
- Added reusable Craft-style session row pieces
  - `frontend/components/conversation-sidebar-item.tsx`
  - `frontend/components/ui/entity-row.tsx`
  - `frontend/components/icons/SquarePenRounded.tsx`
- Tweaked shared sidebar spacing/styling for better Craft parity
  - `frontend/components/ui/sidebar.tsx`
- Added supporting docs for the migration and Craft button rules
  - `docs/craft-button-guidelines.md`
  - `docs/plans/2026-03-25-craft-sidebar-migration-next-steps.md`

## What Users Will Notice
- The old **New Conversation** control becomes a Craft-style **New Session** button in the sidebar header
- Sessions are grouped by **Today**, **Yesterday**, and older dates instead of appearing in one flat list
- Sidebar search now filters session titles, highlights matches, and shows result counts
- Date groups can be collapsed and expanded, with collapsed state persisting across reloads
- Hovering a session row reveals actions for **Open**, **Open in New Tab**, and **Copy Link**
- Empty states now exist for both **no sessions yet** and **no matching sessions**
- Active session rows have stronger Craft-style selected-state treatment

## Manual Testing

### Setup
- Start the frontend with `bun run frontend:dev`
- Run the backend/API needed for auth and conversation data
- Use an authenticated account with conversations across multiple dates and titles

### Test Steps
1. Open `/` on desktop and confirm the sidebar shows the compact **New Session** button above the session list.
2. From `/c/<existing-conversation-id>`, click **New Session** and confirm navigation back to `/`.
3. Verify the sidebar groups sessions under **Today**, **Yesterday**, and older date labels, with newest items first.
4. Collapse a date group, refresh the page, and confirm the collapsed state persists.
5. Type 2+ characters into the sidebar search and confirm filtering, match highlighting, and result counts.
6. Search for a term with no matches and confirm the **No matching sessions** empty state appears.
7. Hover a row and confirm the age label swaps to the `...` actions affordance.
8. Test **Open**, **Open in New Tab**, and **Copy Link** from the row menu.
9. Open `/c/<existing-conversation-id>` and confirm the active row shows selected styling.
10. On mobile, open the sidebar sheet and confirm search, grouping, and row navigation still work.

### Edge Cases
- Verify a brand-new account shows the **No sessions yet** empty state.
- Verify very long titles truncate cleanly without shoving timestamps/actions out of place.
- Verify search still surfaces matches inside groups that were previously collapsed.

## Automated Testing

### Commands
- `bun --cwd frontend typecheck`
- `bun --cwd frontend build`
- `bunx --bun @biomejs/biome check frontend/components/nav-chats.tsx frontend/components/conversation-search-header.tsx frontend/components/conversation-sidebar-item.tsx frontend/components/new-sidebar.tsx frontend/components/ui/entity-row.tsx frontend/components/ui/sidebar.tsx`

### Coverage Gaps
- No automated coverage yet for date grouping, localStorage-backed collapse state, search highlighting/threshold behavior, row hover actions, or mobile sidebar sheet behavior
- No automated coverage for relative age formatting boundaries
- The tooltip advertises `⌘N`, but this diff does not add a keyboard shortcut handler yet

## Checklist
- [x] Self-reviewed
- [x] Tests pass locally
- [x] Types check

## Summary by Sourcery

Update the sidebar to use a Craft-style session navigator with grouped conversations, search, and a compact New Session button.

New Features:
- Introduce a grouped conversation list in the sidebar with Today/Yesterday/older date sections and collapsible groups backed by local storage.
- Add a sidebar search header that filters conversations by title, highlights matches, and shows result counts when active.
- Add a reusable EntityRow component and Craft-style conversation row item with hover actions for opening sessions and copying links.
- Add a Craft-style New Session header button with tooltip and custom SquarePen icon in the sidebar.

Enhancements:
- Adjust sidebar spacing and group label styling to better match the Craft-inspired visual language.

Documentation:
- Document Craft-style button guidelines and outline next steps for the Craft sidebar migration.