### PR TITLE
feat(sidebar): implement rename, delete, resizable layout, and mobile sheet

### DIFF
--- a/.beans/ai-nexus-dss3--implement-remaining-sidebar-flesh.md
+++ b/.beans/ai-nexus-dss3--implement-remaining-sidebar-flesh.md
@@ -1,0 +1,25 @@
+---
+# ai-nexus-dss3
+title: Implement remaining sidebar flesh
+status: completed
+type: feature
+priority: normal
+created_at: 2026-03-29T17:00:55Z
+updated_at: 2026-03-29T17:07:06Z
+---
+
+Implement the remaining Craft-parity sidebar work in ai-nexus.
+
+- [x] Add rename conversation support in the sidebar menu, including backend endpoint if needed
+- [x] Add delete conversation support in the sidebar menu, including backend endpoint if needed
+- [x] Make the desktop sidebar resizable with persisted width and double-click reset to 300px
+- [x] Convert the mobile sidebar to a Sheet with correct trigger/open/close behavior
+- [x] Run validation, review diff, commit code and bean updates
+
+## Summary of Changes
+
+- Added PATCH and DELETE conversation endpoints plus request schema/backend CRUD support.
+- Wired rename and delete actions into the Craft-style sidebar row menu with dialog/alert-dialog flows and React Query cache updates.
+- Added desktop sidebar resize persistence with drag handle and double-click reset to 300px.
+- Ensured mobile sidebar interactions close the Sheet appropriately when starting or opening conversations.
+- Ran frontend typecheck, targeted Biome checks for touched frontend files, backend Python syntax validation, and reviewed the narrowed diff before commit.

--- a/backend/app/api/conversations.py
+++ b/backend/app/api/conversations.py
@@ -13,13 +13,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.agents import create_history_reader_agent, create_utility_agent
 from app.crud.conversation import (
     create_conversation_service,
+    delete_conversation_service,
     get_conversation_service,
     get_conversations_for_user_service,
     update_conversation_title_service,
 )
 from app.db import User, get_async_session
 from app.models import Conversation
-from app.schemas import ConversationCreate, ConversationResponse
+from app.schemas import ConversationCreate, ConversationResponse, ConversationUpdate
 from app.users import current_active_user
 
 # Logger follows module namespace conventions for consistent filtering and tracing.
@@ -203,6 +204,48 @@ def get_conversations_router() -> APIRouter:
             session=session,
         )
         return str(response.content or "")
+
+    @router.patch("/{conversation_id}", response_model=ConversationResponse)
+    async def update_conversation(
+        conversation_id: uuid.UUID,
+        payload: ConversationUpdate,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> ConversationResponse:
+        """Update mutable conversation metadata for the authenticated user."""
+
+        normalized_title = payload.title.strip()
+        if not normalized_title:
+            raise HTTPException(status_code=422, detail="Conversation title cannot be empty")
+
+        conversation = await update_conversation_title_service(
+            title=normalized_title,
+            user_id=user.id,
+            conversation_id=conversation_id,
+            session=session,
+        )
+        if conversation is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+
+        return ConversationResponse(
+            title=conversation.title,
+            id=conversation.id,
+            user_id=conversation.user_id,
+            created_at=conversation.created_at,
+            updated_at=conversation.updated_at,
+        )
+
+    @router.delete("/{conversation_id}", status_code=204)
+    async def delete_conversation(
+        conversation_id: uuid.UUID,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> None:
+        """Delete a conversation owned by the authenticated user."""
+
+        deleted = await delete_conversation_service(user.id, session, conversation_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Conversation not found")
 
     @router.get("")
     async def list_conversations(

--- a/backend/app/crud/conversation.py
+++ b/backend/app/crud/conversation.py
@@ -119,3 +119,27 @@ async def update_conversation_title_service(
     await session.commit()
     await session.refresh(conversation)
     return conversation
+
+
+async def delete_conversation_service(
+    user_id: uuid.UUID, session: AsyncSession, conversation_id: uuid.UUID
+) -> bool:
+    """Delete an existing conversation owned by the given user.
+
+    Returns:
+        ``True`` when a conversation was deleted, otherwise ``False``.
+    """
+    stmt = (
+        select(Conversation)
+        .where(Conversation.id == conversation_id)
+        .where(Conversation.user_id == user_id)
+    )
+    result = await session.execute(stmt)
+    conversation = result.scalar_one_or_none()
+
+    if conversation is None:
+        return False
+
+    await session.delete(conversation)
+    await session.commit()
+    return True

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -81,6 +81,12 @@ class ConversationResponse(BaseModel):
     updated_at: datetime
 
 
+class ConversationUpdate(BaseModel):
+    """Request schema for updating mutable conversation fields."""
+
+    title: str
+
+
 # --- Chat schemas -------------------------------------------------------------
 
 

--- a/frontend/components/new-session-button.tsx
+++ b/frontend/components/new-session-button.tsx
@@ -10,6 +10,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { useSidebar } from '@/components/ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 /**
@@ -24,9 +25,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
  */
 export function NewSessionButton(): React.JSX.Element {
   const router = useRouter();
+  const { isMobile, setOpenMobile } = useSidebar();
 
   /** Navigates to the root page, which generates a fresh conversation UUID. */
   const handleNewConversation = (): void => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
     router.push('/');
   };
 

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { NavChats } from '@/features/nav-chats/NavChats';
 import { NewSessionButton } from './new-session-button';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './ui/resizable';
 import { Separator } from './ui/separator';
 import {
   Sidebar,
@@ -9,42 +10,69 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarProvider,
-  SidebarRail,
   SidebarTrigger,
+  useSidebar,
 } from './ui/sidebar';
 
-/**
- * Application sidebar layout wrapper.
- *
- * Renders the sidebar with a "New Session" button and conversation history,
- * alongside the main content area with a sidebar toggle and header.
- *
- * @param children - The page content to render in the main area.
- */
+function ResizableSidebarContent({ children }: { children: React.ReactNode }) {
+  const { isMobile, state, setDesktopWidth } = useSidebar();
+
+  if (isMobile) {
+    return <>{children}</>;
+  }
+
+  const isCollapsed = state === 'collapsed';
+
+  return (
+    // biome-ignore lint/correctness/useUniqueElementIds: auto-save storage key
+    <ResizablePanelGroup direction="horizontal" id="sidebar_width" className="flex-1">
+      <ResizablePanel
+        defaultSize={300}
+        minSize={240}
+        maxSize={420}
+        collapsible={true}
+        collapsedSize={0}
+        onResize={(size) => {
+          setDesktopWidth(size.inPixels);
+        }}
+        className={`transition-all duration-200 ease-linear ${isCollapsed ? '!hidden' : ''}`}
+      >
+        <Sidebar variant="inset" className="!w-full h-full border-r-0">
+          <SidebarHeader className="px-2 pb-2 shrink-0">
+            <NewSessionButton />
+          </SidebarHeader>
+          <SidebarContent>
+            <NavChats />
+          </SidebarContent>
+        </Sidebar>
+      </ResizablePanel>
+
+      {!isCollapsed && (
+        <ResizableHandle className="w-1 hover:w-2 transition-all hover:bg-sidebar-border bg-transparent" />
+      )}
+
+      <ResizablePanel className="h-full">{children}</ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
 export function NewSidebar({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>
-      <Sidebar variant="inset">
-        <SidebarHeader className="px-2 pb-2 shrink-0">
-          <NewSessionButton />
-        </SidebarHeader>
-        <SidebarContent>
-          <NavChats />
-        </SidebarContent>
-        <SidebarRail />
-      </Sidebar>
-      <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2">
-          <div className="flex items-center gap-2 px-4">
-            <SidebarTrigger className="-ml-1 cursor-pointer" />
-            <Separator
-              orientation="vertical"
-              className="mr-2 data-vertical:h-4 data-vertical:self-auto"
-            />
-          </div>
-        </header>
-        <div className="flex-1">{children}</div>
-      </SidebarInset>
+      <ResizableSidebarContent>
+        <SidebarInset className="peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm border border-transparent shadow-none !m-0 !rounded-none">
+          <header className="flex h-16 shrink-0 items-center gap-2">
+            <div className="flex items-center gap-2 px-4">
+              <SidebarTrigger className="-ml-1 cursor-pointer" />
+              <Separator
+                orientation="vertical"
+                className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+              />
+            </div>
+          </header>
+          <div className="flex-1">{children}</div>
+        </SidebarInset>
+      </ResizableSidebarContent>
     </SidebarProvider>
   );
 }

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarProvider,
+  SidebarRail,
   SidebarTrigger,
 } from './ui/sidebar';
 
@@ -30,6 +31,7 @@ export function NewSidebar({ children }: { children: React.ReactNode }): React.J
         <SidebarContent>
           <NavChats />
         </SidebarContent>
+        <SidebarRail />
       </Sidebar>
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2">

--- a/frontend/components/ui/resizable.tsx
+++ b/frontend/components/ui/resizable.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { GripVertical } from "lucide-react"
+import * as ResizablePrimitive from "@/packages/react-resizable-panels"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const ResizablePanelGroup = ({
+  className,
+  direction,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Group> & { direction?: "horizontal" | "vertical" }) => (
+  <ResizablePrimitive.Group
+    orientation={direction || props.orientation || "horizontal"}
+    className={cn(
+      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      className
+    )}
+    {...props}
+  />
+)
+
+const ResizablePanel = ResizablePrimitive.Panel
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
+  withHandle?: boolean
+}) => (
+  <ResizablePrimitive.Separator
+    className={cn(
+      "relative flex w-px items-center justify-center bg-sidebar-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90 hover:after:bg-sidebar-border in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+      className
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-sidebar-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.Separator>
+)
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -344,85 +344,6 @@ function SidebarTrigger({
 	);
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-	const { setDesktopWidth, resetDesktopWidth } = useSidebar();
-	const dragStateRef = React.useRef<{ startX: number; startWidth: number } | null>(
-		null,
-	);
-
-	React.useEffect(() => {
-		return () => {
-			document.body.style.removeProperty("cursor");
-			document.body.style.removeProperty("user-select");
-		};
-	}, []);
-
-	const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
-		if (event.button !== 0) {
-			return;
-		}
-
-		event.preventDefault();
-		const sidebarWrapper = event.currentTarget.closest("[data-slot='sidebar-wrapper']");
-		const currentWidth = sidebarWrapper
-			? Number.parseFloat(
-					getComputedStyle(sidebarWrapper).getPropertyValue("--sidebar-width"),
-				)
-			: SIDEBAR_DEFAULT_WIDTH;
-
-		dragStateRef.current = {
-			startX: event.clientX,
-			startWidth: Number.isFinite(currentWidth)
-				? currentWidth
-				: SIDEBAR_DEFAULT_WIDTH,
-		};
-
-		document.body.style.cursor = "col-resize";
-		document.body.style.userSelect = "none";
-
-		const handlePointerMove = (moveEvent: PointerEvent) => {
-			const dragState = dragStateRef.current;
-			if (!dragState) {
-				return;
-			}
-
-			setDesktopWidth(dragState.startWidth + (moveEvent.clientX - dragState.startX));
-		};
-
-		const handlePointerUp = () => {
-			dragStateRef.current = null;
-			document.body.style.removeProperty("cursor");
-			document.body.style.removeProperty("user-select");
-			window.removeEventListener("pointermove", handlePointerMove);
-			window.removeEventListener("pointerup", handlePointerUp);
-		};
-
-		window.addEventListener("pointermove", handlePointerMove);
-		window.addEventListener("pointerup", handlePointerUp, { once: true });
-	};
-
-	return (
-		<button
-			data-sidebar="rail"
-			data-slot="sidebar-rail"
-			aria-label="Resize Sidebar"
-			tabIndex={-1}
-			onPointerDown={handlePointerDown}
-			onDoubleClick={resetDesktopWidth}
-			title="Resize Sidebar"
-			className={cn(
-				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
-				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-				"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-				"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-				"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-				"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
 
 function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 	return (
@@ -821,7 +742,6 @@ export {
 	SidebarMenuSubButton,
 	SidebarMenuSubItem,
 	SidebarProvider,
-	SidebarRail,
 	SidebarSeparator,
 	SidebarTrigger,
 	useSidebar,

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -26,10 +26,39 @@ import { cn } from "@/lib/utils";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "18.75rem";
+const SIDEBAR_DEFAULT_WIDTH = 300;
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 420;
+const SIDEBAR_WIDTH_STORAGE_KEY = "sidebar_width";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+function clampSidebarWidth(width: number): number {
+	return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+}
+
+function loadDesktopSidebarWidth(): number {
+	if (typeof window === "undefined") {
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
+
+	try {
+		const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+		if (!storedWidth) {
+			return SIDEBAR_DEFAULT_WIDTH;
+		}
+
+		const parsedWidth = Number.parseInt(storedWidth, 10);
+		if (!Number.isFinite(parsedWidth)) {
+			return SIDEBAR_DEFAULT_WIDTH;
+		}
+
+		return clampSidebarWidth(parsedWidth);
+	} catch {
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
+}
 
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
@@ -39,6 +68,9 @@ type SidebarContextProps = {
 	setOpenMobile: (open: boolean) => void;
 	isMobile: boolean;
 	toggleSidebar: () => void;
+	desktopWidth: number;
+	setDesktopWidth: (width: number) => void;
+	resetDesktopWidth: () => void;
 };
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -67,6 +99,7 @@ function SidebarProvider({
 }) {
 	const isMobile = useIsMobile();
 	const [openMobile, setOpenMobile] = React.useState(false);
+	const [desktopWidth, setDesktopWidthState] = React.useState(loadDesktopSidebarWidth);
 
 	// This is the internal state of the sidebar.
 	// We use openProp and setOpenProp for control from outside the component.
@@ -91,6 +124,29 @@ function SidebarProvider({
 	const toggleSidebar = React.useCallback(() => {
 		return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
 	}, [isMobile, setOpen]);
+
+	const setDesktopWidth = React.useCallback((width: number) => {
+		setDesktopWidthState(clampSidebarWidth(width));
+	}, []);
+
+	const resetDesktopWidth = React.useCallback(() => {
+		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
+	}, []);
+
+	React.useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		try {
+			window.localStorage.setItem(
+				SIDEBAR_WIDTH_STORAGE_KEY,
+				String(desktopWidth),
+			);
+		} catch {
+			// Storage writes are best-effort only for this UI preference.
+		}
+	}, [desktopWidth]);
 
 	// Adds a keyboard shortcut to toggle the sidebar.
 	React.useEffect(() => {
@@ -121,8 +177,21 @@ function SidebarProvider({
 			openMobile,
 			setOpenMobile,
 			toggleSidebar,
+			desktopWidth,
+			setDesktopWidth,
+			resetDesktopWidth,
 		}),
-		[state, open, setOpen, isMobile, openMobile, toggleSidebar],
+		[
+			state,
+			open,
+			setOpen,
+			isMobile,
+			openMobile,
+			toggleSidebar,
+			desktopWidth,
+			setDesktopWidth,
+			resetDesktopWidth,
+		],
 	);
 
 	return (
@@ -131,7 +200,7 @@ function SidebarProvider({
 				data-slot="sidebar-wrapper"
 				style={
 					{
-						"--sidebar-width": SIDEBAR_WIDTH,
+						"--sidebar-width": `${desktopWidth}px`,
 						"--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
 						...style,
 					} as React.CSSProperties
@@ -276,16 +345,71 @@ function SidebarTrigger({
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-	const { toggleSidebar } = useSidebar();
+	const { setDesktopWidth, resetDesktopWidth } = useSidebar();
+	const dragStateRef = React.useRef<{ startX: number; startWidth: number } | null>(
+		null,
+	);
+
+	React.useEffect(() => {
+		return () => {
+			document.body.style.removeProperty("cursor");
+			document.body.style.removeProperty("user-select");
+		};
+	}, []);
+
+	const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+		if (event.button !== 0) {
+			return;
+		}
+
+		event.preventDefault();
+		const sidebarWrapper = event.currentTarget.closest("[data-slot='sidebar-wrapper']");
+		const currentWidth = sidebarWrapper
+			? Number.parseFloat(
+					getComputedStyle(sidebarWrapper).getPropertyValue("--sidebar-width"),
+				)
+			: SIDEBAR_DEFAULT_WIDTH;
+
+		dragStateRef.current = {
+			startX: event.clientX,
+			startWidth: Number.isFinite(currentWidth)
+				? currentWidth
+				: SIDEBAR_DEFAULT_WIDTH,
+		};
+
+		document.body.style.cursor = "col-resize";
+		document.body.style.userSelect = "none";
+
+		const handlePointerMove = (moveEvent: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState) {
+				return;
+			}
+
+			setDesktopWidth(dragState.startWidth + (moveEvent.clientX - dragState.startX));
+		};
+
+		const handlePointerUp = () => {
+			dragStateRef.current = null;
+			document.body.style.removeProperty("cursor");
+			document.body.style.removeProperty("user-select");
+			window.removeEventListener("pointermove", handlePointerMove);
+			window.removeEventListener("pointerup", handlePointerUp);
+		};
+
+		window.addEventListener("pointermove", handlePointerMove);
+		window.addEventListener("pointerup", handlePointerUp, { once: true });
+	};
 
 	return (
 		<button
 			data-sidebar="rail"
 			data-slot="sidebar-rail"
-			aria-label="Toggle Sidebar"
+			aria-label="Resize Sidebar"
 			tabIndex={-1}
-			onClick={toggleSidebar}
-			title="Toggle Sidebar"
+			onPointerDown={handlePointerDown}
+			onDoubleClick={resetDesktopWidth}
+			title="Resize Sidebar"
 			className={cn(
 				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
 				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/frontend/features/nav-chats/ConversationSidebarItem.tsx
+++ b/frontend/features/nav-chats/ConversationSidebarItem.tsx
@@ -2,10 +2,34 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { startTransition, useEffect, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useSidebar } from '@/components/ui/sidebar';
 import { ConversationSidebarItemView } from './ConversationSidebarItemView';
+import { useDeleteConversation, useRenameConversation } from './UseConversationMutations';
 
 interface ConversationSidebarItemProps {
   id: string;
+  titleText: string;
   title: ReactNode;
   updatedAt: string;
   showSeparator: boolean;
@@ -68,33 +92,160 @@ function formatConversationAge(updatedAt: string): string | null {
  */
 export function ConversationSidebarItem({
   id,
+  titleText,
   title,
   updatedAt,
   showSeparator,
 }: ConversationSidebarItemProps): React.JSX.Element {
   const router = useRouter();
   const pathname = usePathname();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const renameConversationMutation = useRenameConversation();
+  const deleteConversationMutation = useDeleteConversation();
+  const [isRenameOpen, setIsRenameOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(titleText);
   const href = `/c/${id}`;
   const isSelected = pathname === href;
   const age = formatConversationAge(updatedAt);
 
+  useEffect(() => {
+    setDraftTitle(titleText);
+  }, [titleText]);
+
   // Compute absolute URL for clipboard operations. No memoization needed —
   // the computation is trivial and href is already stable (derived from id).
   const absoluteHref =
-    typeof window === 'undefined'
-      ? href
-      : new URL(href, window.location.origin).toString();
+    typeof window === 'undefined' ? href : new URL(href, window.location.origin).toString();
+
+  const closeMobileSidebar = (): void => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+  };
+
+  const navigateTo = (target: string): void => {
+    closeMobileSidebar();
+    startTransition(() => {
+      router.push(target);
+    });
+  };
+
+  const handleRenameSubmit = async (): Promise<void> => {
+    const normalizedTitle = draftTitle.trim();
+    if (!normalizedTitle || normalizedTitle === titleText) {
+      setIsRenameOpen(false);
+      setDraftTitle(titleText);
+      return;
+    }
+
+    await renameConversationMutation.mutateAsync({
+      conversationId: id,
+      title: normalizedTitle,
+    });
+    setIsRenameOpen(false);
+  };
+
+  const handleDeleteConfirm = async (): Promise<void> => {
+    await deleteConversationMutation.mutateAsync({ conversationId: id });
+    setIsDeleteOpen(false);
+
+    if (isSelected) {
+      navigateTo('/');
+    }
+  };
 
   return (
-    <ConversationSidebarItemView
-      title={title}
-      isSelected={isSelected}
-      showSeparator={showSeparator}
-      age={age}
-      href={href}
-      absoluteHref={absoluteHref}
-      onClick={() => router.push(href)}
-      onNavigate={(target) => router.push(target)}
-    />
+    <>
+      <ConversationSidebarItemView
+        title={title}
+        isSelected={isSelected}
+        showSeparator={showSeparator}
+        age={age}
+        href={href}
+        absoluteHref={absoluteHref}
+        onClick={() => navigateTo(href)}
+        onNavigate={navigateTo}
+        onRename={() => {
+          setDraftTitle(titleText);
+          setIsRenameOpen(true);
+        }}
+        onDelete={() => setIsDeleteOpen(true)}
+      />
+      <Dialog
+        open={isRenameOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDraftTitle(titleText);
+          }
+          setIsRenameOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Conversation</DialogTitle>
+            <DialogDescription>Update the sidebar title for this conversation.</DialogDescription>
+          </DialogHeader>
+          <form
+            className="grid gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleRenameSubmit();
+            }}
+          >
+            <Input
+              value={draftTitle}
+              onChange={(event) => setDraftTitle(event.target.value)}
+              placeholder="Conversation title"
+              maxLength={255}
+              autoFocus
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setDraftTitle(titleText);
+                  setIsRenameOpen(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={!draftTitle.trim() || renameConversationMutation.isPending}
+              >
+                {renameConversationMutation.isPending ? 'Saving...' : 'Save'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <AlertDialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
+        <AlertDialogContent size="default">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the conversation from your sidebar. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteConversationMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={deleteConversationMutation.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDeleteConfirm();
+              }}
+            >
+              {deleteConversationMutation.isPending ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/features/nav-chats/ConversationSidebarItemView.tsx
+++ b/frontend/features/nav-chats/ConversationSidebarItemView.tsx
@@ -37,6 +37,10 @@ export interface ConversationSidebarItemViewProps {
   onClick: () => void;
   /** Called to navigate in a menu item. */
   onNavigate: (href: string) => void;
+  /** Opens the rename flow for this conversation. */
+  onRename: () => void;
+  /** Opens the delete confirmation for this conversation. */
+  onDelete: () => void;
 }
 
 /** Placeholder status icon for a conversation row (empty circle). */
@@ -70,10 +74,14 @@ function ConversationMenuContent({
   href,
   absoluteHref,
   onNavigate,
+  onRename,
+  onDelete,
 }: {
   href: string;
   absoluteHref: string;
   onNavigate: (href: string) => void;
+  onRename: () => void;
+  onDelete: () => void;
 }): React.JSX.Element {
   const { MenuItem, MenuSeparator, MenuSub, MenuSubTrigger, MenuSubContent } = useMenuComponents();
 
@@ -143,7 +151,7 @@ function ConversationMenuContent({
       <MenuSeparator />
 
       {/* Rename */}
-      <MenuItem onClick={stubAction('Rename')}>
+      <MenuItem onClick={onRename}>
         <Pencil className="h-3.5 w-3.5" />
         <span className="flex-1">Rename</span>
       </MenuItem>
@@ -195,7 +203,7 @@ function ConversationMenuContent({
       <MenuSeparator />
 
       {/* Delete */}
-      <MenuItem variant="destructive" onClick={stubAction('Delete')}>
+      <MenuItem variant="destructive" onClick={onDelete}>
         <Trash2 className="h-3.5 w-3.5" />
         <span className="flex-1">Delete</span>
       </MenuItem>
@@ -219,6 +227,8 @@ export function ConversationSidebarItemView({
   absoluteHref,
   onClick,
   onNavigate,
+  onRename,
+  onDelete,
 }: ConversationSidebarItemViewProps): React.JSX.Element {
   return (
     <SidebarMenuItem>
@@ -239,6 +249,8 @@ export function ConversationSidebarItemView({
             href={href}
             absoluteHref={absoluteHref}
             onNavigate={onNavigate}
+            onRename={onRename}
+            onDelete={onDelete}
           />
         }
       />

--- a/frontend/features/nav-chats/NavChats.tsx
+++ b/frontend/features/nav-chats/NavChats.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
+import { useSidebar } from '@/components/ui/sidebar';
 import useGetConversations from '@/hooks/get-conversations';
 import {
   buildConversationGroups,
@@ -46,6 +47,7 @@ function loadCollapsedGroups(): Set<string> {
  */
 export function NavChats(): React.JSX.Element {
   const router = useRouter();
+  const { isMobile, setOpenMobile } = useSidebar();
   const { data: conversations, isLoading } = useGetConversations();
 
   // --- search ---
@@ -114,7 +116,12 @@ export function NavChats(): React.JSX.Element {
       filteredGroups={filteredGroups}
       collapsedGroups={collapsedGroups}
       onToggleGroup={toggleGroupCollapse}
-      onNewSession={() => router.push('/')}
+      onNewSession={() => {
+        if (isMobile) {
+          setOpenMobile(false);
+        }
+        router.push('/');
+      }}
     />
   );
 }

--- a/frontend/features/nav-chats/NavChatsView.tsx
+++ b/frontend/features/nav-chats/NavChatsView.tsx
@@ -108,6 +108,7 @@ export function NavChatsView({
                       <ConversationSidebarItem
                         key={conversation.id}
                         id={conversation.id}
+                        titleText={conversation.title}
                         title={
                           isSearchActive ? (
                             highlightMatch(conversation.title, searchQuery)

--- a/frontend/features/nav-chats/UseConversationMutations.ts
+++ b/frontend/features/nav-chats/UseConversationMutations.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthedFetch } from '@/hooks/use-authed-fetch';
+import { API_ENDPOINTS } from '@/lib/api';
+import type { Conversation } from '@/lib/types';
+
+interface RenameConversationVariables {
+  conversationId: string;
+  title: string;
+}
+
+interface DeleteConversationVariables {
+  conversationId: string;
+}
+
+function replaceConversation(
+  conversations: Conversation[] | undefined,
+  updatedConversation: Conversation
+): Conversation[] | undefined {
+  if (!conversations) {
+    return conversations;
+  }
+
+  return conversations.map((conversation) =>
+    conversation.id === updatedConversation.id ? updatedConversation : conversation
+  );
+}
+
+function removeConversation(
+  conversations: Conversation[] | undefined,
+  deletedConversationId: string
+): Conversation[] | undefined {
+  if (!conversations) {
+    return conversations;
+  }
+
+  return conversations.filter((conversation) => conversation.id !== deletedConversationId);
+}
+
+export function useRenameConversation() {
+  const fetcher = useAuthedFetch();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['conversations', 'rename'],
+    mutationFn: async ({ conversationId, title }: RenameConversationVariables) => {
+      const response = await fetcher(API_ENDPOINTS.conversations.update(conversationId), {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ title }),
+      });
+
+      return (await response.json()) as Conversation;
+    },
+    onSuccess: (updatedConversation) => {
+      queryClient.setQueryData<Conversation[] | undefined>(['conversations'], (conversations) =>
+        replaceConversation(conversations, updatedConversation)
+      );
+      queryClient.setQueryData<Conversation | undefined>(
+        ['conversations', updatedConversation.id],
+        updatedConversation
+      );
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+    },
+  });
+}
+
+export function useDeleteConversation() {
+  const fetcher = useAuthedFetch();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['conversations', 'delete'],
+    mutationFn: async ({ conversationId }: DeleteConversationVariables) => {
+      await fetcher(API_ENDPOINTS.conversations.delete(conversationId), {
+        method: 'DELETE',
+      });
+
+      return conversationId;
+    },
+    onSuccess: (deletedConversationId) => {
+      queryClient.setQueryData<Conversation[] | undefined>(['conversations'], (conversations) =>
+        removeConversation(conversations, deletedConversationId)
+      );
+      queryClient.removeQueries({ queryKey: ['conversations', deletedConversationId] });
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+    },
+  });
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,8 +2,7 @@
  * Base URL for all API requests.
  * Determined from NEXT_PUBLIC_API_URL environment variable, or defaults to http://localhost:8000
  */
-export const API_BASE_URL =
-	process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
 /**
  * API endpoint definitions for frontend requests.
@@ -11,88 +10,90 @@ export const API_BASE_URL =
  * and plain string properties for static endpoints.
  */
 export const API_ENDPOINTS = {
-	/** Endpoints related to chat functionality */
-	chat: {
-		/**
-		 * Chat streaming endpoint.
-		 * @returns `/api/chat`
-		 */
-		messages: "/api/v1/chat",
-		models: "/api/v1/models",
-	},
-	/** Endpoints for conversation management */
-	conversations: {
-		/**
-		 * Get an individual conversation by ID.
-		 * @param id - Conversation ID
-		 * @returns `/api/v1/conversations/${id}`
-		 */
-		get: (id: string) => `/api/v1/conversations/${id}`,
-		/**
-		 * Get the messages for a conversation by ID.
-		 * @param id - Conversation ID
-		 * @returns `/api/v1/conversations/${id}/messages`
-		 */
-		getMessages: (id: string) => `/api/v1/conversations/${id}/messages`,
-		/**
-		 * Create a conversation.
-		 * @returns `/api/v1/conversations`
-		 */
-		create: (id: string) => `/api/v1/conversations/${id}`,
-		list: "/api/v1/conversations",
-		/**
-		 * Generate a conversation title.
-		 * @param id - Conversation ID
-		 * @returns `/api/v1/conversations/${id}/title`
-		 */
-		generateTitle: (id: string, firstMessage: string) =>
-			`/api/v1/conversations/${id}/title?first_message=${firstMessage}`,
-	},
-	/** Endpoints for authentication actions */
-	auth: {
-		/**
-		 * Login endpoint.
-		 * @returns `/auth/jwt/login`
-		 */
-		login: "/auth/jwt/login",
-		/**
-		 * Register endpoint.
-		 * @returns `/auth/register`
-		 */
-		register: "/auth/register",
-		/**
-		 * Logout endpoint.
-		 * @returns `/auth/logout`
-		 */
-		logout: "/auth/logout",
-		/**
-		 * Get current user info.
-		 * @returns `/me`
-		 */
-		me: "/me",
-	},
-	/** Endpoints related to user management */
-	users: {
-		/**
-		 * Get all users.
-		 * @returns `/users`
-		 */
-		get: "/users",
-	},
-	/** Endpoints for session management */
-	session: {
-		/**
-		 * Get session info.
-		 * @returns `/session`
-		 */
-		get: "/session",
-	},
-	/** Endpoints for token management */
-	token: {
-		/**
-		 * Get token info.
-		 * @returns `/token`
-		 */
-		get: "/token",
-	},
+  /** Endpoints related to chat functionality */
+  chat: {
+    /**
+     * Chat streaming endpoint.
+     * @returns `/api/chat`
+     */
+    messages: '/api/v1/chat',
+    models: '/api/v1/models',
+  },
+  /** Endpoints for conversation management */
+  conversations: {
+    /**
+     * Get an individual conversation by ID.
+     * @param id - Conversation ID
+     * @returns `/api/v1/conversations/${id}`
+     */
+    get: (id: string) => `/api/v1/conversations/${id}`,
+    /**
+     * Get the messages for a conversation by ID.
+     * @param id - Conversation ID
+     * @returns `/api/v1/conversations/${id}/messages`
+     */
+    getMessages: (id: string) => `/api/v1/conversations/${id}/messages`,
+    /**
+     * Create a conversation.
+     * @returns `/api/v1/conversations`
+     */
+    create: (id: string) => `/api/v1/conversations/${id}`,
+    update: (id: string) => `/api/v1/conversations/${id}`,
+    delete: (id: string) => `/api/v1/conversations/${id}`,
+    list: '/api/v1/conversations',
+    /**
+     * Generate a conversation title.
+     * @param id - Conversation ID
+     * @returns `/api/v1/conversations/${id}/title`
+     */
+    generateTitle: (id: string, firstMessage: string) =>
+      `/api/v1/conversations/${id}/title?first_message=${firstMessage}`,
+  },
+  /** Endpoints for authentication actions */
+  auth: {
+    /**
+     * Login endpoint.
+     * @returns `/auth/jwt/login`
+     */
+    login: '/auth/jwt/login',
+    /**
+     * Register endpoint.
+     * @returns `/auth/register`
+     */
+    register: '/auth/register',
+    /**
+     * Logout endpoint.
+     * @returns `/auth/logout`
+     */
+    logout: '/auth/logout',
+    /**
+     * Get current user info.
+     * @returns `/me`
+     */
+    me: '/me',
+  },
+  /** Endpoints related to user management */
+  users: {
+    /**
+     * Get all users.
+     * @returns `/users`
+     */
+    get: '/users',
+  },
+  /** Endpoints for session management */
+  session: {
+    /**
+     * Get session info.
+     * @returns `/session`
+     */
+    get: '/session',
+  },
+  /** Endpoints for token management */
+  token: {
+    /**
+     * Get token info.
+     * @returns `/token`
+     */
+    get: '/token',
+  },
 } as const;

--- a/frontend/packages/react-resizable-panels/components/group/Group.tsx
+++ b/frontend/packages/react-resizable-panels/components/group/Group.tsx
@@ -1,0 +1,391 @@
+// @ts-nocheck
+"use client";
+
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { calculatePanelConstraints } from "../../global/dom/calculatePanelConstraints";
+import { mountGroup } from "../../global/mountGroup";
+import {
+  getMountedGroupState,
+  getRegisteredGroup,
+  subscribeToMountedGroup,
+  updateMountedGroup
+} from "../../global/mutable-state/groups";
+import { getInteractionState } from "../../global/mutable-state/interactions";
+import { layoutNumbersEqual } from "../../global/utils/layoutNumbersEqual";
+import { layoutsEqual } from "../../global/utils/layoutsEqual";
+import { useForceUpdate } from "../../hooks/useForceUpdate";
+import { useId } from "../../hooks/useId";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
+import { useMergedRefs } from "../../hooks/useMergedRefs";
+import { useStableCallback } from "../../hooks/useStableCallback";
+import { useStableObject } from "../../hooks/useStableObject";
+import type { RegisteredPanel } from "../panel/types";
+import type { RegisteredSeparator } from "../separator/types";
+import { GroupContext } from "./GroupContext";
+import { sortByElementOffset } from "./sortByElementOffset";
+import type {
+  GroupProps,
+  Layout,
+  RegisteredGroup,
+  ResizeTargetMinimumSize
+} from "./types";
+import { useGroupImperativeHandle } from "./useGroupImperativeHandle";
+
+/**
+ * A Group wraps a set of resizable Panel components.
+ * Group content can be resized _horizontally_ or _vertically_.
+ *
+ * Group elements always include the following attributes:
+ *
+ * ```html
+ * <div data-group data-testid="group-id-prop" id="group-id-prop">
+ * ```
+ *
+ * ℹ️ [Test id](https://testing-library.com/docs/queries/bytestid/) can be used to narrow selection when unit testing.
+ */
+export function Group({
+  children,
+  className,
+  defaultLayout,
+  disableCursor,
+  disabled,
+  elementRef: elementRefProp,
+  groupRef,
+  id: idProp,
+  onLayoutChange: onLayoutChangeUnstable,
+  onLayoutChanged: onLayoutChangedUnstable,
+  orientation = "horizontal",
+  resizeTargetMinimumSize = {
+    coarse: 20,
+    fine: 10
+  },
+  style,
+  ...rest
+}: GroupProps) {
+  const prevLayoutRef = useRef<{
+    onLayoutChange: Layout;
+    onLayoutChanged: Layout;
+  }>({
+    onLayoutChange: {},
+    onLayoutChanged: {}
+  });
+
+  const onLayoutChangeStable = useStableCallback((layout: Layout) => {
+    if (layoutsEqual(prevLayoutRef.current.onLayoutChange, layout)) {
+      // Memoize callback
+      return;
+    }
+
+    prevLayoutRef.current.onLayoutChange = layout;
+    onLayoutChangeUnstable?.(layout);
+  });
+
+  const onLayoutChangedStable = useStableCallback((layout: Layout) => {
+    if (layoutsEqual(prevLayoutRef.current.onLayoutChanged, layout)) {
+      // Memoize callback
+      return;
+    }
+
+    prevLayoutRef.current.onLayoutChanged = layout;
+    onLayoutChangedUnstable?.(layout);
+  });
+
+  const id = useId(idProp);
+
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  const [panelOrSeparatorChangeSigil, forceUpdate] = useForceUpdate();
+
+  const inMemoryValuesRef = useRef<{
+    lastExpandedPanelSizes: { [panelIds: string]: number };
+    layouts: { [panelIds: string]: Layout };
+    panels: RegisteredPanel[];
+    resizeTargetMinimumSize: ResizeTargetMinimumSize;
+    separators: RegisteredSeparator[];
+  }>({
+    lastExpandedPanelSizes: {},
+    layouts: {},
+    panels: [],
+    resizeTargetMinimumSize,
+    separators: []
+  });
+
+  const mergedRef = useMergedRefs(elementRef, elementRefProp);
+
+  useGroupImperativeHandle(id, groupRef);
+
+  // TRICKY Don't read for state; it will always lag behind by one tick
+  const getPanelStyles = useStableCallback(
+    (groupId: string, panelId: string) => {
+      const interactionState = getInteractionState();
+      const group = getRegisteredGroup(groupId);
+      const groupState = getMountedGroupState(groupId);
+      if (groupState) {
+        let dragActive = false;
+        switch (interactionState.state) {
+          case "active": {
+            dragActive = interactionState.hitRegions.some(
+              (current) => current.group === group
+            );
+            break;
+          }
+        }
+
+        return {
+          flexGrow: groupState.layout[panelId] ?? 1,
+          pointerEvents: dragActive ? "none" : undefined
+        } satisfies CSSProperties;
+      }
+
+      // This is unexpected except for the initial mount (before the group has registered with the global store)
+      if (defaultLayout?.[panelId]) {
+        return {
+          flexGrow: defaultLayout?.[panelId]
+        } satisfies CSSProperties;
+      }
+    }
+  );
+
+  const stableProps = useStableObject({
+    defaultLayout,
+    disableCursor
+  });
+
+  const context = useMemo(
+    () => ({
+      get disableCursor() {
+        return !!stableProps.disableCursor;
+      },
+      getPanelStyles,
+      id,
+      orientation,
+      registerPanel: (panel: RegisteredPanel) => {
+        const inMemoryValues = inMemoryValuesRef.current;
+        inMemoryValues.panels = sortByElementOffset(orientation, [
+          ...inMemoryValues.panels,
+          panel
+        ]);
+
+        forceUpdate();
+
+        return () => {
+          inMemoryValues.panels = inMemoryValues.panels.filter(
+            (current) => current !== panel
+          );
+
+          forceUpdate();
+        };
+      },
+      registerSeparator: (separator: RegisteredSeparator) => {
+        const inMemoryValues = inMemoryValuesRef.current;
+        inMemoryValues.separators = sortByElementOffset(orientation, [
+          ...inMemoryValues.separators,
+          separator
+        ]);
+
+        forceUpdate();
+
+        return () => {
+          inMemoryValues.separators = inMemoryValues.separators.filter(
+            (current) => current !== separator
+          );
+
+          forceUpdate();
+        };
+      },
+      togglePanelDisabled: (panelId: string, disabled: boolean) => {
+        const inMemoryValues = inMemoryValuesRef.current;
+        const panel = inMemoryValues.panels.find(
+          (current) => current.id === panelId
+        );
+        if (panel) {
+          panel.panelConstraints.disabled = disabled;
+        }
+
+        const group = getRegisteredGroup(id);
+        const groupState = getMountedGroupState(id);
+        if (group && groupState) {
+          updateMountedGroup(group, {
+            ...groupState,
+            derivedPanelConstraints: calculatePanelConstraints(group)
+          });
+        }
+      },
+      toggleSeparatorDisabled: (separatorId: string, disabled: boolean) => {
+        const inMemoryValues = inMemoryValuesRef.current;
+        const separator = inMemoryValues.separators.find(
+          (current) => current.id === separatorId
+        );
+        if (separator) {
+          separator.disabled = disabled;
+        }
+      }
+    }),
+    [getPanelStyles, id, forceUpdate, orientation, stableProps]
+  );
+
+  const registeredGroupRef = useRef<RegisteredGroup | null>(null);
+
+  // Register Group and child Panels/Separators with global state
+  // Listen to global state for drag state related to this Group
+  useIsomorphicLayoutEffect(() => {
+    const element = elementRef.current;
+    if (element === null) {
+      return;
+    }
+
+    const inMemoryValues = inMemoryValuesRef.current;
+
+    // Guard against unexpected layout attribute ordering by pre-sorting panel ids/keys; see issues/656
+    let preSortedDefaultLayout: Layout | undefined = undefined;
+    if (stableProps.defaultLayout !== undefined) {
+      if (
+        Object.keys(stableProps.defaultLayout).length ===
+        inMemoryValues.panels.length
+      ) {
+        preSortedDefaultLayout = {};
+        for (const panel of inMemoryValues.panels) {
+          const size = stableProps.defaultLayout[panel.id];
+          if (size !== undefined) {
+            preSortedDefaultLayout[panel.id] = size;
+          }
+        }
+      }
+    }
+
+    const group: RegisteredGroup = {
+      disabled: !!disabled,
+      element,
+      id,
+      mutableState: {
+        defaultLayout: preSortedDefaultLayout,
+        disableCursor: !!stableProps.disableCursor,
+        expandedPanelSizes: inMemoryValuesRef.current.lastExpandedPanelSizes,
+        layouts: inMemoryValuesRef.current.layouts
+      },
+      orientation,
+      panels: inMemoryValues.panels,
+      resizeTargetMinimumSize: inMemoryValues.resizeTargetMinimumSize,
+      separators: inMemoryValues.separators
+    };
+
+    registeredGroupRef.current = group;
+
+    const unmountGroup = mountGroup(group);
+
+    const { defaultLayoutDeferred, derivedPanelConstraints, layout } =
+      getMountedGroupState(group.id, true);
+
+    if (!defaultLayoutDeferred && derivedPanelConstraints.length > 0) {
+      onLayoutChangeStable(layout);
+      onLayoutChangedStable(layout);
+    }
+
+    const removeChangeEventListener = subscribeToMountedGroup(id, (event) => {
+      const { defaultLayoutDeferred, derivedPanelConstraints, layout } =
+        event.next;
+
+      if (defaultLayoutDeferred || derivedPanelConstraints.length === 0) {
+        // This indicates that the Group has not finished mounting yet
+        // Likely because it has been rendered inside of a hidden DOM subtree
+        // Ignore layouts in this case because they will not have been validated
+        return;
+      }
+
+      // Save the layout to in-memory cache so it persists when panel configuration changes
+      // This improves UX for conditionally rendered panels without requiring defaultLayout
+      const panelIdsKey = group.panels.map(({ id }) => id).join(",");
+      group.mutableState.layouts[panelIdsKey] = layout;
+
+      // Also check if any collapsible Panels were collapsed in this update,
+      // and record their previous sizes so we can restore them on expand
+      derivedPanelConstraints.forEach((constraints) => {
+        if (constraints.collapsible) {
+          const { layout: prevLayout } = event.prev ?? {};
+          if (prevLayout) {
+            const isCollapsed = layoutNumbersEqual(
+              constraints.collapsedSize,
+              layout[constraints.panelId]
+            );
+            const wasCollapsed = layoutNumbersEqual(
+              constraints.collapsedSize,
+              prevLayout[constraints.panelId]
+            );
+            if (isCollapsed && !wasCollapsed) {
+              group.mutableState.expandedPanelSizes[constraints.panelId] =
+                prevLayout[constraints.panelId];
+            }
+          }
+        }
+      });
+
+      // Lastly notify layout-change(d) handlers of the update
+      const interactionState = getInteractionState();
+      const isCompleted = interactionState.state !== "active";
+      onLayoutChangeStable(layout);
+      if (isCompleted) {
+        onLayoutChangedStable(layout);
+      }
+    });
+
+    return () => {
+      registeredGroupRef.current = null;
+
+      unmountGroup();
+      removeChangeEventListener();
+    };
+  }, [
+    disabled,
+    id,
+    onLayoutChangedStable,
+    onLayoutChangeStable,
+    orientation,
+    panelOrSeparatorChangeSigil,
+    stableProps
+  ]);
+
+  // Not all props require re-registering the group;
+  // Some can be updated after the group has been registered
+  useEffect(() => {
+    const registeredGroup = registeredGroupRef.current;
+    if (registeredGroup) {
+      registeredGroup.mutableState.defaultLayout = defaultLayout;
+      registeredGroup.mutableState.disableCursor = !!disableCursor;
+    }
+  });
+
+  return (
+    <GroupContext.Provider value={context}>
+      <div
+        {...rest}
+        className={className}
+        data-group
+        data-testid={id}
+        id={id}
+        ref={mergedRef}
+        style={{
+          height: "100%",
+          width: "100%",
+          overflow: "hidden",
+
+          ...style,
+
+          display: "flex",
+          flexDirection: orientation === "horizontal" ? "row" : "column",
+          flexWrap: "nowrap",
+
+          // Inform the browser that the library is handling touch events for this element
+          // but still allow users to scroll content within panels in the non-resizing direction
+          // NOTE This is not an inherited style
+          // See github.com/bvaughn/react-resizable-panels/issues/662
+          touchAction: orientation === "horizontal" ? "pan-y" : "pan-x"
+        }}
+      >
+        {children}
+      </div>
+    </GroupContext.Provider>
+  );
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName
+Group.displayName = "Group";

--- a/frontend/packages/react-resizable-panels/components/group/Group.tsx
+++ b/frontend/packages/react-resizable-panels/components/group/Group.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";

--- a/frontend/packages/react-resizable-panels/components/group/GroupContext.ts
+++ b/frontend/packages/react-resizable-panels/components/group/GroupContext.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { createContext } from "react";
 import type { GroupContextType } from "./types";
 

--- a/frontend/packages/react-resizable-panels/components/group/GroupContext.ts
+++ b/frontend/packages/react-resizable-panels/components/group/GroupContext.ts
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import { createContext } from "react";
+import type { GroupContextType } from "./types";
+
+export const GroupContext = createContext<GroupContextType | null>(null);

--- a/frontend/packages/react-resizable-panels/components/group/auto-save/getStorageKey.ts
+++ b/frontend/packages/react-resizable-panels/components/group/auto-save/getStorageKey.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function getStorageKey(id: string, panelIds: string[]): string {
   return `react-resizable-panels:${[id, ...panelIds].join(":")}`;
 }

--- a/frontend/packages/react-resizable-panels/components/group/auto-save/getStorageKey.ts
+++ b/frontend/packages/react-resizable-panels/components/group/auto-save/getStorageKey.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+export function getStorageKey(id: string, panelIds: string[]): string {
+  return `react-resizable-panels:${[id, ...panelIds].join(":")}`;
+}

--- a/frontend/packages/react-resizable-panels/components/group/readLegacyLayout.ts
+++ b/frontend/packages/react-resizable-panels/components/group/readLegacyLayout.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import type { Layout, LayoutStorage } from "./types";
+import { getStorageKey } from "./auto-save/getStorageKey";
+
+export type LegacyLayout = {
+  [key: string]: {
+    expandToSizes: unknown;
+    layout: number[];
+  };
+};
+
+/**
+ * Reads a legacy layout object from `localStorage`  and converts it to a modern `Layout` object.
+ * For more information see github.com/bvaughn/react-resizable-panels/issues/605
+ */
+export function readLegacyLayout({
+  id,
+  panelIds,
+  storage
+}: {
+  id: string;
+  panelIds?: string[] | undefined;
+  storage: LayoutStorage;
+}): Layout | undefined {
+  const readStorageKey = getStorageKey(id, []);
+
+  const maybeLegacyString = storage.getItem(readStorageKey);
+  if (!maybeLegacyString) {
+    return;
+  }
+
+  try {
+    // Legacy format stored multiple layouts in a single storage record, each keyed by panel ids
+    const maybeLegacyLayout = JSON.parse(maybeLegacyString);
+
+    if (panelIds) {
+      // If panel ids were explicitly provided, search for a matching layout
+      const key = panelIds.join(",");
+      const entry = maybeLegacyLayout[key];
+      if (
+        entry &&
+        Array.isArray(entry.layout) &&
+        panelIds.length === entry.layout.length
+      ) {
+        const layout: Layout = {};
+        for (let index = 0; index < panelIds.length; index++) {
+          layout[panelIds[index]] = entry.layout[index];
+        }
+        return layout;
+      }
+    } else {
+      // If no panel ids were provided, bailout unless the legacy object only contained a single layout
+      const keys = Object.keys(maybeLegacyLayout);
+      if (keys.length === 1) {
+        const entry = maybeLegacyLayout[keys[0]];
+        if (entry && Array.isArray(entry.layout)) {
+          const ids = keys[0].split(",");
+          if (ids.length === entry.layout.length) {
+            const layout: Layout = {};
+            for (let index = 0; index < ids.length; index++) {
+              layout[ids[index]] = entry.layout[index];
+            }
+            return layout;
+          }
+        }
+      }
+    }
+  } catch {
+    // No-op
+  }
+}

--- a/frontend/packages/react-resizable-panels/components/group/readLegacyLayout.ts
+++ b/frontend/packages/react-resizable-panels/components/group/readLegacyLayout.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, LayoutStorage } from "./types";
 import { getStorageKey } from "./auto-save/getStorageKey";
 

--- a/frontend/packages/react-resizable-panels/components/group/sortByElementOffset.ts
+++ b/frontend/packages/react-resizable-panels/components/group/sortByElementOffset.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Orientation } from "./types";
 
 export function sortByElementOffset<

--- a/frontend/packages/react-resizable-panels/components/group/sortByElementOffset.ts
+++ b/frontend/packages/react-resizable-panels/components/group/sortByElementOffset.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import type { Orientation } from "./types";
+
+export function sortByElementOffset<
+  Type extends { element: HTMLElement },
+  ReturnType extends Type[]
+>(orientation: Orientation, panelsOrSeparators: Type[]): ReturnType {
+  return Array.from(panelsOrSeparators).sort(
+    orientation === "horizontal" ? horizontalSort : verticalSort
+  ) as ReturnType;
+}
+
+function horizontalSort<Type extends { element: HTMLElement }>(
+  a: Type,
+  b: Type
+) {
+  const delta = a.element.offsetLeft - b.element.offsetLeft;
+  if (delta !== 0) {
+    return delta;
+  }
+  return a.element.offsetWidth - b.element.offsetWidth;
+}
+
+function verticalSort<Type extends { element: HTMLElement }>(a: Type, b: Type) {
+  const delta = a.element.offsetTop - b.element.offsetTop;
+  if (delta !== 0) {
+    return delta;
+  }
+  return a.element.offsetHeight - b.element.offsetHeight;
+}

--- a/frontend/packages/react-resizable-panels/components/group/types.ts
+++ b/frontend/packages/react-resizable-panels/components/group/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
 import type { RegisteredPanel } from "../panel/types";
 import type { RegisteredSeparator } from "../separator/types";

--- a/frontend/packages/react-resizable-panels/components/group/types.ts
+++ b/frontend/packages/react-resizable-panels/components/group/types.ts
@@ -1,0 +1,187 @@
+// @ts-nocheck
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
+import type { RegisteredPanel } from "../panel/types";
+import type { RegisteredSeparator } from "../separator/types";
+
+/**
+ * Panel group orientation loosely relates to the `aria-orientation` attribute.
+ * It determines how panels are are laid out within the group group and the direction they can be resized in.
+ */
+export type Orientation = "horizontal" | "vertical";
+
+/**
+ * Map of Panel id to flexGrow value;
+ */
+export type Layout = {
+  [id: string]: number;
+};
+
+export type LayoutStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type DragState = {
+  state: "default" | "hover" | "dragging";
+  separatorId: string | undefined;
+};
+
+export type ResizeTargetMinimumSize = {
+  coarse: number;
+  fine: number;
+};
+
+export type RegisteredGroup = Readonly<{
+  disabled: boolean;
+  element: HTMLElement;
+  id: string;
+  mutableState: {
+    defaultLayout: Readonly<Layout> | undefined;
+    disableCursor: boolean;
+    expandedPanelSizes: {
+      [panelId: string]: number;
+    };
+    layouts: {
+      [panelIds: string]: Layout;
+    };
+  };
+  orientation: Orientation;
+  panels: RegisteredPanel[];
+  resizeTargetMinimumSize: ResizeTargetMinimumSize;
+  separators: RegisteredSeparator[];
+}>;
+
+export type GroupContextType = {
+  disableCursor: boolean;
+  getPanelStyles: (
+    groupId: string,
+    panelId: string
+  ) => CSSProperties | undefined;
+  id: string;
+  orientation: Orientation;
+  registerPanel: (panel: RegisteredPanel) => () => void;
+  registerSeparator: (separator: RegisteredSeparator) => () => void;
+  togglePanelDisabled: (id: string, disabled: boolean) => void;
+  toggleSeparatorDisabled: (id: string, disabled: boolean) => void;
+};
+
+/**
+ * Imperative Group API.
+ *
+ * ℹ️ The `useGroupRef` and `useGroupCallbackRef` hooks are exported for convenience use in TypeScript projects.
+ */
+export interface GroupImperativeHandle {
+  /**
+   * Get the Group's current layout as a map of Panel id to percentage (0..100)
+   *
+   * @return Map of Panel id to percentages (specified as numbers ranging between 0..100)
+   */
+  getLayout: () => { [panelId: string]: number };
+
+  /**
+   * Set a new layout for the Group
+   *
+   * @param layout Map of Panel id to percentage (a number between 0..100)
+   * @return Applied layout (after validation)
+   */
+  setLayout: (layout: { [panelId: string]: number }) => Layout;
+}
+
+export type GroupProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Panel and Separator components that comprise this group.
+   */
+  children?: ReactNode | undefined;
+
+  /**
+   * CSS class name.
+   */
+  className?: string | undefined;
+
+  /**
+   * Default layout for the Group.
+   *
+   * ℹ️ This value allows layouts to be remembered between page reloads.
+   *
+   * ⚠️ Slight layout shift may occur when server-rendering panels with percentage-based default sizes.
+   * Refer to the documentation for suggestions on how to minimize the impact of this.
+   */
+  defaultLayout?: Layout | undefined;
+
+  /**
+   * This library sets custom mouse cursor styles to indicate drag state.
+   * Use this prop to disable that behavior for Panels and Separators in this group.
+   */
+  disableCursor?: boolean | undefined;
+
+  /**
+   * Disable resize functionality.
+   */
+  disabled?: boolean | undefined;
+
+  /**
+   * Ref attached to the root `HTMLDivElement`.
+   */
+  elementRef?: Ref<HTMLDivElement | null> | undefined;
+
+  /**
+   * Exposes the following imperative API:
+   * - `getLayout(): Layout`
+   * - `setLayout(layout: Layout): void`
+   *
+   * ℹ️ The `useGroupRef` and `useGroupCallbackRef` hooks are exported for convenience use in TypeScript projects.
+   */
+  groupRef?: Ref<GroupImperativeHandle | null> | undefined;
+
+  /**
+   * Uniquely identifies this group within an application.
+   * Falls back to `useId` when not provided.
+   *
+   * ℹ️ This value will also be assigned to the `data-group` attribute.
+   */
+  id?: string | number | undefined;
+
+  /**
+   * Called when the Group's layout is changing.
+   *
+   * ⚠️ For layout changes caused by pointer events, this method is called each time the pointer is moved.
+   * For most cases, it is recommended to use the `onLayoutChanged` callback instead.
+   */
+  onLayoutChange?: (layout: Layout) => void | undefined;
+
+  /**
+   * Called after the Group's layout has  been changed.
+   *
+   * ℹ️ For layout changes caused by pointer events, this method is not called until the pointer has been released.
+   * This method is recommended when saving layouts to some storage api.
+   */
+  onLayoutChanged?: (layout: Layout) => void | undefined;
+
+  /**
+   * Minimum size of the resizable hit target area (either `Separator` or `Panel` edge)
+   * This threshold ensures are large enough to avoid mis-clicks.
+   *
+   * - Coarse inputs (typically a finger on a touchscreen) have reduced accuracy;
+   * to ensure accessibility and ease of use, hit targets should be larger to prevent mis-clicks.
+   * - Fine inputs (typically a mouse) can be smaller
+   *
+   * ℹ️ [Apple interface guidelines](https://developer.apple.com/design/human-interface-guidelines/accessibility) suggest `20pt` (`27px`) on desktops and `28pt` (`37px`) for touch devices
+   * In practice this seems to be much larger than many of their own applications use though.
+   */
+  resizeTargetMinimumSize?: {
+    coarse: number;
+    fine: number;
+  };
+
+  /**
+   * Specifies the resizable orientation ("horizontal" or "vertical"); defaults to "horizontal"
+   */
+  orientation?: "horizontal" | "vertical" | undefined;
+
+  /**
+   * CSS properties.
+   *
+   * ⚠️ The following styles cannot be overridden: `display`, `flex-direction`, `flex-wrap`, and `overflow`.
+   */
+  style?: CSSProperties | undefined;
+};
+
+export type OnGroupLayoutChange = GroupProps["onLayoutChange"];
+export type OnGroupLayoutChanged = GroupProps["onLayoutChanged"];

--- a/frontend/packages/react-resizable-panels/components/group/useDefaultLayout.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useDefaultLayout.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   useCallback,
   useLayoutEffect,

--- a/frontend/packages/react-resizable-panels/components/group/useDefaultLayout.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useDefaultLayout.ts
@@ -1,0 +1,180 @@
+// @ts-nocheck
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore
+} from "react";
+import { getStorageKey } from "./auto-save/getStorageKey";
+import { readLegacyLayout } from "./readLegacyLayout";
+import type {
+  Layout,
+  LayoutStorage,
+  OnGroupLayoutChange,
+  OnGroupLayoutChanged
+} from "./types";
+
+/**
+ * Saves and restores group layouts between page loads.
+ * It can be configured to store values using `localStorage`, `sessionStorage`, cookies, or any other persistence layer that makes sense for your application.
+ */
+export function useDefaultLayout({
+  debounceSaveMs = 100,
+  panelIds,
+  storage = localStorage,
+  ...rest
+}: {
+  /**
+   * Debounce save operation by the specified number of milliseconds; defaults to 100ms
+   *
+   * @deprecated Use the {@link onLayoutChanged} callback instead; it does not require debouncing
+   */
+  debounceSaveMs?: number;
+
+  /**
+   * For Groups that contain conditionally-rendered Panels, this prop can be used to save and restore multiple layouts.
+   *
+   * ℹ️ This prevents layout shift for server-rendered apps.
+   *
+   * ⚠️ Panel ids must match the Panels rendered within the Group during mount or the initial layout will be incorrect.
+   */
+  panelIds?: string[] | undefined;
+
+  /**
+   * Storage implementation; supports localStorage, sessionStorage, and custom implementations
+   * Refer to documentation site for example integrations.
+   *
+   */
+  storage?: LayoutStorage;
+} & (
+  | {
+      /**
+       * Group id; must be unique in order for layouts to be saved separately.
+       * @deprecated Use the {@link id} param instead
+       */
+      groupId: string;
+    }
+  | {
+      /**
+       * Uniquely identifies a specific group/layout.
+       */
+      id: string;
+    }
+)) {
+  const hasPanelIds = panelIds !== undefined;
+  const id = "id" in rest ? rest.id : rest.groupId;
+
+  const readStorageKey = getStorageKey(id, panelIds ?? []);
+
+  // In the event that a client-only storage API is provided,
+  // useSyncExternalStore prevents server/client hydration mismatch warning
+  // This is not ideal; if possible a server-friendly storage API should be used
+  // Try to read v4 Layout format first
+  const defaultLayoutString = useSyncExternalStore(
+    subscribe,
+    () => storage.getItem(readStorageKey),
+    () => storage.getItem(readStorageKey)
+  );
+  const defaultLayoutModern = useMemo(() => {
+    if (defaultLayoutString) {
+      // Rule out false positive for legacy layout format
+      const parsed = JSON.parse(defaultLayoutString);
+      const values = Object.values(parsed);
+      if (Array.from(values).every((value) => typeof value === "number")) {
+        return parsed as Layout;
+      }
+    }
+  }, [defaultLayoutString]);
+
+  // If not v4 layout was found, check for legacy v3 layout format
+  const defaultLayoutLegacy = useMemo(() => {
+    if (defaultLayoutModern) {
+      return undefined;
+    }
+
+    return readLegacyLayout({
+      id,
+      panelIds,
+      storage
+    });
+  }, [defaultLayoutModern, id, panelIds, storage]);
+
+  const defaultLayout = defaultLayoutModern ?? defaultLayoutLegacy;
+
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearPendingTimeout = useCallback(() => {
+    const timeout = timeoutRef.current;
+    if (timeout) {
+      timeoutRef.current = null;
+
+      clearTimeout(timeout);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    return () => {
+      clearPendingTimeout();
+    };
+  }, [clearPendingTimeout]);
+
+  const onLayoutChanged = useCallback<NonNullable<OnGroupLayoutChanged>>(
+    (layout: Layout) => {
+      clearPendingTimeout();
+
+      let writeStorageKey: string;
+      if (hasPanelIds) {
+        writeStorageKey = getStorageKey(id, Object.keys(layout));
+      } else {
+        writeStorageKey = getStorageKey(id, []);
+      }
+
+      try {
+        storage.setItem(writeStorageKey, JSON.stringify(layout));
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    [clearPendingTimeout, hasPanelIds, id, storage]
+  );
+
+  // TODO Deprecated; remove this in the future release
+  const onLayoutChange = useCallback<NonNullable<OnGroupLayoutChange>>(
+    (layout: Layout) => {
+      clearPendingTimeout();
+
+      if (debounceSaveMs === 0) {
+        onLayoutChanged(layout);
+      } else {
+        timeoutRef.current = setTimeout(() => {
+          onLayoutChanged(layout);
+        }, debounceSaveMs);
+      }
+    },
+    [clearPendingTimeout, debounceSaveMs, onLayoutChanged]
+  );
+
+  return {
+    /**
+     * Pass this value to `Group` as the `defaultLayout` prop.
+     */
+    defaultLayout,
+
+    /**
+     * Attach this callback on the `Group` as the `onLayoutChange` prop.
+     *
+     * @deprecated Use the {@link onLayoutChanged} prop instead.
+     */
+    onLayoutChange,
+
+    /**
+     * Attach this callback on the `Group` as the `onLayoutChanged` prop.
+     */
+    onLayoutChanged
+  };
+}
+
+function subscribe() {
+  return function unsubscribe() {};
+}

--- a/frontend/packages/react-resizable-panels/components/group/useGroupCallbackRef.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupCallbackRef.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import type { GroupImperativeHandle } from "./types";
 

--- a/frontend/packages/react-resizable-panels/components/group/useGroupCallbackRef.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupCallbackRef.ts
@@ -1,0 +1,12 @@
+// @ts-nocheck
+import { useState } from "react";
+import type { GroupImperativeHandle } from "./types";
+
+/**
+ * Convenience hook to return a properly typed ref callback for the Group component.
+ *
+ * Use this hook when you need to share the ref with another component or hook.
+ */
+export function useGroupCallbackRef() {
+  return useState<GroupImperativeHandle | null>(null);
+}

--- a/frontend/packages/react-resizable-panels/components/group/useGroupContext.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupContext.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import { useContext } from "react";
+import { assert } from "../../utils/assert";
+import { GroupContext } from "./GroupContext";
+
+export function useGroupContext() {
+  const context = useContext(GroupContext);
+  assert(
+    context,
+    "Group Context not found; did you render a Panel or Separator outside of a Group?"
+  );
+
+  return context;
+}

--- a/frontend/packages/react-resizable-panels/components/group/useGroupContext.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupContext.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useContext } from "react";
 import { assert } from "../../utils/assert";
 import { GroupContext } from "./GroupContext";

--- a/frontend/packages/react-resizable-panels/components/group/useGroupImperativeHandle.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupImperativeHandle.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import { useImperativeHandle, useRef, type Ref } from "react";
+import { IDENTITY_FUNCTION } from "../../constants";
+import { getImperativeGroupMethods } from "../../global/utils/getImperativeGroupMethods";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
+import type { GroupImperativeHandle } from "./types";
+
+export function useGroupImperativeHandle(
+  groupId: string,
+  groupRef: Ref<GroupImperativeHandle> | undefined
+) {
+  const imperativeGroupRef = useRef<GroupImperativeHandle>({
+    getLayout: () => ({}),
+    setLayout: IDENTITY_FUNCTION
+  });
+
+  useImperativeHandle(groupRef, () => imperativeGroupRef.current, []);
+
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(
+      imperativeGroupRef.current,
+      getImperativeGroupMethods({ groupId })
+    );
+  });
+}

--- a/frontend/packages/react-resizable-panels/components/group/useGroupImperativeHandle.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupImperativeHandle.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useImperativeHandle, useRef, type Ref } from "react";
 import { IDENTITY_FUNCTION } from "../../constants";
 import { getImperativeGroupMethods } from "../../global/utils/getImperativeGroupMethods";

--- a/frontend/packages/react-resizable-panels/components/group/useGroupRef.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupRef.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { useRef } from "react";
+import type { GroupImperativeHandle } from "./types";
+
+/**
+ * Convenience hook to return a properly typed ref for the Group component.
+ */
+export function useGroupRef() {
+  return useRef<GroupImperativeHandle | null>(null);
+}

--- a/frontend/packages/react-resizable-panels/components/group/useGroupRef.ts
+++ b/frontend/packages/react-resizable-panels/components/group/useGroupRef.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useRef } from "react";
 import type { GroupImperativeHandle } from "./types";
 

--- a/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
+++ b/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import {

--- a/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
+++ b/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
@@ -1,0 +1,227 @@
+// @ts-nocheck
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+  type CSSProperties
+} from "react";
+import { subscribeToMountedGroup } from "../../global/mutable-state/groups";
+import { useId } from "../../hooks/useId";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
+import { useMergedRefs } from "../../hooks/useMergedRefs";
+import { useStableCallback } from "../../hooks/useStableCallback";
+import { useStableObject } from "../../hooks/useStableObject";
+import { useGroupContext } from "../group/useGroupContext";
+import type { PanelProps, PanelSize, RegisteredPanel } from "./types";
+import { usePanelImperativeHandle } from "./usePanelImperativeHandle";
+
+/**
+ * A Panel wraps resizable content and can be configured with min/max size constraints and collapsible behavior.
+ *
+ * Panel size props can be in the following formats:
+ * - Percentage of the parent Group (0..100)
+ * - Pixels
+ * - Relative font units (em, rem)
+ * - Viewport relative units (vh, vw)
+ *
+ * ℹ️ Numeric values are assumed to be pixels.
+ * Strings without explicit units are assumed to be percentages (0%..100%).
+ * Percentages may also be specified as strings ending with "%" (e.g. "33%")
+ * Pixels may also be specified as strings ending with the unit "px".
+ * Other units should be specified as strings ending with their CSS property units (e.g. 1rem, 50vh)
+ *
+ * Panel elements always include the following attributes:
+ *
+ * ```html
+ * <div data-panel data-testid="panel-id-prop" id="panel-id-prop">
+ * ```
+ *
+ * ℹ️ [Test id](https://testing-library.com/docs/queries/bytestid/) can be used to narrow selection when unit testing.
+ *
+ * ⚠️ Panel elements must be direct DOM children of their parent Group elements.
+ */
+export function Panel({
+  children,
+  className,
+  collapsedSize = "0%",
+  collapsible = false,
+  defaultSize,
+  disabled,
+  elementRef: elementRefProp,
+  groupResizeBehavior = "preserve-relative-size",
+  id: idProp,
+  maxSize = "100%",
+  minSize = "0%",
+  onResize: onResizeUnstable,
+  panelRef,
+  style,
+  ...rest
+}: PanelProps) {
+  const idIsStable = !!idProp;
+
+  const id = useId(idProp);
+
+  const stableProps = useStableObject({
+    disabled
+  });
+
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  const mergedRef = useMergedRefs(elementRef, elementRefProp);
+
+  const {
+    getPanelStyles,
+    id: groupId,
+    orientation,
+    registerPanel,
+    togglePanelDisabled
+  } = useGroupContext();
+
+  const hasOnResize = onResizeUnstable !== null;
+  const onResizeStable = useStableCallback(
+    (
+      panelSize: PanelSize,
+      _: string | number | undefined,
+      prevPanelSize: PanelSize | undefined
+    ) => {
+      onResizeUnstable?.(panelSize, idProp, prevPanelSize);
+    }
+  );
+
+  // Register Panel with parent Group
+  useIsomorphicLayoutEffect(() => {
+    const element = elementRef.current;
+    if (element !== null) {
+      const registeredPanel: RegisteredPanel = {
+        element,
+        id,
+        idIsStable,
+        mutableValues: {
+          expandToSize: undefined,
+          prevSize: undefined
+        },
+        onResize: hasOnResize ? onResizeStable : undefined,
+        panelConstraints: {
+          groupResizeBehavior,
+          collapsedSize,
+          collapsible,
+          defaultSize,
+          disabled: stableProps.disabled,
+          maxSize,
+          minSize
+        }
+      };
+
+      return registerPanel(registeredPanel);
+    }
+  }, [
+    groupResizeBehavior,
+    collapsedSize,
+    collapsible,
+    defaultSize,
+    hasOnResize,
+    id,
+    idIsStable,
+    maxSize,
+    minSize,
+    onResizeStable,
+    registerPanel,
+    stableProps
+  ]);
+
+  // Not all props require re-registering the panel;
+  useEffect(() => {
+    togglePanelDisabled(id, !!disabled);
+  }, [disabled, id, togglePanelDisabled]);
+
+  usePanelImperativeHandle(id, panelRef);
+
+  // useSyncExternalStore does not support a custom equality check
+  // stringify avoids re-rendering when the style value hasn't changed
+  const read = () => {
+    const maybePanelStyles = getPanelStyles(groupId, id);
+    if (maybePanelStyles) {
+      return JSON.stringify(maybePanelStyles);
+    }
+  };
+
+  const panelStylesString = useSyncExternalStore(
+    (subscribe) => subscribeToMountedGroup(groupId, subscribe),
+    read,
+    read
+  );
+
+  let panelStyles: CSSProperties;
+  if (panelStylesString) {
+    panelStyles = JSON.parse(panelStylesString);
+  } else if (defaultSize) {
+    panelStyles = {
+      flexGrow: undefined,
+      flexShrink: undefined,
+      flexBasis: defaultSize
+    };
+  } else {
+    panelStyles = { flexGrow: 1 };
+  }
+
+  return (
+    <div
+      {...rest}
+      data-disabled={disabled || undefined}
+      data-panel
+      data-testid={id}
+      id={id}
+      ref={mergedRef}
+      style={{
+        ...PROHIBITED_CSS_PROPERTIES,
+
+        display: "flex",
+        flexBasis: 0,
+        flexShrink: 1,
+        overflow: "visible",
+
+        ...panelStyles
+      }}
+    >
+      <div
+        className={className}
+        style={{
+          maxHeight: "100%",
+          maxWidth: "100%",
+          flexGrow: 1,
+          overflow: "auto",
+
+          ...style,
+
+          // Inform the browser that the library is handling touch events for this element
+          // but still allow users to scroll content within panels in the non-resizing direction
+          // NOTE This is not an inherited style
+          // See github.com/bvaughn/react-resizable-panels/issues/662
+          touchAction: orientation === "horizontal" ? "pan-y" : "pan-x"
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName
+Panel.displayName = "Panel";
+
+const PROHIBITED_CSS_PROPERTIES: CSSProperties = {
+  minHeight: 0,
+  maxHeight: "100%",
+  height: "auto",
+
+  minWidth: 0,
+  maxWidth: "100%",
+  width: "auto",
+
+  border: "none",
+  borderWidth: 0,
+  padding: 0,
+  margin: 0
+};

--- a/frontend/packages/react-resizable-panels/components/panel/constants.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/constants.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+export const POINTER_EVENTS_CSS_PROPERTY_NAME =
+  "--react-resizable-panels--panel--pointer-events";

--- a/frontend/packages/react-resizable-panels/components/panel/constants.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/constants.ts
@@ -1,3 +1,2 @@
-// @ts-nocheck
 export const POINTER_EVENTS_CSS_PROPERTY_NAME =
   "--react-resizable-panels--panel--pointer-events";

--- a/frontend/packages/react-resizable-panels/components/panel/types.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { CSSProperties, HTMLAttributes, Ref } from "react";
 
 export type PanelSize = {

--- a/frontend/packages/react-resizable-panels/components/panel/types.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/types.ts
@@ -1,0 +1,235 @@
+// @ts-nocheck
+import type { CSSProperties, HTMLAttributes, Ref } from "react";
+
+export type PanelSize = {
+  asPercentage: number;
+  inPixels: number;
+};
+
+export type GroupResizeBehavior =
+  | "preserve-relative-size"
+  | "preserve-pixel-size";
+
+/**
+ * Numeric Panel constraints are represented as numeric percentages (0..100)
+ * Values specified using other CSS units must be pre-converted.
+ */
+export type PanelConstraints = {
+  collapsedSize: number;
+  collapsible: boolean;
+  defaultSize: number | undefined;
+  disabled: boolean | undefined;
+  groupResizeBehavior?: GroupResizeBehavior | undefined;
+  maxSize: number;
+  minSize: number;
+  panelId: string;
+};
+
+export type SizeUnit = "px" | "%" | "em" | "rem" | "vh" | "vw";
+
+export type RegisteredPanel = {
+  id: string;
+  idIsStable: boolean;
+  element: HTMLDivElement;
+  mutableValues: {
+    expandToSize: number | undefined;
+    prevSize: PanelSize | undefined;
+  };
+  onResize: OnPanelResize | undefined;
+  panelConstraints: PanelConstraintProps;
+};
+
+/**
+ * Imperative Panel API
+ *
+ * ℹ️ The `usePanelRef` and `usePanelCallbackRef` hooks are exported for convenience use in TypeScript projects.
+ */
+export interface PanelImperativeHandle {
+  /**
+   * Collapse the Panel to it's `collapsedSize`.
+   *
+   * ⚠️ This method will do nothing if the Panel is not `collapsible` or if it is already collapsed.
+   */
+  collapse: () => void;
+
+  /**
+   * Expand a collapsed Panel to its most recent size.
+   *
+   * ⚠️ This method will do nothing if the Panel is not currently collapsed.
+   */
+  expand: () => void;
+
+  /**
+   * Get the current size of the Panel in pixels as well as a percentage of the parent group (0..100).
+   *
+   * @return Panel size (in pixels and as a percentage of the parent group)
+   */
+  getSize: () => {
+    asPercentage: number;
+    inPixels: number;
+  };
+
+  /**
+   * The Panel is currently collapsed.
+   */
+  isCollapsed: () => boolean;
+
+  /**
+   * Update the Panel's size.
+   *
+   * Size can be in the following formats:
+   * - Percentage of the parent Group (0..100)
+   * - Pixels
+   * - Relative font units (em, rem)
+   * - Viewport relative units (vh, vw)
+   *
+   * ℹ️ Numeric values are assumed to be pixels.
+   * Strings without explicit units are assumed to be percentages (0%..100%).
+   * Percentages may also be specified as strings ending with "%" (e.g. "33%")
+   * Pixels may also be specified as strings ending with the unit "px".
+   * Other units should be specified as strings ending with their CSS property units (e.g. 1rem, 50vh)
+   *
+   * @param size New panel size
+   * @return Applied size (after validation)
+   */
+  resize: (size: number | string) => void;
+}
+
+type BasePanelAttributes = Omit<HTMLAttributes<HTMLDivElement>, "onResize">;
+
+export type PanelProps = BasePanelAttributes & {
+  /**
+   * CSS class name.
+   *
+   * ⚠️ Class is applied to nested `HTMLDivElement` to avoid styles that interfere with Flex layout.
+   */
+  className?: string | undefined;
+
+  /**
+   * Panel size when collapsed; defaults to 0%.
+   */
+  collapsedSize?: number | string | undefined;
+
+  /**
+   * This panel can be collapsed.
+   *
+   * ℹ️ A collapsible panel will collapse when it's size is less than of the specified `minSize`
+   */
+  collapsible?: boolean | undefined;
+
+  /**
+   * Default size of Panel within its parent group; default is auto-assigned based on the total number of Panels.
+   *
+   * ⚠️ Percentage based sizes may cause slight layout shift when server-rendering.
+   * For more information see the documentation.
+   */
+  defaultSize?: number | string | undefined;
+
+  /**
+   * When disabled, a panel cannot be resized either directly or indirectly (by resizing another panel).
+   */
+  disabled?: boolean | undefined;
+
+  /**
+   * Ref attached to the root `HTMLDivElement`.
+   */
+  elementRef?: Ref<HTMLDivElement | null> | undefined;
+
+  /**
+   * How should this Panel behave if the parent Group is resized?
+   * Defaults to `preserve-relative-size`.
+   *
+   * - `preserve-relative-size`: Retain the current relative size (as a percentage of the Group)
+   * - `preserve-pixel-size`: Retain its current size (in pixels)
+   *
+   * ℹ️ Panel min/max size constraints may impact this behavior.
+   *
+   * ⚠️ A Group must contain at least one Panel with `preserve-relative-size` resize behavior.
+   */
+  groupResizeBehavior?:
+    | "preserve-relative-size"
+    | "preserve-pixel-size"
+    | undefined;
+
+  /**
+   * Uniquely identifies this panel within the parent group.
+   * Falls back to `useId` when not provided.
+   *
+   * ℹ️ This prop is used to associate persisted group layouts with the original panel.
+   *
+   * ℹ️ This value will also be assigned to the `data-panel` attribute.
+   */
+  id?: string | number | undefined;
+
+  /**
+   * Maximum size of Panel within its parent group; defaults to 100%.
+   */
+  maxSize?: number | string | undefined;
+
+  /**
+   * Minimum size of Panel within its parent group; defaults to 0%.
+   */
+  minSize?: number | string | undefined;
+
+  /**
+   * Called when panel sizes change.
+   *
+   * @param panelSize Panel size (both as a percentage of the parent Group and in pixels)
+   * @param id Panel id (if one was provided as a prop)
+   * @param prevPanelSize Previous panel size (will be undefined on mount)
+   */
+  onResize?:
+    | ((
+        panelSize: PanelSize,
+        id: string | number | undefined,
+        prevPanelSize: PanelSize | undefined
+      ) => void)
+    | undefined;
+
+  /**
+   * Exposes the following imperative API:
+   * - `collapse(): void`
+   * - `expand(): void`
+   * - `getSize(): number`
+   * - `isCollapsed(): boolean`
+   * - `resize(size: number): void`
+   *
+   * ℹ️ The `usePanelRef` and `usePanelCallbackRef` hooks are exported for convenience use in TypeScript projects.
+   */
+  panelRef?: Ref<PanelImperativeHandle | null> | undefined;
+
+  /**
+   * CSS properties.
+   *
+   * ⚠️ Style is applied to nested `HTMLDivElement` to avoid styles that interfere with Flex layout.
+   */
+  style?: CSSProperties | undefined;
+};
+
+export type OnPanelResize = PanelProps["onResize"];
+
+/**
+ * Size constraints may be specified in a variety of ways:
+ * - Percentage of the parent Group (0..100)
+ * - Pixels
+ * - Relative font units (em, rem)
+ * - Viewport relative units (vh, vw)
+ *
+ * Numeric values are assumed to be pixels.
+ * Strings without explicit units are assumed to be percentages (0%..100%).
+ *
+ * Percentages may also be specified as strings ending with "%" (e.g. "33%")
+ * Pixels may also be specified as strings ending with the unit "px".
+ *
+ * Other units should be specified as strings ending with their CSS property units (e.g. 1rem, 50vh)
+ */
+export type PanelConstraintProps = Pick<
+  PanelProps,
+  | "collapsedSize"
+  | "collapsible"
+  | "defaultSize"
+  | "disabled"
+  | "groupResizeBehavior"
+  | "maxSize"
+  | "minSize"
+>;

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelCallbackRef.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelCallbackRef.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import type { PanelImperativeHandle } from "./types";
 

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelCallbackRef.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelCallbackRef.ts
@@ -1,0 +1,12 @@
+// @ts-nocheck
+import { useState } from "react";
+import type { PanelImperativeHandle } from "./types";
+
+/**
+ * Convenience hook to return a properly typed ref callback for the Panel component.
+ *
+ * Use this hook when you need to share the ref with another component or hook.
+ */
+export function usePanelCallbackRef() {
+  return useState<PanelImperativeHandle | null>(null);
+}

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelImperativeHandle.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelImperativeHandle.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useImperativeHandle, useRef, type Ref } from "react";
 import { NOOP_FUNCTION } from "../../constants";
 import { getImperativePanelMethods } from "../../global/utils/getImperativePanelMethods";

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelImperativeHandle.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelImperativeHandle.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import { useImperativeHandle, useRef, type Ref } from "react";
+import { NOOP_FUNCTION } from "../../constants";
+import { getImperativePanelMethods } from "../../global/utils/getImperativePanelMethods";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
+import { useGroupContext } from "../group/useGroupContext";
+import type { PanelImperativeHandle } from "./types";
+
+export function usePanelImperativeHandle(
+  panelId: string,
+  panelRef: Ref<PanelImperativeHandle> | undefined
+) {
+  const { id: groupId } = useGroupContext();
+
+  const imperativePanelRef = useRef<PanelImperativeHandle>({
+    collapse: NOOP_FUNCTION,
+    expand: NOOP_FUNCTION,
+    getSize: () => ({
+      asPercentage: 0,
+      inPixels: 0
+    }),
+    isCollapsed: () => false,
+    resize: NOOP_FUNCTION
+  });
+
+  useImperativeHandle(panelRef, () => imperativePanelRef.current, []);
+
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(
+      imperativePanelRef.current,
+      getImperativePanelMethods({ groupId, panelId })
+    );
+  });
+}

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelRef.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelRef.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useRef } from "react";
 import type { PanelImperativeHandle } from "./types";
 

--- a/frontend/packages/react-resizable-panels/components/panel/usePanelRef.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/usePanelRef.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { useRef } from "react";
+import type { PanelImperativeHandle } from "./types";
+
+/**
+ * Convenience hook to return a properly typed ref for the Panel component.
+ */
+export function usePanelRef() {
+  return useRef<PanelImperativeHandle | null>(null);
+}

--- a/frontend/packages/react-resizable-panels/components/separator/Separator.tsx
+++ b/frontend/packages/react-resizable-panels/components/separator/Separator.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import type { Properties } from "csstype";

--- a/frontend/packages/react-resizable-panels/components/separator/Separator.tsx
+++ b/frontend/packages/react-resizable-panels/components/separator/Separator.tsx
@@ -1,0 +1,173 @@
+// @ts-nocheck
+"use client";
+
+import type { Properties } from "csstype";
+import { useEffect, useRef, useState } from "react";
+import { subscribeToMountedGroup } from "../../global/mutable-state/groups";
+import { subscribeToInteractionState } from "../../global/mutable-state/interactions";
+import type { InteractionState } from "../../global/mutable-state/types";
+import { calculateSeparatorAriaValues } from "../../global/utils/calculateSeparatorAriaValues";
+import { useId } from "../../hooks/useId";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
+import { useMergedRefs } from "../../hooks/useMergedRefs";
+import { useStableObject } from "../../hooks/useStableObject";
+import { useGroupContext } from "../group/useGroupContext";
+import type { RegisteredSeparator, SeparatorProps } from "./types";
+
+/**
+ * Separators are not _required_ but they are _recommended_ as they improve keyboard accessibility.
+ *
+ * ⚠️ Separator elements must be direct DOM children of their parent Group elements.
+ *
+ * Separator elements always include the following attributes:
+ *
+ * ```html
+ * <div data-separator data-testid="separator-id-prop" id="separator-id-prop" role="separator">
+ * ```
+ *
+ * ℹ️ [Test id](https://testing-library.com/docs/queries/bytestid/) can be used to narrow selection when unit testing.
+ *
+ * ℹ️ In addition to the attributes shown above, separator also renders all required [WAI-ARIA properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role#associated_wai-aria_roles_states_and_properties).
+ */
+export function Separator({
+  children,
+  className,
+  disabled,
+  elementRef: elementRefProp,
+  id: idProp,
+  style,
+  ...rest
+}: SeparatorProps) {
+  const id = useId(idProp);
+
+  const stableProps = useStableObject({
+    disabled
+  });
+
+  const [aria, setAria] = useState<{
+    valueControls?: string | undefined;
+    valueMin?: number | undefined;
+    valueMax?: number | undefined;
+    valueNow?: number | undefined;
+  }>({});
+
+  const [dragState, setDragState] =
+    useState<InteractionState["state"]>("inactive");
+
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  const mergedRef = useMergedRefs(elementRef, elementRefProp);
+
+  const {
+    disableCursor,
+    id: groupId,
+    orientation: groupOrientation,
+    registerSeparator,
+    toggleSeparatorDisabled
+  } = useGroupContext();
+
+  const orientation =
+    groupOrientation === "horizontal" ? "vertical" : "horizontal";
+
+  // Register Separator with parent Group
+  // Listen to global state for drag state related to this Separator
+  useIsomorphicLayoutEffect(() => {
+    const element = elementRef.current;
+    if (element !== null) {
+      const separator: RegisteredSeparator = {
+        disabled: stableProps.disabled,
+        element,
+        id
+      };
+
+      const unregisterSeparator = registerSeparator(separator);
+
+      const removeInteractionStateChangeListener = subscribeToInteractionState(
+        (event) => {
+          setDragState(
+            event.next.state !== "inactive" &&
+              event.next.hitRegions.some(
+                (hitRegion) => hitRegion.separator === separator
+              )
+              ? event.next.state
+              : "inactive"
+          );
+        }
+      );
+
+      const removeMountedGroupsChangeListener = subscribeToMountedGroup(
+        groupId,
+        (event) => {
+          const { derivedPanelConstraints, layout, separatorToPanels } =
+            event.next;
+          const panels = separatorToPanels.get(separator);
+          if (panels) {
+            const primaryPanel = panels[0];
+            const panelIndex = panels.indexOf(primaryPanel);
+
+            setAria(
+              calculateSeparatorAriaValues({
+                layout,
+                panelConstraints: derivedPanelConstraints,
+                panelId: primaryPanel.id,
+                panelIndex
+              })
+            );
+          }
+        }
+      );
+
+      return () => {
+        removeInteractionStateChangeListener();
+        removeMountedGroupsChangeListener();
+        unregisterSeparator();
+      };
+    }
+  }, [groupId, id, registerSeparator, stableProps]);
+
+  // Not all props require re-registering the separator;
+  useEffect(() => {
+    toggleSeparatorDisabled(id, !!disabled);
+  }, [disabled, id, toggleSeparatorDisabled]);
+
+  let cursor: Properties["cursor"] = undefined;
+  if (disabled && !disableCursor) {
+    cursor = "not-allowed";
+  }
+
+  return (
+    <div
+      {...rest}
+      aria-controls={aria.valueControls}
+      aria-disabled={disabled || undefined}
+      aria-orientation={orientation}
+      aria-valuemax={aria.valueMax}
+      aria-valuemin={aria.valueMin}
+      aria-valuenow={aria.valueNow}
+      children={children}
+      className={className}
+      data-separator={disabled ? "disabled" : dragState}
+      data-testid={id}
+      id={id}
+      ref={mergedRef}
+      role="separator"
+      style={{
+        flexBasis: "auto",
+        cursor,
+
+        ...style,
+
+        flexGrow: 0,
+        flexShrink: 0,
+
+        // Inform the browser that the library is handling touch events for this element
+        // See github.com/bvaughn/react-resizable-panels/issues/662
+        touchAction: "none"
+      }}
+      tabIndex={disabled ? undefined : 0}
+    />
+  );
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName
+Separator.displayName = "Separator";

--- a/frontend/packages/react-resizable-panels/components/separator/types.ts
+++ b/frontend/packages/react-resizable-panels/components/separator/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { CSSProperties, HTMLAttributes, Ref } from "react";
 
 export type RegisteredSeparator = {

--- a/frontend/packages/react-resizable-panels/components/separator/types.ts
+++ b/frontend/packages/react-resizable-panels/components/separator/types.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+import type { CSSProperties, HTMLAttributes, Ref } from "react";
+
+export type RegisteredSeparator = {
+  disabled?: boolean | undefined;
+  element: HTMLDivElement;
+  id: string;
+};
+
+type BaseSeparatorAttributes = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "role" | "tabIndex"
+>;
+
+export type SeparatorProps = BaseSeparatorAttributes & {
+  /**
+   * CSS class name.
+   *
+   * ℹ️ Use the `data-separator` attribute for custom _hover_ and _active_ styles
+   *
+   * ⚠️ The following properties cannot be overridden: `flex-grow`, `flex-shrink`
+   */
+  className?: string | undefined;
+
+  /**
+   * When disabled, the separator cannot be used to resize its neighboring panels.
+   *
+   * ℹ️ The panels may still be resized indirectly (while other panels are being resized).
+   * To prevent a panel from being resized at all, it needs to also be disabled.
+   */
+  disabled?: boolean | undefined;
+
+  /**
+   * Ref attached to the root `HTMLDivElement`.
+   */
+  elementRef?: Ref<HTMLDivElement> | undefined;
+
+  /**
+   * Uniquely identifies the separator within the parent group.
+   * Falls back to `useId` when not provided.
+   *
+   * ℹ️ This value will also be assigned to the `data-separator` attribute.
+   */
+  id?: string | number | undefined;
+
+  /**
+   * CSS properties.
+   *
+   * ℹ️ Use the `data-separator` attribute for custom _hover_ and _active_ styles
+   *
+   * ⚠️ The following properties cannot be overridden: `flex-grow`, `flex-shrink`
+   */
+  style?: CSSProperties | undefined;
+};

--- a/frontend/packages/react-resizable-panels/constants.ts
+++ b/frontend/packages/react-resizable-panels/constants.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Constants used for memoization
 export const EMPTY_ARRAY: unknown[] = [];
 export const EMPTY_DOM_RECT: DOMRectReadOnly = {

--- a/frontend/packages/react-resizable-panels/constants.ts
+++ b/frontend/packages/react-resizable-panels/constants.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+// Constants used for memoization
+export const EMPTY_ARRAY: unknown[] = [];
+export const EMPTY_DOM_RECT: DOMRectReadOnly = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  toJSON: () => {},
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0
+};
+export const EMPTY_OBJECT = {};
+export const EMPTY_POINT = { x: 0, y: 0 };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const IDENTITY_FUNCTION = (value: any) => value;
+export const NOOP_FUNCTION = () => {};
+
+// Cursor flags
+export const CURSOR_FLAG_HORIZONTAL_MIN = 0b0001;
+export const CURSOR_FLAG_HORIZONTAL_MAX = 0b0010;
+export const CURSOR_FLAG_VERTICAL_MIN = 0b0100;
+export const CURSOR_FLAG_VERTICAL_MAX = 0b1000;
+export const CURSOR_FLAGS_HORIZONTAL = 0b0011;
+export const CURSOR_FLAGS_VERTICAL = 0b1100;

--- a/frontend/packages/react-resizable-panels/global/cursor/getCursorStyle.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/getCursorStyle.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Properties } from "csstype";
 import type { RegisteredGroup } from "../../components/group/types";
 import {

--- a/frontend/packages/react-resizable-panels/global/cursor/getCursorStyle.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/getCursorStyle.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import type { Properties } from "csstype";
+import type { RegisteredGroup } from "../../components/group/types";
+import {
+  CURSOR_FLAG_HORIZONTAL_MAX,
+  CURSOR_FLAG_HORIZONTAL_MIN,
+  CURSOR_FLAG_VERTICAL_MAX,
+  CURSOR_FLAG_VERTICAL_MIN
+} from "../../constants";
+import type { InteractionState } from "../mutable-state/types";
+import { supportsAdvancedCursorStyles } from "./supportsAdvancedCursorStyles";
+
+export function getCursorStyle({
+  cursorFlags,
+  groups,
+  state
+}: {
+  cursorFlags: number;
+  groups: RegisteredGroup[];
+  state: InteractionState["state"];
+}): Properties["cursor"] {
+  let horizontalCount = 0;
+  let verticalCount = 0;
+
+  switch (state) {
+    case "active":
+    case "hover": {
+      groups.forEach((group) => {
+        if (group.mutableState.disableCursor) {
+          return;
+        }
+
+        switch (group.orientation) {
+          case "horizontal": {
+            horizontalCount++;
+            break;
+          }
+          case "vertical": {
+            verticalCount++;
+            break;
+          }
+        }
+      });
+    }
+  }
+
+  if (horizontalCount === 0 && verticalCount === 0) {
+    return undefined;
+  }
+
+  switch (state) {
+    case "active": {
+      if (cursorFlags) {
+        if (supportsAdvancedCursorStyles()) {
+          const horizontalMin =
+            (cursorFlags & CURSOR_FLAG_HORIZONTAL_MIN) !== 0;
+          const horizontalMax =
+            (cursorFlags & CURSOR_FLAG_HORIZONTAL_MAX) !== 0;
+          const verticalMin = (cursorFlags & CURSOR_FLAG_VERTICAL_MIN) !== 0;
+          const verticalMax = (cursorFlags & CURSOR_FLAG_VERTICAL_MAX) !== 0;
+
+          if (horizontalMin) {
+            if (verticalMin) {
+              return "se-resize";
+            } else if (verticalMax) {
+              return "ne-resize";
+            } else {
+              return "e-resize";
+            }
+          } else if (horizontalMax) {
+            if (verticalMin) {
+              return "sw-resize";
+            } else if (verticalMax) {
+              return "nw-resize";
+            } else {
+              return "w-resize";
+            }
+          } else if (verticalMin) {
+            return "s-resize";
+          } else if (verticalMax) {
+            return "n-resize";
+          }
+        }
+      }
+      break;
+    }
+  }
+
+  if (supportsAdvancedCursorStyles()) {
+    if (horizontalCount > 0 && verticalCount > 0) {
+      return "move";
+    } else if (horizontalCount > 0) {
+      return "ew-resize";
+    } else {
+      return "ns-resize";
+    }
+  } else {
+    if (horizontalCount > 0 && verticalCount > 0) {
+      return "grab";
+    } else if (horizontalCount > 0) {
+      return "col-resize";
+    } else {
+      return "row-resize";
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/cursor/supportsAdvancedCursorStyles.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/supportsAdvancedCursorStyles.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+let cached: boolean | undefined = undefined;
+
+export function overrideSupportsAdvancedCursorStylesForTesting(
+  override: boolean
+) {
+  cached = override;
+}
+
+/**
+ * Caches and returns if advanced cursor CSS styles are supported.
+ */
+export function supportsAdvancedCursorStyles(): boolean {
+  if (cached === undefined) {
+    cached = false;
+
+    if (typeof window !== "undefined") {
+      if (
+        window.navigator.userAgent.includes("Chrome") ||
+        window.navigator.userAgent.includes("Firefox")
+      ) {
+        cached = true;
+      }
+    }
+  }
+
+  return cached;
+}

--- a/frontend/packages/react-resizable-panels/global/cursor/supportsAdvancedCursorStyles.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/supportsAdvancedCursorStyles.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 let cached: boolean | undefined = undefined;
 
 export function overrideSupportsAdvancedCursorStylesForTesting(

--- a/frontend/packages/react-resizable-panels/global/cursor/updateCursorStyle.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/updateCursorStyle.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getInteractionState } from "../mutable-state/interactions";
 import { getCursorStyle } from "./getCursorStyle";
 

--- a/frontend/packages/react-resizable-panels/global/cursor/updateCursorStyle.ts
+++ b/frontend/packages/react-resizable-panels/global/cursor/updateCursorStyle.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+import { getInteractionState } from "../mutable-state/interactions";
+import { getCursorStyle } from "./getCursorStyle";
+
+const documentToStyleMap = new WeakMap<
+  Document,
+  {
+    prevStyle: string | undefined;
+    styleSheet: CSSStyleSheet;
+  }
+>();
+
+export function updateCursorStyle(ownerDocument: Document) {
+  // NOTE undefined is not technically a valid value but it has been reported that it is present in some environments (Vite HMR?)
+  // See github.com/bvaughn/react-resizable-panels/issues/559
+  if (
+    ownerDocument.defaultView === null ||
+    ownerDocument.defaultView === undefined
+  ) {
+    return;
+  }
+
+  let { prevStyle, styleSheet } = documentToStyleMap.get(ownerDocument) ?? {};
+
+  if (styleSheet === undefined) {
+    styleSheet = new ownerDocument.defaultView.CSSStyleSheet();
+
+    // adoptedStyleSheets is undefined in jsdom
+    if (ownerDocument.adoptedStyleSheets) {
+      ownerDocument.adoptedStyleSheets.push(styleSheet);
+    }
+  }
+
+  const interactionState = getInteractionState();
+
+  switch (interactionState.state) {
+    case "active":
+    case "hover": {
+      const cursorStyle = getCursorStyle({
+        cursorFlags: interactionState.cursorFlags,
+        groups: interactionState.hitRegions.map((current) => current.group),
+        state: interactionState.state
+      });
+
+      const nextStyle = `*, *:hover {cursor: ${cursorStyle} !important; }`;
+      if (prevStyle === nextStyle) {
+        return;
+      }
+
+      prevStyle = nextStyle;
+
+      if (cursorStyle) {
+        if (styleSheet.cssRules.length === 0) {
+          styleSheet.insertRule(nextStyle);
+        } else {
+          styleSheet.replaceSync(nextStyle);
+        }
+      } else if (styleSheet.cssRules.length === 1) {
+        styleSheet.deleteRule(0);
+      }
+      break;
+    }
+    case "inactive": {
+      prevStyle = undefined;
+
+      if (styleSheet.cssRules.length === 1) {
+        styleSheet.deleteRule(0);
+      }
+      break;
+    }
+  }
+
+  documentToStyleMap.set(ownerDocument, {
+    prevStyle,
+    styleSheet
+  });
+}

--- a/frontend/packages/react-resizable-panels/global/dom/calculateAvailableGroupSize.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculateAvailableGroupSize.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import type { RegisteredGroup } from "../../components/group/types";
+
+export function calculateAvailableGroupSize({
+  group
+}: {
+  group: RegisteredGroup;
+}) {
+  const { orientation, panels } = group;
+
+  return panels.reduce((totalSize, panel) => {
+    totalSize +=
+      orientation === "horizontal"
+        ? panel.element.offsetWidth
+        : panel.element.offsetHeight;
+    return totalSize;
+  }, 0);
+}

--- a/frontend/packages/react-resizable-panels/global/dom/calculateAvailableGroupSize.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculateAvailableGroupSize.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { RegisteredGroup } from "../../components/group/types";
 
 export function calculateAvailableGroupSize({

--- a/frontend/packages/react-resizable-panels/global/dom/calculateHitRegions.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculateHitRegions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { sortByElementOffset } from "../../components/group/sortByElementOffset";
 import type { RegisteredGroup } from "../../components/group/types";
 import type { RegisteredPanel } from "../../components/panel/types";

--- a/frontend/packages/react-resizable-panels/global/dom/calculateHitRegions.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculateHitRegions.ts
@@ -1,0 +1,236 @@
+// @ts-nocheck
+import { sortByElementOffset } from "../../components/group/sortByElementOffset";
+import type { RegisteredGroup } from "../../components/group/types";
+import type { RegisteredPanel } from "../../components/panel/types";
+import type { RegisteredSeparator } from "../../components/separator/types";
+import { isHTMLElement } from "../../utils/isHTMLElement";
+import { findClosestRect } from "../utils/findClosestRect";
+import { isCoarsePointer } from "../utils/isCoarsePointer";
+import { calculateAvailableGroupSize } from "./calculateAvailableGroupSize";
+
+type PanelsTuple = [panel: RegisteredPanel, panel: RegisteredPanel];
+
+export type HitRegion = {
+  group: RegisteredGroup;
+  groupSize: number;
+  panels: PanelsTuple;
+  rect: DOMRect;
+  separator?: RegisteredSeparator | undefined;
+};
+
+/**
+ * Determines hit regions for a Group; a hit region is either:
+ * - 1: An explicit Separator element
+ * - 2: The edge of a Panel element that has another Panel beside it
+ *
+ * This method determines bounding rects of all regions for the particular group.
+ */
+export function calculateHitRegions(group: RegisteredGroup) {
+  const { element: groupElement, orientation, panels, separators } = group;
+
+  // Sort elements by offset before traversing
+  const sortedChildElements: HTMLElement[] = sortByElementOffset(
+    orientation,
+    Array.from(groupElement.children)
+      .filter(isHTMLElement)
+      .map((element) => ({ element: element as HTMLElement }))
+  ).map(({ element }) => element);
+
+  const hitRegions: HitRegion[] = [];
+
+  let disabledSeparator = false;
+  let hasInterleavedStaticContent = false;
+  let firstEnabledPanelIndex = -1;
+  let lastEnabledPanelIndex = -1;
+  let numEnabledPanels = 0;
+  let prevPanel: RegisteredPanel | undefined = undefined;
+  let pendingSeparators: RegisteredSeparator[] = [];
+
+  {
+    let currentPanelIndex = -1;
+
+    for (const childElement of sortedChildElements) {
+      if (childElement.hasAttribute("data-panel")) {
+        currentPanelIndex++;
+
+        if (!childElement.hasAttribute("data-disabled")) {
+          numEnabledPanels++;
+
+          if (firstEnabledPanelIndex === -1) {
+            firstEnabledPanelIndex = currentPanelIndex;
+          }
+
+          lastEnabledPanelIndex = currentPanelIndex;
+        }
+      }
+    }
+  }
+
+  // If all (or all but one) of the Panels are disabled, there can be no resize interactions.
+  if (numEnabledPanels > 1) {
+    let currentPanelIndex = -1;
+
+    for (const childElement of sortedChildElements) {
+      if (childElement.hasAttribute("data-panel")) {
+        currentPanelIndex++;
+
+        const panelData = panels.find(
+          (current) => current.element === childElement
+        );
+        if (panelData) {
+          if (prevPanel) {
+            const prevRect = prevPanel.element.getBoundingClientRect();
+            const rect = childElement.getBoundingClientRect();
+
+            let pendingRectsOrSeparators: (DOMRect | RegisteredSeparator)[];
+
+            // If an explicit Separator has been rendered, always watch it
+            // Otherwise watch the entire space between the panels
+            // The one caveat is when there are non-interactive element(s) between panels,
+            // in which case we may need to watch individual panel edges
+            if (hasInterleavedStaticContent) {
+              const firstPanelEdgeRect =
+                orientation === "horizontal"
+                  ? new DOMRect(
+                      prevRect.right,
+                      prevRect.top,
+                      0,
+                      prevRect.height
+                    )
+                  : new DOMRect(
+                      prevRect.left,
+                      prevRect.bottom,
+                      prevRect.width,
+                      0
+                    );
+              const secondPanelEdgeRect =
+                orientation === "horizontal"
+                  ? new DOMRect(rect.left, rect.top, 0, rect.height)
+                  : new DOMRect(rect.left, rect.top, rect.width, 0);
+
+              switch (pendingSeparators.length) {
+                case 0: {
+                  pendingRectsOrSeparators = [
+                    firstPanelEdgeRect,
+                    secondPanelEdgeRect
+                  ];
+                  break;
+                }
+                case 1: {
+                  const separator = pendingSeparators[0];
+                  const closestRect = findClosestRect({
+                    orientation,
+                    rects: [prevRect, rect],
+                    targetRect: separator.element.getBoundingClientRect()
+                  });
+
+                  pendingRectsOrSeparators = [
+                    separator,
+                    closestRect === prevRect
+                      ? secondPanelEdgeRect
+                      : firstPanelEdgeRect
+                  ];
+                  break;
+                }
+                default: {
+                  pendingRectsOrSeparators = pendingSeparators;
+                  break;
+                }
+              }
+            } else {
+              if (pendingSeparators.length) {
+                pendingRectsOrSeparators = pendingSeparators;
+              } else {
+                pendingRectsOrSeparators = [
+                  orientation === "horizontal"
+                    ? new DOMRect(
+                        prevRect.right,
+                        rect.top,
+                        rect.left - prevRect.right,
+                        rect.height
+                      )
+                    : new DOMRect(
+                        rect.left,
+                        prevRect.bottom,
+                        rect.width,
+                        rect.top - prevRect.bottom
+                      )
+                ];
+              }
+            }
+
+            for (const rectOrSeparator of pendingRectsOrSeparators) {
+              let rect =
+                "width" in rectOrSeparator
+                  ? rectOrSeparator
+                  : rectOrSeparator.element.getBoundingClientRect();
+
+              const minHitTargetSize = isCoarsePointer()
+                ? group.resizeTargetMinimumSize.coarse
+                : group.resizeTargetMinimumSize.fine;
+              if (rect.width < minHitTargetSize) {
+                const delta = minHitTargetSize - rect.width;
+                rect = new DOMRect(
+                  rect.x - delta / 2,
+                  rect.y,
+                  rect.width + delta,
+                  rect.height
+                );
+              }
+              if (rect.height < minHitTargetSize) {
+                const delta = minHitTargetSize - rect.height;
+                rect = new DOMRect(
+                  rect.x,
+                  rect.y - delta / 2,
+                  rect.width,
+                  rect.height + delta
+                );
+              }
+
+              const skip =
+                currentPanelIndex <= firstEnabledPanelIndex ||
+                currentPanelIndex > lastEnabledPanelIndex;
+
+              if (!disabledSeparator && !skip) {
+                hitRegions.push({
+                  group,
+                  groupSize: calculateAvailableGroupSize({ group }),
+                  panels: [prevPanel, panelData],
+                  separator:
+                    "width" in rectOrSeparator ? undefined : rectOrSeparator,
+                  rect
+                });
+              }
+
+              disabledSeparator = false;
+            }
+          }
+
+          hasInterleavedStaticContent = false;
+          prevPanel = panelData;
+          pendingSeparators = [];
+        }
+      } else if (childElement.hasAttribute("data-separator")) {
+        if (childElement.ariaDisabled !== null) {
+          disabledSeparator = true;
+        }
+
+        const separatorData = separators.find(
+          (current) => current.element === childElement
+        );
+        if (separatorData) {
+          // Separators will be included implicitly in the area between the previous and next panel
+          // It's important to track them though, to handle the scenario of non-interactive group content
+          pendingSeparators.push(separatorData);
+        } else {
+          prevPanel = undefined;
+          pendingSeparators = [];
+        }
+      } else {
+        hasInterleavedStaticContent = true;
+      }
+    }
+  }
+
+  return hitRegions;
+}

--- a/frontend/packages/react-resizable-panels/global/dom/calculatePanelConstraints.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculatePanelConstraints.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { RegisteredGroup } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { sizeStyleToPixels } from "../styles/sizeStyleToPixels";

--- a/frontend/packages/react-resizable-panels/global/dom/calculatePanelConstraints.ts
+++ b/frontend/packages/react-resizable-panels/global/dom/calculatePanelConstraints.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+import type { RegisteredGroup } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { sizeStyleToPixels } from "../styles/sizeStyleToPixels";
+import { formatLayoutNumber } from "../utils/formatLayoutNumber";
+import { calculateAvailableGroupSize } from "./calculateAvailableGroupSize";
+
+export function calculatePanelConstraints(group: RegisteredGroup) {
+  const { panels } = group;
+
+  const groupSize = calculateAvailableGroupSize({ group });
+  if (groupSize === 0) {
+    // Can't calculate anything meaningful if the group has a width/height of 0
+    // (This could indicate that it's within a hidden subtree)
+    return panels.map<PanelConstraints>((current) => ({
+      groupResizeBehavior: current.panelConstraints.groupResizeBehavior,
+      collapsedSize: 0,
+      collapsible: current.panelConstraints.collapsible === true,
+      defaultSize: undefined,
+      disabled: current.panelConstraints.disabled,
+      minSize: 0,
+      maxSize: 100,
+      panelId: current.id
+    }));
+  }
+
+  return panels.map<PanelConstraints>((panel) => {
+    const { element, panelConstraints } = panel;
+
+    let collapsedSize = 0;
+    if (panelConstraints.collapsedSize !== undefined) {
+      const pixels = sizeStyleToPixels({
+        groupSize,
+        panelElement: element,
+        styleProp: panelConstraints.collapsedSize
+      });
+
+      collapsedSize = formatLayoutNumber((pixels / groupSize) * 100);
+    }
+
+    let defaultSize: number | undefined = undefined;
+    if (panelConstraints.defaultSize !== undefined) {
+      const pixels = sizeStyleToPixels({
+        groupSize,
+        panelElement: element,
+        styleProp: panelConstraints.defaultSize
+      });
+
+      defaultSize = formatLayoutNumber((pixels / groupSize) * 100);
+    }
+
+    let minSize = 0;
+    if (panelConstraints.minSize !== undefined) {
+      const pixels = sizeStyleToPixels({
+        groupSize,
+        panelElement: element,
+        styleProp: panelConstraints.minSize
+      });
+
+      minSize = formatLayoutNumber((pixels / groupSize) * 100);
+    }
+
+    let maxSize = 100;
+    if (panelConstraints.maxSize !== undefined) {
+      const pixels = sizeStyleToPixels({
+        groupSize,
+        panelElement: element,
+        styleProp: panelConstraints.maxSize
+      });
+
+      maxSize = formatLayoutNumber((pixels / groupSize) * 100);
+    }
+
+    return {
+      groupResizeBehavior: panelConstraints.groupResizeBehavior,
+      collapsedSize,
+      collapsible: panelConstraints.collapsible === true,
+      defaultSize,
+      disabled: panelConstraints.disabled,
+      minSize,
+      maxSize,
+      panelId: panel.id
+    };
+  });
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentDoubleClick.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentDoubleClick.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import { getMountedGroups } from "../mutable-state/groups";
+import { findMatchingHitRegions } from "../utils/findMatchingHitRegions";
+import { getImperativePanelMethods } from "../utils/getImperativePanelMethods";
+
+export function onDocumentDoubleClick(event: MouseEvent) {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  const mountedGroups = getMountedGroups();
+  const hitRegions = findMatchingHitRegions(event, mountedGroups);
+  hitRegions.forEach((current) => {
+    if (current.separator) {
+      const panelWithDefaultSize = current.panels.find(
+        (panel) => panel.panelConstraints.defaultSize !== undefined
+      );
+      if (panelWithDefaultSize) {
+        const defaultSize = panelWithDefaultSize.panelConstraints.defaultSize;
+        const api = getImperativePanelMethods({
+          groupId: current.group.id,
+          panelId: panelWithDefaultSize.id
+        });
+        if (api && defaultSize !== undefined) {
+          api.resize(defaultSize);
+
+          event.preventDefault();
+        }
+      }
+    }
+  });
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentDoubleClick.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentDoubleClick.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getMountedGroups } from "../mutable-state/groups";
 import { findMatchingHitRegions } from "../utils/findMatchingHitRegions";
 import { getImperativePanelMethods } from "../utils/getImperativePanelMethods";

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentKeyDown.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentKeyDown.ts
@@ -1,0 +1,139 @@
+// @ts-nocheck
+import { assert } from "../../utils/assert";
+import { getMountedGroupState } from "../mutable-state/groups";
+import { adjustLayoutForSeparator } from "../utils/adjustLayoutForSeparator";
+import { findSeparatorGroup } from "../utils/findSeparatorGroup";
+
+export function onDocumentKeyDown(event: KeyboardEvent) {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  const separatorElement = event.currentTarget as HTMLElement;
+
+  const group = findSeparatorGroup(separatorElement);
+  if (group.disabled) {
+    return;
+  }
+
+  switch (event.key) {
+    case "ArrowDown": {
+      event.preventDefault();
+
+      if (group.orientation === "vertical") {
+        adjustLayoutForSeparator(separatorElement, 5);
+      }
+      break;
+    }
+    case "ArrowLeft": {
+      event.preventDefault();
+
+      if (group.orientation === "horizontal") {
+        adjustLayoutForSeparator(separatorElement, -5);
+      }
+      break;
+    }
+    case "ArrowRight": {
+      event.preventDefault();
+
+      if (group.orientation === "horizontal") {
+        adjustLayoutForSeparator(separatorElement, 5);
+      }
+      break;
+    }
+    case "ArrowUp": {
+      event.preventDefault();
+
+      if (group.orientation === "vertical") {
+        adjustLayoutForSeparator(separatorElement, -5);
+      }
+      break;
+    }
+    case "End": {
+      event.preventDefault();
+
+      // Moves splitter to the position that gives the primary pane its largest allowed size.
+      // This may completely collapse the secondary pane.
+
+      adjustLayoutForSeparator(separatorElement, 100);
+      break;
+    }
+    case "Enter": {
+      event.preventDefault();
+
+      // If the primary pane is not collapsed, collapses the pane.
+      // If the pane is collapsed, restores the splitter to its previous position.
+
+      const group = findSeparatorGroup(separatorElement);
+
+      const groupState = getMountedGroupState(group.id, true);
+      const { derivedPanelConstraints, layout, separatorToPanels } = groupState;
+
+      const separator = group.separators.find(
+        (current) => current.element === separatorElement
+      );
+      assert(separator, "Matching separator not found");
+
+      const panels = separatorToPanels.get(separator);
+      assert(panels, "Matching panels not found");
+
+      const primaryPanel = panels[0];
+      const constraints = derivedPanelConstraints.find(
+        (current) => current.panelId === primaryPanel.id
+      );
+      assert(constraints, "Panel metadata not found");
+
+      if (constraints.collapsible) {
+        const prevSize = layout[primaryPanel.id];
+
+        const nextSize =
+          constraints.collapsedSize === prevSize
+            ? (group.mutableState.expandedPanelSizes[primaryPanel.id] ??
+              constraints.minSize)
+            : constraints.collapsedSize;
+
+        adjustLayoutForSeparator(separatorElement, nextSize - prevSize);
+      }
+      break;
+    }
+    case "F6": {
+      event.preventDefault();
+
+      // Cycle through window panes.
+
+      const group = findSeparatorGroup(separatorElement);
+
+      const separatorElements = group.separators.map(
+        (separator) => separator.element
+      );
+
+      const index = Array.from(separatorElements).findIndex(
+        (current) => current === event.currentTarget
+      );
+      assert(index !== null, "Index not found");
+
+      const nextIndex = event.shiftKey
+        ? index > 0
+          ? index - 1
+          : separatorElements.length - 1
+        : index + 1 < separatorElements.length
+          ? index + 1
+          : 0;
+
+      const nextSeparatorElement = separatorElements[nextIndex] as HTMLElement;
+      nextSeparatorElement.focus({
+        preventScroll: true
+      });
+      break;
+    }
+    case "Home": {
+      event.preventDefault();
+
+      // Moves splitter to the position that gives the primary pane its smallest allowed size.
+      // This may completely collapse the primary pane.
+
+      adjustLayoutForSeparator(separatorElement, -100);
+      break;
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentKeyDown.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentKeyDown.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { assert } from "../../utils/assert";
 import { getMountedGroupState } from "../mutable-state/groups";
 import { adjustLayoutForSeparator } from "../utils/adjustLayoutForSeparator";

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerDown.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerDown.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../../components/group/types";
 import { getMountedGroups } from "../mutable-state/groups";
 import { updateInteractionState } from "../mutable-state/interactions";

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerDown.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerDown.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../../components/group/types";
+import { getMountedGroups } from "../mutable-state/groups";
+import { updateInteractionState } from "../mutable-state/interactions";
+import { findMatchingHitRegions } from "../utils/findMatchingHitRegions";
+
+export function onDocumentPointerDown(event: PointerEvent) {
+  if (event.defaultPrevented) {
+    return;
+  } else if (event.pointerType === "mouse" && event.button > 0) {
+    return;
+  }
+
+  const mountedGroups = getMountedGroups();
+
+  const hitRegions = findMatchingHitRegions(event, mountedGroups);
+
+  const initialLayoutMap = new Map<RegisteredGroup, Layout>();
+
+  let didChangeFocus = false;
+
+  hitRegions.forEach((current) => {
+    if (current.separator) {
+      if (!didChangeFocus) {
+        didChangeFocus = true;
+
+        current.separator.element.focus({
+          preventScroll: true
+        });
+
+        // TRICKY
+        // Calling setPointerCapture() here would help with detecting pointer "pointermove"/"pointerup" events that happen over iframes
+        // but it would also prevent "click" events from firing if the use releases without actually dragging
+        // Because of this, it's safer to wait until the first "pointermove" event to set capture
+      }
+    }
+
+    const match = mountedGroups.get(current.group);
+    if (match) {
+      initialLayoutMap.set(current.group, match.layout);
+    }
+  });
+
+  updateInteractionState({
+    cursorFlags: 0,
+    hitRegions,
+    initialLayoutMap,
+    pointerDownAtPoint: { x: event.clientX, y: event.clientY },
+    state: "active"
+  });
+
+  if (hitRegions.length) {
+    event.preventDefault();
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerLeave.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerLeave.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+import { getMountedGroups } from "../mutable-state/groups";
+import { getInteractionState } from "../mutable-state/interactions";
+import { updateActiveHitRegions } from "../utils/updateActiveHitRegion";
+
+export function onDocumentPointerLeave(event: PointerEvent) {
+  const mountedGroups = getMountedGroups();
+  const interactionState = getInteractionState();
+
+  switch (interactionState.state) {
+    case "active": {
+      updateActiveHitRegions({
+        document: event.currentTarget as Document,
+        event,
+        hitRegions: interactionState.hitRegions,
+        initialLayoutMap: interactionState.initialLayoutMap,
+        mountedGroups,
+        prevCursorFlags: interactionState.cursorFlags
+      });
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerLeave.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerLeave.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getMountedGroups } from "../mutable-state/groups";
 import { getInteractionState } from "../mutable-state/interactions";
 import { updateActiveHitRegions } from "../utils/updateActiveHitRegion";

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerMove.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerMove.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { updateCursorStyle } from "../cursor/updateCursorStyle";
 import {
   getMountedGroups,

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerMove.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerMove.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import { updateCursorStyle } from "../cursor/updateCursorStyle";
+import {
+  getMountedGroups,
+  getMountedGroupState,
+  updateMountedGroup
+} from "../mutable-state/groups";
+import {
+  getInteractionState,
+  updateInteractionState
+} from "../mutable-state/interactions";
+import { findMatchingHitRegions } from "../utils/findMatchingHitRegions";
+import { updateActiveHitRegions } from "../utils/updateActiveHitRegion";
+
+export function onDocumentPointerMove(event: PointerEvent) {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  const interactionState = getInteractionState();
+  const mountedGroups = getMountedGroups();
+
+  switch (interactionState.state) {
+    case "active": {
+      // Edge case (see #340)
+      // Detect when the pointer has been released outside an iframe on a different domain
+      if (
+        // Skip this check for "pointerleave" events, else Firefox triggers a false positive (see #514)
+        event.buttons === 0
+      ) {
+        updateInteractionState({
+          cursorFlags: 0,
+          state: "inactive"
+        });
+
+        // Dispatch one more "change" event after the interaction state has been reset
+        // Groups use this as a signal to call onLayoutChanged
+        interactionState.hitRegions.forEach((hitRegion) => {
+          const groupState = getMountedGroupState(hitRegion.group.id, true);
+          updateMountedGroup(hitRegion.group, groupState);
+        });
+
+        return;
+      }
+
+      for (const hitRegion of interactionState.hitRegions) {
+        if (hitRegion.separator) {
+          const { element } = hitRegion.separator;
+          if (!element.hasPointerCapture?.(event.pointerId)) {
+            element.setPointerCapture?.(event.pointerId);
+          }
+        }
+      }
+
+      updateActiveHitRegions({
+        document: event.currentTarget as Document,
+        event,
+        hitRegions: interactionState.hitRegions,
+        initialLayoutMap: interactionState.initialLayoutMap,
+        mountedGroups,
+        pointerDownAtPoint: interactionState.pointerDownAtPoint,
+        prevCursorFlags: interactionState.cursorFlags
+      });
+      break;
+    }
+    default: {
+      // Update HitRegions if a drag has not been started
+      const hitRegions = findMatchingHitRegions(event, mountedGroups);
+
+      if (hitRegions.length === 0) {
+        if (interactionState.state !== "inactive") {
+          updateInteractionState({
+            cursorFlags: 0,
+            state: "inactive"
+          });
+        }
+      } else {
+        updateInteractionState({
+          cursorFlags: 0,
+          hitRegions,
+          state: "hover"
+        });
+      }
+
+      updateCursorStyle(event.currentTarget as Document);
+      break;
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerOut.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerOut.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import {
+  getInteractionState,
+  updateInteractionState
+} from "../mutable-state/interactions";
+
+export function onDocumentPointerOut(event: PointerEvent) {
+  // For some reason, "pointerout" events don't fire if the `relatedTarget` is an iframe
+  // This can leave the `data-separator` attribute in an invalid state ("hover") which in turn might break styles
+  // The easiest fix for this case is to reset the interaction state in this specific circumstance
+  // See issues/645
+  if (event.relatedTarget instanceof HTMLIFrameElement) {
+    const interactionState = getInteractionState();
+    switch (interactionState.state) {
+      case "hover": {
+        updateInteractionState({
+          cursorFlags: 0,
+          state: "inactive"
+        });
+      }
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerOut.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerOut.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   getInteractionState,
   updateInteractionState

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerUp.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerUp.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { updateCursorStyle } from "../cursor/updateCursorStyle";
 import {
   getMountedGroupState,

--- a/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerUp.ts
+++ b/frontend/packages/react-resizable-panels/global/event-handlers/onDocumentPointerUp.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import { updateCursorStyle } from "../cursor/updateCursorStyle";
+import {
+  getMountedGroupState,
+  updateMountedGroup
+} from "../mutable-state/groups";
+import {
+  getInteractionState,
+  updateInteractionState
+} from "../mutable-state/interactions";
+
+export function onDocumentPointerUp(event: PointerEvent) {
+  if (event.defaultPrevented) {
+    return;
+  } else if (event.pointerType === "mouse" && event.button > 0) {
+    return;
+  }
+
+  const interactionState = getInteractionState();
+
+  switch (interactionState.state) {
+    case "active": {
+      updateInteractionState({
+        cursorFlags: 0,
+        state: "inactive"
+      });
+
+      if (interactionState.hitRegions.length > 0) {
+        updateCursorStyle(event.currentTarget as Document);
+
+        // Dispatch one more "change" event after the interaction state has been reset
+        // Groups use this as a signal to call onLayoutChanged
+        interactionState.hitRegions.forEach((hitRegion) => {
+          const groupState = getMountedGroupState(hitRegion.group.id, true);
+          updateMountedGroup(hitRegion.group, groupState);
+        });
+
+        event.preventDefault();
+      }
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/mountGroup.ts
+++ b/frontend/packages/react-resizable-panels/global/mountGroup.ts
@@ -1,0 +1,225 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../components/group/types";
+import { assert } from "../utils/assert";
+import { calculateAvailableGroupSize } from "./dom/calculateAvailableGroupSize";
+import { calculateHitRegions } from "./dom/calculateHitRegions";
+import { calculatePanelConstraints } from "./dom/calculatePanelConstraints";
+import { onDocumentDoubleClick } from "./event-handlers/onDocumentDoubleClick";
+import { onDocumentKeyDown } from "./event-handlers/onDocumentKeyDown";
+import { onDocumentPointerDown } from "./event-handlers/onDocumentPointerDown";
+import { onDocumentPointerLeave } from "./event-handlers/onDocumentPointerLeave";
+import { onDocumentPointerMove } from "./event-handlers/onDocumentPointerMove";
+import { onDocumentPointerOut } from "./event-handlers/onDocumentPointerOut";
+import { onDocumentPointerUp } from "./event-handlers/onDocumentPointerUp";
+import {
+  deleteMutableGroup,
+  getMountedGroupState,
+  updateMountedGroup
+} from "./mutable-state/groups";
+import type { SeparatorToPanelsMap } from "./mutable-state/types";
+import { calculateDefaultLayout } from "./utils/calculateDefaultLayout";
+import { layoutsEqual } from "./utils/layoutsEqual";
+import { notifyPanelOnResize } from "./utils/notifyPanelOnResize";
+import { objectsEqual } from "./utils/objectsEqual";
+import { preserveFixedPanelSizes } from "./utils/preserveFixedPanelSizes";
+import { validateLayoutKeys } from "./utils/validateLayoutKeys";
+import { validatePanelGroupLayout } from "./utils/validatePanelGroupLayout";
+
+const ownerDocumentReferenceCounts = new Map<Document, number>();
+
+export function mountGroup(group: RegisteredGroup) {
+  let isMounted = true;
+
+  assert(
+    group.element.ownerDocument.defaultView,
+    "Cannot register an unmounted Group"
+  );
+
+  const ResizeObserver = group.element.ownerDocument.defaultView.ResizeObserver;
+
+  const panelIds = new Set<string>();
+  const separatorIds = new Set<string>();
+
+  // Add Panels with onResize callbacks to ResizeObserver
+  // Add Group to ResizeObserver also in order to sync % based constraints
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { borderBoxSize, target } = entry;
+      if (target === group.element) {
+        if (isMounted) {
+          const groupSize = calculateAvailableGroupSize({ group });
+          if (groupSize === 0) {
+            // Can't calculate anything meaningful if the group has a width/height of 0
+            // (This could indicate that it's within a hidden subtree)
+            return;
+          }
+
+          const groupState = getMountedGroupState(group.id);
+          if (!groupState) {
+            // Not mounted yet
+            return;
+          }
+
+          // Update non-percentage based constraints
+          const nextDerivedPanelConstraints = calculatePanelConstraints(group);
+
+          // Revalidate layout in case constraints have changed or group size changed
+          const prevLayout = groupState.defaultLayoutDeferred
+            ? calculateDefaultLayout(nextDerivedPanelConstraints)
+            : groupState.layout;
+          const unsafeLayout = preserveFixedPanelSizes({
+            group,
+            nextGroupSize: groupSize,
+            prevGroupSize: groupState.groupSize,
+            prevLayout
+          });
+          const nextLayout = validatePanelGroupLayout({
+            layout: unsafeLayout,
+            panelConstraints: nextDerivedPanelConstraints
+          });
+
+          if (
+            !groupState.defaultLayoutDeferred &&
+            layoutsEqual(groupState.layout, nextLayout) &&
+            objectsEqual(
+              groupState.derivedPanelConstraints,
+              nextDerivedPanelConstraints
+            ) &&
+            groupState.groupSize === groupSize
+          ) {
+            return;
+          }
+
+          updateMountedGroup(group, {
+            defaultLayoutDeferred: false,
+            derivedPanelConstraints: nextDerivedPanelConstraints,
+            groupSize,
+            layout: nextLayout,
+            separatorToPanels: groupState.separatorToPanels
+          });
+        }
+      } else {
+        notifyPanelOnResize(group, target as HTMLElement, borderBoxSize);
+      }
+    }
+  });
+
+  resizeObserver.observe(group.element);
+
+  group.panels.forEach((panel) => {
+    assert(
+      !panelIds.has(panel.id),
+      `Panel ids must be unique; id "${panel.id}" was used more than once`
+    );
+
+    panelIds.add(panel.id);
+
+    if (panel.onResize) {
+      resizeObserver.observe(panel.element);
+    }
+  });
+
+  const groupSize = calculateAvailableGroupSize({ group });
+
+  // Calculate initial layout for the new Panel configuration
+  const derivedPanelConstraints = calculatePanelConstraints(group);
+  const panelIdsKey = group.panels.map(({ id }) => id).join(",");
+
+  // Gracefully handle an invalid default layout
+  // This could happen when e.g. useDefaultLayout is combined with dynamic Panels
+  // In this case the best we can do is ignore the incoming layout
+  let defaultLayout: Layout | undefined = group.mutableState.defaultLayout;
+  if (defaultLayout) {
+    if (!validateLayoutKeys(group.panels, defaultLayout)) {
+      defaultLayout = undefined;
+    }
+  }
+
+  const defaultLayoutUnsafe: Layout =
+    group.mutableState.layouts[panelIdsKey] ??
+    defaultLayout ??
+    calculateDefaultLayout(derivedPanelConstraints);
+  const defaultLayoutSafe = validatePanelGroupLayout({
+    layout: defaultLayoutUnsafe,
+    panelConstraints: derivedPanelConstraints
+  });
+
+  const ownerDocument = group.element.ownerDocument;
+
+  ownerDocumentReferenceCounts.set(
+    ownerDocument,
+    (ownerDocumentReferenceCounts.get(ownerDocument) ?? 0) + 1
+  );
+
+  const separatorToPanels: SeparatorToPanelsMap = new Map();
+  const hitRegions = calculateHitRegions(group);
+  hitRegions.forEach((hitRegion) => {
+    if (hitRegion.separator) {
+      separatorToPanels.set(hitRegion.separator, hitRegion.panels);
+    }
+  });
+
+  updateMountedGroup(group, {
+    defaultLayoutDeferred: groupSize === 0,
+    derivedPanelConstraints,
+    groupSize,
+    layout: defaultLayoutSafe,
+    separatorToPanels
+  });
+
+  group.separators.forEach((separator) => {
+    assert(
+      !separatorIds.has(separator.id),
+      `Separator ids must be unique; id "${separator.id}" was used more than once`
+    );
+
+    separatorIds.add(separator.id);
+
+    separator.element.addEventListener("keydown", onDocumentKeyDown);
+  });
+
+  // If this is the first group to be mounted, initialize event handlers
+  if (ownerDocumentReferenceCounts.get(ownerDocument) === 1) {
+    ownerDocument.addEventListener("dblclick", onDocumentDoubleClick, true);
+    ownerDocument.addEventListener("pointerdown", onDocumentPointerDown, true);
+    ownerDocument.addEventListener("pointerleave", onDocumentPointerLeave);
+    ownerDocument.addEventListener("pointermove", onDocumentPointerMove);
+    ownerDocument.addEventListener("pointerout", onDocumentPointerOut);
+    ownerDocument.addEventListener("pointerup", onDocumentPointerUp, true);
+  }
+
+  return function unmountGroup() {
+    isMounted = false;
+
+    ownerDocumentReferenceCounts.set(
+      ownerDocument,
+      Math.max(0, (ownerDocumentReferenceCounts.get(ownerDocument) ?? 0) - 1)
+    );
+
+    deleteMutableGroup(group);
+
+    group.separators.forEach((separator) => {
+      separator.element.removeEventListener("keydown", onDocumentKeyDown);
+    });
+
+    // If this was the last group to be mounted, tear down event handlers
+    if (!ownerDocumentReferenceCounts.get(ownerDocument)) {
+      ownerDocument.removeEventListener(
+        "dblclick",
+        onDocumentDoubleClick,
+        true
+      );
+      ownerDocument.removeEventListener(
+        "pointerdown",
+        onDocumentPointerDown,
+        true
+      );
+      ownerDocument.removeEventListener("pointerleave", onDocumentPointerLeave);
+      ownerDocument.removeEventListener("pointermove", onDocumentPointerMove);
+      ownerDocument.removeEventListener("pointerout", onDocumentPointerOut);
+      ownerDocument.removeEventListener("pointerup", onDocumentPointerUp, true);
+    }
+
+    resizeObserver.disconnect();
+  };
+}

--- a/frontend/packages/react-resizable-panels/global/mountGroup.ts
+++ b/frontend/packages/react-resizable-panels/global/mountGroup.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../components/group/types";
 import { assert } from "../utils/assert";
 import { calculateAvailableGroupSize } from "./dom/calculateAvailableGroupSize";

--- a/frontend/packages/react-resizable-panels/global/mutable-state/groups.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/groups.ts
@@ -1,0 +1,102 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { EventEmitter } from "../../utils/EventEmitter";
+import type { SeparatorToPanelsMap } from "./types";
+
+type State = {
+  defaultLayoutDeferred: boolean;
+  derivedPanelConstraints: PanelConstraints[];
+  groupSize: number;
+  layout: Layout;
+  separatorToPanels: SeparatorToPanelsMap;
+};
+
+export type MountedGroups = Map<RegisteredGroup, State>;
+
+let map: MountedGroups = new Map();
+
+type GroupChangeEvent = {
+  group: RegisteredGroup;
+  next: State;
+  prev: State | undefined;
+};
+type GroupsChangeEvent = {
+  next: MountedGroups;
+  prev: MountedGroups;
+};
+
+const eventEmitter = new EventEmitter<{
+  groupChange: GroupChangeEvent;
+  groupsChange: GroupsChangeEvent;
+}>();
+
+export function deleteMutableGroup(group: RegisteredGroup) {
+  map = new Map(map);
+  map.delete(group);
+}
+
+export function getRegisteredGroup(
+  groupId: string
+): RegisteredGroup | undefined;
+export function getRegisteredGroup(
+  groupId: string,
+  assert: true
+): RegisteredGroup;
+export function getRegisteredGroup(groupId: string, assert?: boolean) {
+  for (const [group] of map) {
+    if (group.id === groupId) {
+      return group;
+    }
+  }
+
+  if (assert) {
+    throw Error(`Could not find data for Group with id ${groupId}`);
+  }
+
+  return undefined;
+}
+
+export function getMountedGroupState(groupId: string): State | undefined;
+export function getMountedGroupState(groupId: string, assert: true): State;
+export function getMountedGroupState(groupId: string, assert?: boolean) {
+  for (const [group, mountedGroup] of map) {
+    if (group.id === groupId) {
+      return mountedGroup;
+    }
+  }
+
+  if (assert) {
+    throw Error(`Could not find data for Group with id ${groupId}`);
+  }
+
+  return undefined;
+}
+
+export function getMountedGroups() {
+  return map;
+}
+
+export function subscribeToMountedGroup(
+  groupId: string,
+  callback: (event: GroupChangeEvent) => void
+) {
+  return eventEmitter.addListener("groupChange", (event) => {
+    if (event.group.id === groupId) {
+      callback(event);
+    }
+  });
+}
+
+export function updateMountedGroup(group: RegisteredGroup, next: State) {
+  const prev = map.get(group);
+
+  map = new Map(map);
+  map.set(group, next);
+
+  eventEmitter.emit("groupChange", {
+    group,
+    prev,
+    next
+  });
+}

--- a/frontend/packages/react-resizable-panels/global/mutable-state/groups.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/groups.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { EventEmitter } from "../../utils/EventEmitter";

--- a/frontend/packages/react-resizable-panels/global/mutable-state/interactions.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/interactions.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import { EventEmitter } from "../../utils/EventEmitter";
+import type { InteractionState } from "./types";
+
+let state: InteractionState = {
+  cursorFlags: 0,
+  state: "inactive"
+};
+
+type ChangeEvent = {
+  next: InteractionState;
+  prev: InteractionState;
+};
+
+const eventEmitter = new EventEmitter<{
+  change: ChangeEvent;
+}>();
+
+export function getInteractionState() {
+  return state;
+}
+
+export function subscribeToInteractionState(
+  callback: (event: ChangeEvent) => void
+) {
+  return eventEmitter.addListener("change", callback);
+}
+
+export function updateCursorFlags(cursorFlags: number) {
+  const prev = state;
+
+  const next = { ...state };
+  next.cursorFlags = cursorFlags;
+
+  state = next;
+
+  eventEmitter.emit("change", {
+    prev,
+    next
+  });
+}
+
+export function updateInteractionState(next: InteractionState) {
+  const prev = state;
+
+  state = next;
+
+  eventEmitter.emit("change", {
+    prev,
+    next
+  });
+}

--- a/frontend/packages/react-resizable-panels/global/mutable-state/interactions.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/interactions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { EventEmitter } from "../../utils/EventEmitter";
 import type { InteractionState } from "./types";
 

--- a/frontend/packages/react-resizable-panels/global/mutable-state/types.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../../components/group/types";
 import type { RegisteredPanel } from "../../components/panel/types";
 import type { RegisteredSeparator } from "../../components/separator/types";

--- a/frontend/packages/react-resizable-panels/global/mutable-state/types.ts
+++ b/frontend/packages/react-resizable-panels/global/mutable-state/types.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../../components/group/types";
+import type { RegisteredPanel } from "../../components/panel/types";
+import type { RegisteredSeparator } from "../../components/separator/types";
+import type { Point } from "../../types";
+import type { HitRegion } from "../dom/calculateHitRegions";
+
+export type InteractionInactive = {
+  cursorFlags: 0;
+  state: "inactive";
+};
+
+export type InteractionHover = {
+  cursorFlags: 0;
+  hitRegions: HitRegion[];
+  state: "hover";
+};
+
+export type InteractionActive = {
+  cursorFlags: number;
+  hitRegions: HitRegion[];
+  initialLayoutMap: Map<RegisteredGroup, Layout>;
+  pointerDownAtPoint: Point;
+  state: "active";
+};
+
+export type InteractionState =
+  | InteractionInactive
+  | InteractionHover
+  | InteractionActive;
+
+export type SeparatorToPanelsMap = Map<
+  RegisteredSeparator,
+  [primaryPanel: RegisteredPanel, secondaryPanel: RegisteredPanel]
+>;

--- a/frontend/packages/react-resizable-panels/global/styles/convertEmToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertEmToPixels.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function convertEmToPixels(element: Element, value: number) {
   const style = getComputedStyle(element);
   const fontSize = parseFloat(style.fontSize);

--- a/frontend/packages/react-resizable-panels/global/styles/convertEmToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertEmToPixels.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+export function convertEmToPixels(element: Element, value: number) {
+  const style = getComputedStyle(element);
+  const fontSize = parseFloat(style.fontSize);
+
+  return value * fontSize;
+}

--- a/frontend/packages/react-resizable-panels/global/styles/convertRemToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertRemToPixels.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+export function convertRemToPixels(element: Element, value: number) {
+  const style = getComputedStyle(element.ownerDocument.body);
+  const fontSize = parseFloat(style.fontSize);
+
+  return value * fontSize;
+}

--- a/frontend/packages/react-resizable-panels/global/styles/convertRemToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertRemToPixels.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function convertRemToPixels(element: Element, value: number) {
   const style = getComputedStyle(element.ownerDocument.body);
   const fontSize = parseFloat(style.fontSize);

--- a/frontend/packages/react-resizable-panels/global/styles/convertVhToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertVhToPixels.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function convertVhToPixels(value: number) {
   return (value / 100) * window.innerHeight;
 }

--- a/frontend/packages/react-resizable-panels/global/styles/convertVhToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertVhToPixels.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+export function convertVhToPixels(value: number) {
+  return (value / 100) * window.innerHeight;
+}

--- a/frontend/packages/react-resizable-panels/global/styles/convertVwToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertVwToPixels.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+export function convertVwToPixels(value: number) {
+  return (value / 100) * window.innerWidth;
+}

--- a/frontend/packages/react-resizable-panels/global/styles/convertVwToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/convertVwToPixels.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function convertVwToPixels(value: number) {
   return (value / 100) * window.innerWidth;
 }

--- a/frontend/packages/react-resizable-panels/global/styles/parseSizeAndUnit.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/parseSizeAndUnit.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { SizeUnit } from "../../components/panel/types";
 
 export function parseSizeAndUnit(

--- a/frontend/packages/react-resizable-panels/global/styles/parseSizeAndUnit.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/parseSizeAndUnit.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import type { SizeUnit } from "../../components/panel/types";
+
+export function parseSizeAndUnit(
+  size: number | string
+): [numeric: number, size: SizeUnit] {
+  switch (typeof size) {
+    case "number": {
+      return [size, "px"];
+    }
+    case "string": {
+      const numeric = parseFloat(size);
+
+      if (size.endsWith("%")) {
+        return [numeric, "%"];
+      } else if (size.endsWith("px")) {
+        return [numeric, "px"];
+      } else if (size.endsWith("rem")) {
+        return [numeric, "rem"];
+      } else if (size.endsWith("em")) {
+        return [numeric, "em"];
+      } else if (size.endsWith("vh")) {
+        return [numeric, "vh"];
+      } else if (size.endsWith("vw")) {
+        return [numeric, "vw"];
+      }
+
+      return [numeric, "%"];
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/styles/sizeStyleToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/sizeStyleToPixels.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { convertEmToPixels } from "./convertEmToPixels";
 import { convertRemToPixels } from "./convertRemToPixels";
 import { convertVhToPixels } from "./convertVhToPixels";

--- a/frontend/packages/react-resizable-panels/global/styles/sizeStyleToPixels.ts
+++ b/frontend/packages/react-resizable-panels/global/styles/sizeStyleToPixels.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { convertEmToPixels } from "./convertEmToPixels";
+import { convertRemToPixels } from "./convertRemToPixels";
+import { convertVhToPixels } from "./convertVhToPixels";
+import { convertVwToPixels } from "./convertVwToPixels";
+import { parseSizeAndUnit } from "./parseSizeAndUnit";
+
+export function sizeStyleToPixels({
+  groupSize,
+  panelElement,
+  styleProp
+}: {
+  groupSize: number;
+  panelElement: HTMLElement;
+  styleProp: number | string;
+}) {
+  let pixels: number | undefined = undefined;
+
+  const [size, unit] = parseSizeAndUnit(styleProp);
+
+  switch (unit) {
+    case "%": {
+      pixels = (size / 100) * groupSize;
+      break;
+    }
+    case "px": {
+      pixels = size;
+      break;
+    }
+    case "rem": {
+      pixels = convertRemToPixels(panelElement, size);
+      break;
+    }
+    case "em": {
+      pixels = convertEmToPixels(panelElement, size);
+      break;
+    }
+    case "vh": {
+      pixels = convertVhToPixels(size);
+      break;
+    }
+    case "vw": {
+      pixels = convertVwToPixels(size);
+      break;
+    }
+  }
+
+  return pixels;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/adjustLayoutByDelta.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/adjustLayoutByDelta.ts
@@ -1,0 +1,384 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { assert } from "../../utils/assert";
+import { isArrayEqual } from "../../utils/isArrayEqual";
+import { compareLayoutNumbers } from "../utils/compareLayoutNumbers";
+import { layoutNumbersEqual } from "../utils/layoutNumbersEqual";
+import { validatePanelSize } from "../utils/validatePanelSize";
+
+// All units must be in percentages; pixel values should be pre-converted
+export function adjustLayoutByDelta({
+  delta,
+  initialLayout: initialLayoutProp,
+  panelConstraints: panelConstraintsArray,
+  pivotIndices,
+  prevLayout: prevLayoutProp,
+  trigger
+}: {
+  delta: number;
+  initialLayout: Layout;
+  panelConstraints: PanelConstraints[];
+  pivotIndices: number[];
+  prevLayout: Layout;
+  trigger?: "imperative-api" | "keyboard" | "mouse-or-touch";
+}): Layout {
+  if (layoutNumbersEqual(delta, 0)) {
+    return initialLayoutProp;
+  }
+
+  const overrideDisabledPanels = trigger === "imperative-api";
+
+  const initialLayout = Object.values(initialLayoutProp);
+  const prevLayout = Object.values(prevLayoutProp);
+  const nextLayout = [...initialLayout];
+
+  const [firstPivotIndex, secondPivotIndex] = pivotIndices;
+  assert(firstPivotIndex != null, "Invalid first pivot index");
+  assert(secondPivotIndex != null, "Invalid second pivot index");
+
+  let deltaApplied = 0;
+
+  // const DEBUG = [];
+  // DEBUG.push(`adjustLayoutByDelta()`);
+  // DEBUG.push(`  initialLayout: ${initialLayout.join(", ")}`);
+  // DEBUG.push(`  prevLayout: ${prevLayout.join(", ")}`);
+  // DEBUG.push(`  delta: ${delta}`);
+  // DEBUG.push(`  pivotIndices: ${pivotIndices.join(", ")}`);
+  // DEBUG.push(`  trigger: ${trigger}`);
+  // DEBUG.push("");
+
+  // A resizing panel affects the panels before or after it.
+  //
+  // A negative delta means the panel(s) immediately after the separator should grow/expand by decreasing its offset.
+  // Other panels may also need to shrink/contract (and shift) to make room, depending on the min weights.
+  //
+  // A positive delta means the panel(s) immediately before the separator should "expand".
+  // This is accomplished by shrinking/contracting (and shifting) one or more of the panels after the separator.
+
+  {
+    switch (trigger) {
+      case "keyboard": {
+        // If this is a resize triggered by a keyboard event, our logic for expanding/collapsing is different.
+        // We no longer check the halfway threshold because this may prevent the panel from expanding at all.
+        {
+          // Check if we should expand a collapsed panel
+          const index = delta < 0 ? secondPivotIndex : firstPivotIndex;
+          const panelConstraints = panelConstraintsArray[index];
+          assert(
+            panelConstraints,
+            `Panel constraints not found for index ${index}`
+          );
+
+          const {
+            collapsedSize = 0,
+            collapsible,
+            minSize = 0
+          } = panelConstraints;
+
+          // DEBUG.push(`edge case check 1: ${index}`);
+          // DEBUG.push(`  -> collapsible? ${collapsible}`);
+          if (collapsible) {
+            const prevSize = initialLayout[index];
+            assert(
+              prevSize != null,
+              `Previous layout not found for panel index ${index}`
+            );
+
+            if (layoutNumbersEqual(prevSize, collapsedSize)) {
+              const localDelta = minSize - prevSize;
+              // DEBUG.push(`  -> expand delta: ${localDelta}`);
+
+              if (compareLayoutNumbers(localDelta, Math.abs(delta)) > 0) {
+                delta = delta < 0 ? 0 - localDelta : localDelta;
+                // DEBUG.push(`  -> delta: ${delta}`);
+              }
+            }
+          }
+        }
+
+        {
+          // Check if we should collapse a panel at its minimum size
+          const index = delta < 0 ? firstPivotIndex : secondPivotIndex;
+          const panelConstraints = panelConstraintsArray[index];
+          assert(
+            panelConstraints,
+            `No panel constraints found for index ${index}`
+          );
+
+          const {
+            collapsedSize = 0,
+            collapsible,
+            minSize = 0
+          } = panelConstraints;
+
+          // DEBUG.push(`edge case check 2: ${index}`);
+          // DEBUG.push(`  -> collapsible? ${collapsible}`);
+          if (collapsible) {
+            const prevSize = initialLayout[index];
+            assert(
+              prevSize != null,
+              `Previous layout not found for panel index ${index}`
+            );
+
+            if (layoutNumbersEqual(prevSize, minSize)) {
+              const localDelta = prevSize - collapsedSize;
+              // DEBUG.push(`  -> expand delta: ${localDelta}`);
+
+              if (compareLayoutNumbers(localDelta, Math.abs(delta)) > 0) {
+                delta = delta < 0 ? 0 - localDelta : localDelta;
+                // DEBUG.push(`  -> delta: ${delta}`);
+              }
+            }
+          }
+        }
+        break;
+      }
+      default: {
+        // If we're starting from a collapsed state, dragging past the halfway point should cause the panel to expand
+        // This can happen for positive or negative drags, and panels on either side of the separator can be collapsible
+        // The easiest way to support this is to detect this scenario and pre-adjust the delta before applying the rest of the layout algorithm
+        // DEBUG.push(`edge case check 3: collapsible panels`);
+
+        const index = delta < 0 ? secondPivotIndex : firstPivotIndex;
+        const panelConstraints = panelConstraintsArray[index];
+        assert(
+          panelConstraints,
+          `Panel constraints not found for index ${index}`
+        );
+
+        const prevSize = initialLayout[index];
+
+        const { collapsible, collapsedSize, minSize } = panelConstraints;
+        if (collapsible && compareLayoutNumbers(prevSize, minSize) < 0) {
+          // DEBUG.push(`  -> collapsible ${delta < 0 ? "2nd" : "1st"} panel`);
+          if (delta > 0) {
+            const gapSize = minSize - collapsedSize;
+            const halfwayDelta = gapSize / 2;
+            // DEBUG.push(`  -> halfway delta: ${halfwayDelta}`);
+            // DEBUG.push(`       collapsed: ${collapsedSize}`);
+            // DEBUG.push(`       min: ${minSize}`);
+
+            const nextSize = prevSize + delta;
+            if (compareLayoutNumbers(nextSize, minSize) < 0) {
+              // DEBUG.push("  -> adjusting delta");
+              // DEBUG.push(`       from: ${delta}`);
+              delta =
+                compareLayoutNumbers(delta, halfwayDelta) <= 0 ? 0 : gapSize;
+              // DEBUG.push(`       to: ${delta}`);
+            }
+          } else {
+            const gapSize = minSize - collapsedSize;
+            const halfwayDelta = 100 - gapSize / 2;
+            // DEBUG.push(`  -> halfway delta: ${halfwayDelta}`);
+            // DEBUG.push(`       collapsed: ${100 - collapsedSize}`);
+            // DEBUG.push(`       min: ${100 - minSize}`);
+
+            const nextSize = prevSize - delta;
+            if (compareLayoutNumbers(nextSize, minSize) < 0) {
+              // DEBUG.push("  -> adjusting delta");
+              // DEBUG.push(`       from: ${delta}`);
+              delta =
+                compareLayoutNumbers(100 + delta, halfwayDelta) > 0
+                  ? 0
+                  : -gapSize;
+              // DEBUG.push(`       to: ${delta}`);
+            }
+          }
+        }
+        break;
+      }
+    }
+    // DEBUG.push("");
+  }
+
+  {
+    // Pre-calculate max available delta in the opposite direction of our pivot.
+    // This will be the maximum amount we're allowed to expand/contract the panels in the primary direction.
+    // If this amount is less than the requested delta, adjust the requested delta.
+    // If this amount is greater than the requested delta, that's useful information too–
+    // as an expanding panel might change from collapsed to min size.
+
+    const increment = delta < 0 ? 1 : -1;
+
+    let index = delta < 0 ? secondPivotIndex : firstPivotIndex;
+    let maxAvailableDelta = 0;
+
+    // DEBUG.push("pre calc...");
+    while (true) {
+      const prevSize = initialLayout[index];
+      assert(
+        prevSize != null,
+        `Previous layout not found for panel index ${index}`
+      );
+
+      const maxSafeSize = validatePanelSize({
+        overrideDisabledPanels,
+        panelConstraints: panelConstraintsArray[index],
+        prevSize,
+        size: 100
+      });
+      const delta = maxSafeSize - prevSize;
+      // DEBUG.push(`  ${index}: ${prevSize} -> ${maxSafeSize}`);
+
+      maxAvailableDelta += delta;
+      index += increment;
+
+      if (index < 0 || index >= panelConstraintsArray.length) {
+        break;
+      }
+    }
+
+    // DEBUG.push(`  -> max available delta: ${maxAvailableDelta}`);
+    const minAbsDelta = Math.min(Math.abs(delta), Math.abs(maxAvailableDelta));
+    delta = delta < 0 ? 0 - minAbsDelta : minAbsDelta;
+    // DEBUG.push(`  -> adjusted delta: ${delta}`);
+    // DEBUG.push("");
+  }
+
+  {
+    // Delta added to a panel needs to be subtracted from other panels (within the constraints that those panels allow).
+
+    const pivotIndex = delta < 0 ? firstPivotIndex : secondPivotIndex;
+    let index = pivotIndex;
+    while (index >= 0 && index < panelConstraintsArray.length) {
+      const deltaRemaining = Math.abs(delta) - Math.abs(deltaApplied);
+
+      const prevSize = initialLayout[index];
+      assert(
+        prevSize != null,
+        `Previous layout not found for panel index ${index}`
+      );
+
+      const unsafeSize = prevSize - deltaRemaining;
+      const safeSize = validatePanelSize({
+        overrideDisabledPanels,
+        panelConstraints: panelConstraintsArray[index],
+        prevSize,
+        size: unsafeSize
+      });
+
+      if (!layoutNumbersEqual(prevSize, safeSize)) {
+        deltaApplied += prevSize - safeSize;
+
+        nextLayout[index] = safeSize;
+
+        if (
+          deltaApplied
+            .toFixed(3)
+            .localeCompare(Math.abs(delta).toFixed(3), undefined, {
+              numeric: true
+            }) >= 0
+        ) {
+          break;
+        }
+      }
+
+      if (delta < 0) {
+        index--;
+      } else {
+        index++;
+      }
+    }
+  }
+  // DEBUG.push(`after 1: ${nextLayout.join(", ")}`);
+  // DEBUG.push(`  deltaApplied: ${deltaApplied}`);
+  // DEBUG.push("");
+
+  // If we were unable to resize any of the panels panels, return the previous state.
+  // This will essentially bailout and ignore e.g. drags past a panel's boundaries
+  if (isArrayEqual(prevLayout, nextLayout)) {
+    // DEBUG.push(`bailout to previous layout: ${prevLayout.join(", ")}`);
+    // console.log(DEBUG.join("\n"));
+
+    return prevLayoutProp;
+  }
+
+  {
+    // Now distribute the applied delta to the panels in the other direction
+    const pivotIndex = delta < 0 ? secondPivotIndex : firstPivotIndex;
+
+    const prevSize = initialLayout[pivotIndex];
+    assert(
+      prevSize != null,
+      `Previous layout not found for panel index ${pivotIndex}`
+    );
+
+    const unsafeSize = prevSize + deltaApplied;
+    const safeSize = validatePanelSize({
+      overrideDisabledPanels,
+      panelConstraints: panelConstraintsArray[pivotIndex],
+      prevSize,
+      size: unsafeSize
+    });
+
+    // Adjust the pivot panel before, but only by the amount that surrounding panels were able to shrink/contract.
+    nextLayout[pivotIndex] = safeSize;
+
+    // Edge case where expanding or contracting one panel caused another one to change collapsed state
+    if (!layoutNumbersEqual(safeSize, unsafeSize)) {
+      let deltaRemaining = unsafeSize - safeSize;
+
+      const pivotIndex = delta < 0 ? secondPivotIndex : firstPivotIndex;
+      let index = pivotIndex;
+      while (index >= 0 && index < panelConstraintsArray.length) {
+        const prevSize = nextLayout[index];
+        assert(
+          prevSize != null,
+          `Previous layout not found for panel index ${index}`
+        );
+
+        const unsafeSize = prevSize + deltaRemaining;
+        const safeSize = validatePanelSize({
+          overrideDisabledPanels,
+          panelConstraints: panelConstraintsArray[index],
+          prevSize,
+          size: unsafeSize
+        });
+
+        if (!layoutNumbersEqual(prevSize, safeSize)) {
+          deltaRemaining -= safeSize - prevSize;
+
+          nextLayout[index] = safeSize;
+        }
+
+        if (layoutNumbersEqual(deltaRemaining, 0)) {
+          break;
+        }
+
+        if (delta > 0) {
+          index--;
+        } else {
+          index++;
+        }
+      }
+    }
+  }
+  // DEBUG.push(`after 2: ${nextLayout.join(", ")}`);
+  // DEBUG.push(`  deltaApplied: ${deltaApplied}`);
+  // DEBUG.push("");
+
+  const totalSize = Object.values(nextLayout).reduce(
+    (total, size) => size + total,
+    0
+  );
+  // DEBUG.push(`total size: ${totalSize}`);
+
+  // If our new layout doesn't add up to 100%, that means the requested delta can't be applied
+  // In that case, fall back to our most recent valid layout
+  // Allow for a small rounding difference, else e.g. 3 panel layouts may never be considered valid
+  if (!layoutNumbersEqual(totalSize, 100, 0.1)) {
+    // DEBUG.push(`bailout to previous layout: ${prevLayout.join(", ")}`);
+    // console.log(DEBUG.join("\n"));
+
+    return prevLayoutProp;
+  }
+
+  const prevLayoutKeys = Object.keys(prevLayoutProp);
+
+  // console.log(DEBUG.join("\n"));
+  return nextLayout.reduce<Layout>((accumulated, current, index) => {
+    accumulated[prevLayoutKeys[index]] = current;
+    return accumulated;
+  }, {});
+}

--- a/frontend/packages/react-resizable-panels/global/utils/adjustLayoutByDelta.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/adjustLayoutByDelta.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { assert } from "../../utils/assert";

--- a/frontend/packages/react-resizable-panels/global/utils/adjustLayoutForSeparator.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/adjustLayoutForSeparator.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { assert } from "../../utils/assert";
+import {
+  getMountedGroupState,
+  updateMountedGroup
+} from "../mutable-state/groups";
+import { adjustLayoutByDelta } from "./adjustLayoutByDelta";
+import { findSeparatorGroup } from "./findSeparatorGroup";
+import { getImperativeGroupMethods } from "./getImperativeGroupMethods";
+import { layoutsEqual } from "./layoutsEqual";
+import { validatePanelGroupLayout } from "./validatePanelGroupLayout";
+
+export function adjustLayoutForSeparator(
+  separatorElement: HTMLElement,
+  delta: number
+) {
+  const group = findSeparatorGroup(separatorElement);
+  const groupState = getMountedGroupState(group.id, true);
+
+  const separator = group.separators.find(
+    (current) => current.element === separatorElement
+  );
+  assert(separator, "Matching separator not found");
+
+  const panels = groupState.separatorToPanels.get(separator);
+  assert(panels, "Matching panels not found");
+
+  const pivotIndices = panels.map((panel) => group.panels.indexOf(panel));
+
+  const groupAPI = getImperativeGroupMethods({ groupId: group.id });
+  const prevLayout = groupAPI.getLayout();
+
+  const unsafeLayout = adjustLayoutByDelta({
+    delta,
+    initialLayout: prevLayout,
+    panelConstraints: groupState.derivedPanelConstraints,
+    pivotIndices,
+    prevLayout,
+    trigger: "keyboard"
+  });
+  const nextLayout = validatePanelGroupLayout({
+    layout: unsafeLayout,
+    panelConstraints: groupState.derivedPanelConstraints
+  });
+
+  if (!layoutsEqual(prevLayout, nextLayout)) {
+    updateMountedGroup(group, {
+      defaultLayoutDeferred: groupState.defaultLayoutDeferred,
+      derivedPanelConstraints: groupState.derivedPanelConstraints,
+      groupSize: groupState.groupSize,
+      layout: nextLayout,
+      separatorToPanels: groupState.separatorToPanels
+    });
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/utils/adjustLayoutForSeparator.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/adjustLayoutForSeparator.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { assert } from "../../utils/assert";
 import {
   getMountedGroupState,

--- a/frontend/packages/react-resizable-panels/global/utils/calculateDefaultLayout.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/calculateDefaultLayout.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { formatLayoutNumber } from "./formatLayoutNumber";
+
+export function calculateDefaultLayout(
+  derivedPanelConstraints: PanelConstraints[]
+): Layout {
+  let explicitCount = 0;
+  let total = 0;
+
+  const layout: Layout = {};
+
+  for (const current of derivedPanelConstraints) {
+    if (current.defaultSize !== undefined) {
+      explicitCount++;
+
+      const size = formatLayoutNumber(current.defaultSize);
+
+      total += size;
+      layout[current.panelId] = size;
+    } else {
+      // @ts-expect-error Add panel keys in order to simplify traversal elsewhere; we'll fill them in in the loop below
+      layout[current.panelId] = undefined;
+    }
+  }
+
+  const remainingPanelCount = derivedPanelConstraints.length - explicitCount;
+  if (remainingPanelCount !== 0) {
+    const size = formatLayoutNumber((100 - total) / remainingPanelCount);
+
+    for (const current of derivedPanelConstraints) {
+      if (current.defaultSize === undefined) {
+        layout[current.panelId] = size;
+      }
+    }
+  }
+
+  return layout;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/calculateDefaultLayout.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/calculateDefaultLayout.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { formatLayoutNumber } from "./formatLayoutNumber";

--- a/frontend/packages/react-resizable-panels/global/utils/calculateSeparatorAriaValues.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/calculateSeparatorAriaValues.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { adjustLayoutByDelta } from "./adjustLayoutByDelta";
+import { validatePanelGroupLayout } from "./validatePanelGroupLayout";
+
+export function calculateSeparatorAriaValues({
+  layout,
+  panelConstraints,
+  panelId,
+  panelIndex
+}: {
+  layout: Layout;
+  panelConstraints: PanelConstraints[];
+  panelId: string;
+  panelIndex: number;
+}): {
+  valueControls: string | undefined;
+  valueMax: number | undefined;
+  valueMin: number | undefined;
+  valueNow: number | undefined;
+} {
+  let valueMax: number | undefined = undefined;
+  let valueMin: number | undefined = undefined;
+
+  const panelSize = layout[panelId];
+
+  const constraints = panelConstraints.find(
+    (current) => current.panelId === panelId
+  );
+  if (constraints) {
+    const maxSize = constraints.maxSize;
+    const minSize = constraints.collapsible
+      ? constraints.collapsedSize
+      : constraints.minSize;
+
+    const pivotIndices = [panelIndex, panelIndex + 1];
+
+    const minSizeLayout = validatePanelGroupLayout({
+      layout: adjustLayoutByDelta({
+        delta: minSize - panelSize,
+        initialLayout: layout,
+        panelConstraints,
+        pivotIndices,
+        prevLayout: layout
+      }),
+      panelConstraints
+    });
+
+    valueMin = minSizeLayout[panelId];
+
+    const maxSizeLayout = validatePanelGroupLayout({
+      layout: adjustLayoutByDelta({
+        delta: maxSize - panelSize,
+        initialLayout: layout,
+        panelConstraints,
+        pivotIndices,
+        prevLayout: layout
+      }),
+      panelConstraints
+    });
+
+    valueMax = maxSizeLayout[panelId];
+  }
+
+  return {
+    valueControls: panelId,
+    valueMax,
+    valueMin,
+    valueNow: panelSize
+  };
+}

--- a/frontend/packages/react-resizable-panels/global/utils/calculateSeparatorAriaValues.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/calculateSeparatorAriaValues.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { adjustLayoutByDelta } from "./adjustLayoutByDelta";

--- a/frontend/packages/react-resizable-panels/global/utils/compareLayoutNumbers.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/compareLayoutNumbers.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { layoutNumbersEqual } from "./layoutNumbersEqual";
 
 export function compareLayoutNumbers(actual: number, expected: number) {

--- a/frontend/packages/react-resizable-panels/global/utils/compareLayoutNumbers.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/compareLayoutNumbers.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { layoutNumbersEqual } from "./layoutNumbersEqual";
+
+export function compareLayoutNumbers(actual: number, expected: number) {
+  if (layoutNumbersEqual(actual, expected)) {
+    return 0;
+  } else {
+    return actual > expected ? 1 : -1;
+  }
+}

--- a/frontend/packages/react-resizable-panels/global/utils/doRectsIntersect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/doRectsIntersect.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Rect } from "../../types";
 
 export function doRectsIntersect(a: Rect, b: Rect): boolean {

--- a/frontend/packages/react-resizable-panels/global/utils/doRectsIntersect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/doRectsIntersect.ts
@@ -1,0 +1,11 @@
+// @ts-nocheck
+import type { Rect } from "../../types";
+
+export function doRectsIntersect(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}

--- a/frontend/packages/react-resizable-panels/global/utils/findClosestHitRegion.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findClosestHitRegion.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import type { Orientation } from "../../components/group/types";
+import type { Point } from "../../types";
+import type { HitRegion } from "../dom/calculateHitRegions";
+import { getDistanceBetweenPointAndRect } from "./getDistanceBetweenPointAndRect";
+
+export function findClosestHitRegion(
+  orientation: Orientation,
+  hitRegions: HitRegion[],
+  point: Point
+) {
+  let closestHitRegion: HitRegion | undefined = undefined;
+  let minDistance = {
+    x: Infinity,
+    y: Infinity
+  };
+
+  for (const hitRegion of hitRegions) {
+    const data = getDistanceBetweenPointAndRect(point, hitRegion.rect);
+    switch (orientation) {
+      case "horizontal": {
+        if (data.x <= minDistance.x) {
+          closestHitRegion = hitRegion;
+          minDistance = data;
+        }
+        break;
+      }
+      case "vertical": {
+        if (data.y <= minDistance.y) {
+          closestHitRegion = hitRegion;
+          minDistance = data;
+        }
+        break;
+      }
+    }
+  }
+
+  return closestHitRegion
+    ? {
+        distance: minDistance,
+        hitRegion: closestHitRegion
+      }
+    : undefined;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/findClosestHitRegion.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findClosestHitRegion.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Orientation } from "../../components/group/types";
 import type { Point } from "../../types";
 import type { HitRegion } from "../dom/calculateHitRegions";

--- a/frontend/packages/react-resizable-panels/global/utils/findClosestRect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findClosestRect.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import type { Orientation } from "../../components/group/types";
+import { assert } from "../../utils/assert";
+import { getDistanceBetweenPointAndRect } from "./getDistanceBetweenPointAndRect";
+
+export function findClosestRect({
+  orientation,
+  rects,
+  targetRect
+}: {
+  orientation: Orientation;
+  rects: DOMRectReadOnly[];
+  targetRect: DOMRectReadOnly;
+}): DOMRectReadOnly {
+  const centerPoint = {
+    x: targetRect.x + targetRect.width / 2,
+    y: targetRect.y + targetRect.height / 2
+  };
+
+  let closestRect: DOMRectReadOnly | undefined = undefined;
+  let minDistance = Number.MAX_VALUE;
+
+  for (const rect of rects) {
+    const { x, y } = getDistanceBetweenPointAndRect(centerPoint, rect);
+
+    const distance = orientation === "horizontal" ? x : y;
+
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestRect = rect;
+    }
+  }
+
+  assert(closestRect, "No rect found");
+
+  return closestRect;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/findClosestRect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findClosestRect.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Orientation } from "../../components/group/types";
 import { assert } from "../../utils/assert";
 import { getDistanceBetweenPointAndRect } from "./getDistanceBetweenPointAndRect";

--- a/frontend/packages/react-resizable-panels/global/utils/findMatchingHitRegions.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findMatchingHitRegions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   calculateHitRegions,
   type HitRegion

--- a/frontend/packages/react-resizable-panels/global/utils/findMatchingHitRegions.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findMatchingHitRegions.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import {
+  calculateHitRegions,
+  type HitRegion
+} from "../dom/calculateHitRegions";
+import type { MountedGroups } from "../mutable-state/groups";
+import { findClosestHitRegion } from "./findClosestHitRegion";
+import { isViableHitTarget } from "./isViableHitTarget";
+
+export function findMatchingHitRegions(
+  event: {
+    clientX: number;
+    clientY: number;
+    target: EventTarget | null;
+  },
+  mountedGroups: MountedGroups
+): HitRegion[] {
+  const matchingHitRegions: HitRegion[] = [];
+
+  mountedGroups.forEach((_, groupData) => {
+    if (groupData.disabled) {
+      return;
+    }
+
+    const hitRegions = calculateHitRegions(groupData);
+    const match = findClosestHitRegion(groupData.orientation, hitRegions, {
+      x: event.clientX,
+      y: event.clientY
+    });
+    if (
+      match &&
+      match.distance.x <= 0 &&
+      match.distance.y <= 0 &&
+      isViableHitTarget({
+        groupElement: groupData.element,
+        hitRegion: match.hitRegion.rect,
+        pointerEventTarget: event.target
+      })
+    ) {
+      matchingHitRegions.push(match.hitRegion);
+    }
+  });
+
+  return matchingHitRegions;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/findSeparatorGroup.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findSeparatorGroup.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getMountedGroups } from "../mutable-state/groups";
 
 export function findSeparatorGroup(separatorElement: HTMLElement) {

--- a/frontend/packages/react-resizable-panels/global/utils/findSeparatorGroup.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/findSeparatorGroup.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import { getMountedGroups } from "../mutable-state/groups";
+
+export function findSeparatorGroup(separatorElement: HTMLElement) {
+  const mountedGroups = getMountedGroups();
+
+  for (const [group] of mountedGroups) {
+    if (
+      group.separators.some(
+        (separator) => separator.element === separatorElement
+      )
+    ) {
+      return group;
+    }
+  }
+
+  throw Error("Could not find parent Group for separator element");
+}

--- a/frontend/packages/react-resizable-panels/global/utils/formatLayoutNumber.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/formatLayoutNumber.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+export function formatLayoutNumber(number: number) {
+  return parseFloat(number.toFixed(3));
+}

--- a/frontend/packages/react-resizable-panels/global/utils/formatLayoutNumber.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/formatLayoutNumber.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function formatLayoutNumber(number: number) {
   return parseFloat(number.toFixed(3));
 }

--- a/frontend/packages/react-resizable-panels/global/utils/getDistanceBetweenPointAndRect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getDistanceBetweenPointAndRect.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Point } from "../../types";
 
 export function getDistanceBetweenPointAndRect(

--- a/frontend/packages/react-resizable-panels/global/utils/getDistanceBetweenPointAndRect.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getDistanceBetweenPointAndRect.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import type { Point } from "../../types";
+
+export function getDistanceBetweenPointAndRect(
+  point: Point,
+  rect: DOMRectReadOnly
+) {
+  return {
+    x:
+      point.x >= rect.left && point.x <= rect.right
+        ? 0
+        : Math.min(
+            Math.abs(point.x - rect.left),
+            Math.abs(point.x - rect.right)
+          ),
+    y:
+      point.y >= rect.top && point.y <= rect.bottom
+        ? 0
+        : Math.min(
+            Math.abs(point.y - rect.top),
+            Math.abs(point.y - rect.bottom)
+          )
+  };
+}

--- a/frontend/packages/react-resizable-panels/global/utils/getImperativeGroupMethods.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getImperativeGroupMethods.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type {
   GroupImperativeHandle,
   Layout

--- a/frontend/packages/react-resizable-panels/global/utils/getImperativeGroupMethods.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getImperativeGroupMethods.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import type {
+  GroupImperativeHandle,
+  Layout
+} from "../../components/group/types";
+import { getMountedGroups, updateMountedGroup } from "../mutable-state/groups";
+import { layoutsEqual } from "./layoutsEqual";
+import { validatePanelGroupLayout } from "./validatePanelGroupLayout";
+
+export function getImperativeGroupMethods({
+  groupId
+}: {
+  groupId: string;
+}): GroupImperativeHandle {
+  const find = () => {
+    const mountedGroups = getMountedGroups();
+    for (const [group, value] of mountedGroups) {
+      if (group.id === groupId) {
+        return { group, ...value };
+      }
+    }
+
+    throw Error(`Could not find Group with id "${groupId}"`);
+  };
+
+  return {
+    getLayout() {
+      const { defaultLayoutDeferred, layout } = find();
+
+      if (defaultLayoutDeferred) {
+        // This indicates that the Group has not finished mounting yet
+        // Likely because it has been rendered inside of a hidden DOM subtree
+        // Any layout value will not have been validated and so it should not be returned
+        return {};
+      }
+
+      return layout;
+    },
+    setLayout(unsafeLayout: Layout) {
+      const {
+        defaultLayoutDeferred,
+        derivedPanelConstraints,
+        group,
+        groupSize,
+        layout: prevLayout,
+        separatorToPanels
+      } = find();
+
+      const nextLayout = validatePanelGroupLayout({
+        layout: unsafeLayout,
+        panelConstraints: derivedPanelConstraints
+      });
+
+      if (defaultLayoutDeferred) {
+        // This indicates that the Group has not finished mounting yet
+        // Likely because it has been rendered inside of a hidden DOM subtree
+        // In this case we cannot fully validate the layout, so we shouldn't apply it
+        // It's okay to run the validate function above though,
+        // it will still warn about certain types of errors (e.g. wrong number of panels)
+        return prevLayout;
+      }
+
+      if (!layoutsEqual(prevLayout, nextLayout)) {
+        updateMountedGroup(group, {
+          defaultLayoutDeferred,
+          derivedPanelConstraints,
+          groupSize,
+          layout: nextLayout,
+          separatorToPanels
+        });
+      }
+
+      return nextLayout;
+    }
+  };
+}

--- a/frontend/packages/react-resizable-panels/global/utils/getImperativePanelMethods.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getImperativePanelMethods.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { PanelImperativeHandle } from "../../components/panel/types";
 import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
 import { getMountedGroups, updateMountedGroup } from "../mutable-state/groups";

--- a/frontend/packages/react-resizable-panels/global/utils/getImperativePanelMethods.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/getImperativePanelMethods.ts
@@ -1,0 +1,184 @@
+// @ts-nocheck
+import type { PanelImperativeHandle } from "../../components/panel/types";
+import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
+import { getMountedGroups, updateMountedGroup } from "../mutable-state/groups";
+import { sizeStyleToPixels } from "../styles/sizeStyleToPixels";
+import { adjustLayoutByDelta } from "./adjustLayoutByDelta";
+import { formatLayoutNumber } from "./formatLayoutNumber";
+import { layoutNumbersEqual } from "./layoutNumbersEqual";
+import { layoutsEqual } from "./layoutsEqual";
+import { validatePanelGroupLayout } from "./validatePanelGroupLayout";
+
+export function getImperativePanelMethods({
+  groupId,
+  panelId
+}: {
+  groupId: string;
+  panelId: string;
+}): PanelImperativeHandle {
+  const find = () => {
+    const mountedGroups = getMountedGroups();
+    for (const [
+      group,
+      {
+        defaultLayoutDeferred,
+        derivedPanelConstraints,
+        layout,
+        groupSize,
+        separatorToPanels
+      }
+    ] of mountedGroups) {
+      if (group.id === groupId) {
+        return {
+          defaultLayoutDeferred,
+          derivedPanelConstraints,
+          group,
+          groupSize,
+          layout,
+          separatorToPanels
+        };
+      }
+    }
+
+    throw Error(`Group ${groupId} not found`);
+  };
+
+  const getPanelConstraints = () => {
+    const match = find().derivedPanelConstraints.find(
+      (current) => current.panelId === panelId
+    );
+    if (match !== undefined) {
+      return match;
+    }
+
+    throw Error(`Panel constraints not found for Panel ${panelId}`);
+  };
+
+  const getPanel = () => {
+    const match = find().group.panels.find((current) => current.id === panelId);
+    if (match !== undefined) {
+      return match;
+    }
+
+    throw Error(`Layout not found for Panel ${panelId}`);
+  };
+
+  const getPanelSize = () => {
+    const match = find().layout[panelId];
+    if (match !== undefined) {
+      return match;
+    }
+
+    throw Error(`Layout not found for Panel ${panelId}`);
+  };
+
+  const setPanelSize = (nextSize: number) => {
+    const prevSize = getPanelSize();
+    if (nextSize === prevSize) {
+      return;
+    }
+
+    const {
+      defaultLayoutDeferred,
+      derivedPanelConstraints,
+      group,
+      groupSize,
+      layout: prevLayout,
+      separatorToPanels
+    } = find();
+
+    const index = group.panels.findIndex((current) => current.id === panelId);
+    const isLastPanel = index === group.panels.length - 1;
+
+    const unsafeLayout = adjustLayoutByDelta({
+      delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,
+      initialLayout: prevLayout,
+      panelConstraints: derivedPanelConstraints,
+      pivotIndices: isLastPanel ? [index - 1, index] : [index, index + 1],
+      prevLayout,
+      trigger: "imperative-api"
+    });
+
+    const nextLayout = validatePanelGroupLayout({
+      layout: unsafeLayout,
+      panelConstraints: derivedPanelConstraints
+    });
+    if (!layoutsEqual(prevLayout, nextLayout)) {
+      updateMountedGroup(group, {
+        defaultLayoutDeferred,
+        derivedPanelConstraints,
+        groupSize,
+        layout: nextLayout,
+        separatorToPanels
+      });
+    }
+  };
+
+  return {
+    collapse: () => {
+      const { collapsible, collapsedSize } = getPanelConstraints();
+      const { mutableValues } = getPanel();
+      const size = getPanelSize();
+
+      if (collapsible && size !== collapsedSize) {
+        // Store previous size in to restore if expand() is called
+        mutableValues.expandToSize = size;
+
+        setPanelSize(collapsedSize);
+      }
+    },
+    expand: () => {
+      const { collapsible, collapsedSize, minSize } = getPanelConstraints();
+      const { mutableValues } = getPanel();
+      const size = getPanelSize();
+
+      if (collapsible && size === collapsedSize) {
+        // Restore pre-collapse size, fallback to minSize
+        let nextSize = mutableValues.expandToSize ?? minSize;
+
+        // Edge case: if minSize is 0, pick something meaningful to expand the panel to
+        if (nextSize === 0) {
+          nextSize = 1;
+        }
+
+        setPanelSize(nextSize);
+      }
+    },
+    getSize: () => {
+      const { group } = find();
+      const asPercentage = getPanelSize();
+      const { element } = getPanel();
+
+      const inPixels =
+        group.orientation === "horizontal"
+          ? element.offsetWidth
+          : element.offsetHeight;
+
+      return {
+        asPercentage,
+        inPixels
+      };
+    },
+    isCollapsed: () => {
+      const { collapsible, collapsedSize } = getPanelConstraints();
+      const size = getPanelSize();
+
+      return collapsible && layoutNumbersEqual(collapsedSize, size);
+    },
+    resize: (size: number | string) => {
+      const { group } = find();
+      const { element } = getPanel();
+      const groupSize = calculateAvailableGroupSize({ group });
+
+      const asPixels = sizeStyleToPixels({
+        groupSize,
+        panelElement: element,
+        styleProp: size
+      });
+
+      const asPercentage = formatLayoutNumber((asPixels / groupSize) * 100);
+
+      setPanelSize(asPercentage);
+    }
+  } satisfies PanelImperativeHandle;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/isCoarsePointer.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/isCoarsePointer.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+let cached: boolean | undefined = undefined;
+
+/**
+ * Caches and returns matchMedia()'s computed value for "pointer:coarse"
+ */
+export function isCoarsePointer(): boolean {
+  if (cached === undefined) {
+    if (typeof matchMedia === "function") {
+      cached = !!matchMedia("(pointer:coarse)").matches;
+    } else {
+      cached = false;
+    }
+  }
+
+  return cached;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/isCoarsePointer.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/isCoarsePointer.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 let cached: boolean | undefined = undefined;
 
 /**

--- a/frontend/packages/react-resizable-panels/global/utils/isViableHitTarget.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/isViableHitTarget.ts
@@ -1,0 +1,56 @@
+// @ts-nocheck
+import { isHTMLElement } from "../../utils/isHTMLElement";
+import { compare } from "../../vendor/stacking-order";
+import { doRectsIntersect } from "./doRectsIntersect";
+
+// This library adds pointer event handlers to the Window for two reasons:
+// 1. It allows detecting when the pointer is "near" to a panel border or separator element,
+//    (which can be particularly helpful on touch devices)
+// 2. It allows detecting pointer interactions that apply to multiple, nearby panels/separators
+//    (in the event of e.g. nested groups)
+//
+// Because events are handled at the Window, it's important to detect when another element is "above" a separator (e.g. a modal)
+// as this should prevent the separator element from being clicked.
+// This function does that determination.
+export function isViableHitTarget({
+  groupElement,
+  hitRegion,
+  pointerEventTarget
+}: {
+  groupElement: HTMLElement;
+  hitRegion: DOMRect;
+  pointerEventTarget: EventTarget | null;
+}) {
+  if (
+    !isHTMLElement(pointerEventTarget) ||
+    pointerEventTarget.contains(groupElement) ||
+    groupElement.contains(pointerEventTarget)
+  ) {
+    // Calculating stacking order has a cost;
+    // If either group or element contain the other, the click is safe and we can skip calculating the indices
+    return true;
+  }
+
+  if (compare(pointerEventTarget, groupElement) > 0) {
+    // If the pointer target is above the separator, check for overlap
+    // If they are near each other, but not overlapping, then the separator is still a viable target
+    //
+    // Note that it's not sufficient to compare only the target
+    // The target might be a small element inside of a larger container
+    // (For example, a SPAN or a DIV inside of a larger modal dialog)
+    let currentElement: HTMLElement | SVGElement | null = pointerEventTarget;
+    while (currentElement) {
+      if (currentElement.contains(groupElement)) {
+        return true;
+      } else if (
+        doRectsIntersect(currentElement.getBoundingClientRect(), hitRegion)
+      ) {
+        return false;
+      }
+
+      currentElement = currentElement.parentElement;
+    }
+  }
+
+  return true;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/isViableHitTarget.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/isViableHitTarget.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { isHTMLElement } from "../../utils/isHTMLElement";
 import { compare } from "../../vendor/stacking-order";
 import { doRectsIntersect } from "./doRectsIntersect";

--- a/frontend/packages/react-resizable-panels/global/utils/layoutNumbersEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/layoutNumbersEqual.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import { formatLayoutNumber } from "./formatLayoutNumber";
+
+export function layoutNumbersEqual(
+  actual: number,
+  expected: number,
+  minimumDelta = 0
+) {
+  return (
+    Math.abs(formatLayoutNumber(actual) - formatLayoutNumber(expected)) <=
+    minimumDelta
+  );
+}

--- a/frontend/packages/react-resizable-panels/global/utils/layoutNumbersEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/layoutNumbersEqual.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { formatLayoutNumber } from "./formatLayoutNumber";
 
 export function layoutNumbersEqual(

--- a/frontend/packages/react-resizable-panels/global/utils/layoutsEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/layoutsEqual.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import { compareLayoutNumbers } from "./compareLayoutNumbers";
 

--- a/frontend/packages/react-resizable-panels/global/utils/layoutsEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/layoutsEqual.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import { compareLayoutNumbers } from "./compareLayoutNumbers";
+
+export function layoutsEqual(a: Layout, b: Layout): boolean {
+  if (Object.keys(a).length !== Object.keys(b).length) {
+    return false;
+  }
+
+  for (const id in a) {
+    // Edge case: Panel id has been changed
+    if (b[id] === undefined || compareLayoutNumbers(a[id], b[id]) !== 0) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/notifyPanelOnResize.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/notifyPanelOnResize.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { RegisteredGroup } from "../../components/group/types";
 import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
 import { formatLayoutNumber } from "./formatLayoutNumber";

--- a/frontend/packages/react-resizable-panels/global/utils/notifyPanelOnResize.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/notifyPanelOnResize.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import type { RegisteredGroup } from "../../components/group/types";
+import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
+import { formatLayoutNumber } from "./formatLayoutNumber";
+
+export function notifyPanelOnResize(
+  group: RegisteredGroup,
+  element: HTMLElement,
+  borderBoxSize: readonly ResizeObserverSize[]
+) {
+  const resizeObserverSize = borderBoxSize[0];
+  if (!resizeObserverSize) {
+    return;
+  }
+
+  const panel = group.panels.find((current) => current.element === element);
+  if (!panel || !panel.onResize) {
+    return;
+  }
+
+  const groupSize = calculateAvailableGroupSize({ group });
+
+  const panelSize =
+    group.orientation === "horizontal"
+      ? panel.element.offsetWidth
+      : panel.element.offsetHeight;
+
+  const prevSize = panel.mutableValues.prevSize;
+  const nextSize = {
+    asPercentage: formatLayoutNumber((panelSize / groupSize) * 100),
+    inPixels: panelSize
+  };
+  panel.mutableValues.prevSize = nextSize;
+
+  panel.onResize(nextSize, panel.id, prevSize);
+}

--- a/frontend/packages/react-resizable-panels/global/utils/objectsEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/objectsEqual.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function objectsEqual(a: object, b: object) {
   const keys = Object.keys(a);
   if (keys.length !== Object.keys(b).length) {

--- a/frontend/packages/react-resizable-panels/global/utils/objectsEqual.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/objectsEqual.ts
@@ -1,0 +1,15 @@
+// @ts-nocheck
+export function objectsEqual(a: object, b: object) {
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  for (const key in a) {
+    if (a[key as keyof typeof a] !== b[key as keyof typeof b]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/preserveFixedPanelSizes.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/preserveFixedPanelSizes.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../../components/group/types";
+import { formatLayoutNumber } from "./formatLayoutNumber";
+
+export function preserveFixedPanelSizes({
+  group,
+  nextGroupSize,
+  prevGroupSize,
+  prevLayout
+}: {
+  group: RegisteredGroup;
+  nextGroupSize: number;
+  prevGroupSize: number;
+  prevLayout: Layout;
+}) {
+  if (
+    prevGroupSize <= 0 ||
+    nextGroupSize <= 0 ||
+    prevGroupSize === nextGroupSize
+  ) {
+    return prevLayout;
+  }
+
+  let fixedPanelsTotalSize = 0;
+  let flexiblePanelsTotalPrevSize = 0;
+  let hasPreservePixelSizePanels = false;
+
+  const fixedPanels = new Map<string, number>();
+  const flexiblePanelIds: string[] = [];
+
+  for (const panel of group.panels) {
+    const prevPanelSize = prevLayout[panel.id] ?? 0;
+    switch (panel.panelConstraints.groupResizeBehavior) {
+      case "preserve-pixel-size": {
+        hasPreservePixelSizePanels = true;
+
+        const prevPanelSizeInPixels = (prevPanelSize / 100) * prevGroupSize;
+        const nextPanelSize = formatLayoutNumber(
+          (prevPanelSizeInPixels / nextGroupSize) * 100
+        );
+
+        fixedPanels.set(panel.id, nextPanelSize);
+        fixedPanelsTotalSize += nextPanelSize;
+        break;
+      }
+      case "preserve-relative-size":
+      default: {
+        flexiblePanelIds.push(panel.id);
+        flexiblePanelsTotalPrevSize += prevPanelSize;
+        break;
+      }
+    }
+  }
+
+  if (!hasPreservePixelSizePanels || flexiblePanelIds.length === 0) {
+    return prevLayout;
+  }
+
+  const remainingSize = 100 - fixedPanelsTotalSize;
+  const nextLayout = { ...prevLayout };
+
+  fixedPanels.forEach((size, panelId) => {
+    nextLayout[panelId] = size;
+  });
+
+  if (flexiblePanelsTotalPrevSize > 0) {
+    for (const panelId of flexiblePanelIds) {
+      const prevSize = prevLayout[panelId] ?? 0;
+      nextLayout[panelId] = formatLayoutNumber(
+        (prevSize / flexiblePanelsTotalPrevSize) * remainingSize
+      );
+    }
+  } else {
+    const evenSize = formatLayoutNumber(
+      remainingSize / flexiblePanelIds.length
+    );
+    for (const panelId of flexiblePanelIds) {
+      nextLayout[panelId] = evenSize;
+    }
+  }
+
+  return nextLayout;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/preserveFixedPanelSizes.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/preserveFixedPanelSizes.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../../components/group/types";
 import { formatLayoutNumber } from "./formatLayoutNumber";
 

--- a/frontend/packages/react-resizable-panels/global/utils/updateActiveHitRegion.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/updateActiveHitRegion.ts
@@ -1,0 +1,142 @@
+// @ts-nocheck
+import type { Layout, RegisteredGroup } from "../../components/group/types";
+import {
+  CURSOR_FLAG_HORIZONTAL_MAX,
+  CURSOR_FLAG_HORIZONTAL_MIN,
+  CURSOR_FLAG_VERTICAL_MAX,
+  CURSOR_FLAG_VERTICAL_MIN,
+  CURSOR_FLAGS_HORIZONTAL,
+  CURSOR_FLAGS_VERTICAL
+} from "../../constants";
+import type { Point } from "../../types";
+import { updateCursorStyle } from "../cursor/updateCursorStyle";
+import type { HitRegion } from "../dom/calculateHitRegions";
+import {
+  updateMountedGroup,
+  type MountedGroups
+} from "../mutable-state/groups";
+import { updateCursorFlags } from "../mutable-state/interactions";
+import { adjustLayoutByDelta } from "./adjustLayoutByDelta";
+import { layoutsEqual } from "./layoutsEqual";
+
+export function updateActiveHitRegions({
+  document,
+  event,
+  hitRegions,
+  initialLayoutMap,
+  mountedGroups,
+  pointerDownAtPoint,
+  prevCursorFlags
+}: {
+  document: Document;
+  event: {
+    clientX: number;
+    clientY: number;
+    movementX: number;
+    movementY: number;
+  };
+  hitRegions: HitRegion[];
+  initialLayoutMap: Map<RegisteredGroup, Layout>;
+  mountedGroups: MountedGroups;
+  pointerDownAtPoint?: Point;
+  prevCursorFlags: number;
+}) {
+  let nextCursorFlags = 0;
+
+  // Note that HitRegions are frozen once a drag has started
+  // Modify the Group layouts for all matching HitRegions though
+  hitRegions.forEach((current) => {
+    const { group, groupSize } = current;
+    const { orientation, panels } = group;
+    const { disableCursor } = group.mutableState;
+
+    let deltaAsPercentage = 0;
+    if (pointerDownAtPoint) {
+      if (orientation === "horizontal") {
+        deltaAsPercentage =
+          ((event.clientX - pointerDownAtPoint.x) / groupSize) * 100;
+      } else {
+        deltaAsPercentage =
+          ((event.clientY - pointerDownAtPoint.y) / groupSize) * 100;
+      }
+    } else {
+      if (orientation === "horizontal") {
+        deltaAsPercentage = event.clientX < 0 ? -100 : 100;
+      } else {
+        deltaAsPercentage = event.clientY < 0 ? -100 : 100;
+      }
+    }
+
+    const initialLayout = initialLayoutMap.get(group);
+    const groupState = mountedGroups.get(group);
+    if (!initialLayout || !groupState) {
+      return;
+    }
+
+    const {
+      defaultLayoutDeferred,
+      derivedPanelConstraints,
+      groupSize: mountedGroupSize,
+      layout: prevLayout,
+      separatorToPanels
+    } = groupState;
+    if (derivedPanelConstraints && prevLayout && separatorToPanels) {
+      const nextLayout = adjustLayoutByDelta({
+        delta: deltaAsPercentage,
+        initialLayout,
+        panelConstraints: derivedPanelConstraints,
+        pivotIndices: current.panels.map((panel) => panels.indexOf(panel)),
+        prevLayout,
+        trigger: "mouse-or-touch"
+      });
+
+      if (layoutsEqual(nextLayout, prevLayout)) {
+        if (deltaAsPercentage !== 0 && !disableCursor) {
+          // An unchanged means the cursor has exceeded the allowed bounds
+          switch (orientation) {
+            case "horizontal": {
+              nextCursorFlags |=
+                deltaAsPercentage < 0
+                  ? CURSOR_FLAG_HORIZONTAL_MIN
+                  : CURSOR_FLAG_HORIZONTAL_MAX;
+              break;
+            }
+            case "vertical": {
+              nextCursorFlags |=
+                deltaAsPercentage < 0
+                  ? CURSOR_FLAG_VERTICAL_MIN
+                  : CURSOR_FLAG_VERTICAL_MAX;
+              break;
+            }
+          }
+        }
+      } else {
+        updateMountedGroup(current.group, {
+          defaultLayoutDeferred,
+          derivedPanelConstraints: derivedPanelConstraints,
+          groupSize: mountedGroupSize,
+          layout: nextLayout,
+          separatorToPanels
+        });
+      }
+    }
+  });
+
+  // Edge case
+  // Re-use previous horizontal/vertical cursor flags if there's been no movement since the last event
+  // This accounts for edge cases in browsers like Firefox that sometimes round clientX/clientY values
+  let cursorFlags = 0;
+  if (event.movementX === 0) {
+    cursorFlags |= prevCursorFlags & CURSOR_FLAGS_HORIZONTAL;
+  } else {
+    cursorFlags |= nextCursorFlags & CURSOR_FLAGS_HORIZONTAL;
+  }
+  if (event.movementY === 0) {
+    cursorFlags |= prevCursorFlags & CURSOR_FLAGS_VERTICAL;
+  } else {
+    cursorFlags |= nextCursorFlags & CURSOR_FLAGS_VERTICAL;
+  }
+
+  updateCursorFlags(cursorFlags);
+  updateCursorStyle(document);
+}

--- a/frontend/packages/react-resizable-panels/global/utils/updateActiveHitRegion.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/updateActiveHitRegion.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout, RegisteredGroup } from "../../components/group/types";
 import {
   CURSOR_FLAG_HORIZONTAL_MAX,

--- a/frontend/packages/react-resizable-panels/global/utils/validateLayoutKeys.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validateLayoutKeys.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import type { RegisteredPanel } from "../../components/panel/types";
 

--- a/frontend/packages/react-resizable-panels/global/utils/validateLayoutKeys.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validateLayoutKeys.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import type { RegisteredPanel } from "../../components/panel/types";
+
+export function validateLayoutKeys(panels: RegisteredPanel[], layout: Layout) {
+  const panelIds = panels.map((panel) => panel.id);
+  const layoutKeys = Object.keys(layout);
+
+  if (panelIds.length !== layoutKeys.length) {
+    return false;
+  }
+
+  for (const panelId of panelIds) {
+    if (!layoutKeys.includes(panelId)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/validatePanelGroupLayout.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validatePanelGroupLayout.ts
@@ -1,0 +1,99 @@
+// @ts-nocheck
+import type { Layout } from "../../components/group/types";
+import type { PanelConstraints } from "../../components/panel/types";
+import { assert } from "../../utils/assert";
+import { layoutNumbersEqual } from "./layoutNumbersEqual";
+import { validatePanelSize } from "./validatePanelSize";
+
+// All units must be in percentages; pixel values should be pre-converted
+export function validatePanelGroupLayout({
+  layout,
+  panelConstraints
+}: {
+  layout: Layout;
+  panelConstraints: PanelConstraints[];
+}): Layout {
+  const prevLayout = Object.values(layout);
+  const nextLayout = [...prevLayout];
+
+  const nextLayoutTotalSize = nextLayout.reduce(
+    (accumulated, current) => accumulated + current,
+    0
+  );
+
+  // Validate layout expectations
+  if (nextLayout.length !== panelConstraints.length) {
+    throw Error(
+      `Invalid ${panelConstraints.length} panel layout: ${nextLayout
+        .map((size) => `${size}%`)
+        .join(", ")}`
+    );
+  } else if (
+    !layoutNumbersEqual(nextLayoutTotalSize, 100) &&
+    nextLayout.length > 0
+  ) {
+    for (let index = 0; index < panelConstraints.length; index++) {
+      const unsafeSize = nextLayout[index];
+      assert(unsafeSize != null, `No layout data found for index ${index}`);
+      const safeSize = (100 / nextLayoutTotalSize) * unsafeSize;
+      nextLayout[index] = safeSize;
+    }
+  }
+
+  let remainingSize = 0;
+
+  // First pass: Validate the proposed layout given each panel's constraints
+  for (let index = 0; index < panelConstraints.length; index++) {
+    const prevSize = prevLayout[index];
+    assert(prevSize != null, `No layout data found for index ${index}`);
+
+    const unsafeSize = nextLayout[index];
+    assert(unsafeSize != null, `No layout data found for index ${index}`);
+
+    const safeSize = validatePanelSize({
+      overrideDisabledPanels: true,
+      panelConstraints: panelConstraints[index],
+      prevSize,
+      size: unsafeSize
+    });
+
+    if (unsafeSize != safeSize) {
+      remainingSize += unsafeSize - safeSize;
+
+      nextLayout[index] = safeSize;
+    }
+  }
+
+  // If there is additional, left over space, assign it to any panel(s) that permits it
+  // (It's not worth taking multiple additional passes to evenly distribute)
+  if (!layoutNumbersEqual(remainingSize, 0)) {
+    for (let index = 0; index < panelConstraints.length; index++) {
+      const prevSize = nextLayout[index];
+      assert(prevSize != null, `No layout data found for index ${index}`);
+      const unsafeSize = prevSize + remainingSize;
+      const safeSize = validatePanelSize({
+        overrideDisabledPanels: true,
+        panelConstraints: panelConstraints[index],
+        prevSize,
+        size: unsafeSize
+      });
+
+      if (prevSize !== safeSize) {
+        remainingSize -= safeSize - prevSize;
+        nextLayout[index] = safeSize;
+
+        // Once we've used up the remainder, bail
+        if (layoutNumbersEqual(remainingSize, 0)) {
+          break;
+        }
+      }
+    }
+  }
+
+  const prevLayoutKeys = Object.keys(layout);
+
+  return nextLayout.reduce<Layout>((accumulated, current, index) => {
+    accumulated[prevLayoutKeys[index]] = current;
+    return accumulated;
+  }, {});
+}

--- a/frontend/packages/react-resizable-panels/global/utils/validatePanelGroupLayout.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validatePanelGroupLayout.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Layout } from "../../components/group/types";
 import type { PanelConstraints } from "../../components/panel/types";
 import { assert } from "../../utils/assert";

--- a/frontend/packages/react-resizable-panels/global/utils/validatePanelSize.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validatePanelSize.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import type { PanelConstraints } from "../../components/panel/types";
+import { compareLayoutNumbers } from "./compareLayoutNumbers";
+import { formatLayoutNumber } from "./formatLayoutNumber";
+
+// Panel size must be in percentages; pixel values should be pre-converted
+export function validatePanelSize({
+  overrideDisabledPanels,
+  panelConstraints,
+  prevSize,
+  size
+}: {
+  overrideDisabledPanels?: boolean;
+  panelConstraints: PanelConstraints;
+  prevSize: number;
+  size: number;
+}) {
+  const {
+    collapsedSize = 0,
+    collapsible,
+    disabled,
+    maxSize = 100,
+    minSize = 0
+  } = panelConstraints;
+
+  if (disabled && !overrideDisabledPanels) {
+    return prevSize;
+  }
+
+  if (compareLayoutNumbers(size, minSize) < 0) {
+    if (collapsible) {
+      // Collapsible panels should snap closed or open only once they cross the halfway point between collapsed and min size.
+      const halfwayPoint = (collapsedSize + minSize) / 2;
+      if (compareLayoutNumbers(size, halfwayPoint) < 0) {
+        size = collapsedSize;
+      } else {
+        size = minSize;
+      }
+    } else {
+      size = minSize;
+    }
+  }
+
+  size = Math.min(maxSize, size);
+  size = formatLayoutNumber(size);
+
+  return size;
+}

--- a/frontend/packages/react-resizable-panels/global/utils/validatePanelSize.ts
+++ b/frontend/packages/react-resizable-panels/global/utils/validatePanelSize.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { PanelConstraints } from "../../components/panel/types";
 import { compareLayoutNumbers } from "./compareLayoutNumbers";
 import { formatLayoutNumber } from "./formatLayoutNumber";

--- a/frontend/packages/react-resizable-panels/hooks/useForceUpdate.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useForceUpdate.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { useCallback, useState } from "react";
+
+export function useForceUpdate() {
+  const [sigil, setSigil] = useState({});
+
+  const forceUpdate = useCallback(() => setSigil({}), []);
+
+  return [sigil as unknown, forceUpdate] as const;
+}

--- a/frontend/packages/react-resizable-panels/hooks/useForceUpdate.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useForceUpdate.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useCallback, useState } from "react";
 
 export function useForceUpdate() {

--- a/frontend/packages/react-resizable-panels/hooks/useId.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useId.ts
@@ -1,0 +1,8 @@
+// @ts-nocheck
+import { useId as useIdReact } from "react";
+
+export function useId(stableId: number | string | undefined) {
+  const dynamicId = useIdReact();
+
+  return `${stableId ?? dynamicId}`;
+}

--- a/frontend/packages/react-resizable-panels/hooks/useId.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useId.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useId as useIdReact } from "react";
 
 export function useId(stableId: number | string | undefined) {

--- a/frontend/packages/react-resizable-panels/hooks/useIsomorphicLayoutEffect.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useLayoutEffect } from "react";
 
 export const useIsomorphicLayoutEffect =

--- a/frontend/packages/react-resizable-panels/hooks/useIsomorphicLayoutEffect.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import { useEffect, useLayoutEffect } from "react";
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/frontend/packages/react-resizable-panels/hooks/useMergedRefs.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useMergedRefs.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { type Ref } from "react";
+import { useStableCallback } from "./useStableCallback";
+
+type PossibleRef<Type> = Ref<Type> | undefined;
+
+export function useMergedRefs<Type>(...refs: PossibleRef<Type>[]) {
+  return useStableCallback((value: Type | null) => {
+    refs.forEach((ref) => {
+      if (ref) {
+        switch (typeof ref) {
+          case "function": {
+            ref(value);
+            break;
+          }
+          case "object": {
+            ref.current = value;
+            break;
+          }
+        }
+      }
+    });
+  });
+}

--- a/frontend/packages/react-resizable-panels/hooks/useMergedRefs.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useMergedRefs.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { type Ref } from "react";
 import { useStableCallback } from "./useStableCallback";
 

--- a/frontend/packages/react-resizable-panels/hooks/useStableArray.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableArray.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import { useRef } from "react";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+
+export function useStableArray<Type>(unstableArray: Type[]): Type[] {
+  const ref = useRef<Type[]>([...unstableArray]);
+
+  useIsomorphicLayoutEffect(() => {
+    const stableArray = ref.current;
+    stableArray.splice(0);
+    unstableArray.forEach((current) => {
+      stableArray.push(current);
+    });
+  }, [unstableArray]);
+
+  return ref.current;
+}

--- a/frontend/packages/react-resizable-panels/hooks/useStableArray.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableArray.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useRef } from "react";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 

--- a/frontend/packages/react-resizable-panels/hooks/useStableCallback.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableCallback.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { useCallback, useRef } from "react";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+
+// Forked from useEventCallback (usehooks-ts)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export function useStableCallback<Callback extends Function>(
+  fn: Callback
+): Callback {
+  const ref = useRef<Callback>(fn);
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+
+  return useCallback(
+    (...args: unknown[]) => ref.current?.(...args),
+    [ref]
+  ) as unknown as Callback;
+}

--- a/frontend/packages/react-resizable-panels/hooks/useStableCallback.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableCallback.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useCallback, useRef } from "react";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 

--- a/frontend/packages/react-resizable-panels/hooks/useStableObject.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableObject.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useRef } from "react";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 

--- a/frontend/packages/react-resizable-panels/hooks/useStableObject.ts
+++ b/frontend/packages/react-resizable-panels/hooks/useStableObject.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import { useRef } from "react";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+
+export function useStableObject<Type extends object>(
+  unstableObject: Type
+): Type {
+  const ref = useRef<Type>({ ...unstableObject });
+
+  useIsomorphicLayoutEffect(() => {
+    for (const key in unstableObject) {
+      ref.current[key] = unstableObject[key];
+    }
+  }, [unstableObject]);
+
+  return ref.current;
+}

--- a/frontend/packages/react-resizable-panels/index.ts
+++ b/frontend/packages/react-resizable-panels/index.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+export { Group } from "./components/group/Group";
+export { useDefaultLayout } from "./components/group/useDefaultLayout";
+export { useGroupCallbackRef } from "./components/group/useGroupCallbackRef";
+export { useGroupRef } from "./components/group/useGroupRef";
+export { Panel } from "./components/panel/Panel";
+export { usePanelCallbackRef } from "./components/panel/usePanelCallbackRef";
+export { usePanelRef } from "./components/panel/usePanelRef";
+export { Separator } from "./components/separator/Separator";
+
+export { isCoarsePointer } from "./global/utils/isCoarsePointer";
+
+export type {
+  GroupImperativeHandle,
+  GroupProps,
+  Layout,
+  LayoutStorage,
+  OnGroupLayoutChange,
+  Orientation
+} from "./components/group/types";
+export type {
+  OnPanelResize,
+  PanelImperativeHandle,
+  PanelProps,
+  PanelSize,
+  SizeUnit
+} from "./components/panel/types";
+export type { SeparatorProps } from "./components/separator/types";

--- a/frontend/packages/react-resizable-panels/index.ts
+++ b/frontend/packages/react-resizable-panels/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export { Group } from "./components/group/Group";
 export { useDefaultLayout } from "./components/group/useDefaultLayout";
 export { useGroupCallbackRef } from "./components/group/useGroupCallbackRef";

--- a/frontend/packages/react-resizable-panels/types.ts
+++ b/frontend/packages/react-resizable-panels/types.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+export type Dimensions = {
+  height: number;
+  width: number;
+};
+
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type PointerPrecision = {
+  coarse: number;
+  precise: number;
+};
+
+export type Rect = Dimensions & Point;

--- a/frontend/packages/react-resizable-panels/types.ts
+++ b/frontend/packages/react-resizable-panels/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export type Dimensions = {
   height: number;
   width: number;

--- a/frontend/packages/react-resizable-panels/utils/EventEmitter.ts
+++ b/frontend/packages/react-resizable-panels/utils/EventEmitter.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export type EventMap = {
   [key: string]: unknown;
 };

--- a/frontend/packages/react-resizable-panels/utils/EventEmitter.ts
+++ b/frontend/packages/react-resizable-panels/utils/EventEmitter.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck
+export type EventMap = {
+  [key: string]: unknown;
+};
+
+export type EventListener<Data> = (data: Data) => void;
+
+export class EventEmitter<Events extends EventMap> {
+  #listenerMap: {
+    [Key in keyof Events]?: EventListener<Events[Key]>[];
+  } = {};
+
+  addListener<Type extends keyof Events>(
+    type: Type,
+    listener: EventListener<Events[Type]>
+  ) {
+    const listeners = this.#listenerMap[type];
+    if (listeners === undefined) {
+      this.#listenerMap[type] = [listener];
+    } else {
+      if (!listeners.includes(listener)) {
+        listeners.push(listener);
+      }
+    }
+
+    return () => {
+      this.removeListener(type, listener);
+    };
+  }
+
+  emit<Type extends keyof Events>(type: Type, data: Events[Type]) {
+    const listeners = this.#listenerMap[type];
+    if (listeners !== undefined) {
+      if (listeners.length === 1) {
+        const listener = listeners[0];
+        listener.call(null, data);
+      } else {
+        let didThrow = false;
+        let caughtError = null;
+
+        // Clone the current listeners before calling
+        // in case calling triggers listeners to be added or removed
+        const clonedListeners = Array.from(listeners);
+        for (let i = 0; i < clonedListeners.length; i++) {
+          const listener = clonedListeners[i];
+          try {
+            listener.call(null, data);
+          } catch (error) {
+            if (caughtError === null) {
+              didThrow = true;
+              caughtError = error;
+            }
+          }
+        }
+
+        if (didThrow) {
+          throw caughtError;
+        }
+      }
+    }
+  }
+
+  removeAllListeners() {
+    this.#listenerMap = {};
+  }
+
+  removeListener<Type extends keyof Events>(
+    type: Type,
+    listener: EventListener<Events[Type]>
+  ) {
+    const listeners = this.#listenerMap[type];
+    if (listeners !== undefined) {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/utils/assert.ts
+++ b/frontend/packages/react-resizable-panels/utils/assert.ts
@@ -1,0 +1,9 @@
+// @ts-nocheck
+export function assert(
+  expectedCondition: unknown,
+  message: string = "Assertion error"
+): asserts expectedCondition {
+  if (!expectedCondition) {
+    throw Error(message);
+  }
+}

--- a/frontend/packages/react-resizable-panels/utils/assert.ts
+++ b/frontend/packages/react-resizable-panels/utils/assert.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function assert(
   expectedCondition: unknown,
   message: string = "Assertion error"

--- a/frontend/packages/react-resizable-panels/utils/isArrayEqual.ts
+++ b/frontend/packages/react-resizable-panels/utils/isArrayEqual.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+export function isArrayEqual(a: number[], b: number[]) {
+  if (a.length !== b.length) {
+    return false;
+  } else {
+    for (let index = 0; index < a.length; index++) {
+      if (a[index] != b[index]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/frontend/packages/react-resizable-panels/utils/isArrayEqual.ts
+++ b/frontend/packages/react-resizable-panels/utils/isArrayEqual.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export function isArrayEqual(a: number[], b: number[]) {
   if (a.length !== b.length) {
     return false;

--- a/frontend/packages/react-resizable-panels/utils/isHTMLElement.ts
+++ b/frontend/packages/react-resizable-panels/utils/isHTMLElement.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+// Detects HTMLElement without requiring instanceof and browser globals
+export function isHTMLElement(value: unknown): value is HTMLElement {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "nodeType" in value &&
+    value.nodeType === Node.ELEMENT_NODE
+  );
+}

--- a/frontend/packages/react-resizable-panels/utils/isHTMLElement.ts
+++ b/frontend/packages/react-resizable-panels/utils/isHTMLElement.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Detects HTMLElement without requiring instanceof and browser globals
 export function isHTMLElement(value: unknown): value is HTMLElement {
   return (

--- a/frontend/packages/react-resizable-panels/utils/isShadowRoot.ts
+++ b/frontend/packages/react-resizable-panels/utils/isShadowRoot.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+// Detects ShadowRoot without requiring instanceof and browser globals
+export function isShadowRoot(value: unknown): value is ShadowRoot {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "nodeType" in value &&
+    value.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+  );
+}

--- a/frontend/packages/react-resizable-panels/utils/isShadowRoot.ts
+++ b/frontend/packages/react-resizable-panels/utils/isShadowRoot.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Detects ShadowRoot without requiring instanceof and browser globals
 export function isShadowRoot(value: unknown): value is ShadowRoot {
   return (

--- a/frontend/packages/react-resizable-panels/utils/parseNumericStyleValue.ts
+++ b/frontend/packages/react-resizable-panels/utils/parseNumericStyleValue.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { CSSProperties } from "react";
 
 export function parseNumericStyleValue(

--- a/frontend/packages/react-resizable-panels/utils/parseNumericStyleValue.ts
+++ b/frontend/packages/react-resizable-panels/utils/parseNumericStyleValue.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import type { CSSProperties } from "react";
+
+export function parseNumericStyleValue(
+  value: CSSProperties["height"]
+): number | undefined {
+  if (value !== undefined) {
+    switch (typeof value) {
+      case "number": {
+        return value;
+      }
+      case "string": {
+        if (value.endsWith("px")) {
+          return parseFloat(value);
+        }
+        break;
+      }
+    }
+  }
+}

--- a/frontend/packages/react-resizable-panels/vendor/stacking-order.ts
+++ b/frontend/packages/react-resizable-panels/vendor/stacking-order.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Forked from NPM stacking-order@2.0.0
 // - github.com/Rich-Harris/stacking-order/issues/3
 // - github.com/Rich-Harris/stacking-order/issues/6

--- a/frontend/packages/react-resizable-panels/vendor/stacking-order.ts
+++ b/frontend/packages/react-resizable-panels/vendor/stacking-order.ts
@@ -1,0 +1,142 @@
+// @ts-nocheck
+// Forked from NPM stacking-order@2.0.0
+// - github.com/Rich-Harris/stacking-order/issues/3
+// - github.com/Rich-Harris/stacking-order/issues/6
+
+import { assert } from "../utils/assert";
+import { isShadowRoot } from "../utils/isShadowRoot";
+
+/**
+ * Determine which of two nodes appears in front of the other —
+ * if `a` is in front, returns 1, otherwise returns -1
+ * @param {HTMLElement | SVGElement} a
+ * @param {HTMLElement | SVGElement} b
+ */
+export function compare(
+  a: HTMLElement | SVGElement,
+  b: HTMLElement | SVGElement
+): number {
+  if (a === b) throw new Error("Cannot compare node with itself");
+
+  const ancestors = {
+    a: get_ancestors(a),
+    b: get_ancestors(b)
+  };
+
+  let common_ancestor;
+
+  // remove shared ancestors
+  while (ancestors.a.at(-1) === ancestors.b.at(-1)) {
+    common_ancestor = ancestors.a.pop() as HTMLElement;
+    ancestors.b.pop();
+  }
+
+  assert(
+    common_ancestor,
+    "Stacking order can only be calculated for elements with a common ancestor"
+  );
+
+  const z_indexes = {
+    a: get_z_index(find_stacking_context(ancestors.a)),
+    b: get_z_index(find_stacking_context(ancestors.b))
+  };
+
+  if (z_indexes.a === z_indexes.b) {
+    const children = common_ancestor.childNodes;
+
+    const furthest_ancestors = {
+      a: ancestors.a.at(-1),
+      b: ancestors.b.at(-1)
+    };
+
+    let i = children.length;
+    while (i--) {
+      const child = children[i];
+      if (child === furthest_ancestors.a) return 1;
+      if (child === furthest_ancestors.b) return -1;
+    }
+  }
+
+  return Math.sign(z_indexes.a - z_indexes.b);
+}
+
+const props =
+  /\b(?:position|zIndex|opacity|transform|webkitTransform|mixBlendMode|filter|webkitFilter|isolation)\b/;
+
+/** @param {HTMLElement | SVGElement} node */
+function is_flex_item(node: HTMLElement | SVGElement) {
+  // @ts-expect-error ParentNode vs Element
+  const display = getComputedStyle(get_parent(node) ?? node).display;
+  return display === "flex" || display === "inline-flex";
+}
+
+/** @param {HTMLElement | SVGElement} node */
+function creates_stacking_context(node: HTMLElement | SVGElement) {
+  const style = getComputedStyle(node);
+
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+  if (style.position === "fixed") return true;
+  // Forked to fix upstream bug https://github.com/Rich-Harris/stacking-order/issues/3
+  // if (
+  //   (style.zIndex !== "auto" && style.position !== "static") ||
+  //   is_flex_item(node)
+  // )
+  if (
+    style.zIndex !== "auto" &&
+    (style.position !== "static" || is_flex_item(node))
+  )
+    return true;
+  if (+style.opacity < 1) return true;
+  if ("transform" in style && style.transform !== "none") return true;
+  if ("webkitTransform" in style && style.webkitTransform !== "none")
+    return true;
+  if ("mixBlendMode" in style && style.mixBlendMode !== "normal") return true;
+  if ("filter" in style && style.filter !== "none") return true;
+  if ("webkitFilter" in style && style.webkitFilter !== "none") return true;
+  if ("isolation" in style && style.isolation === "isolate") return true;
+  if (props.test(style.willChange)) return true;
+  // @ts-expect-error Unrecognized prop
+  if (style.webkitOverflowScrolling === "touch") return true;
+
+  return false;
+}
+
+/** @param {(HTMLElement| SVGElement)[]} nodes */
+function find_stacking_context(nodes: (HTMLElement | SVGElement)[]) {
+  let i = nodes.length;
+
+  while (i--) {
+    const node = nodes[i];
+    assert(node, "Missing node");
+    if (creates_stacking_context(node)) return node;
+  }
+
+  return null;
+}
+
+/** @param {HTMLElement | SVGElement} node */
+function get_z_index(node: HTMLElement | SVGElement | null) {
+  return (node && Number(getComputedStyle(node).zIndex)) || 0;
+}
+
+/** @param {HTMLElement} node */
+function get_ancestors(node: HTMLElement | SVGElement | null) {
+  const ancestors = [];
+
+  while (node) {
+    ancestors.push(node);
+    // @ts-expect-error ParentNode vs Element
+    node = get_parent(node);
+  }
+
+  return ancestors; // [ node, ... <body>, <html>, document ]
+}
+
+/** @param {HTMLElement} node */
+function get_parent(node: HTMLElement) {
+  const { parentNode } = node;
+  if (isShadowRoot(parentNode)) {
+    return parentNode.host;
+  }
+  return parentNode;
+}


### PR DESCRIPTION
## Summary

This PR implements the remaining "Sidebar Flesh" features required for exact parity with Craft Agents, as outlined in the PR #40 follow-up plans.

## Changes
- **Rename & Delete Conversations:** Added full end-to-end support in the `EntityRow` context menus.
- **Backend APIs:** Implemented `PATCH /api/v1/conversations/{id}` and `DELETE /api/v1/conversations/{id}`.
- **Optimistic State & Navigation:** 
  - Added TanStack Query mutations with optimistic cache updates for instantaneous UI reflection.
  - Deleting the active conversation automatically navigates the user back to `/`.
- **Resizable Sidebar:** Added a drag rail for resizing the desktop sidebar. Width preferences are persisted in `localStorage` and a double-click on the rail snaps it back to the default `300px`.
- **Mobile Sheet:** Refactored the mobile sidebar to use the standard responsive `Sheet` component. It properly closes on navigation or when creating a new chat.

## Testing Instructions
1. **Validation:** Run `bun run --cwd frontend typecheck` and `bunx --bun @biomejs/biome check frontend`
2. **Backend:** Start the backend with `uv run fastapi dev backend/main.py`
3. **UI Verification:**
   - Open a sidebar context menu and click "Rename". Verify the dialog updates the title immediately upon save.
   - Delete a conversation and confirm it disappears from the list.
   - Delete the currently active conversation and verify the app navigates to `/`.
   - Drag the sidebar rail to resize, refresh the page to confirm width persistence, and double-click to reset.
   - Switch to a mobile viewport, open the sidebar, select a chat, and ensure the sheet closes automatically.

## User Impact
Massively improves sidebar utility. Users can now natively manage their chat history (Rename/Delete) and customize their workspace layout via a resizable sidebar. Mobile users get a native sheet experience that properly gets out of the way after selection.

## Summary by Sourcery

Add sidebar conversation management (rename/delete), a resizable desktop sidebar with persisted width, and improved mobile sidebar behavior.

New Features:
- Support renaming conversations from the sidebar with dialog-based UI and backend PATCH endpoint.
- Support deleting conversations from the sidebar with confirmation flow and backend DELETE endpoint.
- Enable drag-to-resize behavior for the desktop sidebar with persisted width and double-click reset.
- Close the mobile sidebar sheet automatically when starting a new session or opening a conversation.

Enhancements:
- Integrate optimistic React Query mutations to keep conversation lists and details in sync after rename/delete actions.
- Standardize conversation API endpoint definitions to include update and delete helpers.
- Improve navigation helpers so mobile sidebar state is coordinated with route changes.

Chores:
- Record the sidebar feature work in a Beans tracking document.