### PR TITLE
fix(auth): add secure dev admin login shortcut

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,3 +49,12 @@ CORS_ORIGINS=["http://localhost:3001","http://ai-nexus.localhost:1355"]
 # Google Gemini API Key
 # Get from: https://aistudio.google.com/apikey
 GOOGLE_API_KEY=your-google-api-key-here
+
+# ===========================================
+# DEV ADMIN LOGIN
+# ===========================================
+
+# Seeded admin account used by the dev-only login shortcut.
+# The shortcut is disabled automatically when ENV=prod.
+ADMIN_EMAIL=admin@nexus-ai.dev
+ADMIN_PASSWORD=admin1234

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+
+from app.core.config import settings
+from app.users import UserManager, auth_backend, get_jwt_strategy, get_user_manager
+
+
+def get_auth_router() -> APIRouter:
+    router = APIRouter(tags=["auth"])
+
+    @router.post("/auth/dev-login")
+    async def dev_login(
+        user_manager: UserManager = Depends(get_user_manager),
+    ):
+        """Log in with the seeded admin account without exposing its password to the client."""
+        if settings.is_production:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Dev login is not available in production.",
+            )
+
+        if (not settings.admin_email) or (not settings.admin_password):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Dev login is not configured on this deployment.",
+            )
+
+        credentials = OAuth2PasswordRequestForm(
+            grant_type="password",
+            username=settings.admin_email,
+            password=settings.admin_password,
+            scope="",
+        )
+        user = await user_manager.authenticate(credentials)
+
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Dev login credentials are misconfigured on this deployment.",
+            )
+
+        if not user.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="The dev admin account is inactive.",
+            )
+
+        return await auth_backend.login(get_jwt_strategy(), user)
+
+    return router

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,8 +40,8 @@ class Settings(BaseSettings):
     # The base directory where workspaces will be stored. Each workspace can contain files, configurations, and other resources specific to a user's project or environment.
     workspace_base_dir: str = "/data/workspaces"
     # Admin user credentials (for testing).
-    admin_email: str = "admin@nexus-ai.dev"
-    admin_password: str = "admin1234"
+    admin_email: str | None = None
+    admin_password: str | None = None
 
     @property
     def is_production(self) -> bool:

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.auth import get_auth_router
 from app.api.chat import get_chat_router
 from app.api.conversations import get_conversations_router
 from app.api.models import get_models_router
@@ -64,6 +65,9 @@ def create_app() -> FastAPI:
 
     fastapi_app.include_router(
         fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
+    )
+    fastapi_app.include_router(
+        get_auth_router(),
     )
     fastapi_app.include_router(
         fastapi_users.get_register_router(UserRead, UserCreate),

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,7 +4,5 @@
 # Backend API base URL
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
-# Optional dev / preview login shortcut.
-# Only exposed on the login page in local dev or non-production Vercel environments.
-TEST_USER_EMAIL=
-TEST_USER_PASSWORD=
+# The dev admin login button now uses backend-only credentials.
+# Configure ADMIN_EMAIL / ADMIN_PASSWORD in the backend environment instead.

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,41 +1,25 @@
 import { LoginForm } from '@/features/auth/LoginForm';
 
 /**
- * Returns test-user credentials when running in local development.
+ * Returns whether the dev admin shortcut should be shown.
  *
- * On deployed previews the env vars may exist but are NOT returned,
- * because the server component would serialize them into the client
- * HTML/JS bundle — exposing the password publicly.
+ * The actual credentials remain on the backend. We only expose a boolean
+ * here, so previews and dev deployments can show the button safely.
  */
-function getTestUserCredentials(): {
-  testUserEmail: string | undefined;
-  testUserPassword: string | undefined;
-} {
-  // Only expose test credentials in local development — never on deployed
-  // previews, where the password would be serialized into client HTML/JS.
-  const shouldExposeTestUser = process.env.VERCEL_ENV === 'development';
-
-  if (!shouldExposeTestUser) {
-    return {
-      testUserEmail: undefined,
-      testUserPassword: undefined,
-    };
-  }
-
-  return {
-    testUserEmail: process.env.TEST_USER_EMAIL,
-    testUserPassword: process.env.TEST_USER_PASSWORD,
-  };
+function canUseDevAdminLogin(): boolean {
+  // VERCEL_ENV is undefined in local dev, 'preview' on preview deploys,
+  // and 'production' only in production — so this correctly covers all non-prod environments.
+  return process.env.VERCEL_ENV !== 'production';
 }
 
-/** Login page — renders the login form with optional dev-only test user shortcut. */
+/** Login page — renders the login form with an optional dev-only admin shortcut. */
 export default function Page(): React.JSX.Element {
-  const { testUserEmail, testUserPassword } = getTestUserCredentials();
+  const showDevAdminLogin = canUseDevAdminLogin();
 
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <LoginForm testUserEmail={testUserEmail} testUserPassword={testUserPassword} />
+        <LoginForm canUseDevAdminLogin={showDevAdminLogin} />
       </div>
     </div>
   );

--- a/frontend/features/auth/LoginForm.tsx
+++ b/frontend/features/auth/LoginForm.tsx
@@ -3,17 +3,12 @@
 import { useRouter } from 'next/navigation';
 import type React from 'react';
 import { useId, useState } from 'react';
-import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
 import { LoginFormView } from './LoginFormView';
+import { useLoginMutation, useDevAdminLoginMutation } from './hooks/use-login-mutations';
 
 interface LoginFormProps extends React.ComponentProps<'div'> {
   canUseDevAdminLogin?: boolean;
 }
-
-type LoginCredentials = {
-  email: string;
-  password: string;
-};
 
 /**
  * Container for the login form.
@@ -33,97 +28,53 @@ export function LoginForm({
   const formId = useId();
   const emailId = `${formId}-email`;
   const passwordId = `${formId}-password`;
+
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [localErrorMessage, setLocalErrorMessage] = useState('');
+
   const router = useRouter();
-  /** Sends credentials to the login API and redirects on success. */
-  const submitLogin = async ({ email, password }: LoginCredentials): Promise<void> => {
-    setIsLoading(true);
 
-    try {
-      // TODO: This inline fetch needs to be moved to a custom hook.
-      // TODO: Especially now that we also use this in the signup form.
-      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({ username: email, password }),
-        credentials: 'include',
-      });
+  const loginMutation = useLoginMutation();
+  const devLoginMutation = useDevAdminLoginMutation();
 
-      // Handle errors.
-      // TODO: This same code is used on both the login and signup forms, which means it should be moved to a shared function.
-      if (!response.ok) {
-        let nextErrorMessage = 'Unable to log in with those credentials.';
+  const isLoading = loginMutation.isPending || devLoginMutation.isPending;
 
-        try {
-          const error = await response.json();
-          if (typeof error?.detail === 'string') {
-            nextErrorMessage = error.detail;
-          }
-        } catch {
-          // Ignore JSON parse failures and keep the generic message.
-        }
-
-        setErrorMessage(nextErrorMessage);
-        return;
-      }
-
-      // Reset the error message.
-      // We do it here, so the Alert component doesn't jump unnecessarily every time we press the submit button.
-      setErrorMessage('');
-
-      // Redirect to the homepage.
-      router.push('/');
-    } catch {
-      setErrorMessage('Unable to reach the login service.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  /** Calls a backend-only shortcut that logs in with the seeded admin account. */
-  const submitDevAdminLogin = async (): Promise<void> => {
-    setIsLoading(true);
-
-    try {
-      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.devLogin}`, {
-        method: 'POST',
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        let nextErrorMessage = 'Unable to use the dev admin login shortcut.';
-
-        try {
-          const error = await response.json();
-          if (typeof error?.detail === 'string') {
-            nextErrorMessage = error.detail;
-          }
-        } catch {
-          // Ignore JSON parse failures and keep the generic message.
-        }
-
-        setErrorMessage(nextErrorMessage);
-        return;
-      }
-
-      setErrorMessage('');
-      router.push('/');
-    } catch {
-      setErrorMessage('Unable to reach the login service.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  // Prefer the local (network) error if the service failed to be reached entirely,
+  // otherwise show the specific API error from React Query.
+  const currentError =
+    localErrorMessage || loginMutation.error?.message || devLoginMutation.error?.message || '';
 
   /** Form submit handler — prevents default page refresh. */
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    await submitLogin({ email, password });
+    setLocalErrorMessage('');
+    loginMutation.reset();
+    devLoginMutation.reset();
+
+    try {
+      await loginMutation.mutateAsync({ email, password });
+      router.push('/');
+    } catch {
+      // Avoid raw fetch boilerplate: the hook handles standard detail extraction.
+      // If an error is thrown here that wasn't an API error (e.g. network down),
+      // it gets captured as mutation error anyway, but we keep the catch block
+      // just in case fetch itself throws synchronously.
+    }
+  };
+
+  /** Calls a backend-only shortcut that logs in with the seeded admin account. */
+  const handleDevAdminLogin = async (): Promise<void> => {
+    setLocalErrorMessage('');
+    loginMutation.reset();
+    devLoginMutation.reset();
+
+    try {
+      await devLoginMutation.mutateAsync();
+      router.push('/');
+    } catch {
+      // Hook parses detail. Handled above.
+    }
   };
 
   return (
@@ -135,11 +86,11 @@ export function LoginForm({
       onEmailChange={setEmail}
       password={password}
       onPasswordChange={setPassword}
-      errorMessage={errorMessage}
+      errorMessage={currentError}
       isLoading={isLoading}
       canUseDevAdminLogin={canUseDevAdminLogin}
       onSubmit={handleSubmit}
-      onDevAdminLogin={submitDevAdminLogin}
+      onDevAdminLogin={handleDevAdminLogin}
       {...divProps}
     />
   );

--- a/frontend/features/auth/LoginForm.tsx
+++ b/frontend/features/auth/LoginForm.tsx
@@ -7,8 +7,7 @@ import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
 import { LoginFormView } from './LoginFormView';
 
 interface LoginFormProps extends React.ComponentProps<'div'> {
-  testUserEmail?: string;
-  testUserPassword?: string;
+  canUseDevAdminLogin?: boolean;
 }
 
 type LoginCredentials = {
@@ -22,13 +21,11 @@ type LoginCredentials = {
  * Owns form state, validation, API calls, and navigation on success.
  * Delegates all rendering to `LoginFormView`.
  *
- * @param testUserEmail    - Pre-filled email for the dev-only "Test User" button.
- * @param testUserPassword - Pre-filled password for the dev-only "Test User" button.
+ * @param canUseDevAdminLogin - Whether to show the dev-only admin shortcut button.
  */
 export function LoginForm({
   className,
-  testUserEmail,
-  testUserPassword,
+  canUseDevAdminLogin = false,
   ...props
 }: LoginFormProps): React.JSX.Element {
   // Destructure onSubmit from rest to avoid conflict with our custom onSubmit prop.
@@ -41,8 +38,6 @@ export function LoginForm({
   const [errorMessage, setErrorMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
-  const canUseTestUser = Boolean(testUserEmail && testUserPassword);
-
   /** Sends credentials to the login API and redirects on success. */
   const submitLogin = async ({ email, password }: LoginCredentials): Promise<void> => {
     setIsLoading(true);
@@ -90,23 +85,45 @@ export function LoginForm({
     }
   };
 
+  /** Calls a backend-only shortcut that logs in with the seeded admin account. */
+  const submitDevAdminLogin = async (): Promise<void> => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.devLogin}`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        let nextErrorMessage = 'Unable to use the dev admin login shortcut.';
+
+        try {
+          const error = await response.json();
+          if (typeof error?.detail === 'string') {
+            nextErrorMessage = error.detail;
+          }
+        } catch {
+          // Ignore JSON parse failures and keep the generic message.
+        }
+
+        setErrorMessage(nextErrorMessage);
+        return;
+      }
+
+      setErrorMessage('');
+      router.push('/');
+    } catch {
+      setErrorMessage('Unable to reach the login service.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   /** Form submit handler — prevents default page refresh. */
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
     await submitLogin({ email, password });
-  };
-
-  /** Dev-only shortcut to log in as the test user. */
-  const handleTestUserLogin = async (): Promise<void> => {
-    if (!testUserEmail || !testUserPassword) {
-      return;
-    }
-
-    setEmail(testUserEmail);
-    await submitLogin({
-      email: testUserEmail,
-      password: testUserPassword,
-    });
   };
 
   return (
@@ -120,9 +137,9 @@ export function LoginForm({
       onPasswordChange={setPassword}
       errorMessage={errorMessage}
       isLoading={isLoading}
-      canUseTestUser={canUseTestUser}
+      canUseDevAdminLogin={canUseDevAdminLogin}
       onSubmit={handleSubmit}
-      onTestUserLogin={handleTestUserLogin}
+      onDevAdminLogin={submitDevAdminLogin}
       {...divProps}
     />
   );

--- a/frontend/features/auth/LoginFormView.tsx
+++ b/frontend/features/auth/LoginFormView.tsx
@@ -23,19 +23,19 @@ export interface LoginFormViewProps extends Omit<React.ComponentProps<'div'>, 'o
   errorMessage: string;
   /** Whether a login request is in-flight (disables buttons). */
   isLoading: boolean;
-  /** Whether the dev-only "Test User" shortcut is available. */
-  canUseTestUser: boolean;
+  /** Whether the dev-only admin shortcut is available. */
+  canUseDevAdminLogin: boolean;
   /** Called when the form is submitted. */
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  /** Called when the "Test User" button is clicked. */
-  onTestUserLogin: () => void;
+  /** Called when the "Dev Admin" button is clicked. */
+  onDevAdminLogin: () => void;
 }
 
 /**
  * Pure presentation layer for the login form.
  *
  * Renders the card with email/password fields, error alert, submit button,
- * optional test-user shortcut, and signup link. All state and async logic
+ * optional dev-admin shortcut, and signup link. All state and async logic
  * live in the container (`LoginForm`).
  */
 export function LoginFormView({
@@ -48,9 +48,9 @@ export function LoginFormView({
   onPasswordChange,
   errorMessage,
   isLoading,
-  canUseTestUser,
+  canUseDevAdminLogin,
   onSubmit,
-  onTestUserLogin,
+  onDevAdminLogin,
   ...props
 }: LoginFormViewProps): React.JSX.Element {
   return (
@@ -108,18 +108,18 @@ export function LoginFormView({
                 <Button type="submit" disabled={isLoading}>
                   Login
                 </Button>
-                {canUseTestUser && (
+                {canUseDevAdminLogin && (
                   <>
                     <Button
                       variant="outline"
                       type="button"
-                      onClick={onTestUserLogin}
+                      onClick={onDevAdminLogin}
                       disabled={isLoading}
                     >
-                      Test User
+                      Dev Admin
                     </Button>
                     <FieldDescription className="text-center text-xs">
-                      Dev-only shortcut for the shared test account.
+                      Dev-only shortcut for the seeded admin account.
                     </FieldDescription>
                   </>
                 )}

--- a/frontend/features/auth/hooks/use-login-mutations.ts
+++ b/frontend/features/auth/hooks/use-login-mutations.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
+
+/** Arguments for a standard email/password login request. */
+export interface LoginArgs {
+  email: string;
+  password: string;
+}
+
+/** Error structure from FastAPI. */
+interface FastAPIError {
+  detail: string | Array<unknown>;
+}
+
+/** Helper to parse standard FastAPI error responses or throw generic fallbacks. */
+async function handleResponseError(response: Response, defaultMessage: string): Promise<never> {
+  let message = defaultMessage;
+  try {
+    const errorBody = (await response.json()) as FastAPIError;
+    if (typeof errorBody?.detail === 'string') {
+      message = errorBody.detail;
+    } else if (Array.isArray(errorBody?.detail)) {
+      message = 'Invalid request payload.';
+    }
+  } catch {
+    // If JSON parsing fails, we keep the default message.
+  }
+  throw new Error(message);
+}
+
+/**
+ * Hook to authenticate via standard email/password form data.
+ */
+export function useLoginMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, LoginArgs>({
+    mutationFn: async ({ email, password }) => {
+      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({ username: email, password }),
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        await handleResponseError(response, 'Unable to log in with those credentials.');
+      }
+    },
+    onSuccess: () => {
+      // Invalidate any queries that depend on auth state (e.g. user profile).
+      void queryClient.invalidateQueries();
+    },
+  });
+}
+
+/**
+ * Hook to trigger the backend-only dev admin login shortcut.
+ */
+export function useDevAdminLoginMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, void>({
+    mutationFn: async () => {
+      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.devLogin}`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        await handleResponseError(response, 'Unable to use the dev admin login shortcut.');
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+    },
+  });
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -56,6 +56,11 @@ export const API_ENDPOINTS = {
 		 */
 		login: "/auth/jwt/login",
 		/**
+		 * Dev-only admin login shortcut.
+		 * @returns `/auth/dev-login`
+		 */
+		devLogin: "/auth/dev-login",
+		/**
 		 * Register endpoint.
 		 * @returns `/auth/register`
 		 */


### PR DESCRIPTION
## What changed
- add a backend-only `/auth/dev-login` endpoint that logs into the seeded admin account without serializing the password into the frontend
- replace the old test-user credential pass-through on the login page with a simple non-production `Dev Admin` button
- document that the shortcut now uses backend `ADMIN_EMAIL` / `ADMIN_PASSWORD` values

## Why
The previous shortcut only worked when `VERCEL_ENV === development`, so it missed local runs and Vercel preview. It also depended on passing credentials through the server component, which risks exposing the password in rendered HTML/JS.

## Verification
- `cd frontend && bun run typecheck`
- `cd backend && DATABASE_URL=postgresql://user:pass@localhost:5432/db AUTH_SECRET=dev-secret GOOGLE_API_KEY=dev-google-key FERNET_KEY=ZGV2LWZlcm5ldC1rZXktMzItYnl0ZXMtZmFrZSE= CORS_ORIGINS=["http://localhost:3001"] COOKIE_DOMAIN=localhost uv run python - <<'PY' ... create_app route check ... PY`

## Summary by Sourcery

Add a backend-driven dev admin login shortcut and wire it into the frontend login flow while avoiding exposure of credentials to the client.

New Features:
- Introduce a backend-only /auth/dev-login endpoint that logs in using the seeded admin account based on configured admin credentials.
- Expose a dev-only "Dev Admin" button on the login page that triggers the backend shortcut without sending credentials from the client.

Bug Fixes:
- Ensure dev login is available in local, development, and preview environments instead of only when VERCEL_ENV is development.

Enhancements:
- Refine the login form and view props to use a simple boolean flag for showing the dev admin shortcut instead of passing test user credentials through the frontend.
- Hook the custom auth router into the FastAPI app so the dev login endpoint is registered.