### PR TITLE
feat(db): add local SQLite fallback with preserved config comments

### DIFF
--- a/backend/app/core/agents.py
+++ b/backend/app/core/agents.py
@@ -4,6 +4,7 @@ from typing import List
 from agno.agent import Message
 from agno.agent.agent import Agent
 from agno.db.postgres.postgres import PostgresDb
+from agno.db.sqlite.sqlite import SqliteDb
 from agno.models.google.gemini import Gemini
 from agno.run.agent import RunOutput
 from agno.tools.local_file_system import LocalFileSystemTools
@@ -12,8 +13,12 @@ from agno.tools.mcp.mcp import MCPTools
 from app.core.config import settings
 from app.core.workspace import get_user_workspace
 
+
 # Initialize the Agno database.
-agno_db = PostgresDb(settings.db_url_sync)
+if settings.is_sqlite:
+    agno_db = SqliteDb(db_url=settings.db_url_sync)
+else:
+    agno_db = PostgresDb(db_url=settings.db_url_sync)
 
 
 def create_agent(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -63,20 +63,57 @@ class Settings(BaseSettings):
         return self.env == "prod"
 
     @property
+    def _normalized_database_url(self) -> str:
+        """Return the configured database URL in a normalized form."""
+        from urllib.parse import urlparse
+        
+        url = self.database_url.strip()
+        if not url:
+            return "sqlite:///./nexus.db"
+
+        parsed = urlparse(url)
+        if parsed.scheme.startswith(("postgresql", "sqlite")):
+            return url
+
+        if url.endswith(".db") or "/" in url or url.startswith("."):
+            return f"sqlite:///{url}"
+
+        return url
+
+    @property
+    def is_sqlite(self) -> bool:
+        """Whether the configured database uses SQLite."""
+        from urllib.parse import urlparse
+        return urlparse(self._normalized_database_url).scheme.startswith("sqlite")
+
+    @property
     def db_url_sync(self) -> str:
         """
         Returns the database URL formatted for synchronous connections. If the original database URL starts with "postgresql+psycopg://", it replaces it with "postgresql://" to ensure compatibility with sync database drivers.
         """
-        return self.db_url_async
+        if not self.database_url.strip():
+            return "sqlite:///./nexus.db"
+
+        url = self._normalized_database_url
+        if url.startswith("postgresql+psycopg://"):
+            return url.replace("postgresql+psycopg://", "postgresql://", 1)
+        if url.startswith("sqlite+aiosqlite://"):
+            return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+        return url
 
     @property
     def db_url_async(self) -> str:
         """
         Returns the database URL formatted for asynchronous connections. If the original database URL starts with "postgresql://", it replaces it with "postgresql+psycopg://" to ensure compatibility with async database drivers.
         """
-        url = self.database_url
+        if not self.database_url.strip():
+            return "sqlite+aiosqlite:///./nexus.db"
+
+        url = self._normalized_database_url
         if url.startswith("postgresql://"):
-            url = url.replace("postgresql://", "postgresql+psycopg://")
+            return url.replace("postgresql://", "postgresql+psycopg://", 1)
+        if url.startswith("sqlite://") and not url.startswith("sqlite+aiosqlite://"):
+            return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
         return url
 
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,7 +1,7 @@
 """
 Database configuration and session management.
 
-Uses SQLAlchemy async engine with postgresql. The User model is defined here
+Uses SQLAlchemy async engine with PostgreSQL or local SQLite. The User model is defined here
 (rather than in models.py) because fastapi-users requires it at import time
 for its dependency chain.
 """
@@ -16,6 +16,9 @@ from sqlalchemy.orm import DeclarativeBase
 from app.core.config import settings
 
 
+engine_kwargs = {"connect_args": {"check_same_thread": False}} if settings.is_sqlite else {}
+
+
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy ORM models."""
 
@@ -28,7 +31,7 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     pass
 
 
-engine = create_async_engine(settings.db_url_async)
+engine = create_async_engine(settings.db_url_async, **engine_kwargs)
 async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "agno[async-postgres,postgres]>=2.3.21",
+    "aiosqlite>=0.22.1",
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.127.0",
     "google-genai>=1.56.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,15 @@ postgres = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -74,6 +83,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agno", extra = ["async-postgres", "postgres"] },
+    { name = "aiosqlite" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "google-genai" },
@@ -93,6 +103,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agno", extras = ["async-postgres", "postgres"], specifier = ">=2.3.21" },
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.3" },
     { name = "google-genai", specifier = ">=1.56.0" },

--- a/frontend/features/auth/LoginForm.tsx
+++ b/frontend/features/auth/LoginForm.tsx
@@ -40,6 +40,13 @@ export function LoginForm({
 
   const isLoading = loginMutation.isPending || devLoginMutation.isPending;
 
+  const setFriendlyNetworkError = (error: unknown): void => {
+    const message = error instanceof Error ? error.message : '';
+    if (message === 'Failed to fetch') {
+      setLocalErrorMessage('Unable to connect to the backend. Is the server running?');
+    }
+  };
+
   // Prefer the local (network) error if the service failed to be reached entirely,
   // otherwise show the specific API error from React Query.
   const currentError =
@@ -55,11 +62,8 @@ export function LoginForm({
     try {
       await loginMutation.mutateAsync({ email, password });
       router.push('/');
-    } catch {
-      // Avoid raw fetch boilerplate: the hook handles standard detail extraction.
-      // If an error is thrown here that wasn't an API error (e.g. network down),
-      // it gets captured as mutation error anyway, but we keep the catch block
-      // just in case fetch itself throws synchronously.
+    } catch (error) {
+      setFriendlyNetworkError(error);
     }
   };
 
@@ -72,8 +76,8 @@ export function LoginForm({
     try {
       await devLoginMutation.mutateAsync();
       router.push('/');
-    } catch {
-      // Hook parses detail. Handled above.
+    } catch (error) {
+      setFriendlyNetworkError(error);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "frontend:dev": "bun --cwd frontend dev",
-    "dev:backend": "portless api.app.nexus-ai --app-port 8000 uv run --project backend fastapi dev backend/main.py",
+    "dev:backend": "bunx portless api.app.nexus-ai --app-port 8000 uv run --project backend fastapi dev backend/main.py",
     "dev": "bun run dev.ts",
     "commit": "bun run commit.ts",
     "lint:policies": "bun run check-policies.mjs"


### PR DESCRIPTION
## Add SQLite database support as fallback option

Introduces SQLite database support alongside existing PostgreSQL functionality. The application now automatically detects and configures the appropriate database driver based on the `DATABASE_URL` setting, defaulting to a local SQLite file when no URL is provided.

### Changes

- Added `aiosqlite` dependency for async SQLite operations
- Implemented database type detection in configuration with `is_sqlite` property
- Added URL normalization logic to handle various database URL formats
- Updated database engine initialization to conditionally use SQLite or PostgreSQL drivers
- Modified agent initialization to select appropriate database backend
- Enhanced login form error handling to display user-friendly network connection messages
- Updated development script to use `bunx portless` for better cross-platform compatibility

The system maintains full backward compatibility with existing PostgreSQL configurations while enabling local development with SQLite when no database URL is specified.