### PR TITLE
docs: establish GitHub Actions security and concurrency rules

### DIFF
--- a/.claude/rules/github-actions/explicit-pr-descriptions.md
+++ b/.claude/rules/github-actions/explicit-pr-descriptions.md
@@ -1,0 +1,10 @@
+---
+description: Ensure Pull Request descriptions are honest and accurate
+globs: .github/workflows/*.yml
+---
+# Explicit Pull Request Descriptions
+
+When creating, updating, or reviewing a Pull Request that introduces workflow automation or other changes:
+1. **Never Make Undocumented Scope Creeps:** Never silently bundle new features, new triggers, or architectural shifts inside a PR without explicitly stating them in the PR title and description.
+2. **Accurate Execution Context:** Ensure the PR accurately reflects the execution trigger (e.g. `on: push` vs `on: pull_request_target`). Do not copy-paste testing instructions or summaries from other sources if they contradict the actual implementation in the diff.
+3. **If You Touch It, Describe It:** If you change an action's trigger, modify its target, or update its permissions from what was originally documented, rewrite the PR description to match reality before merging.

--- a/.claude/rules/github-actions/prevent-workflow-races.md
+++ b/.claude/rules/github-actions/prevent-workflow-races.md
@@ -1,0 +1,13 @@
+---
+description: Ensure GitHub Actions workflows are safe from concurrency and race conditions
+globs: .github/workflows/*.yml
+---
+# Prevent Workflow Races
+
+Workflows that can be triggered by rapid external events (like `pull_request_target: [labeled]`, `issue_comment`, or `push`) must prevent race conditions caused by multiple identical jobs executing concurrently against the same branch.
+
+When implementing or modifying a GitHub Actions workflow, follow these constraints:
+1. **Concurrency Grouping:** Always apply a `concurrency: group:` block to the workflow or job if the workflow modifies code, force-pushes, or runs complex stateful side-effects.
+   - Example: `concurrency: group: auto-rebase-${{ github.event.pull_request.number || github.run_id }}`
+2. **Empty Payload Guards:** When handling webhook event data (like `github.event.pull_request.number`), always implement hard checks (`if [[ -z "$PR_NUMBER" ]]; then exit 1; fi`) and fail loudly rather than silently executing logic on empty/null strings.
+3. **Cancel-in-Progress:** Specify `cancel-in-progress: true` when newer triggers (like a recent push) invalidate the need for an older, currently running job on the same PR. Specify `false` if the job executes critical transactional steps that should not be interrupted.

--- a/.claude/rules/github-actions/safe-pull-request-target.md
+++ b/.claude/rules/github-actions/safe-pull-request-target.md
@@ -1,0 +1,13 @@
+---
+description: Ensure safe usage of elevated pull_request_target permissions
+globs: .github/workflows/*.yml
+---
+# Safe pull_request_target Usage
+
+The `pull_request_target` event runs workflows in the context of the **base repository**, meaning it has access to write tokens and repository secrets even when triggered by an untrusted fork PR.
+
+When implementing or modifying a workflow using `pull_request_target`, follow these strict constraints:
+1. **Never Checkout the PR Head:** By default, `actions/checkout` checks out the *base branch* on `pull_request_target`. Never override this with `ref: ${{ github.event.pull_request.head.sha }}` unless you are explicitly running isolated code. Doing so allows malicious code from an untrusted fork to execute with elevated privileges.
+2. **Never Execute Untrusted Code:** Do not run `npm install`, build scripts, test suites, or any arbitrary code located within the PR branch during a `pull_request_target` run.
+3. **Explicit Base Ref Guarding:** Always guard the execution by explicitly checking the target branch (e.g., `if: github.event.pull_request.base.ref == 'development'`) to avoid accidentally acting on PRs targeting arbitrary feature or release branches.
+4. **Document Intent:** Add explicit comments above the `pull_request_target` trigger outlining why it is necessary and confirming the safety assumptions (e.g., that no PR code is executed).

--- a/.claude/rules/github-actions/secure-action-pinning.md
+++ b/.claude/rules/github-actions/secure-action-pinning.md
@@ -1,0 +1,12 @@
+---
+description: Ensure third-party GitHub Actions are securely pinned
+globs: .github/workflows/*.yml
+---
+# Secure Action Pinning
+
+When adding or modifying third-party GitHub Actions (`uses:`), follow these security constraints:
+
+1. **Pin by Commit SHA:** Always pin third-party actions to an exact, full-length commit SHA rather than a mutable tag (like `@v1` or `@master`). Tags can be hijacked or silently updated, which opens the repository to supply-chain attacks.
+   - Good: `uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2`
+   - Bad: `uses: actions/checkout@v4`
+2. **Comment the Version:** Include the human-readable version tag as a comment next to the SHA so maintainers know what version is being used.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - **Backend (`backend/`)**: Python FastAPI application. API routes in `backend/app/api/`, database models in `backend/app/models/`, CRUD operations in `backend/app/crud/`.
 - **Docs (`docs/`)**: Project documentation, migration plans, and design specs.
 - **Tasks (`.beans/`)**: Markdown-based task tracking. Update the status of `.beans` files as work is completed.
-- **AI Rules (`.claude/rules/`)**: Strict context and design patterns to follow. Always read and abide by the rules inside `.claude/rules/react/` and `.claude/rules/typescript/` when modifying or creating new code.
+- **AI Rules (`.claude/rules/`)**: Strict context and design patterns to follow. Always read and abide by the rules inside `.claude/rules/react/`, `.claude/rules/typescript/`, and `.claude/rules/github-actions/` when modifying or creating new code.
 - **Rule**: Frontend code must only communicate with the backend via the established API endpoints (using `useAuthedFetch` or TanStack Query mutations). Do not mix frontend and backend responsibilities.
 - **Rule**: UI components should follow the established Craft Agents design language (e.g., `popover-styled` classes, exact radius matching).
 - **Rule**: Ensure PascalCase is used for components inside `frontend/features/`.
@@ -70,3 +70,4 @@ We rely on `just` as our primary task runner for the repository.
 - **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
 - Bug investigations: read source code of relevant dependencies and all related local code before concluding; aim for high-confidence root cause.
 - Code style: add brief comments for tricky logic.
+- **GitHub Actions Rules (`.claude/rules/github-actions/`)**: Strict context and design patterns to follow when creating or modifying CI/CD workflows and actions.


### PR DESCRIPTION
## Summary

After the extensive review cycles in the auto-rebase PRs, we identified several recurring security and architectural edge cases that agents and contributors need to actively avoid when working with GitHub Actions.

This PR distills those lessons into four distinct, declarative rules inside `.claude/rules/github-actions/`. They act as automated guardrails to ensure we don't repeat the same mistakes in future workflows.

## Changes
- Added `.claude/rules/github-actions/secure-action-pinning.md`: Enforces hard SHA pinning for all third-party actions to prevent supply-chain hijack attacks via mutable tags.
- Added `.claude/rules/github-actions/safe-pull-request-target.md`: Outlines the exact boundaries and dangers of the elevated `pull_request_target` trigger, explicitly forbidding the checkout or execution of untrusted PR head code.
- Added `.claude/rules/github-actions/prevent-workflow-races.md`: Mandates the use of `concurrency: group:` blocks and loud `exit 1` guards against empty GitHub API payloads to prevent silent failures and race conditions.
- Added `.claude/rules/github-actions/explicit-pr-descriptions.md`: Requires agents to accurately describe the execution context (e.g. `on: push` vs `pull_request_target`) and forbids undocumented scope creep within CI/CD PRs.
- Updated `AGENTS.md` to point all AI assistants to the new `.claude/rules/github-actions/` directory before modifying any workflows.

## User Impact
Massively reduces the likelihood of introducing CI/CD security vulnerabilities or logic races. Future agents will read these rules before proposing workflow changes and will automatically pin SHAs, handle concurrency, and respect the `pull_request_target` boundaries from the start.

## Summary by Sourcery

Add new GitHub Actions security and concurrency rules and integrate them into the agent guidance.

Documentation:
- Document secure pinning of third-party GitHub Actions by commit SHA.
- Document safe usage constraints and documentation requirements for pull_request_target workflows.
- Document requirements to prevent workflow race conditions using concurrency groups, payload guards, and cancel-in-progress settings.
- Document expectations for accurate, explicit PR descriptions when modifying CI/CD workflows.
- Update AGENTS.md to reference the new GitHub Actions rules directory and guidance for workflow changes.