### PR TITLE
chore: enforce React Query mutations rule

### DIFF
--- a/.beans/ai-nexus-juqj--vendor-react-resizable-panels-for-sidebar-resize.md
+++ b/.beans/ai-nexus-juqj--vendor-react-resizable-panels-for-sidebar-resize.md
@@ -1,0 +1,20 @@
+---
+# ai-nexus-juqj
+title: Vendor react-resizable-panels for sidebar resize
+status: in-progress
+type: task
+created_at: 2026-03-29T21:30:19Z
+updated_at: 2026-03-29T21:30:19Z
+---
+
+Prepare a dedicated review-friendly PR that vendors react-resizable-panels without changing sidebar behavior.
+
+- [ ] Create an isolated branch from development
+- [ ] Copy the vendored library files and wrapper used by sidebar resize
+- [ ] Verify typecheck/lint on the isolated change
+- [ ] Commit with the bean file included
+- [ ] Open a PR with focused reviewer guidance
+
+## Summary of Changes
+
+Pending.

--- a/.claude/rules/github-actions/explicit-pr-descriptions.md
+++ b/.claude/rules/github-actions/explicit-pr-descriptions.md
@@ -6,5 +6,6 @@ globs: .github/workflows/*.yml
 
 When creating, updating, or reviewing a Pull Request that introduces workflow automation or other changes:
 1. **Never Make Undocumented Scope Creeps:** Never silently bundle new features, new triggers, or architectural shifts inside a PR without explicitly stating them in the PR title and description.
-2. **Accurate Execution Context:** Ensure the PR accurately reflects the execution trigger (e.g. `on: push` vs `on: pull_request_target`). Do not copy-paste testing instructions or summaries from other sources if they contradict the actual implementation in the diff.
-3. **If You Touch It, Describe It:** If you change an action's trigger, modify its target, or update its permissions from what was originally documented, rewrite the PR description to match reality before merging.
+2. **Always Update PR Descriptions on Code Changes:** If you push new commits to an existing PR that change how the feature works, you MUST immediately run `gh pr edit <number> --title "..." --body "..."` to update the PR title and description so it matches the new reality. Do not let the PR description drift from the actual implementation.
+3. **Accurate Execution Context:** Ensure the PR accurately reflects the execution trigger (e.g. `on: push` vs `on: pull_request_target`). Do not copy-paste testing instructions or summaries from other sources if they contradict the actual implementation in the diff.
+4. **If You Touch It, Describe It:** If you change an action's trigger, modify its target, or update its permissions from what was originally documented, rewrite the PR description to match reality before merging.

--- a/.claude/rules/react/use-react-query-mutations.md
+++ b/.claude/rules/react/use-react-query-mutations.md
@@ -1,0 +1,81 @@
+---
+description: When making state-changing network requests (POST/PUT/PATCH/DELETE), always use TanStack React Query mutations instead of raw fetch calls inside components.
+globs: ["frontend/**/*.{ts,tsx}"]
+tags: [react, data-fetching, architecture]
+---
+
+# Use React Query Mutations
+
+Always use `@tanstack/react-query`'s `useMutation` hook for state-changing network requests (like form submissions, deletes, or updates) instead of raw `fetch` calls with `try/catch/finally` inside components.
+
+## Scope
+Raw `fetch` is permitted inside custom hooks, non-state-changing GETs, Server Components, and shared API clients. The goal is to keep components focused on presentation, not mutation boilerplate.
+
+## Why
+- **Automatic Lifecycle State:** `useMutation` provides `isPending`, `isSuccess`, and `error` states automatically, preventing you from having to manually juggle `setIsLoading(true/false)` and `setErrorMessage(...)` boilerplate in your components.
+- **Cache Invalidation:** Mutations cleanly hook into the React Query cache via `onSuccess: () => queryClient.invalidateQueries(...)`, allowing you to seamlessly refresh related data across the app after a successful write.
+- **Separation of Concerns:** It keeps network fetching and error-parsing logic out of the UI layer.
+
+## Bad Pattern (Raw Fetch)
+Do not manage loading and error state manually with `fetch` inside components.
+
+```tsx
+const [isLoading, setIsLoading] = useState(false);
+const [error, setError] = useState('');
+
+const submitForm = async () => {
+  setIsLoading(true);
+  try {
+    const res = await fetch('/api/submit', { method: 'POST' });
+    if (!res.ok) throw new Error('Failed');
+    // Success...
+  } catch (err) {
+    setError('Failed to submit.');
+  } finally {
+    setIsLoading(false);
+  }
+}
+```
+
+## Good Pattern (useMutation)
+Extract the fetch into a `useMutation` hook and use its built-in state variables. Use the application's shared API endpoints and fetch utilities.
+
+**`use-submit-form.ts`:**
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthedFetch } from '@/hooks/useAuthedFetch';
+import { API_ENDPOINTS } from '@/lib/api';
+
+export function useSubmitForm() {
+  const queryClient = useQueryClient();
+  const authedFetch = useAuthedFetch();
+
+  return useMutation({
+    mutationFn: async (data: Payload) => {
+      const response = await authedFetch(API_ENDPOINTS.submitForm, {
+        method: 'POST',
+        body: JSON.stringify(data)
+      });
+      if (!response.ok) {
+        throw new Error('Failed to submit.');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['some-data'] });
+    }
+  });
+}
+```
+
+**`MyComponent.tsx`:**
+```tsx
+const submitMutation = useSubmitForm();
+
+const handleSubmit = async () => {
+  await submitMutation.mutateAsync({ foo: 'bar' });
+}
+
+// Access state cleanly:
+// submitMutation.isPending
+// submitMutation.error?.message
+```


### PR DESCRIPTION
Adds an explicit .claude/rules/react/use-react-query-mutations.md rule to ban raw fetch boilerplate inside React components for state-changing endpoints in favor of useMutation.

## Summary by Sourcery

Document React Query mutation usage guidelines and tighten PR description requirements for workflow changes.

Documentation:
- Add a React rule requiring state-changing requests in components to use React Query mutations rather than raw fetch boilerplate.

Chores:
- Update GitHub Actions PR description rules to mandate keeping titles and descriptions in sync with new commits.
- Add a bean task to track vendoring react-resizable-panels for sidebar resize in a focused future PR.