### PR TITLE
feat(db): add automatic local SQLite fallback for dev environment

### DIFF
--- a/backend/app/core/agents.py
+++ b/backend/app/core/agents.py
@@ -4,6 +4,7 @@ from typing import List
 from agno.agent import Message
 from agno.agent.agent import Agent
 from agno.db.postgres.postgres import PostgresDb
+from agno.db.sqlite.sqlite import SqliteDb
 from agno.models.google.gemini import Gemini
 from agno.run.agent import RunOutput
 from agno.tools.local_file_system import LocalFileSystemTools
@@ -12,8 +13,12 @@ from agno.tools.mcp.mcp import MCPTools
 from app.core.config import settings
 from app.core.workspace import get_user_workspace
 
+
 # Initialize the Agno database.
-agno_db = PostgresDb(settings.db_url_sync)
+if settings.is_sqlite:
+    agno_db = SqliteDb(db_url=settings.db_url_sync)
+else:
+    agno_db = PostgresDb(db_url=settings.db_url_sync)
 
 
 def create_agent(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,8 +3,12 @@ Application settings.
 """
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_SQLITE_ASYNC_URL = "sqlite+aiosqlite:///./nexus.db"
+DEFAULT_SQLITE_SYNC_URL = "sqlite:///./nexus.db"
 
 
 class Settings(BaseSettings):
@@ -52,20 +56,53 @@ class Settings(BaseSettings):
         return self.env == "prod"
 
     @property
+    def _normalized_database_url(self) -> str:
+        """Return the configured database URL or the local SQLite fallback."""
+        url = self.database_url.strip()
+        if not url:
+            return DEFAULT_SQLITE_SYNC_URL
+
+        parsed = urlparse(url)
+        if parsed.scheme.startswith(("postgresql", "sqlite")):
+            return url
+
+        if url.endswith(".db") or "/" in url or url.startswith("."):
+            return f"sqlite:///{url}"
+
+        return url
+
+    @property
+    def is_sqlite(self) -> bool:
+        """Whether the configured database uses SQLite."""
+        scheme = urlparse(self._normalized_database_url).scheme
+        return scheme.startswith("sqlite")
+
+    @property
     def db_url_sync(self) -> str:
-        """
-        Returns the database URL formatted for synchronous connections. If the original database URL starts with "postgresql+psycopg://", it replaces it with "postgresql://" to ensure compatibility with sync database drivers.
-        """
-        return self.db_url_async
+        """Return the sync database URL for Agno storage."""
+        if not self.database_url.strip():
+            return DEFAULT_SQLITE_SYNC_URL
+
+        url = self._normalized_database_url
+        if url.startswith("postgresql://"):
+            return url.replace("postgresql://", "postgresql+psycopg://", 1)
+        if url.startswith("sqlite+aiosqlite://"):
+            return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+        return url
 
     @property
     def db_url_async(self) -> str:
-        """
-        Returns the database URL formatted for asynchronous connections. If the original database URL starts with "postgresql://", it replaces it with "postgresql+psycopg://" to ensure compatibility with async database drivers.
-        """
-        url = self.database_url
+        """Return the async database URL for SQLAlchemy."""
+        if not self.database_url.strip():
+            return DEFAULT_SQLITE_ASYNC_URL
+
+        url = self._normalized_database_url
         if url.startswith("postgresql://"):
-            url = url.replace("postgresql://", "postgresql+psycopg://")
+            return url.replace("postgresql://", "postgresql+psycopg://", 1)
+        if url.startswith("sqlite://") and not url.startswith("sqlite+aiosqlite://"):
+            return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+        if url.startswith("sqlite+aiosqlite://"):
+            return url
         return url
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,4 @@
-"""
-Application settings.
-"""
+"""Application settings."""
 
 from pathlib import Path
 from urllib.parse import urlparse
@@ -12,52 +10,35 @@ DEFAULT_SQLITE_SYNC_URL = "sqlite:///./nexus.db"
 
 
 class Settings(BaseSettings):
-    """
-    Application settings. This class uses Pydantic's BaseSettings to automatically read environment variables and provide type validation.
-    """
+    """Application settings loaded from environment variables."""
 
-    # Load environment variables from a .env file in the current directory, with UTF-8 encoding. This allows you to define your settings in a .env file instead of setting them directly in the environment.
     model_config = SettingsConfigDict(
         env_file=Path(__file__).resolve().parents[2] / ".env",
         env_file_encoding="utf-8",
         extra="ignore",
     )
 
-    # The URL for the database connection.
     database_url: str = ""
-    # The secret key used for signing authentication tokens. This should be set to a secure random value in production.
     auth_secret: str
-    # The environment in which the application is running. Can be "dev" for development or "prod" for production.
     env: str = "dev"
-    # The API key for Google services.
     google_api_key: str
-    # Fernet Encryption Key (used to encrypt API keys)
     fernet_key: str
-    # CORS
     cors_origins: list[str]
     cors_origin_regex: str | None = r"^https:\/\/.*\.vercel\.app$"
-    # The domain to set for cookies (e.g., "example.com"). This is important for authentication cookies to work correctly across subdomains.
     cookie_domain: str
-    # Optional secret required to register a new account. When set, anyone
-    # attempting to register must supply this value as ``invite_code`` in the
-    # request body. Leave unset (or empty) to allow open registration.
     registration_secret: str = ""
-    # The base directory where workspaces will be stored. Each workspace can contain files, configurations, and other resources specific to a user's project or environment.
     workspace_base_dir: str = "/data/workspaces"
-    # Admin user credentials (for testing).
     admin_email: str | None = None
     admin_password: str | None = None
 
     @property
     def is_production(self) -> bool:
-        """
-        A convenience property that returns True if the application is running in production mode (i.e., if env is set to "prod").
-        """
+        """Whether the app is running in production mode."""
         return self.env == "prod"
 
     @property
     def _normalized_database_url(self) -> str:
-        """Return the configured database URL or the local SQLite fallback."""
+        """Return the configured database URL in a normalized form."""
         url = self.database_url.strip()
         if not url:
             return DEFAULT_SQLITE_SYNC_URL
@@ -74,25 +55,24 @@ class Settings(BaseSettings):
     @property
     def is_sqlite(self) -> bool:
         """Whether the configured database uses SQLite."""
-        scheme = urlparse(self._normalized_database_url).scheme
-        return scheme.startswith("sqlite")
+        return urlparse(self._normalized_database_url).scheme.startswith("sqlite")
 
     @property
     def db_url_sync(self) -> str:
-        """Return the sync database URL for Agno storage."""
+        """Return the sync database URL."""
         if not self.database_url.strip():
             return DEFAULT_SQLITE_SYNC_URL
 
         url = self._normalized_database_url
-        if url.startswith("postgresql://"):
-            return url.replace("postgresql://", "postgresql+psycopg://", 1)
+        if url.startswith("postgresql+psycopg://"):
+            return url.replace("postgresql+psycopg://", "postgresql://", 1)
         if url.startswith("sqlite+aiosqlite://"):
             return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
         return url
 
     @property
     def db_url_async(self) -> str:
-        """Return the async database URL for SQLAlchemy."""
+        """Return the async database URL."""
         if not self.database_url.strip():
             return DEFAULT_SQLITE_ASYNC_URL
 
@@ -101,8 +81,6 @@ class Settings(BaseSettings):
             return url.replace("postgresql://", "postgresql+psycopg://", 1)
         if url.startswith("sqlite://") and not url.startswith("sqlite+aiosqlite://"):
             return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
-        if url.startswith("sqlite+aiosqlite://"):
-            return url
         return url
 
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,7 +1,7 @@
 """
 Database configuration and session management.
 
-Uses SQLAlchemy async engine with postgresql. The User model is defined here
+Uses SQLAlchemy async engine with PostgreSQL or local SQLite. The User model is defined here
 (rather than in models.py) because fastapi-users requires it at import time
 for its dependency chain.
 """

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -16,6 +16,9 @@ from sqlalchemy.orm import DeclarativeBase
 from app.core.config import settings
 
 
+engine_kwargs = {"connect_args": {"check_same_thread": False}} if settings.is_sqlite else {}
+
+
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy ORM models."""
 
@@ -28,7 +31,7 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     pass
 
 
-engine = create_async_engine(settings.db_url_async)
+engine = create_async_engine(settings.db_url_async, **engine_kwargs)
 async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "agno[async-postgres,postgres]>=2.3.21",
+    "aiosqlite>=0.22.1",
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.127.0",
     "google-genai>=1.56.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,15 @@ postgres = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -74,6 +83,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agno", extra = ["async-postgres", "postgres"] },
+    { name = "aiosqlite" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "google-genai" },
@@ -93,6 +103,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agno", extras = ["async-postgres", "postgres"], specifier = ">=2.3.21" },
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.3" },
     { name = "google-genai", specifier = ">=1.56.0" },

--- a/frontend/features/auth/LoginForm.tsx
+++ b/frontend/features/auth/LoginForm.tsx
@@ -40,6 +40,13 @@ export function LoginForm({
 
   const isLoading = loginMutation.isPending || devLoginMutation.isPending;
 
+  const setFriendlyNetworkError = (error: unknown): void => {
+    const message = error instanceof Error ? error.message : '';
+    if (message === 'Failed to fetch') {
+      setLocalErrorMessage('Unable to connect to the backend. Is the server running?');
+    }
+  };
+
   // Prefer the local (network) error if the service failed to be reached entirely,
   // otherwise show the specific API error from React Query.
   const currentError =
@@ -55,11 +62,8 @@ export function LoginForm({
     try {
       await loginMutation.mutateAsync({ email, password });
       router.push('/');
-    } catch {
-      // Avoid raw fetch boilerplate: the hook handles standard detail extraction.
-      // If an error is thrown here that wasn't an API error (e.g. network down),
-      // it gets captured as mutation error anyway, but we keep the catch block
-      // just in case fetch itself throws synchronously.
+    } catch (error) {
+      setFriendlyNetworkError(error);
     }
   };
 
@@ -72,8 +76,8 @@ export function LoginForm({
     try {
       await devLoginMutation.mutateAsync();
       router.push('/');
-    } catch {
-      // Hook parses detail. Handled above.
+    } catch (error) {
+      setFriendlyNetworkError(error);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "frontend:dev": "bun --cwd frontend dev",
-    "dev:backend": "portless api.app.nexus-ai --app-port 8000 uv run --project backend fastapi dev backend/main.py",
+    "dev:backend": "bunx portless api.app.nexus-ai --app-port 8000 uv run --project backend fastapi dev backend/main.py",
     "dev": "bun run dev.ts",
     "commit": "bun run commit.ts",
     "lint:policies": "bun run check-policies.mjs"


### PR DESCRIPTION
## Summary
- add a local SQLite fallback when `DATABASE_URL` is empty or points at a local sqlite file
- normalize async SQLAlchemy vs sync Agno database URLs for Postgres and SQLite
- switch Agno storage between `PostgresDb` and `SqliteDb` automatically
- add `aiosqlite` so the local async SQLite engine can actually start

## Verification
- instantiated `Settings` with empty/Postgres/SQLite values and verified `db_url_sync` + `db_url_async` outputs
- imported `app.core.agents` with SQLite and Postgres env values and verified the selected Agno DB class
- imported `app.db` with SQLite and Postgres env values and verified the SQLAlchemy async driver name

## Summary by Sourcery

Add automatic local SQLite fallback and normalize database URLs for both async SQLAlchemy and sync Agno usage.

New Features:
- Provide an automatic local SQLite database fallback when no DATABASE_URL is configured or when a local SQLite file path is supplied.
- Automatically switch Agno storage between PostgresDb and SqliteDb based on the resolved database URL.

Enhancements:
- Normalize Postgres and SQLite URLs for consistent async and sync database usage across the app.

Build:
- Add aiosqlite dependency to support the async SQLite engine.