### PR TITLE
feat(frontend): add resizable sidebar with clean code rules

### DIFF
--- a/.claude/rules/clean-code/avoid-redundant-state.md
+++ b/.claude/rules/clean-code/avoid-redundant-state.md
@@ -1,0 +1,74 @@
+---
+description: Avoid redundant state representations in React components
+globs: **/*.{ts,tsx,js,jsx}
+---
+# Clean Code: Avoid Redundant State
+
+Redundant state occurs when the same information is represented in multiple ways within a component's state. This violates the DRY (Don't Repeat Yourself) principle and creates potential for inconsistency.
+
+## Rule
+
+**Never maintain multiple state variables that represent the same information in different formats.**
+
+If you have a union type or enum for state, do not also maintain a boolean or other derived representation of that same state.
+
+## Why This Matters
+
+1. **Single Source of Truth**: Having multiple representations of the same state creates multiple sources of truth, leading to potential inconsistencies
+2. **Maintenance Burden**: Changes must be synchronized across all representations
+3. **Cognitive Load**: Developers must understand and maintain the relationship between redundant states
+4. **Bug Risk**: States can become out of sync, causing subtle bugs
+
+## Bad Example
+
+```tsx
+// BAD: Redundant state - 'open' boolean duplicates 'state' union
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";  // Primary representation
+  open: boolean;                     // Redundant - derived from state
+  setOpen: (open: boolean) => void;
+};
+
+function Component() {
+  const [state, setState] = useState<"expanded" | "collapsed">("expanded");
+  const open = state === "expanded";  // Derived value, but then stored...
+  // ... later stored in context as separate boolean
+}
+```
+
+## Good Example
+
+```tsx
+// GOOD: Single source of truth with derived values where needed
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  setState: (state: "expanded" | "collapsed") => void;
+};
+
+function Component() {
+  const [state, setState] = useState<"expanded" | "collapsed">("expanded");
+
+  // Derive boolean locally when needed, don't store it
+  const isExpanded = state === "expanded";
+
+  return <div data-expanded={isExpanded}>...</div>;
+}
+```
+
+## Pattern: Derive, Don't Duplicate
+
+When you need different representations of the same state:
+
+1. **Choose the most precise representation** as your source of truth (prefer union types over booleans)
+2. **Derive other representations** locally where needed using simple transformations
+3. **Never store derived values** in state or context
+
+## Checklist
+
+Before adding a new state variable, ask:
+
+- [ ] Can this value be derived from existing state?
+- [ ] Does this represent the same information as another state variable?
+- [ ] Would changing one state require changing this state to stay consistent?
+
+If you answer "yes" to any of these, don't add the state variable. Derive it instead.

--- a/.claude/rules/clean-code/limit-nesting-depth.md
+++ b/.claude/rules/clean-code/limit-nesting-depth.md
@@ -1,0 +1,266 @@
+---
+description: Limit nesting depth to improve code readability and maintainability
+globs: **/*.{ts,tsx,js,jsx,py,pyw}
+---
+# Clean Code: Limit Nesting Depth
+
+Deep nesting makes code harder to read, understand, and maintain. Functions with excessive nesting depth (more than 2-3 levels) should be refactored.
+
+## Rule
+
+**Keep nesting depth to a maximum of 3 levels. Prefer 1-2 levels when possible.**
+
+Use early returns, guard clauses, and extracted functions to reduce nesting.
+
+## Why This Matters
+
+1. **Cognitive Load**: Each nesting level requires tracking more context in working memory
+2. **Readability**: Deeply nested code is harder to scan and understand
+3. **Error-Prone**: Nested conditions are more likely to contain logic errors
+4. **Testing**: Deeply nested code has more execution paths to test
+
+## Techniques to Reduce Nesting
+
+### 1. Early Returns (Guard Clauses)
+
+Return early for edge cases instead of wrapping the main logic in conditions.
+
+```tsx
+// BAD: Nested conditions (3+ levels)
+function loadDesktopSidebarWidth(): number {
+  if (typeof window !== "undefined") {
+    try {
+      const storedWidth = window.localStorage.getItem(STORAGE_KEY);
+      if (storedWidth) {
+        const parsedWidth = Number.parseInt(storedWidth, 10);
+        if (Number.isFinite(parsedWidth)) {
+          return clampSidebarWidth(parsedWidth);
+        }
+      }
+    } catch {
+      return DEFAULT_WIDTH;
+    }
+  }
+  return DEFAULT_WIDTH;
+}
+
+// GOOD: Early returns (1-2 levels max)
+function loadDesktopSidebarWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_WIDTH;
+
+  const storedWidth = window.localStorage.getItem(STORAGE_KEY);
+  if (!storedWidth) return DEFAULT_WIDTH;
+
+  const parsedWidth = Number.parseInt(storedWidth, 10);
+  if (!Number.isFinite(parsedWidth)) return DEFAULT_WIDTH;
+
+  return clampSidebarWidth(parsedWidth);
+}
+```
+
+### 2. Extract Functions
+
+Break complex nested logic into smaller, named functions.
+
+```tsx
+// BAD: Deep nesting with complex logic
+function processOrder(order: Order) {
+  if (order.status === 'pending') {
+    if (order.items.length > 0) {
+      if (order.customer.verified) {
+        if (order.total > 0) {
+          // Process payment
+          if (payment.success) {
+            // Update inventory
+            if (inventory.available) {
+              // Ship order
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// GOOD: Extracted functions with descriptive names
+function processOrder(order: Order) {
+  if (!canProcessOrder(order)) return;
+
+  const payment = processPayment(order);
+  if (!payment.success) return;
+
+  if (!updateInventory(order)) return;
+
+  shipOrder(order);
+}
+
+function canProcessOrder(order: Order): boolean {
+  return (
+    order.status === 'pending' &&
+    order.items.length > 0 &&
+    order.customer.verified &&
+    order.total > 0
+  );
+}
+```
+
+### 3. Invert Conditions
+
+Check for failure conditions first and return early.
+
+```tsx
+// BAD: Nested success path
+function validateUser(user: User) {
+  if (user) {
+    if (user.email) {
+      if (user.email.includes('@')) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// GOOD: Early returns for failure cases
+function validateUser(user: User): boolean {
+  if (!user) return false;
+  if (!user.email) return false;
+  if (!user.email.includes('@')) return false;
+
+  return true;
+}
+
+// EVEN BETTER: Combined condition when appropriate
+function validateUser(user: User): boolean {
+  return Boolean(user?.email?.includes('@'));
+}
+```
+
+### 4. Replace Nested Conditionals with Polymorphism
+
+For complex branching logic, consider using polymorphism or strategy pattern.
+
+```tsx
+// BAD: Deep nesting with type checks
+function getDiscount(customer: Customer, order: Order) {
+  if (customer.type === 'gold') {
+    if (order.total > 1000) {
+      return 0.20;
+    } else {
+      return 0.15;
+    }
+  } else if (customer.type === 'silver') {
+    if (order.total > 500) {
+      return 0.10;
+    } else {
+      return 0.05;
+    }
+  }
+  return 0;
+}
+
+// GOOD: Strategy pattern
+const DISCOUNT_STRATEGIES = {
+  gold: (total: number) => total > 1000 ? 0.20 : 0.15,
+  silver: (total: number) => total > 500 ? 0.10 : 0.05,
+  bronze: () => 0,
+} as const;
+
+function getDiscount(customer: Customer, order: Order): number {
+  const strategy = DISCOUNT_STRATEGIES[customer.type];
+  return strategy(order.total);
+}
+```
+
+### 5. Flatten Loops with Continue
+
+Use `continue` to avoid nesting inside loops.
+
+```tsx
+// BAD: Nested loop conditions
+for (const item of items) {
+  if (item.active) {
+    if (item.price > 0) {
+      if (!item.deleted) {
+        process(item);
+      }
+    }
+  }
+}
+
+// GOOD: Guard clauses with continue
+for (const item of items) {
+  if (!item.active) continue;
+  if (item.price <= 0) continue;
+  if (item.deleted) continue;
+
+  process(item);
+}
+```
+
+## React-Specific Patterns
+
+### Early Return in Components
+
+```tsx
+// BAD: Nested JSX conditionals
+function UserProfile({ user }: Props) {
+  return (
+    <div>
+      {user ? (
+        user.verified ? (
+          user.active ? (
+            <ProfileCard user={user} />
+          ) : (
+            <InactiveMessage />
+          )
+        ) : (
+          <VerificationPrompt />
+        )
+      ) : (
+        <LoginPrompt />
+      )}
+    </div>
+  );
+}
+
+// GOOD: Early returns
+function UserProfile({ user }: Props) {
+  if (!user) return <LoginPrompt />;
+  if (!user.verified) return <VerificationPrompt />;
+  if (!user.active) return <InactiveMessage />;
+
+  return <ProfileCard user={user} />;
+}
+```
+
+## Measuring Nesting Depth
+
+Count the indentation levels:
+
+```tsx
+function example() {           // Level 0
+  if (condition) {             // Level 1
+    for (const item of items) { // Level 2
+      if (item.valid) {        // Level 3 - TOO DEEP!
+        // ...
+      }
+    }
+  }
+}
+```
+
+## Checklist
+
+When you see nesting beyond 2-3 levels:
+
+- [ ] Can I use an early return / guard clause?
+- [ ] Can I extract a helper function?
+- [ ] Can I invert the condition?
+- [ ] Can I combine conditions with logical operators?
+- [ ] Can I use a strategy pattern or lookup table?
+
+## References
+
+- Clean Code by Robert C. Martin, Chapter 3: Functions
+- Code Complete by Steve McConnell, Chapter 19: General Control Issues

--- a/.claude/rules/clean-code/no-lint-suppressions.md
+++ b/.claude/rules/clean-code/no-lint-suppressions.md
@@ -1,0 +1,149 @@
+---
+description: Avoid suppressing linter warnings; fix root causes instead
+globs: **/*.{ts,tsx,js,jsx,py,pyw}
+---
+# Clean Code: No Lint Suppressions
+
+Linter rules exist to catch bugs, enforce best practices, and maintain code quality. Suppressing linter warnings should be extremely rare and always justified.
+
+## Rule
+
+**Do not add inline lint suppressions (`// biome-ignore`, `// eslint-disable`, `// @ts-ignore`, etc.) unless absolutely necessary.**
+
+When suppression is necessary, it must be accompanied by a comment explaining why the code is intentionally correct and why the rule cannot express that.
+
+## Why This Matters
+
+1. **Masks Real Issues**: Suppressions hide potential bugs and code smells
+2. **Technical Debt**: Each suppression is technical debt that accumulates over time
+3. **Precedent**: One suppression encourages others, degrading code quality
+4. **Lost Context**: Future developers won't understand why the suppression exists
+
+## Fix Root Causes First
+
+Before adding a suppression, try these approaches in order:
+
+1. **Refactor the code** to satisfy the linter rule properly
+2. **Extract to a separate function** if complexity is the issue
+3. **Use proper types** instead of `any` or type assertions
+4. **Rename or restructure** to make the code clearer
+5. **Provide unique IDs** instead of suppressing duplicate ID warnings
+
+## Rare Justified Suppressions
+
+Suppressions are only acceptable when ALL of these are true:
+
+1. **The code is intentionally correct** - you're not working around a bug
+2. **The linter cannot express the safety** - the rule is overly conservative for this case
+3. **Refactoring would make code worse** - alternative approaches reduce clarity
+4. **A comment explains why** - future developers understand the decision
+
+### Example of Justified Suppression
+
+```tsx
+// BAD: No explanation, ID should actually be unique
+<div id="user-list">
+  {/* biome-ignore lint/correctness/useUniqueElementIds: */}
+  {users.map(user => <UserCard key={user.id} id="card" />)}
+</div>
+
+// GOOD: Clear explanation of intentional pattern
+<form>
+  {/* biome-ignore lint/suspicious/noDocumentCookie: Sidebar state is a
+       non-sensitive UI preference. Using document.cookie is intentional here
+       for SSR cookie persistence, not security-sensitive data. */}
+  document.cookie = `sidebar_state=${isOpen}`;
+</form>
+```
+
+## Common Suppressions to Avoid
+
+### 1. `@ts-ignore` / `@ts-nocheck`
+
+**Never use these.** They disable all type checking.
+
+```tsx
+// BAD: Completely disables type checking
+// @ts-ignore
+const result = someFunction(wrongType);
+
+// GOOD: Fix the type properly
+const result = someFunction(correctType);
+```
+
+### 2. Duplicate IDs
+
+**Always use unique IDs.** If IDs must be dynamic, generate them properly.
+
+```tsx
+// BAD: Suppressing duplicate ID warning
+{/* biome-ignore lint/correctness/useUniqueElementIds: */}
+<div id="panel">...</div>
+
+// GOOD: Use unique, descriptive IDs
+<div id="user-settings-panel">...</div>
+<div id="notification-settings-panel">...</div>
+
+// GOOD: Generate unique IDs when needed
+<div id={`panel-${panelId}`}>...</div>
+```
+
+### 3. `no-explicit-any`
+
+**Never suppress this.** Use proper types instead.
+
+```tsx
+// BAD: any with suppression
+{/* biome-ignore lint/suspicious/noExplicitAny: */}
+function process(data: any) { }
+
+// GOOD: Use proper types
+function process(data: UserData) { }
+
+// GOOD: Use unknown if type is truly unknown, then narrow
+function process(data: unknown) {
+  if (isUserData(data)) {
+    // Now data is UserData
+  }
+}
+```
+
+## Pattern: Refactor Instead
+
+```tsx
+// BAD: Suppressing complexity warning
+{/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: */}
+function processUser(user: User) {
+  if (user.isActive) {
+    if (user.role === 'admin') {
+      if (user.permissions.includes('write')) {
+        // ... 50 more lines of nested logic
+      }
+    }
+  }
+}
+
+// GOOD: Extract helper functions to reduce complexity
+function processUser(user: User) {
+  if (!user.isActive) return;
+
+  if (isAdminWithWriteAccess(user)) {
+    handleAdminWrite(user);
+  }
+}
+
+function isAdminWithWriteAccess(user: User): boolean {
+  return user.role === 'admin' && user.permissions.includes('write');
+}
+
+function handleAdminWrite(user: User) {
+  // Extracted logic
+}
+```
+
+## Enforcement
+
+- Code reviews must challenge every lint suppression
+- PRs with suppressions require explicit justification
+- Periodic audits to remove unnecessary suppressions
+- Consider suppressions as technical debt items to be resolved

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -1,13 +1,13 @@
-import { NewSidebar } from "@/components/new-sidebar";
+import { AppLayout } from "@/components/app-layout";
 
-export default function AppLayout({
+export default function AppLayoutWrapper({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
 	return (
 		<>
-			<NewSidebar>{children}</NewSidebar>
+			<AppLayout>{children}</AppLayout>
 		</>
 	);
 }

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -77,9 +77,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         </div>
       </ResizablePanel>
 
-      {!isCollapsed && (
-        <ResizableHandle className="w-1 hover:w-2 transition-all hover:bg-sidebar-border bg-transparent" />
-      )}
+      {!isCollapsed && <ResizableHandle />}
 
       <ResizablePanel className="h-full">{children}</ResizablePanel>
     </ResizablePanelGroup>

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -30,11 +30,24 @@ import {
  * Renders resizable panels on desktop, plain content on mobile.
  */
 function ResizableSidebarContent({ children }: { children: React.ReactNode }): React.JSX.Element {
-  const { isMobile, state, setDesktopWidth } = useSidebar();
+  const { isMobile, state, desktopWidth, setDesktopWidth } = useSidebar();
   const panelGroupId = React.useId();
 
+  // Mobile: Sidebar renders as a Sheet overlay alongside main content
   if (isMobile) {
-    return <>{children}</>;
+    return (
+      <>
+        <Sidebar>
+          <SidebarHeader className="px-2 pb-2 shrink-0">
+            <NewSessionButton />
+          </SidebarHeader>
+          <SidebarContent>
+            <NavChats />
+          </SidebarContent>
+        </Sidebar>
+        {children}
+      </>
+    );
   }
 
   const isCollapsed = state === 'collapsed';
@@ -42,7 +55,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
   return (
     <ResizablePanelGroup direction="horizontal" id={panelGroupId} className="flex-1">
       <ResizablePanel
-        defaultSize={300}
+        defaultSize={desktopWidth}
         minSize={240}
         maxSize={420}
         collapsible={true}
@@ -52,14 +65,16 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         }}
         className={`transition-all duration-200 ease-linear ${isCollapsed ? '!hidden' : ''}`}
       >
-        <Sidebar variant="inset" className="!w-full h-full border-r-0">
+        {/* Render content directly — ResizablePanel handles sizing via flex,
+            Sidebar's gap div + fixed positioning would conflict */}
+        <div className="bg-sidebar text-sidebar-foreground flex h-full flex-col">
           <SidebarHeader className="px-2 pb-2 shrink-0">
             <NewSessionButton />
           </SidebarHeader>
           <SidebarContent>
             <NavChats />
           </SidebarContent>
-        </Sidebar>
+        </div>
       </ResizablePanel>
 
       {!isCollapsed && (
@@ -79,7 +94,7 @@ export function AppLayout({ children }: { children: React.ReactNode }): React.JS
   return (
     <SidebarProvider>
       <ResizableSidebarContent>
-        <SidebarInset className="peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm border border-transparent shadow-none !m-0 !rounded-none">
+        <SidebarInset>
           <header className="flex h-16 shrink-0 items-center gap-2">
             <div className="flex items-center gap-2 px-4">
               <SidebarTrigger className="-ml-1 cursor-pointer" />

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import { NavChats } from '@/features/nav-chats/NavChats';
 import { NewSessionButton } from './new-session-button';
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './ui/resizable';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup, usePanelRef } from './ui/resizable';
 import { Separator } from './ui/separator';
 import {
   Sidebar,
@@ -30,8 +30,23 @@ import {
  * Renders resizable panels on desktop, plain content on mobile.
  */
 function ResizableSidebarContent({ children }: { children: React.ReactNode }): React.JSX.Element {
-  const { isMobile, state, desktopWidth, setDesktopWidth } = useSidebar();
+  const { isMobile, state, setState, desktopWidth, setDesktopWidth } = useSidebar();
   const panelGroupId = React.useId();
+  const sidebarPanelRef = usePanelRef();
+
+  // Drive the panel's collapse/expand from the sidebar context state
+  // so that the toggle button, keyboard shortcut, etc. all work through
+  // the library's layout engine (smooth flex transitions) instead of CSS display:none.
+  React.useEffect(() => {
+    const panel = sidebarPanelRef.current;
+    if (!panel) return;
+
+    if (state === 'collapsed' && !panel.isCollapsed()) {
+      panel.collapse();
+    } else if (state === 'expanded' && panel.isCollapsed()) {
+      panel.expand();
+    }
+  }, [state, sidebarPanelRef]);
 
   // Mobile: Sidebar renders as a Sheet overlay alongside main content
   if (isMobile) {
@@ -50,24 +65,31 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
     );
   }
 
-  const isCollapsed = state === 'collapsed';
-
   return (
     <ResizablePanelGroup direction="horizontal" id={panelGroupId} className="flex-1">
       <ResizablePanel
+        panelRef={sidebarPanelRef}
         defaultSize={desktopWidth}
         minSize={240}
         maxSize={420}
         collapsible={true}
         collapsedSize={0}
         onResize={(size) => {
-          setDesktopWidth(size.inPixels);
+          // Sync context state when panel collapses/expands via drag
+          if (size.inPixels === 0 && state !== 'collapsed') {
+            setState('collapsed');
+          } else if (size.inPixels > 0 && state !== 'expanded') {
+            setState('expanded');
+          }
+          // Only persist non-zero widths
+          if (size.inPixels > 0) {
+            setDesktopWidth(size.inPixels);
+          }
         }}
-        className={`transition-all duration-200 ease-linear ${isCollapsed ? '!hidden' : ''}`}
       >
         {/* Render content directly — ResizablePanel handles sizing via flex,
             Sidebar's gap div + fixed positioning would conflict */}
-        <div className="bg-sidebar text-sidebar-foreground flex h-full flex-col">
+        <div className="bg-sidebar text-sidebar-foreground flex h-full flex-col overflow-hidden">
           <SidebarHeader className="px-2 pb-2 shrink-0">
             <NewSessionButton />
           </SidebarHeader>
@@ -77,7 +99,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         </div>
       </ResizablePanel>
 
-      {!isCollapsed && <ResizableHandle />}
+      <ResizableHandle />
 
       <ResizablePanel className="h-full">{children}</ResizablePanel>
     </ResizablePanelGroup>

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -1,11 +1,11 @@
 /**
- * Application sidebar with resizable desktop layout.
+ * Application layout with resizable sidebar.
  *
- * Wraps the main sidebar component with a ResizablePanel on desktop for user-controlled
- * width adjustment. On mobile, renders as a standard sheet overlay. Includes navigation
- * chats and new session button in the sidebar content.
+ * Provides the main app layout structure with a resizable sidebar on desktop and
+ * a mobile-friendly sheet overlay. Integrates SidebarProvider, navigation, and
+ * content area with proper responsive behavior.
  *
- * @fileoverview Main app sidebar with desktop resize support
+ * @fileoverview Main app layout with resizable sidebar support
  */
 
 'use client';
@@ -72,10 +72,10 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
 }
 
 /**
- * Main application sidebar with resizable desktop layout and mobile sheet.
- * Provides navigation, session management, and user-controlled width on desktop.
+ * Main application layout with resizable sidebar and content area.
+ * Provides full-page structure with sidebar navigation and responsive behavior.
  */
-export function NewSidebar({ children }: { children: React.ReactNode }): React.JSX.Element {
+export function AppLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>
       <ResizableSidebarContent>

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -16,6 +16,8 @@ import { NewSessionButton } from './new-session-button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup, usePanelRef } from './ui/resizable';
 import { Separator } from './ui/separator';
 import {
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
   Sidebar,
   SidebarContent,
   SidebarHeader,
@@ -24,6 +26,9 @@ import {
   SidebarTrigger,
   useSidebar,
 } from './ui/sidebar';
+
+/** Duration of the sidebar collapse/expand CSS transition in ms. */
+const COLLAPSE_ANIMATION_DURATION_MS = 250;
 
 /**
  * Sidebar content wrapper with conditional resizable layout.
@@ -50,16 +55,16 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
     if (state === 'collapsed' && !panel.isCollapsed()) {
       isAnimatingRef.current = true;
       panel.collapse();
-      // Clear after CSS transition completes (200ms + buffer)
+      // Clear after CSS transition completes
       setTimeout(() => {
         isAnimatingRef.current = false;
-      }, 250);
+      }, COLLAPSE_ANIMATION_DURATION_MS);
     } else if (state === 'expanded' && panel.isCollapsed()) {
       isAnimatingRef.current = true;
       panel.expand();
       setTimeout(() => {
         isAnimatingRef.current = false;
-      }, 250);
+      }, COLLAPSE_ANIMATION_DURATION_MS);
     }
   }, [state, sidebarPanelRef]);
 
@@ -87,8 +92,8 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         defaultSize={desktopWidth}
         outerStyle={{ transition: 'flex-grow 200ms ease-out' }}
         style={{ overflow: 'hidden' }}
-        minSize={240}
-        maxSize={420}
+        minSize={SIDEBAR_MIN_WIDTH}
+        maxSize={SIDEBAR_MAX_WIDTH}
         collapsible={true}
         collapsedSize={0}
         onResize={(size) => {
@@ -113,6 +118,9 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
           className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden"
           style={{
             opacity: state === 'collapsed' ? 0 : 1,
+            // Disable pointer events when invisible to prevent click-dead-zones
+            // per the hidden-overlay-pointer-events rule.
+            pointerEvents: state === 'collapsed' ? 'none' : 'auto',
             transition: 'opacity 150ms ease-out',
           }}
         >

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -86,6 +86,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         panelRef={sidebarPanelRef}
         defaultSize={desktopWidth}
         outerStyle={{ transition: 'flex-grow 200ms ease-out' }}
+        style={{ overflow: 'hidden' }}
         minSize={240}
         maxSize={420}
         collapsible={true}
@@ -106,9 +107,15 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
           }
         }}
       >
-        {/* Render content directly — ResizablePanel handles sizing via flex,
-            Sidebar's gap div + fixed positioning would conflict */}
-        <div className="bg-sidebar text-sidebar-foreground flex h-full flex-col overflow-hidden">
+        {/* Content keeps min-width so layout never reflows during collapse —
+            the panel clips via overflow:hidden and the content fades out. */}
+        <div
+          className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden"
+          style={{
+            opacity: state === 'collapsed' ? 0 : 1,
+            transition: 'opacity 150ms ease-out',
+          }}
+        >
           <SidebarHeader className="px-2 pb-2 shrink-0">
             <NewSessionButton />
           </SidebarHeader>

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -34,6 +34,12 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
   const panelGroupId = React.useId();
   const sidebarPanelRef = usePanelRef();
 
+  // Guards onResize from syncing state while a programmatic collapse/expand
+  // animation is in-flight — without this, ResizeObserver fires intermediate
+  // sizes during the CSS flex-grow transition, causing a feedback loop that
+  // fights the collapse/expand.
+  const isAnimatingRef = React.useRef(false);
+
   // Drive the panel's collapse/expand from the sidebar context state
   // so that the toggle button, keyboard shortcut, etc. all work through
   // the library's layout engine (smooth flex transitions) instead of CSS display:none.
@@ -42,9 +48,18 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
     if (!panel) return;
 
     if (state === 'collapsed' && !panel.isCollapsed()) {
+      isAnimatingRef.current = true;
       panel.collapse();
+      // Clear after CSS transition completes (200ms + buffer)
+      setTimeout(() => {
+        isAnimatingRef.current = false;
+      }, 250);
     } else if (state === 'expanded' && panel.isCollapsed()) {
+      isAnimatingRef.current = true;
       panel.expand();
+      setTimeout(() => {
+        isAnimatingRef.current = false;
+      }, 250);
     }
   }, [state, sidebarPanelRef]);
 
@@ -70,18 +85,22 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
       <ResizablePanel
         panelRef={sidebarPanelRef}
         defaultSize={desktopWidth}
+        outerStyle={{ transition: 'flex-grow 200ms ease-out' }}
         minSize={240}
         maxSize={420}
         collapsible={true}
         collapsedSize={0}
         onResize={(size) => {
-          // Sync context state when panel collapses/expands via drag
-          if (size.inPixels === 0 && state !== 'collapsed') {
-            setState('collapsed');
-          } else if (size.inPixels > 0 && state !== 'expanded') {
-            setState('expanded');
+          // Skip state sync during programmatic collapse/expand animation
+          // to prevent ResizeObserver intermediate values from fighting the transition
+          if (!isAnimatingRef.current) {
+            if (size.inPixels === 0 && state !== 'collapsed') {
+              setState('collapsed');
+            } else if (size.inPixels > 0 && state !== 'expanded') {
+              setState('expanded');
+            }
           }
-          // Only persist non-zero widths
+          // Always persist non-zero widths
           if (size.inPixels > 0) {
             setDesktopWidth(size.inPixels);
           }

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -10,6 +10,7 @@
 
 'use client';
 
+import React from 'react';
 import { NavChats } from '@/features/nav-chats/NavChats';
 import { NewSessionButton } from './new-session-button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './ui/resizable';
@@ -30,6 +31,7 @@ import {
  */
 function ResizableSidebarContent({ children }: { children: React.ReactNode }): React.JSX.Element {
   const { isMobile, state, setDesktopWidth } = useSidebar();
+  const panelGroupId = React.useId();
 
   if (isMobile) {
     return <>{children}</>;
@@ -38,8 +40,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
   const isCollapsed = state === 'collapsed';
 
   return (
-    // biome-ignore lint/correctness/useUniqueElementIds: auto-save storage key
-    <ResizablePanelGroup direction="horizontal" id="sidebar_width" className="flex-1">
+    <ResizablePanelGroup direction="horizontal" id={panelGroupId} className="flex-1">
       <ResizablePanel
         defaultSize={300}
         minSize={240}

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -1,3 +1,13 @@
+/**
+ * Application sidebar with resizable desktop layout.
+ *
+ * Wraps the main sidebar component with a ResizablePanel on desktop for user-controlled
+ * width adjustment. On mobile, renders as a standard sheet overlay. Includes navigation
+ * chats and new session button in the sidebar content.
+ *
+ * @fileoverview Main app sidebar with desktop resize support
+ */
+
 'use client';
 
 import { NavChats } from '@/features/nav-chats/NavChats';
@@ -14,7 +24,11 @@ import {
   useSidebar,
 } from './ui/sidebar';
 
-function ResizableSidebarContent({ children }: { children: React.ReactNode }) {
+/**
+ * Sidebar content wrapper with conditional resizable layout.
+ * Renders resizable panels on desktop, plain content on mobile.
+ */
+function ResizableSidebarContent({ children }: { children: React.ReactNode }): React.JSX.Element {
   const { isMobile, state, setDesktopWidth } = useSidebar();
 
   if (isMobile) {
@@ -56,6 +70,10 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Main application sidebar with resizable desktop layout and mobile sheet.
+ * Provides navigation, session management, and user-controlled width on desktop.
+ */
 export function NewSidebar({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>

--- a/frontend/components/new-sidebar.tsx
+++ b/frontend/components/new-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { NavChats } from '@/features/nav-chats/NavChats';
 import { NewSessionButton } from './new-session-button';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './ui/resizable';
 import { Separator } from './ui/separator';
 import {
   Sidebar,
@@ -10,39 +11,68 @@ import {
   SidebarInset,
   SidebarProvider,
   SidebarTrigger,
+  useSidebar,
 } from './ui/sidebar';
 
-/**
- * Application sidebar layout wrapper.
- *
- * Renders the sidebar with a "New Session" button and conversation history,
- * alongside the main content area with a sidebar toggle and header.
- *
- * @param children - The page content to render in the main area.
- */
+function ResizableSidebarContent({ children }: { children: React.ReactNode }) {
+  const { isMobile, state, setDesktopWidth } = useSidebar();
+
+  if (isMobile) {
+    return <>{children}</>;
+  }
+
+  const isCollapsed = state === 'collapsed';
+
+  return (
+    // biome-ignore lint/correctness/useUniqueElementIds: auto-save storage key
+    <ResizablePanelGroup direction="horizontal" id="sidebar_width" className="flex-1">
+      <ResizablePanel
+        defaultSize={300}
+        minSize={240}
+        maxSize={420}
+        collapsible={true}
+        collapsedSize={0}
+        onResize={(size) => {
+          setDesktopWidth(size.inPixels);
+        }}
+        className={`transition-all duration-200 ease-linear ${isCollapsed ? '!hidden' : ''}`}
+      >
+        <Sidebar variant="inset" className="!w-full h-full border-r-0">
+          <SidebarHeader className="px-2 pb-2 shrink-0">
+            <NewSessionButton />
+          </SidebarHeader>
+          <SidebarContent>
+            <NavChats />
+          </SidebarContent>
+        </Sidebar>
+      </ResizablePanel>
+
+      {!isCollapsed && (
+        <ResizableHandle className="w-1 hover:w-2 transition-all hover:bg-sidebar-border bg-transparent" />
+      )}
+
+      <ResizablePanel className="h-full">{children}</ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
 export function NewSidebar({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>
-      <Sidebar variant="inset">
-        <SidebarHeader className="px-2 pb-2 shrink-0">
-          <NewSessionButton />
-        </SidebarHeader>
-        <SidebarContent>
-          <NavChats />
-        </SidebarContent>
-      </Sidebar>
-      <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2">
-          <div className="flex items-center gap-2 px-4">
-            <SidebarTrigger className="-ml-1 cursor-pointer" />
-            <Separator
-              orientation="vertical"
-              className="mr-2 data-vertical:h-4 data-vertical:self-auto"
-            />
-          </div>
-        </header>
-        <div className="flex-1">{children}</div>
-      </SidebarInset>
+      <ResizableSidebarContent>
+        <SidebarInset className="peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm border border-transparent shadow-none !m-0 !rounded-none">
+          <header className="flex h-16 shrink-0 items-center gap-2">
+            <div className="flex items-center gap-2 px-4">
+              <SidebarTrigger className="-ml-1 cursor-pointer" />
+              <Separator
+                orientation="vertical"
+                className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+              />
+            </div>
+          </header>
+          <div className="flex-1">{children}</div>
+        </SidebarInset>
+      </ResizableSidebarContent>
     </SidebarProvider>
   );
 }

--- a/frontend/components/ui/resizable.tsx
+++ b/frontend/components/ui/resizable.tsx
@@ -11,6 +11,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/** Hook that returns a ref for the Panel imperative handle (collapse/expand/resize). */
+const usePanelRef = ResizablePrimitive.usePanelRef;
+
 /**
  * Container component for resizable panels.
  * @param props - Component props including className, direction, and all Group props
@@ -78,4 +81,4 @@ const ResizableHandle = ({
 	</ResizablePrimitive.Separator>
 );
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle };
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle, usePanelRef };

--- a/frontend/components/ui/resizable.tsx
+++ b/frontend/components/ui/resizable.tsx
@@ -3,13 +3,13 @@
  * Provides a set of composable panel components with resize handles for building split-pane layouts.
  */
 
-"use client"
+"use client";
 
-import { GripVertical } from "lucide-react"
-import * as ResizablePrimitive from "@/packages/react-resizable-panels"
-import * as React from "react"
+import { GripVertical } from "lucide-react";
+import * as ResizablePrimitive from "@/packages/react-resizable-panels";
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 /**
  * Container component for resizable panels.
@@ -17,26 +17,28 @@ import { cn } from "@/lib/utils"
  * @returns JSX element containing the resizable panel group
  */
 const ResizablePanelGroup = ({
-  className,
-  direction,
-  orientation: orientationProp,
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Group> & { direction?: "horizontal" | "vertical" }): React.JSX.Element => (
-  <ResizablePrimitive.Group
-    {...props}
-    orientation={direction ?? orientationProp ?? "horizontal"}
-    className={cn(
-      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-      className
-    )}
-  />
-)
+	className,
+	direction,
+	orientation: orientationProp,
+	...props
+}: React.ComponentProps<typeof ResizablePrimitive.Group> & {
+	direction?: "horizontal" | "vertical";
+}): React.JSX.Element => (
+	<ResizablePrimitive.Group
+		{...props}
+		orientation={direction ?? orientationProp ?? "horizontal"}
+		className={cn(
+			"flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+			className,
+		)}
+	/>
+);
 
 /**
  * Individual resizable panel component.
  * Re-exported from react-resizable-panels.
  */
-const ResizablePanel = ResizablePrimitive.Panel
+const ResizablePanel = ResizablePrimitive.Panel;
 
 /**
  * Handle component for resizing panels.
@@ -45,25 +47,35 @@ const ResizablePanel = ResizablePrimitive.Panel
  * @returns JSX element containing the resize handle
  */
 const ResizableHandle = ({
-  withHandle,
-  className,
-  ...props
+	withHandle,
+	className,
+	...props
 }: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
-  withHandle?: boolean
+	withHandle?: boolean;
 }): React.JSX.Element => (
-  <ResizablePrimitive.Separator
-    className={cn(
-      "relative flex w-px items-center justify-center bg-sidebar-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90 hover:after:bg-sidebar-border in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-      className
-    )}
-    {...props}
-  >
-    {withHandle && (
-      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-sidebar-border">
-        <GripVertical className="h-2.5 w-2.5" />
-      </div>
-    )}
-  </ResizablePrimitive.Separator>
-)
+	<ResizablePrimitive.Separator
+		className={cn(
+			"relative flex w-px items-center justify-center cursor-col-resize",
+			// Invisible hit area via ::after — wider target without shifting layout
+			"after:absolute after:inset-y-0 after:left-1/2 after:w-3 after:-translate-x-1/2",
+			// Visual feedback on hover and active drag (only the ::after stripe)
+			"hover:after:bg-sidebar-border data-[separator=active]:after:bg-sidebar-border",
+			// Focus ring for keyboard accessibility
+			"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1",
+			// Vertical orientation overrides
+			"data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:cursor-row-resize",
+			"data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-3 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0",
+			"[&[data-panel-group-direction=vertical]>div]:rotate-90",
+			className,
+		)}
+		{...props}
+	>
+		{withHandle && (
+			<div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-sidebar-border">
+				<GripVertical className="h-2.5 w-2.5" />
+			</div>
+		)}
+	</ResizablePrimitive.Separator>
+);
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -35,9 +35,9 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 const SIDEBAR_STATE_STORAGE_KEY = "sidebar_state";
-const SIDEBAR_DEFAULT_WIDTH = 300;
-const SIDEBAR_MIN_WIDTH = 240;
-const SIDEBAR_MAX_WIDTH = 420;
+export const SIDEBAR_DEFAULT_WIDTH = 300;
+export const SIDEBAR_MIN_WIDTH = 240;
+export const SIDEBAR_MAX_WIDTH = 420;
 const SIDEBAR_WIDTH_STORAGE_KEY = "sidebar_width";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
@@ -58,13 +58,18 @@ function clampSidebarWidth(width: number): number {
 function loadDesktopSidebarWidth(): number {
 	if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH;
 
-	const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
-	if (!storedWidth) return SIDEBAR_DEFAULT_WIDTH;
+	try {
+		const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+		if (!storedWidth) return SIDEBAR_DEFAULT_WIDTH;
 
-	const parsedWidth = Number.parseInt(storedWidth, 10);
-	if (!Number.isFinite(parsedWidth)) return SIDEBAR_DEFAULT_WIDTH;
+		const parsedWidth = Number.parseInt(storedWidth, 10);
+		if (!Number.isFinite(parsedWidth)) return SIDEBAR_DEFAULT_WIDTH;
 
-	return clampSidebarWidth(parsedWidth);
+		return clampSidebarWidth(parsedWidth);
+	} catch {
+		// Storage reads can throw in private browsing or blocked storage.
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
 }
 
 type SidebarContextProps = {
@@ -117,15 +122,18 @@ function SidebarProvider({
 	const [desktopWidth, setDesktopWidthState] = React.useState(loadDesktopSidebarWidth);
 
 	// Internal state management using "expanded" | "collapsed"
-
 	const [_state, _setState] = React.useState<"expanded" | "collapsed">(
 		() => {
 			if (typeof window === "undefined") {
 				return defaultOpen ? "expanded" : "collapsed";
 			}
-			const stored = window.localStorage.getItem(SIDEBAR_STATE_STORAGE_KEY);
-			if (stored === "expanded" || stored === "collapsed") {
-				return stored;
+			try {
+				const stored = window.localStorage.getItem(SIDEBAR_STATE_STORAGE_KEY);
+				if (stored === "expanded" || stored === "collapsed") {
+					return stored;
+				}
+			} catch {
+				// Storage reads can throw in private browsing or blocked storage.
 			}
 			return defaultOpen ? "expanded" : "collapsed";
 		}
@@ -135,7 +143,6 @@ function SidebarProvider({
 	const state = openProp !== undefined
 		? (openProp ? "expanded" : "collapsed")
 		: _state;
-
 
 	const setState = React.useCallback(
 		(newState: "expanded" | "collapsed") => {
@@ -162,27 +169,11 @@ function SidebarProvider({
 		if (isMobile) {
 			setOpenMobile((open) => !open);
 		} else {
-			_setState((currentState) => {
-				const newState = currentState === "expanded" ? "collapsed" : "expanded";
-				// Sync with external prop handler if provided
-				if (setOpenProp) {
-					setOpenProp(newState === "expanded");
-				}
-				// Persist state to localStorage
-				if (typeof window !== "undefined") {
-					try {
-						window.localStorage.setItem(SIDEBAR_STATE_STORAGE_KEY, newState);
-					} catch {
-						// Storage writes are best-effort only for this UI preference.
-					}
-				}
-				return newState;
-			});
+			setState(state === "expanded" ? "collapsed" : "expanded");
 		}
-	}, [isMobile, setOpenProp]);
+	}, [isMobile, state, setState]);
 
 	// Set the desktop sidebar width and clamp it to valid range.
-
 	const setDesktopWidth = React.useCallback((width: number): void => {
 		setDesktopWidthState(clampSidebarWidth(width));
 	}, []);
@@ -192,12 +183,9 @@ function SidebarProvider({
 		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
 	}, []);
 
-
+	// useEffect justified: persisting desktopWidth to localStorage is a side effect
+	// that must happen after render, and effects don't run on SSR.
 	React.useEffect(() => {
-		if (typeof window === "undefined") {
-			return;
-		}
-
 		try {
 			window.localStorage.setItem(
 				SIDEBAR_WIDTH_STORAGE_KEY,

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -1,3 +1,13 @@
+/**
+ * Sidebar component with resizable desktop layout and collapsible mobile sheet.
+ *
+ * Provides a flexible sidebar container with support for desktop resizing via drag handle,
+ * persistent width storage, mobile sheet overlay, and keyboard shortcuts. Includes nested
+ * header/content/footer sections and integrates with ResizablePanel for desktop layouts.
+ *
+ * @fileoverview Collapsible sidebar with desktop resize and mobile sheet support
+ */
+
 "use client";
 
 import { IconLayoutSidebar } from "@tabler/icons-react";
@@ -34,10 +44,18 @@ const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
+/**
+ * Clamp sidebar width to valid range.
+ * Ensures the width stays between SIDEBAR_MIN_WIDTH and SIDEBAR_MAX_WIDTH.
+ */
 function clampSidebarWidth(width: number): number {
 	return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
 }
 
+/**
+ * Load the persisted desktop sidebar width from localStorage.
+ * Returns SIDEBAR_DEFAULT_WIDTH if no valid stored value is found.
+ */
 function loadDesktopSidebarWidth(): number {
 	if (typeof window === "undefined") {
 		return SIDEBAR_DEFAULT_WIDTH;
@@ -61,15 +79,25 @@ function loadDesktopSidebarWidth(): number {
 }
 
 type SidebarContextProps = {
+	/** Current sidebar state ("expanded" or "collapsed"). */
 	state: "expanded" | "collapsed";
+	/** Whether the sidebar is open (desktop). */
 	open: boolean;
+	/** Set the sidebar open state (desktop). */
 	setOpen: (open: boolean) => void;
+	/** Whether the mobile sidebar sheet is open. */
 	openMobile: boolean;
+	/** Set the mobile sidebar sheet open state. */
 	setOpenMobile: (open: boolean) => void;
+	/** Whether the current viewport is mobile. */
 	isMobile: boolean;
+	/** Toggle the sidebar (mobile or desktop depending on viewport). */
 	toggleSidebar: () => void;
+	/** Current desktop sidebar width in pixels. */
 	desktopWidth: number;
+	/** Set the desktop sidebar width in pixels (clamped to valid range). */
 	setDesktopWidth: (width: number) => void;
+	/** Reset the desktop sidebar width to default. */
 	resetDesktopWidth: () => void;
 };
 
@@ -121,15 +149,17 @@ function SidebarProvider({
 	);
 
 	// Helper to toggle the sidebar.
-	const toggleSidebar = React.useCallback(() => {
+	const toggleSidebar = React.useCallback((): void => {
 		return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
 	}, [isMobile, setOpen]);
 
-	const setDesktopWidth = React.useCallback((width: number) => {
+	/** Set the desktop sidebar width and clamp it to valid range. */
+	const setDesktopWidth = React.useCallback((width: number): void => {
 		setDesktopWidthState(clampSidebarWidth(width));
 	}, []);
 
-	const resetDesktopWidth = React.useCallback(() => {
+	/** Reset the desktop sidebar width to default value. */
+	const resetDesktopWidth = React.useCallback((): void => {
 		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
 	}, []);
 

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -26,10 +26,39 @@ import { cn } from "@/lib/utils";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "18.75rem";
+const SIDEBAR_DEFAULT_WIDTH = 300;
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 420;
+const SIDEBAR_WIDTH_STORAGE_KEY = "sidebar_width";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+function clampSidebarWidth(width: number): number {
+	return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+}
+
+function loadDesktopSidebarWidth(): number {
+	if (typeof window === "undefined") {
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
+
+	try {
+		const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+		if (!storedWidth) {
+			return SIDEBAR_DEFAULT_WIDTH;
+		}
+
+		const parsedWidth = Number.parseInt(storedWidth, 10);
+		if (!Number.isFinite(parsedWidth)) {
+			return SIDEBAR_DEFAULT_WIDTH;
+		}
+
+		return clampSidebarWidth(parsedWidth);
+	} catch {
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
+}
 
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
@@ -39,6 +68,9 @@ type SidebarContextProps = {
 	setOpenMobile: (open: boolean) => void;
 	isMobile: boolean;
 	toggleSidebar: () => void;
+	desktopWidth: number;
+	setDesktopWidth: (width: number) => void;
+	resetDesktopWidth: () => void;
 };
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -67,6 +99,7 @@ function SidebarProvider({
 }) {
 	const isMobile = useIsMobile();
 	const [openMobile, setOpenMobile] = React.useState(false);
+	const [desktopWidth, setDesktopWidthState] = React.useState(loadDesktopSidebarWidth);
 
 	// This is the internal state of the sidebar.
 	// We use openProp and setOpenProp for control from outside the component.
@@ -91,6 +124,29 @@ function SidebarProvider({
 	const toggleSidebar = React.useCallback(() => {
 		return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
 	}, [isMobile, setOpen]);
+
+	const setDesktopWidth = React.useCallback((width: number) => {
+		setDesktopWidthState(clampSidebarWidth(width));
+	}, []);
+
+	const resetDesktopWidth = React.useCallback(() => {
+		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
+	}, []);
+
+	React.useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		try {
+			window.localStorage.setItem(
+				SIDEBAR_WIDTH_STORAGE_KEY,
+				String(desktopWidth),
+			);
+		} catch {
+			// Storage writes are best-effort only for this UI preference.
+		}
+	}, [desktopWidth]);
 
 	// Adds a keyboard shortcut to toggle the sidebar.
 	React.useEffect(() => {
@@ -121,8 +177,21 @@ function SidebarProvider({
 			openMobile,
 			setOpenMobile,
 			toggleSidebar,
+			desktopWidth,
+			setDesktopWidth,
+			resetDesktopWidth,
 		}),
-		[state, open, setOpen, isMobile, openMobile, toggleSidebar],
+		[
+			state,
+			open,
+			setOpen,
+			isMobile,
+			openMobile,
+			toggleSidebar,
+			desktopWidth,
+			setDesktopWidth,
+			resetDesktopWidth,
+		],
 	);
 
 	return (
@@ -131,7 +200,7 @@ function SidebarProvider({
 				data-slot="sidebar-wrapper"
 				style={
 					{
-						"--sidebar-width": SIDEBAR_WIDTH,
+						"--sidebar-width": `${desktopWidth}px`,
 						"--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
 						...style,
 					} as React.CSSProperties
@@ -275,30 +344,6 @@ function SidebarTrigger({
 	);
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-	const { toggleSidebar } = useSidebar();
-
-	return (
-		<button
-			data-sidebar="rail"
-			data-slot="sidebar-rail"
-			aria-label="Toggle Sidebar"
-			tabIndex={-1}
-			onClick={toggleSidebar}
-			title="Toggle Sidebar"
-			className={cn(
-				"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
-				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-				"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-				"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-				"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-				"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
 
 function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 	return (
@@ -697,7 +742,6 @@ export {
 	SidebarMenuSubButton,
 	SidebarMenuSubItem,
 	SidebarProvider,
-	SidebarRail,
 	SidebarSeparator,
 	SidebarTrigger,
 	useSidebar,

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -57,34 +57,22 @@ function clampSidebarWidth(width: number): number {
  * Returns SIDEBAR_DEFAULT_WIDTH if no valid stored value is found.
  */
 function loadDesktopSidebarWidth(): number {
-	if (typeof window === "undefined") {
-		return SIDEBAR_DEFAULT_WIDTH;
-	}
+	if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH;
 
-	try {
-		const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
-		if (!storedWidth) {
-			return SIDEBAR_DEFAULT_WIDTH;
-		}
+	const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+	if (!storedWidth) return SIDEBAR_DEFAULT_WIDTH;
 
-		const parsedWidth = Number.parseInt(storedWidth, 10);
-		if (!Number.isFinite(parsedWidth)) {
-			return SIDEBAR_DEFAULT_WIDTH;
-		}
+	const parsedWidth = Number.parseInt(storedWidth, 10);
+	if (!Number.isFinite(parsedWidth)) return SIDEBAR_DEFAULT_WIDTH;
 
-		return clampSidebarWidth(parsedWidth);
-	} catch {
-		return SIDEBAR_DEFAULT_WIDTH;
-	}
+	return clampSidebarWidth(parsedWidth);
 }
 
 type SidebarContextProps = {
 	/** Current sidebar state ("expanded" or "collapsed"). */
 	state: "expanded" | "collapsed";
-	/** Whether the sidebar is open (desktop). */
-	open: boolean;
-	/** Set the sidebar open state (desktop). */
-	setOpen: (open: boolean) => void;
+	/** Set the sidebar state (desktop). */
+	setState: (state: "expanded" | "collapsed") => void;
 	/** Whether the mobile sidebar sheet is open. */
 	openMobile: boolean;
 	/** Set the mobile sidebar sheet open state. */
@@ -129,39 +117,49 @@ function SidebarProvider({
 	const [openMobile, setOpenMobile] = React.useState(false);
 	const [desktopWidth, setDesktopWidthState] = React.useState(loadDesktopSidebarWidth);
 
-	// This is the internal state of the sidebar.
-	// We use openProp and setOpenProp for control from outside the component.
-	const [_open, _setOpen] = React.useState(defaultOpen);
-	const open = openProp ?? _open;
-	const setOpen = React.useCallback(
-		(value: boolean | ((value: boolean) => boolean)) => {
-			const openState = typeof value === "function" ? value(open) : value;
+	// Internal state management using "expanded" | "collapsed"
+	const [_state, _setState] = React.useState<"expanded" | "collapsed">(
+		defaultOpen ? "expanded" : "collapsed"
+	);
+
+	// Convert external boolean prop to internal state type
+	const state = openProp !== undefined
+		? (openProp ? "expanded" : "collapsed")
+		: _state;
+
+	const setState = React.useCallback(
+		(newState: "expanded" | "collapsed") => {
+			const isOpen = newState === "expanded";
 			if (setOpenProp) {
-				setOpenProp(openState);
+				setOpenProp(isOpen);
 			} else {
-				_setOpen(openState);
+				_setState(newState);
 			}
 
 			// biome-ignore lint/suspicious/noDocumentCookie: sidebar state is a simple non-sensitive preference
-			document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${isOpen}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 		},
-		[setOpenProp, open],
+		[setOpenProp],
 	);
 
 	// Helper to toggle the sidebar.
 	const toggleSidebar = React.useCallback((): void => {
-		return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-	}, [isMobile, setOpen]);
+		if (isMobile) {
+			setOpenMobile((open) => !open);
+		} else {
+			setState(state === "expanded" ? "collapsed" : "expanded");
+		}
+	}, [isMobile, state, setState]);
 
-	/** Set the desktop sidebar width and clamp it to valid range. */
-	const setDesktopWidth = React.useCallback((width: number): void => {
+	// Set the desktop sidebar width and clamp it to valid range.
+	const setDesktopWidth = (width: number): void => {
 		setDesktopWidthState(clampSidebarWidth(width));
-	}, []);
+	};
 
-	/** Reset the desktop sidebar width to default value. */
-	const resetDesktopWidth = React.useCallback((): void => {
+	// Reset the desktop sidebar width to default value.
+	const resetDesktopWidth = (): void => {
 		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
-	}, []);
+	};
 
 	React.useEffect(() => {
 		if (typeof window === "undefined") {
@@ -194,15 +192,10 @@ function SidebarProvider({
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [toggleSidebar]);
 
-	// We add a state so that we can do data-state="expanded" or "collapsed".
-	// This makes it easier to style the sidebar with Tailwind classes.
-	const state = open ? "expanded" : "collapsed";
-
 	const contextValue = React.useMemo<SidebarContextProps>(
 		() => ({
 			state,
-			open,
-			setOpen,
+			setState,
 			isMobile,
 			openMobile,
 			setOpenMobile,
@@ -213,8 +206,7 @@ function SidebarProvider({
 		}),
 		[
 			state,
-			open,
-			setOpen,
+			setState,
 			isMobile,
 			openMobile,
 			toggleSidebar,

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -34,8 +34,7 @@ import { TopBarButton } from "@/components/ui/top-bar-button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state";
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_STATE_STORAGE_KEY = "sidebar_state";
 const SIDEBAR_DEFAULT_WIDTH = 300;
 const SIDEBAR_MIN_WIDTH = 240;
 const SIDEBAR_MAX_WIDTH = 420;
@@ -135,8 +134,14 @@ function SidebarProvider({
 				_setState(newState);
 			}
 
-			// biome-ignore lint/suspicious/noDocumentCookie: sidebar state is a simple non-sensitive preference
-			document.cookie = `${SIDEBAR_COOKIE_NAME}=${newState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+			// Persist state to localStorage
+			if (typeof window !== "undefined") {
+				try {
+					window.localStorage.setItem(SIDEBAR_STATE_STORAGE_KEY, newState);
+				} catch {
+					// Storage writes are best-effort only for this UI preference.
+				}
+			}
 		},
 		[setOpenProp],
 	);
@@ -152,8 +157,14 @@ function SidebarProvider({
 				if (setOpenProp) {
 					setOpenProp(newState === "expanded");
 				}
-				// Update cookie
-				document.cookie = `${SIDEBAR_COOKIE_NAME}=${newState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+				// Persist state to localStorage
+				if (typeof window !== "undefined") {
+					try {
+						window.localStorage.setItem(SIDEBAR_STATE_STORAGE_KEY, newState);
+					} catch {
+						// Storage writes are best-effort only for this UI preference.
+					}
+				}
 				return newState;
 			});
 		}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -117,14 +117,25 @@ function SidebarProvider({
 	const [desktopWidth, setDesktopWidthState] = React.useState(loadDesktopSidebarWidth);
 
 	// Internal state management using "expanded" | "collapsed"
+
 	const [_state, _setState] = React.useState<"expanded" | "collapsed">(
-		defaultOpen ? "expanded" : "collapsed"
+		() => {
+			if (typeof window === "undefined") {
+				return defaultOpen ? "expanded" : "collapsed";
+			}
+			const stored = window.localStorage.getItem(SIDEBAR_STATE_STORAGE_KEY);
+			if (stored === "expanded" || stored === "collapsed") {
+				return stored;
+			}
+			return defaultOpen ? "expanded" : "collapsed";
+		}
 	);
 
 	// Convert external boolean prop to internal state type
 	const state = openProp !== undefined
 		? (openProp ? "expanded" : "collapsed")
 		: _state;
+
 
 	const setState = React.useCallback(
 		(newState: "expanded" | "collapsed") => {
@@ -171,14 +182,16 @@ function SidebarProvider({
 	}, [isMobile, setOpenProp]);
 
 	// Set the desktop sidebar width and clamp it to valid range.
-	const setDesktopWidth = (width: number): void => {
+
+	const setDesktopWidth = React.useCallback((width: number): void => {
 		setDesktopWidthState(clampSidebarWidth(width));
-	};
+	}, []);
 
 	// Reset the desktop sidebar width to default value.
-	const resetDesktopWidth = (): void => {
+	const resetDesktopWidth = React.useCallback((): void => {
 		setDesktopWidthState(SIDEBAR_DEFAULT_WIDTH);
-	};
+	}, []);
+
 
 	React.useEffect(() => {
 		if (typeof window === "undefined") {

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -129,15 +129,14 @@ function SidebarProvider({
 
 	const setState = React.useCallback(
 		(newState: "expanded" | "collapsed") => {
-			const isOpen = newState === "expanded";
 			if (setOpenProp) {
-				setOpenProp(isOpen);
+				setOpenProp(newState === "expanded");
 			} else {
 				_setState(newState);
 			}
 
 			// biome-ignore lint/suspicious/noDocumentCookie: sidebar state is a simple non-sensitive preference
-			document.cookie = `${SIDEBAR_COOKIE_NAME}=${isOpen}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${newState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 		},
 		[setOpenProp],
 	);
@@ -147,9 +146,18 @@ function SidebarProvider({
 		if (isMobile) {
 			setOpenMobile((open) => !open);
 		} else {
-			setState(state === "expanded" ? "collapsed" : "expanded");
+			_setState((currentState) => {
+				const newState = currentState === "expanded" ? "collapsed" : "expanded";
+				// Sync with external prop handler if provided
+				if (setOpenProp) {
+					setOpenProp(newState === "expanded");
+				}
+				// Update cookie
+				document.cookie = `${SIDEBAR_COOKIE_NAME}=${newState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+				return newState;
+			});
 		}
-	}, [isMobile, state, setState]);
+	}, [isMobile, setOpenProp]);
 
 	// Set the desktop sidebar width and clamp it to valid range.
 	const setDesktopWidth = (width: number): void => {

--- a/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
+++ b/frontend/packages/react-resizable-panels/components/panel/Panel.tsx
@@ -1,20 +1,15 @@
-"use client";
+'use client';
 
-import {
-  useEffect,
-  useRef,
-  useSyncExternalStore,
-  type CSSProperties
-} from "react";
-import { subscribeToMountedGroup } from "../../global/mutable-state/groups";
-import { useId } from "../../hooks/useId";
-import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
-import { useMergedRefs } from "../../hooks/useMergedRefs";
-import { useStableCallback } from "../../hooks/useStableCallback";
-import { useStableObject } from "../../hooks/useStableObject";
-import { useGroupContext } from "../group/useGroupContext";
-import type { PanelProps, PanelSize, RegisteredPanel } from "./types";
-import { usePanelImperativeHandle } from "./usePanelImperativeHandle";
+import { type CSSProperties, useEffect, useRef, useSyncExternalStore } from 'react';
+import { subscribeToMountedGroup } from '../../global/mutable-state/groups';
+import { useId } from '../../hooks/useId';
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
+import { useMergedRefs } from '../../hooks/useMergedRefs';
+import { useStableCallback } from '../../hooks/useStableCallback';
+import { useStableObject } from '../../hooks/useStableObject';
+import { useGroupContext } from '../group/useGroupContext';
+import type { PanelProps, PanelSize, RegisteredPanel } from './types';
+import { usePanelImperativeHandle } from './usePanelImperativeHandle';
 
 /**
  * A Panel wraps resizable content and can be configured with min/max size constraints and collapsible behavior.
@@ -44,16 +39,17 @@ import { usePanelImperativeHandle } from "./usePanelImperativeHandle";
 export function Panel({
   children,
   className,
-  collapsedSize = "0%",
+  collapsedSize = '0%',
   collapsible = false,
   defaultSize,
   disabled,
   elementRef: elementRefProp,
-  groupResizeBehavior = "preserve-relative-size",
+  groupResizeBehavior = 'preserve-relative-size',
   id: idProp,
-  maxSize = "100%",
-  minSize = "0%",
+  maxSize = '100%',
+  minSize = '0%',
   onResize: onResizeUnstable,
+  outerStyle,
   panelRef,
   style,
   ...rest
@@ -63,7 +59,7 @@ export function Panel({
   const id = useId(idProp);
 
   const stableProps = useStableObject({
-    disabled
+    disabled,
   });
 
   const elementRef = useRef<HTMLDivElement | null>(null);
@@ -75,7 +71,7 @@ export function Panel({
     id: groupId,
     orientation,
     registerPanel,
-    togglePanelDisabled
+    togglePanelDisabled,
   } = useGroupContext();
 
   const hasOnResize = onResizeUnstable !== null;
@@ -99,7 +95,7 @@ export function Panel({
         idIsStable,
         mutableValues: {
           expandToSize: undefined,
-          prevSize: undefined
+          prevSize: undefined,
         },
         onResize: hasOnResize ? onResizeStable : undefined,
         panelConstraints: {
@@ -109,8 +105,8 @@ export function Panel({
           defaultSize,
           disabled: stableProps.disabled,
           maxSize,
-          minSize
-        }
+          minSize,
+        },
       };
 
       return registerPanel(registeredPanel);
@@ -127,7 +123,7 @@ export function Panel({
     minSize,
     onResizeStable,
     registerPanel,
-    stableProps
+    stableProps,
   ]);
 
   // Not all props require re-registering the panel;
@@ -159,7 +155,7 @@ export function Panel({
     panelStyles = {
       flexGrow: undefined,
       flexShrink: undefined,
-      flexBasis: defaultSize
+      flexBasis: defaultSize,
     };
   } else {
     panelStyles = { flexGrow: 1 };
@@ -176,21 +172,30 @@ export function Panel({
       style={{
         ...PROHIBITED_CSS_PROPERTIES,
 
-        display: "flex",
+        display: 'flex',
         flexBasis: 0,
         flexShrink: 1,
-        overflow: "visible",
+        overflow: 'visible',
 
-        ...panelStyles
+        ...panelStyles,
+
+        // outerStyle is spread last so consumers can set transition, etc.
+        // Disable transitions during drag so the handle tracks instantly.
+        ...(outerStyle && {
+          ...outerStyle,
+          ...(panelStyles.pointerEvents === 'none' && {
+            transition: undefined,
+          }),
+        }),
       }}
     >
       <div
         className={className}
         style={{
-          maxHeight: "100%",
-          maxWidth: "100%",
+          maxHeight: '100%',
+          maxWidth: '100%',
           flexGrow: 1,
-          overflow: "auto",
+          overflow: 'auto',
 
           ...style,
 
@@ -198,7 +203,7 @@ export function Panel({
           // but still allow users to scroll content within panels in the non-resizing direction
           // NOTE This is not an inherited style
           // See github.com/bvaughn/react-resizable-panels/issues/662
-          touchAction: orientation === "horizontal" ? "pan-y" : "pan-x"
+          touchAction: orientation === 'horizontal' ? 'pan-y' : 'pan-x',
         }}
       >
         {children}
@@ -208,19 +213,19 @@ export function Panel({
 }
 
 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName
-Panel.displayName = "Panel";
+Panel.displayName = 'Panel';
 
 const PROHIBITED_CSS_PROPERTIES: CSSProperties = {
   minHeight: 0,
-  maxHeight: "100%",
-  height: "auto",
+  maxHeight: '100%',
+  height: 'auto',
 
   minWidth: 0,
-  maxWidth: "100%",
-  width: "auto",
+  maxWidth: '100%',
+  width: 'auto',
 
-  border: "none",
+  border: 'none',
   borderWidth: 0,
   padding: 0,
-  margin: 0
+  margin: 0,
 };

--- a/frontend/packages/react-resizable-panels/components/panel/types.ts
+++ b/frontend/packages/react-resizable-panels/components/panel/types.ts
@@ -1,13 +1,11 @@
-import type { CSSProperties, HTMLAttributes, Ref } from "react";
+import type { CSSProperties, HTMLAttributes, Ref } from 'react';
 
 export type PanelSize = {
   asPercentage: number;
   inPixels: number;
 };
 
-export type GroupResizeBehavior =
-  | "preserve-relative-size"
-  | "preserve-pixel-size";
+export type GroupResizeBehavior = 'preserve-relative-size' | 'preserve-pixel-size';
 
 /**
  * Numeric Panel constraints are represented as numeric percentages (0..100)
@@ -24,7 +22,7 @@ export type PanelConstraints = {
   panelId: string;
 };
 
-export type SizeUnit = "px" | "%" | "em" | "rem" | "vh" | "vw";
+export type SizeUnit = 'px' | '%' | 'em' | 'rem' | 'vh' | 'vw';
 
 export type RegisteredPanel = {
   id: string;
@@ -94,7 +92,7 @@ export interface PanelImperativeHandle {
   resize: (size: number | string) => void;
 }
 
-type BasePanelAttributes = Omit<HTMLAttributes<HTMLDivElement>, "onResize">;
+type BasePanelAttributes = Omit<HTMLAttributes<HTMLDivElement>, 'onResize'>;
 
 export type PanelProps = BasePanelAttributes & {
   /**
@@ -145,10 +143,7 @@ export type PanelProps = BasePanelAttributes & {
    *
    * ⚠️ A Group must contain at least one Panel with `preserve-relative-size` resize behavior.
    */
-  groupResizeBehavior?:
-    | "preserve-relative-size"
-    | "preserve-pixel-size"
-    | undefined;
+  groupResizeBehavior?: 'preserve-relative-size' | 'preserve-pixel-size' | undefined;
 
   /**
    * Uniquely identifies this panel within the parent group.
@@ -198,6 +193,16 @@ export type PanelProps = BasePanelAttributes & {
   panelRef?: Ref<PanelImperativeHandle | null> | undefined;
 
   /**
+   * CSS properties applied to the outer layout `HTMLDivElement`.
+   *
+   * Use this for properties that must live alongside the flex sizing styles
+   * (e.g. `transition` on `flex-grow` for animated collapse/expand).
+   *
+   * ⚠️ Properties that conflict with flex layout (`display`, `flexBasis`, etc.) will be overridden.
+   */
+  outerStyle?: CSSProperties | undefined;
+
+  /**
    * CSS properties.
    *
    * ⚠️ Style is applied to nested `HTMLDivElement` to avoid styles that interfere with Flex layout.
@@ -205,7 +210,7 @@ export type PanelProps = BasePanelAttributes & {
   style?: CSSProperties | undefined;
 };
 
-export type OnPanelResize = PanelProps["onResize"];
+export type OnPanelResize = PanelProps['onResize'];
 
 /**
  * Size constraints may be specified in a variety of ways:
@@ -224,11 +229,11 @@ export type OnPanelResize = PanelProps["onResize"];
  */
 export type PanelConstraintProps = Pick<
   PanelProps,
-  | "collapsedSize"
-  | "collapsible"
-  | "defaultSize"
-  | "disabled"
-  | "groupResizeBehavior"
-  | "maxSize"
-  | "minSize"
+  | 'collapsedSize'
+  | 'collapsible'
+  | 'defaultSize'
+  | 'disabled'
+  | 'groupResizeBehavior'
+  | 'maxSize'
+  | 'minSize'
 >;


### PR DESCRIPTION
### TL;DR

Replaced the basic sidebar with a resizable desktop layout and added clean code rules for avoiding redundant state, limiting nesting depth, and preventing lint suppressions.

### What changed?

- **Sidebar Enhancement**: Replaced `NewSidebar` component with `AppLayout` that supports desktop resizing via drag handles, persistent width storage, and smooth collapse/expand animations
- **State Management**: Refactored sidebar context to use a single "expanded"/"collapsed" state instead of redundant boolean representations
- **Resizable Components**: Enhanced `ResizablePanel` with `outerStyle` prop for CSS transitions and added `usePanelRef` hook for imperative panel control
- **Clean Code Rules**: Added three new coding standards:
  - Avoid redundant state representations in React components
  - Limit nesting depth to maximum 3 levels using early returns and extracted functions
  - Prohibit lint suppressions without proper justification

### How to test?

1. **Desktop Resizing**: Drag the sidebar handle to resize, verify width persists across page reloads
2. **Mobile Behavior**: Test on mobile viewport to ensure sheet overlay functionality works
3. **Keyboard Shortcut**: Press 'b' to toggle sidebar collapse/expand
4. **State Persistence**: Refresh page and verify sidebar state and width are restored
5. **Smooth Animations**: Toggle sidebar and observe CSS transition effects during collapse/expand

### Why make this change?

- **Better UX**: Users can now customize sidebar width to their preference and it persists across sessions
- **Code Quality**: Eliminated redundant state (boolean + union type) following DRY principles and single source of truth
- **Performance**: Smooth animations provide better visual feedback during state transitions
- **Standards**: Established clean code guidelines to prevent technical debt accumulation and improve maintainability