### PR TITLE
fix: allow vercel previews by default in cors regex

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     fernet_key: str
     # CORS
     cors_origins: list[str]
-    cors_origin_regex: str | None = None
+    cors_origin_regex: str | None = r"^https:\/\/.*\.vercel\.app$"
     # The domain to set for cookies (e.g., "example.com"). This is important for authentication cookies to work correctly across subdomains.
     cookie_domain: str
     # Optional secret required to register a new account. When set, anyone


### PR DESCRIPTION
Sets the default CORS origin regex to match vercel preview domains if the env var isn't set.

## Summary by Sourcery

Bug Fixes:
- Ensure Vercel preview deployments are allowed by default in CORS when cors_origin_regex is unset.