### PR TITLE
fix(ci): restore OIDC permission for Claude PR refresh

### DIFF
--- a/.github/workflows/claude-pr-refresh.yml
+++ b/.github/workflows/claude-pr-refresh.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: claude-pr-refresh-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Summary
Restores the missing OIDC permission for the Claude PR refresh workflow so the GitHub Action can mint an ID token and authenticate successfully during PR metadata refresh runs.

## What Changed
- adds `id-token: write` back to the top-level `permissions` block in `.github/workflows/claude-pr-refresh.yml`
- leaves the rest of the workflow unchanged:
  - same `pull_request` triggers (`opened`, `synchronize`, `reopened`)
  - same same-repo guard for secret safety
  - same pinned action SHAs
  - same narrow `gh api` fallback scope
  - same checkout depth and concurrency behavior

## What Maintainers Will Notice
- before this change, the `Claude PR Refresh` workflow could fail with:
  - `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`
- after this change, the workflow should be able to request the GitHub OIDC token it needs and proceed with PR title/body refresh normally
- there are no user-facing app or UI changes in this PR

## Manual Testing
1. Open or update a same-repo PR targeting `development`.
2. Confirm the `Claude PR Refresh` workflow runs on the PR event.
3. Open the workflow logs and verify the Claude action no longer fails on missing OIDC token permissions.
4. Confirm the workflow finishes successfully and updates the PR title and/or description directly.
5. Re-test on another `synchronize` event to confirm the fix holds across repeated runs.

## Automated Testing
Static checks only (workflow change):
- `git diff --check origin/development...HEAD -- .github/workflows/claude-pr-refresh.yml`
- verify `.github/workflows/claude-pr-refresh.yml` includes `id-token: write`

## Coverage Gaps
- not validated locally end-to-end because OIDC behavior only exists in a real GitHub Actions run
- confirmation still depends on one live same-repo PR run going green

## Summary by Sourcery

CI:
- Grant the workflow `id-token: write` permission in `.github/workflows/claude-pr-refresh.yml` to enable GitHub OIDC token minting for PR refresh runs.