### PR TITLE
ci(pr): auto-refresh PR title and description with Claude

### DIFF
--- a/.github/workflows/claude-pr-refresh.yml
+++ b/.github/workflows/claude-pr-refresh.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Refresh PR title and description
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-pr-refresh.yml
+++ b/.github/workflows/claude-pr-refresh.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: read
 
 concurrency:
   group: claude-pr-refresh-${{ github.event.pull_request.number || github.run_id }}
@@ -25,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Refresh PR title and description
         uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
@@ -34,8 +33,6 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            BASE BRANCH: ${{ github.event.pull_request.base.ref }}
-            HEAD BRANCH: ${{ github.event.pull_request.head.ref }}
 
             Update this pull request's title and description so they match the current diff against the base branch.
 
@@ -60,4 +57,4 @@ jobs:
             First try `gh pr edit`.
             If `gh pr edit` fails, use `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --method PATCH` instead.
 
-          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(cat:*),Bash(ls:*)"'
+          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}:*),Bash(cat:*),Bash(ls:*)"'

--- a/.github/workflows/claude-pr-refresh.yml
+++ b/.github/workflows/claude-pr-refresh.yml
@@ -10,10 +10,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-  id-token: write
 
 concurrency:
-  group: claude-pr-refresh-${{ github.event.pull_request.number }}
+  group: claude-pr-refresh-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -24,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Refresh PR title and description
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-pr-refresh.yml
+++ b/.github/workflows/claude-pr-refresh.yml
@@ -1,0 +1,64 @@
+name: Claude PR Refresh
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - development
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+concurrency:
+  group: claude-pr-refresh-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  refresh-pr:
+    # Skip fork PRs: plain pull_request workflows do not receive repo secrets there.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Refresh PR title and description
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            BASE BRANCH: ${{ github.event.pull_request.base.ref }}
+            HEAD BRANCH: ${{ github.event.pull_request.head.ref }}
+
+            Update this pull request's title and description so they match the current diff against the base branch.
+
+            Requirements:
+            - inspect the actual PR diff, not stale commit history
+            - produce a specific title in `type(scope): description` format
+            - rewrite the PR body so it is accurate and specific
+            - include these sections when they apply:
+              - Summary
+              - What Changed
+              - What Users Will Notice
+              - Manual Testing
+              - Automated Testing
+              - Coverage Gaps
+            - keep the description honest; if tests were not run, say so plainly
+            - do not leave a review comment or issue comment
+            - update the existing PR directly
+
+            Use repository guidance when relevant, especially:
+            - `.claude/rules/github-actions/explicit-pr-descriptions.md`
+
+            First try `gh pr edit`.
+            If `gh pr edit` fails, use `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --method PATCH` instead.
+
+          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(cat:*),Bash(ls:*)"'


### PR DESCRIPTION
## Summary
Adds a dedicated Claude-powered workflow that refreshes PR titles and descriptions whenever a PR targeting `development` is opened, reopened, or updated with new commits.

## What Changed
- adds `.github/workflows/claude-pr-refresh.yml`
- triggers on `pull_request` with `opened`, `reopened`, and `synchronize`
- grants only the permissions this workflow needs:
  - `contents: read`
  - `pull-requests: write`
- removes unused `issues: read`
- checks out the repository with `fetch-depth: 1`, which is sufficient for the current `gh pr diff` / PR-API based tool path
- pins workflow actions to full commit SHAs with human-readable version comments:
  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
  - `anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82`
- removes untrusted branch names from the Claude prompt so PR authors cannot inject instructions via crafted branch refs
- uses `anthropics/claude-code-action` with a focused prompt to:
  - inspect the live PR diff
  - generate a `type(scope): description` title
  - rewrite the PR body with accurate summary, testing, and coverage-gap sections
  - avoid posting review comments and edit the PR instead
- scopes the `gh api` fallback in `claude_args` to the current PR endpoint instead of allowing arbitrary repo API calls
- adds per-PR concurrency with a `github.run_id` fallback so repeated pushes collapse into the latest refresh run
- skips fork PRs because plain `pull_request` workflows do not receive repository secrets there

## What Users Will Notice
- PRs against `development` should keep their title and description aligned with the actual diff after new pushes
- maintainers should spend less time manually fixing stale PR metadata
- the workflow no longer feeds untrusted branch names into the Claude prompt
- the Claude action fallback path is narrower and less dangerous if it misbehaves
- fork PRs will not use this automation under the current secret-safe setup

## Manual Testing
1. Open a PR targeting `development` from a same-repo branch.
2. Confirm the `Claude PR Refresh` workflow runs on PR open.
3. Push another commit to the same PR branch.
4. Confirm the workflow re-runs on `synchronize`.
5. Verify the PR title/body update to match the new diff.
6. Confirm the workflow updates the PR directly rather than leaving a review comment.

## Automated Testing
- Not run locally; this is a GitHub Actions workflow addition.

## Coverage Gaps
- not validated against a live same-repo PR run yet in this branch
- fork PR behavior is intentionally skipped rather than supported
- the narrow `gh api` tool pattern depends on the Claude action honoring the allowlist format as expected