### PR TITLE
fix(ui): add ARIA labels to combobox icon buttons

### DIFF
--- a/frontend/components/ui/combobox.tsx
+++ b/frontend/components/ui/combobox.tsx
@@ -39,7 +39,9 @@ function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
 	return (
 		<ComboboxPrimitive.Clear
 			data-slot="combobox-clear"
-			render={<InputGroupButton variant="ghost" size="icon-xs" />}
+			render={
+				<InputGroupButton aria-label="Clear" variant="ghost" size="icon-xs" />
+			}
 			className={cn(className)}
 			{...props}
 		>
@@ -253,7 +255,9 @@ function ComboboxChip({
 			{children}
 			{showRemove && (
 				<ComboboxPrimitive.ChipRemove
-					render={<Button variant="ghost" size="icon-xs" />}
+					render={
+						<Button aria-label="Remove" variant="ghost" size="icon-xs" />
+					}
 					className="-ml-1 opacity-50 hover:opacity-100"
 					data-slot="combobox-chip-remove"
 				>


### PR DESCRIPTION
This is the clean, minimal version of PR #59.

## What changed
- add `aria-label="Clear"` to the combobox clear button
- add `aria-label="Remove"` to the combobox chip remove button

## What is intentionally excluded
- no formatter churn
- no `pnpm-lock.yaml`
- no React Query devtools changes
- no unrelated typing/build fixes

This keeps the accessibility fix isolated and reviewable.

## Summary by Sourcery

Improve accessibility of combobox controls by adding ARIA labels to icon-only buttons.

Bug Fixes:
- Add an ARIA label to the combobox clear icon button to make it accessible to screen readers.
- Add an ARIA label to the combobox chip remove icon button to improve screen reader accessibility.