### PR TITLE
fix: make auth cookie SameSite configurable for cross-domain dev

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,8 +36,10 @@ REGISTRATION_SECRET=
 # - prod: cookies with Secure flag (requires https)
 ENV=dev
 
-# Cookie domain for auth cookies (e.g., "nexus-ai.localhost" or "yourdomain.com")
+# Cookie domain for auth cookies (e.g., "nexus-ai.localhost" or "yourdomain.com"). Optional.
 COOKIE_DOMAIN=nexus-ai.localhost
+# Cross-site cookie behavior ("lax", "strict", "none"). Set to "none" for Vercel previews.
+COOKIE_SAMESITE=lax
 
 # CORS allowed origins (JSON array)
 CORS_ORIGINS=["http://localhost:3001","http://ai-nexus.localhost:1355"]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,9 @@ ENV=dev
 COOKIE_DOMAIN=nexus-ai.localhost
 # Cross-site cookie behavior ("lax", "strict", "none"). Set to "none" for Vercel previews.
 COOKIE_SAMESITE=lax
+# Force the Secure flag on auth cookies (true/false). Optional. Defaults to true if ENV=prod.
+# Required if COOKIE_SAMESITE=none.
+# COOKIE_SECURE=true
 
 # CORS allowed origins (JSON array)
 CORS_ORIGINS=["http://localhost:3001","http://ai-nexus.localhost:1355"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,7 +33,9 @@ class Settings(BaseSettings):
     cors_origins: list[str]
     cors_origin_regex: str | None = None
     # The domain to set for cookies (e.g., "example.com"). This is important for authentication cookies to work correctly across subdomains.
-    cookie_domain: str
+    cookie_domain: str | None = None
+    # Controls cross-site cookie behavior ("lax", "strict", "none"). Set to "none" (with secure=True) to allow auth across completely different domains (like Vercel previews).
+    cookie_samesite: str = "lax"
     # Optional secret required to register a new account. When set, anyone
     # attempting to register must supply this value as ``invite_code`` in the
     # request body. Leave unset (or empty) to allow open registration.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     cookie_domain: str | None = None
     # Controls cross-site cookie behavior ("lax", "strict", "none"). Set to "none" (with secure=True) to allow auth across completely different domains (like Vercel previews).
     cookie_samesite: Literal["lax", "strict", "none"] = "lax"
+    # If True, forces the Secure flag on cookies. If False, forces HTTP allowed. If None, auto-detects based on is_production.
+    cookie_secure: bool | None = None
     # Optional secret required to register a new account. When set, anyone
     # attempting to register must supply this value as ``invite_code`` in the
     # request body. Leave unset (or empty) to allow open registration.
@@ -51,8 +53,9 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_secure_cookie(self) -> "Settings":
-        if self.cookie_samesite == "none" and not self.is_production:
-            raise ValueError("cookie_samesite='none' requires HTTPS (which is tied to is_production in this template).")
+        secure = self.cookie_secure if self.cookie_secure is not None else self.is_production
+        if self.cookie_samesite == "none" and not secure:
+            raise ValueError("cookie_samesite='none' requires HTTPS (cookie_secure must be True, or run with ENV=prod).")
         return self
 
     @property

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,7 +3,10 @@ Application settings.
 """
 
 from pathlib import Path
+from typing import Literal
 
+from typing import Any, Literal
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -35,7 +38,7 @@ class Settings(BaseSettings):
     # The domain to set for cookies (e.g., "example.com"). This is important for authentication cookies to work correctly across subdomains.
     cookie_domain: str | None = None
     # Controls cross-site cookie behavior ("lax", "strict", "none"). Set to "none" (with secure=True) to allow auth across completely different domains (like Vercel previews).
-    cookie_samesite: str = "lax"
+    cookie_samesite: Literal["lax", "strict", "none"] = "lax"
     # Optional secret required to register a new account. When set, anyone
     # attempting to register must supply this value as ``invite_code`` in the
     # request body. Leave unset (or empty) to allow open registration.
@@ -45,6 +48,12 @@ class Settings(BaseSettings):
     # Admin user credentials (for testing).
     admin_email: str | None = None
     admin_password: str | None = None
+
+    @model_validator(mode="after")
+    def validate_secure_cookie(self) -> "Settings":
+        if self.cookie_samesite == "none" and not self.is_production:
+            raise ValueError("cookie_samesite='none' requires HTTPS (which is tied to is_production in this template).")
+        return self
 
     @property
     def is_production(self) -> bool:

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -78,8 +78,8 @@ async def get_user_manager(
 # --- Transport & Strategy ---------------------------------------------------
 
 should_secure_cookie = (
-    settings.is_production
-)  # Use secure cookies in production, but allow non-secure in development
+    settings.cookie_secure if settings.cookie_secure is not None else settings.is_production
+)  # Use secure cookies if requested, otherwise fallback to is_production
 
 cookie_transport = CookieTransport(
     cookie_name="session_token",

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -4,7 +4,7 @@ User management and authentication using FastAPI-Users. This module defines the 
 
 import uuid
 from collections.abc import AsyncGenerator
-from typing import Optional, Any
+from typing import AsyncGenerator, Optional
 
 from fastapi import Depends, HTTPException, Request, Response
 from fastapi_users import (
@@ -85,7 +85,7 @@ cookie_transport = CookieTransport(
     cookie_name="session_token",
     cookie_httponly=True,
     cookie_secure=should_secure_cookie,
-    cookie_samesite=cast(Any, settings.cookie_samesite),
+    cookie_samesite=settings.cookie_samesite,
     cookie_max_age=3600,
     cookie_domain=settings.cookie_domain,
 )

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -4,7 +4,7 @@ User management and authentication using FastAPI-Users. This module defines the 
 
 import uuid
 from collections.abc import AsyncGenerator
-from typing import Optional
+from typing import Optional, Any
 
 from fastapi import Depends, HTTPException, Request, Response
 from fastapi_users import (
@@ -85,7 +85,7 @@ cookie_transport = CookieTransport(
     cookie_name="session_token",
     cookie_httponly=True,
     cookie_secure=should_secure_cookie,
-    cookie_samesite="lax",
+    cookie_samesite=cast(Any, settings.cookie_samesite),
     cookie_max_age=3600,
     cookie_domain=settings.cookie_domain,
 )


### PR DESCRIPTION
Exposes `cookie_samesite` and makes `cookie_domain` optional so that the dev backend can serve Vercel preview domains and localhost simultaneously by setting `COOKIE_SAMESITE=none` and `COOKIE_SECURE=true` in the environment.

## Summary by Sourcery

Make authentication cookie security and SameSite behavior configurable while relaxing the requirement for a global cookie domain.

New Features:
- Add configurable cookie_samesite setting with support for lax, strict, and none.
- Add optional cookie_secure setting to explicitly control the Secure flag on auth cookies.

Enhancements:
- Make cookie_domain optional to support scenarios without a shared cookie domain.
- Derive cookie transport security settings from the new configuration options instead of hardcoding them.
- Validate that cookie_samesite="none" is only allowed when cookies are sent over HTTPS.