### PR TITLE
ci: trigger auto-rebase immediately when label is applied

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,9 +1,11 @@
-name: Auto-rebase labeled PRs on development push
+name: Auto-rebase labeled PRs
 
 on:
   push:
     branches:
       - development
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: write
@@ -15,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.set-prs.outputs.prs }}
+    # If triggered by a label, only run if the label added was exactly "auto-rebase".
+    # If triggered by a push, run unconditionally.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'auto-rebase')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - development
+  # pull_request_target is used deliberately: this workflow never executes
+  # code from the PR branch, so the elevated base-branch token is safe.
   pull_request_target:
     types: [labeled]
+    branches:
+      - development
   issue_comment:
     types: [created]
 
@@ -13,22 +17,25 @@ permissions:
   contents: write
   pull-requests: write
 
+# Prevent race conditions if multiple triggers fire for the same PR simultaneously
+concurrency:
+  group: rebase-pr-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   get-prs:
     name: Find Open PRs
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.set-prs.outputs.prs }}
-    # If triggered by a label, only run if the label added was exactly "auto-rebase".
-    # If triggered by a comment, only run if it's "/rebase" from an OWNER/COLLABORATOR/MEMBER.
-    # If triggered by a push, run unconditionally (it will sweep for labeled PRs).
+    # Guard: Only run if the base branch is exactly 'development' (for PR events), and check the specific trigger conditions.
     if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'auto-rebase') ||
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'development' && github.event.label.name == 'auto-rebase') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/rebase') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association))
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -41,8 +48,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            if [[ -z "$ISSUE_NUMBER" ]]; then
+              echo "No issue number found, skipping." && exit 1
+            fi
             echo "prs=[$ISSUE_NUMBER]" >> $GITHUB_OUTPUT
           elif [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            if [[ -z "$PR_NUMBER" ]]; then
+              echo "No PR number found, skipping." && exit 1
+            fi
             echo "prs=[$PR_NUMBER]" >> $GITHUB_OUTPUT
           else
             # Note: PRs MUST have the "auto-rebase" label applied to be included here.
@@ -62,7 +75,7 @@ jobs:
         pr: ${{ fromJson(needs.get-prs.outputs.prs) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,4 +1,4 @@
-name: Auto-rebase labeled PRs
+name: Auto-rebase PRs
 
 on:
   push:
@@ -6,6 +6,8 @@ on:
       - development
   pull_request_target:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
@@ -18,10 +20,12 @@ jobs:
     outputs:
       prs: ${{ steps.set-prs.outputs.prs }}
     # If triggered by a label, only run if the label added was exactly "auto-rebase".
-    # If triggered by a push, run unconditionally.
+    # If triggered by a comment, only run if it's "/rebase" from an OWNER/COLLABORATOR/MEMBER.
+    # If triggered by a push, run unconditionally (it will sweep for labeled PRs).
     if: >-
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'auto-rebase')
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'auto-rebase') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/rebase') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association))
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,11 +36,20 @@ jobs:
         id: set-prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Note: PRs MUST have the "auto-rebase" label applied to be included here.
-          # This prevents the bot from force-pushing over active work.
-          PRS=$(gh pr list --base development --state open --search "label:auto-rebase" --json number -q '[.[] | .number]')
-          echo "prs=$PRS" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            echo "prs=[$ISSUE_NUMBER]" >> $GITHUB_OUTPUT
+          elif [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            echo "prs=[$PR_NUMBER]" >> $GITHUB_OUTPUT
+          else
+            # Note: PRs MUST have the "auto-rebase" label applied to be included here.
+            # This prevents the bot from force-pushing over active work.
+            PRS=$(gh pr list --base development --state open --search "label:auto-rebase" --json number -q '[.[] | .number]')
+            echo "prs=$PRS" >> $GITHUB_OUTPUT
+          fi
 
   rebase:
     name: Rebase PR #${{ matrix.pr }}


### PR DESCRIPTION
## Summary

Follow-up to PR #45. Waiting for the next push to `development` made the `auto-rebase` label feel broken or unresponsive when a user first applies it.

This PR wires an instant trigger directly into the workflow (`pull_request_target: [labeled]`). 

Now it handles both cases perfectly:
1. **The Catch-up Sweep:** Whenever anyone pushes to `development`, it sweeps through and auto-rebases every open PR that has the `auto-rebase` label.
2. **The Instant Trigger:** The absolute *second* you attach the `auto-rebase` label to a PR, the workflow instantly wakes up, checks that the label was exactly `auto-rebase`, and immediately runs the rebase on that specific branch without waiting.

## Testing Instructions
1. Open a test PR targeting `development`.
2. Apply the `auto-rebase` label.
3. Observe the Actions tab instantly run the workflow and rebase the branch.

## Summary by Sourcery

Trigger the auto-rebase workflow both on pushes to the development branch and when the auto-rebase label is applied to a pull request, ensuring immediate rebase behavior on labeling.

CI:
- Extend the rebase workflow to run on pull_request_target labeled events in addition to pushes to the development branch.
- Gate the rebase job so it only runs for push events or when the added label name is exactly auto-rebase.