### PR TITLE
ci: fallback to raw Claude CLI to bypass event restrictions

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -105,6 +105,7 @@ jobs:
             echo "Clean rebase successful. Force pushing..."
             git push origin "$BRANCH_NAME" --force-with-lease
             echo "conflict=false" >> $GITHUB_OUTPUT
+            gh pr comment $PR_NUMBER --body "✅ **Automated Rebase Successful:** Branch was cleanly rebased onto \`development\`."
           else
             echo "Merge conflict detected! Preparing for Claude Code autonomous resolution..."
             echo "conflict=true" >> $GITHUB_OUTPUT
@@ -119,18 +120,21 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           just install
 
-      - name: Resolve conflicts with Claude Code
+      - name: Resolve conflicts with Claude Code (CLI)
         if: steps.rebase.outputs.conflict == 'true'
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            This repository is currently in the middle of a git rebase with merge conflicts.
-            Find all files with conflict markers (<<<<<<<).
-            Intelligently resolve the conflicts to preserve the intent of both branches.
-            Once resolved, use the Bash tool to run `git add -u` and `git rebase --continue`.
-            Ensure the rebase completes successfully. Do NOT push the branch yourself, just finish the rebase.
-          claude_args: '--accept-all --allowed-tools "Edit,Read,Write,Glob,Grep,Bash(git status),Bash(git add -u),Bash(git rebase --continue)"'
+        env:
+          # We CANNOT use the anthropics/claude-code-action@v1 here because it hard-fails 
+          # on 'push' events ("Unsupported event type: push"). Instead, we run the CLI directly.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -z "$ANTHROPIC_API_KEY" ]]; then
+            echo "Error: ANTHROPIC_API_KEY is not set. Claude Code cannot run."
+            exit 1
+          fi
+          
+          npm install -g @anthropic-ai/claude-code
+          
+          claude -p "This repository is currently in the middle of a git rebase with merge conflicts. Find all files with conflict markers (<<<<<<<). Intelligently resolve the conflicts to preserve the intent of both branches. Once resolved, use the Bash tool to run 'git add -u' and 'git rebase --continue'. Ensure the rebase completes successfully. Do NOT push the branch yourself, just finish the rebase." --accept-all --allowed-tools "Edit,Read,Write,Glob,Grep,Bash(git status),Bash(git add -u),Bash(git rebase --continue)"
 
       - name: Run Build and Lint Gates (just check)
         if: steps.rebase.outputs.conflict == 'true'


### PR DESCRIPTION
## Summary
The official `anthropics/claude-code-action@v1` action has a hardcoded check that causes it to immediately crash with `Unsupported event type: push` if it is triggered by a `push` event. Since our auto-rebase sweeper is triggered on `push: branches: [development]`, using the Anthropic action wrapper is fundamentally incompatible with our use case.

## Changes
- Ripped out the `anthropics/claude-code-action@v1` wrapper.
- Replaced it with a native `npm install -g @anthropic-ai/claude-code` and raw `claude -p` command execution.
- This entirely bypasses the action's event restrictions while maintaining identical functionality and security guardrails (`--allowed-tools`).
- Note: This requires `ANTHROPIC_API_KEY` to be present in GitHub secrets since we aren't using the OAuth token wrapper anymore.
- Added a step to automatically drop a GitHub PR comment on success (e.g. `✅ **Automated Rebase Successful:** Branch was cleanly rebased onto development.`) so you're notified even when Claude isn't triggered.

## Summary by Sourcery

Replace the Anthropic Claude Code GitHub Action with direct CLI invocation in the rebase workflow to support push-triggered runs and add PR notifications on successful auto-rebases.

CI:
- Update rebase workflow to call the Claude Code CLI directly using an API key instead of the anthropics/claude-code-action wrapper, preserving allowed tools configuration.
- Add a GitHub CLI step to comment on the pull request when an automated rebase completes successfully, even when no conflicts occur.