### PR TITLE
fix(actions): use a real Claude trigger token for rebase handoff

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -85,6 +85,7 @@ jobs:
         id: rebase
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_TRIGGER_TOKEN: ${{ secrets.CLAUDE_TRIGGER_TOKEN }}
           PR_NUMBER: ${{ matrix.pr }}
         run: |
           git config --global user.name "github-actions[bot]"
@@ -106,7 +107,19 @@ jobs:
             git push origin "$BRANCH_NAME" --force-with-lease
             gh pr comment $PR_NUMBER --body "✅ **Automated Rebase Successful:** Branch was cleanly rebased onto \`development\`."
           else
-            echo "Merge conflict detected! Aborting git rebase and delegating to Claude..."
+            echo "Merge conflict detected! Aborting git rebase and handing off to Claude..."
             git rebase --abort
-            gh pr comment $PR_NUMBER --body "@claude[agent] The automated rebase for this PR failed due to merge conflicts. Please run \`git fetch origin development\`, \`git checkout $BRANCH_NAME\`, \`git rebase origin/development\`, find all files with conflict markers (\`<<<<<<<\`), resolve them intelligently to preserve the intent of both branches, and then run \`git add -u\`, \`git rebase --continue\`, and finally \`git push origin $BRANCH_NAME --force-with-lease\`."
+
+            CLAUDE_REQUEST=$(printf '@claude[agent] The automated rebase for this PR failed due to merge conflicts. Please run `git fetch origin development`, `git checkout %s`, `git rebase origin/development`, find all files with conflict markers (`<<<<<<<`), resolve them intelligently to preserve the intent of both branches, and then run `git add -u`, `git rebase --continue`, and finally `git push origin %s --force-with-lease`.' "$BRANCH_NAME" "$BRANCH_NAME")
+
+            if [[ -n "$CLAUDE_TRIGGER_TOKEN" ]]; then
+              # Comments authored with the repository GITHUB_TOKEN show up as github-actions[bot]
+              # and Claude ignores that automated mention. Use a separate user/app token
+              # (preferably octagent) so the handoff matches the working manual comment path.
+              GH_TOKEN="$CLAUDE_TRIGGER_TOKEN" gh pr comment "$PR_NUMBER" --body "$CLAUDE_REQUEST"
+            else
+              MANUAL_FOLLOWUP=$(printf '⚠️ **Automated Rebase Blocked by Conflicts:** `CLAUDE_TRIGGER_TOKEN` is not configured, so this workflow cannot summon Claude automatically. A maintainer needs to post this comment manually:\n\n%s' "$CLAUDE_REQUEST")
+              GH_TOKEN="$GITHUB_TOKEN" gh pr comment "$PR_NUMBER" --body "$MANUAL_FOLLOWUP"
+              echo "::warning::CLAUDE_TRIGGER_TOKEN is not configured; posted manual follow-up instructions instead of a dead @claude[agent] mention from github-actions[bot]."
+            fi
           fi


### PR DESCRIPTION
## Summary
- stop posting the Claude handoff comment with the repo `GITHUB_TOKEN`
- prefer a dedicated `CLAUDE_TRIGGER_TOKEN` for the `@claude[agent]` mention
- if that secret is missing, post an honest manual-follow-up comment instead of a dead bot summon

## Root cause
The rebase workflow was posting the fallback `@claude[agent]` comment as `github-actions[bot]` via the repository `GITHUB_TOKEN`. In practice that path is ignored by Claude, while the same comment posted manually by a real repo user works. Anthropic's FAQ for Claude Code Action also calls this out: automated workflow mentions need a PAT or separate app token rather than the repo `GITHUB_TOKEN`.

Observed evidence in this repo:
- PR #41 / #54 / #56 contain ignored `github-actions[bot]` rebase handoff comments
- PR #41 and #56 show manual `@claude[agent]` comments from Octavian getting a Claude response

## Caveat
This needs a repo secret named `CLAUDE_TRIGGER_TOKEN` that belongs to a write-capable account Claude should honor. `octagent` is the intended choice for this personal repo. Without that secret, the workflow now leaves a manual instruction comment instead of pretending the bot mention worked.

## Summary by Sourcery

Improve the rebase workflow’s Claude handoff behavior when automated rebases hit merge conflicts.

Enhancements:
- Use a dedicated CLAUDE_TRIGGER_TOKEN for posting Claude handoff comments instead of the default repository GITHUB_TOKEN.
- Add a fallback path that posts explicit manual follow-up instructions when CLAUDE_TRIGGER_TOKEN is not configured.