### PR TITLE
fix: add cookie_secure override for dev environments

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,9 @@ ENV=dev
 COOKIE_DOMAIN=nexus-ai.localhost
 # Cross-site cookie behavior ("lax", "strict", "none"). Set to "none" for Vercel previews.
 COOKIE_SAMESITE=lax
+# Force the Secure flag on auth cookies (true/false). Optional. Defaults to true if ENV=prod.
+# Required if COOKIE_SAMESITE=none.
+# COOKIE_SECURE=true
 
 # CORS allowed origins (JSON array)
 CORS_ORIGINS=["http://localhost:3001","http://ai-nexus.localhost:1355"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     cookie_domain: str | None = None
     # Controls cross-site cookie behavior ("lax", "strict", "none"). Set to "none" (with secure=True) to allow auth across completely different domains (like Vercel previews).
     cookie_samesite: Literal["lax", "strict", "none"] = "lax"
+    # If True, forces the Secure flag on cookies. If False, forces HTTP allowed. If None, auto-detects based on is_production.
+    cookie_secure: bool | None = None
     # Optional secret required to register a new account. When set, anyone
     # attempting to register must supply this value as ``invite_code`` in the
     # request body. Leave unset (or empty) to allow open registration.
@@ -51,8 +53,9 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_secure_cookie(self) -> "Settings":
-        if self.cookie_samesite == "none" and not self.is_production:
-            raise ValueError("cookie_samesite='none' requires HTTPS (which is tied to is_production in this template).")
+        secure = self.cookie_secure if self.cookie_secure is not None else self.is_production
+        if self.cookie_samesite == "none" and not secure:
+            raise ValueError("cookie_samesite='none' requires HTTPS (cookie_secure must be True, or run with ENV=prod).")
         return self
 
     @property

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -78,8 +78,8 @@ async def get_user_manager(
 # --- Transport & Strategy ---------------------------------------------------
 
 should_secure_cookie = (
-    settings.is_production
-)  # Use secure cookies in production, but allow non-secure in development
+    settings.cookie_secure if settings.cookie_secure is not None else settings.is_production
+)  # Use secure cookies if requested, otherwise fallback to is_production
 
 cookie_transport = CookieTransport(
     cookie_name="session_token",


### PR DESCRIPTION
Allows setting `COOKIE_SECURE=true` explicitly in the environment so that `COOKIE_SAMESITE=none` passes validation even when `ENV=dev` (e.g. on Railway, which provides HTTPS automatically despite being a dev environment).

## Summary by Sourcery

Allow overriding cookie security behavior independently of environment to support secure cookies in non-production setups.

New Features:
- Add configurable cookie_secure setting to control the Secure flag on cookies independent of ENV.

Bug Fixes:
- Relax cookie_samesite='none' validation to allow secure cookies in development when cookie_secure is explicitly enabled.

Enhancements:
- Update cookie transport to use cookie_secure when set, falling back to production-based behavior otherwise.

Documentation:
- Document cookie_secure usage in the example environment configuration.