### PR TITLE
feat(nav-chats): add hooks, contexts, and label badge (2/3)

### DIFF
--- a/.beans/ai-nexus-x6zc--add-concurrency-limiter-to-conversation-search-fet.md
+++ b/.beans/ai-nexus-x6zc--add-concurrency-limiter-to-conversation-search-fet.md
@@ -1,0 +1,11 @@
+---
+# ai-nexus-x6zc
+title: Add concurrency limiter to conversation search fetching
+status: todo
+type: task
+priority: low
+created_at: 2026-04-04T06:52:48Z
+updated_at: 2026-04-04T06:52:48Z
+---
+
+Promise.all in useConversationSearch fires unbounded concurrent requests for all uncached conversations. If the conversation list grows large (hundreds+), this can overwhelm the backend and browser. Add a concurrency pool (e.g. p-limit or manual batching) to cap parallel requests.

--- a/frontend/features/nav-chats/ConversationLabelBadge.tsx
+++ b/frontend/features/nav-chats/ConversationLabelBadge.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { ConversationLabel } from '@/lib/types';
+
+function resolveBadgeColor(label: ConversationLabel): { backgroundColor: string; color: string } {
+  if (label.color) {
+    return {
+      backgroundColor: `color-mix(in srgb, ${label.color} 6%, transparent)`,
+      color: `color-mix(in srgb, ${label.color} 75%, var(--foreground))`,
+    };
+  }
+
+  return {
+    backgroundColor: 'rgba(var(--foreground-rgb), 0.05)',
+    color: 'rgba(var(--foreground-rgb), 0.8)',
+  };
+}
+
+export function normalizeConversationLabel(label: ConversationLabel | string): ConversationLabel {
+  if (typeof label !== 'string') {
+    return label;
+  }
+
+  const [namePart = label, valuePart] = label.split(':');
+  return {
+    id: namePart.trim().toLowerCase().replace(/\s+/g, '-'),
+    name: namePart.trim(),
+    value: valuePart?.trim(),
+  };
+}
+
+export function ConversationLabelBadge({
+  label,
+}: {
+  label: ConversationLabel | string;
+}): React.JSX.Element {
+  const normalized = normalizeConversationLabel(label);
+  const style = resolveBadgeColor(normalized);
+
+  return (
+    <div
+      role="presentation"
+      className="shrink-0 h-[18px] max-w-[120px] px-1.5 text-[10px] font-medium rounded flex items-center whitespace-nowrap gap-0.5"
+      onMouseDown={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
+      style={style}
+    >
+      <span className="truncate">{normalized.name}</span>
+      {normalized.value ? (
+        <>
+          <span style={{ opacity: 0.4 }}>·</span>
+          <span className="font-normal truncate min-w-0" style={{ opacity: 0.75 }}>
+            {normalized.value}
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/features/nav-chats/ConversationLabelBadge.tsx
+++ b/frontend/features/nav-chats/ConversationLabelBadge.tsx
@@ -1,3 +1,16 @@
+/**
+ * @file ConversationLabelBadge.tsx
+ *
+ * Renders a small colored pill for a conversation label in the sidebar.
+ *
+ * Labels can arrive as either structured objects (from the API) or plain
+ * strings (legacy format, e.g. "status:active"). The normalizer handles
+ * both so the rendering path doesn't need to branch.
+ *
+ * The pill intercepts all pointer/click events to prevent accidentally
+ * selecting or navigating the parent conversation row when the user
+ * interacts with the label itself.
+ */
 'use client';
 
 import type { ConversationLabel } from '@/lib/types';
@@ -16,6 +29,11 @@ function resolveBadgeColor(label: ConversationLabel): { backgroundColor: string;
   };
 }
 
+/**
+ * Convert a string label like "status:active" into a structured ConversationLabel.
+ * Splits on the FIRST colon only so values containing colons are preserved intact.
+ * If the label is already an object, returns it unchanged.
+ */
 export function normalizeConversationLabel(label: ConversationLabel | string): ConversationLabel {
   if (typeof label !== 'string') {
     return label;
@@ -40,6 +58,11 @@ export function normalizeConversationLabel(label: ConversationLabel | string): C
   };
 }
 
+/**
+ * Renders a single label as a colored pill. Accepts both structured and
+ * string labels. Stops event propagation so clicking the pill doesn't
+ * trigger the parent row's selection/navigation handler.
+ */
 export function ConversationLabelBadge({
   label,
 }: {

--- a/frontend/features/nav-chats/ConversationLabelBadge.tsx
+++ b/frontend/features/nav-chats/ConversationLabelBadge.tsx
@@ -21,7 +21,18 @@ export function normalizeConversationLabel(label: ConversationLabel | string): C
     return label;
   }
 
-  const [namePart = label, valuePart] = label.split(':');
+  const separatorIndex = label.indexOf(':');
+
+  let namePart: string;
+  let valuePart: string | undefined;
+
+  if (separatorIndex === -1) {
+    namePart = label;
+  } else {
+    namePart = label.slice(0, separatorIndex);
+    valuePart = label.slice(separatorIndex + 1);
+  }
+
   return {
     id: namePart.trim().toLowerCase().replace(/\s+/g, '-'),
     name: namePart.trim(),
@@ -41,9 +52,15 @@ export function ConversationLabelBadge({
     <div
       role="presentation"
       className="shrink-0 h-[18px] max-w-[120px] px-1.5 text-[10px] font-medium rounded flex items-center whitespace-nowrap gap-0.5"
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
       onMouseDown={(event) => {
         event.stopPropagation();
         event.preventDefault();
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
       }}
       style={style}
     >

--- a/frontend/features/nav-chats/chat-activity-context.tsx
+++ b/frontend/features/nav-chats/chat-activity-context.tsx
@@ -1,21 +1,46 @@
+/**
+ * @file chat-activity-context.tsx
+ *
+ * Provides a shared context for tracking which conversation is currently active
+ * in the chat panel. The sidebar needs to know this so it can show activity
+ * indicators (loading spinners, unread badges) on the correct row without
+ * prop-drilling through the entire component tree.
+ *
+ * Without this context, the sidebar and the chat panel would need a common
+ * parent to hoist the "active conversation" state into, which doesn't exist
+ * cleanly in the current layout (sidebar and chat are siblings under different
+ * layout regions).
+ */
 'use client';
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
 import type { AgnoMessage } from '@/lib/types';
 
+/** Snapshot of the conversation currently open in the chat panel. */
 type ActiveConversationState = {
   conversationId: string | null;
   chatHistory: AgnoMessage[];
   isLoading: boolean;
 };
 
+/** Context value exposed to consumers: current state + mutation helpers. */
 type ChatActivityContextValue = ActiveConversationState & {
+  /** Replace the active conversation state entirely (used when opening a chat). */
   setActiveConversation: (state: ActiveConversationState) => void;
+  /**
+   * Clear the active conversation, but only if the given ID matches.
+   * Guards against race conditions where a slow close callback fires
+   * after a new conversation was already opened.
+   */
   clearActiveConversation: (conversationId: string) => void;
 };
 
 const ChatActivityContext = createContext<ChatActivityContextValue | null>(null);
 
+/**
+ * Provides chat activity state to the sidebar and any other component
+ * that needs to know which conversation is currently open.
+ */
 export function ChatActivityProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
   const [state, setState] = useState<ActiveConversationState>({
     conversationId: null,
@@ -41,6 +66,10 @@ export function ChatActivityProvider({ children }: { children: React.ReactNode }
   return <ChatActivityContext.Provider value={value}>{children}</ChatActivityContext.Provider>;
 }
 
+/**
+ * Access the chat activity context. Must be called inside a ChatActivityProvider.
+ * @throws If called outside the provider tree.
+ */
 export function useChatActivity(): ChatActivityContextValue {
   const context = useContext(ChatActivityContext);
   if (!context) {

--- a/frontend/features/nav-chats/chat-activity-context.tsx
+++ b/frontend/features/nav-chats/chat-activity-context.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import type { AgnoMessage } from '@/lib/types';
+
+type ActiveConversationState = {
+  conversationId: string | null;
+  chatHistory: AgnoMessage[];
+  isLoading: boolean;
+};
+
+type ChatActivityContextValue = ActiveConversationState & {
+  setActiveConversation: (state: ActiveConversationState) => void;
+  clearActiveConversation: (conversationId: string) => void;
+};
+
+const ChatActivityContext = createContext<ChatActivityContextValue | null>(null);
+
+export function ChatActivityProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const [state, setState] = useState<ActiveConversationState>({
+    conversationId: null,
+    chatHistory: [],
+    isLoading: false,
+  });
+
+  const value = useMemo<ChatActivityContextValue>(
+    () => ({
+      ...state,
+      setActiveConversation: setState,
+      clearActiveConversation: (conversationId) => {
+        setState((current) =>
+          current.conversationId === conversationId
+            ? { conversationId: null, chatHistory: [], isLoading: false }
+            : current
+        );
+      },
+    }),
+    [state]
+  );
+
+  return <ChatActivityContext.Provider value={value}>{children}</ChatActivityContext.Provider>;
+}
+
+export function useChatActivity(): ChatActivityContextValue {
+  const context = useContext(ChatActivityContext);
+  if (!context) {
+    throw new Error('useChatActivity must be used within ChatActivityProvider.');
+  }
+  return context;
+}

--- a/frontend/features/nav-chats/conversation-selection.ts
+++ b/frontend/features/nav-chats/conversation-selection.ts
@@ -1,0 +1,104 @@
+export type MultiSelectState = {
+  selected: string | null;
+  selectedIds: Set<string>;
+  anchorId: string | null;
+  anchorIndex: number;
+};
+
+export function createInitialSelectionState(): MultiSelectState {
+  return {
+    selected: null,
+    selectedIds: new Set<string>(),
+    anchorId: null,
+    anchorIndex: -1,
+  };
+}
+
+export function singleSelect(id: string, index: number): MultiSelectState {
+  return {
+    selected: id,
+    selectedIds: new Set([id]),
+    anchorId: id,
+    anchorIndex: index,
+  };
+}
+
+export function toggleSelect(state: MultiSelectState, id: string, index: number): MultiSelectState {
+  const nextIds = new Set(state.selectedIds);
+
+  if (nextIds.has(id)) {
+    if (nextIds.size <= 1) {
+      return state;
+    }
+
+    nextIds.delete(id);
+    return {
+      selected: state.selected === id ? [...nextIds][0] ?? null : state.selected,
+      selectedIds: nextIds,
+      anchorId: id,
+      anchorIndex: index,
+    };
+  }
+
+  nextIds.add(id);
+  return {
+    selected: id,
+    selectedIds: nextIds,
+    anchorId: id,
+    anchorIndex: index,
+  };
+}
+
+export function rangeSelect(state: MultiSelectState, toIndex: number, items: string[]): MultiSelectState {
+  if (items.length === 0) {
+    return state;
+  }
+
+  const clampedIndex = Math.max(0, Math.min(toIndex, items.length - 1));
+
+  let anchorIndex = clampedIndex;
+  if (state.anchorIndex >= 0 && state.anchorIndex < items.length && items[state.anchorIndex] === state.anchorId) {
+    anchorIndex = state.anchorIndex;
+  } else if (state.anchorId) {
+    const foundIndex = items.indexOf(state.anchorId);
+    anchorIndex = foundIndex >= 0 ? foundIndex : clampedIndex;
+  }
+
+  const start = Math.min(anchorIndex, clampedIndex);
+  const end = Math.max(anchorIndex, clampedIndex);
+  const selectedIds = new Set<string>();
+
+  for (let index = start; index <= end; index += 1) {
+    const itemId = items[index];
+    if (itemId) {
+      selectedIds.add(itemId);
+    }
+  }
+
+  const selectedId = items[clampedIndex] ?? state.selected;
+  const anchorId = state.anchorId ?? items[anchorIndex] ?? selectedId;
+
+  return {
+    selected: selectedId,
+    selectedIds,
+    anchorId,
+    anchorIndex,
+  };
+}
+
+export function clearMultiSelect(state: MultiSelectState): MultiSelectState {
+  if (!state.selected) {
+    return createInitialSelectionState();
+  }
+
+  return {
+    selected: state.selected,
+    selectedIds: new Set([state.selected]),
+    anchorId: state.selected,
+    anchorIndex: state.anchorIndex,
+  };
+}
+
+export function isMultiSelectActive(state: MultiSelectState): boolean {
+  return state.selectedIds.size > 1;
+}

--- a/frontend/features/nav-chats/conversation-selection.ts
+++ b/frontend/features/nav-chats/conversation-selection.ts
@@ -1,10 +1,34 @@
+/**
+ * @file conversation-selection.ts
+ *
+ * Pure state machine for multi-select behavior in the sidebar conversation list.
+ * Kept framework-agnostic (no React) so it can be unit-tested without rendering
+ * and reused if the sidebar is ever ported to a different UI layer.
+ *
+ * The selection model mirrors native OS list selection:
+ *   - Click: select one, deselect everything else.
+ *   - Cmd/Ctrl+Click: toggle one item in/out of the selection.
+ *   - Shift+Click: select a contiguous range from the anchor to the target.
+ *
+ * An "anchor" is the item where the last deliberate selection action started.
+ * Range selects extend from the anchor to the new target. The anchor survives
+ * list reordering because rangeSelect re-finds it by ID if the cached index
+ * goes stale.
+ */
+
+/** Immutable snapshot of the current selection. */
 export type MultiSelectState = {
+  /** The "focused" or "primary" selected item (used for keyboard navigation). */
   selected: string | null;
+  /** All currently selected item IDs. Size > 1 means multi-select is active. */
   selectedIds: Set<string>;
+  /** The item that anchors shift+click range selections. */
   anchorId: string | null;
+  /** Cached index of the anchor in the item list (may go stale after reorder). */
   anchorIndex: number;
 };
 
+/** Returns a blank selection state with nothing selected. */
 export function createInitialSelectionState(): MultiSelectState {
   return {
     selected: null,
@@ -14,6 +38,10 @@ export function createInitialSelectionState(): MultiSelectState {
   };
 }
 
+/**
+ * Select exactly one item, clearing all others.
+ * Sets the anchor so future shift+clicks extend from this point.
+ */
 export function singleSelect(id: string, index: number): MultiSelectState {
   return {
     selected: id,
@@ -23,10 +51,16 @@ export function singleSelect(id: string, index: number): MultiSelectState {
   };
 }
 
+/**
+ * Toggle an item in or out of the selection (Cmd/Ctrl+Click).
+ * Never allows the selection to drop to zero; if the user tries to
+ * deselect the last remaining item, the state is returned unchanged.
+ */
 export function toggleSelect(state: MultiSelectState, id: string, index: number): MultiSelectState {
   const nextIds = new Set(state.selectedIds);
 
   if (nextIds.has(id)) {
+    // Don't allow deselecting the last item — always keep at least one.
     if (nextIds.size <= 1) {
       return state;
     }
@@ -49,6 +83,13 @@ export function toggleSelect(state: MultiSelectState, id: string, index: number)
   };
 }
 
+/**
+ * Select a contiguous range from the anchor to the target index (Shift+Click).
+ *
+ * The anchor is resilient to reordering because we re-find it by `anchorId`
+ * if the cached `anchorIndex` no longer matches. This prevents stale index
+ * references from selecting the wrong range after the list is re-sorted.
+ */
 export function rangeSelect(state: MultiSelectState, toIndex: number, items: string[]): MultiSelectState {
   if (items.length === 0) {
     return state;
@@ -56,6 +97,7 @@ export function rangeSelect(state: MultiSelectState, toIndex: number, items: str
 
   const clampedIndex = Math.max(0, Math.min(toIndex, items.length - 1));
 
+  // Re-resolve the anchor by ID if the cached index is stale.
   let anchorIndex = clampedIndex;
   if (state.anchorIndex >= 0 && state.anchorIndex < items.length && items[state.anchorIndex] === state.anchorId) {
     anchorIndex = state.anchorIndex;
@@ -86,6 +128,10 @@ export function rangeSelect(state: MultiSelectState, toIndex: number, items: str
   };
 }
 
+/**
+ * Collapse multi-select back to a single selection on the currently focused item.
+ * If nothing is focused, resets to the initial empty state entirely.
+ */
 export function clearMultiSelect(state: MultiSelectState): MultiSelectState {
   if (!state.selected) {
     return createInitialSelectionState();
@@ -99,6 +145,7 @@ export function clearMultiSelect(state: MultiSelectState): MultiSelectState {
   };
 }
 
+/** True when more than one item is selected (batch operations should be available). */
 export function isMultiSelectActive(state: MultiSelectState): boolean {
   return state.selectedIds.size > 1;
 }

--- a/frontend/features/nav-chats/sidebar-focus.tsx
+++ b/frontend/features/nav-chats/sidebar-focus.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+export type FocusZoneId = 'sidebar' | 'navigator' | 'chat';
+export type FocusIntent = 'keyboard' | 'click' | 'programmatic';
+
+export interface FocusZoneOptions {
+  intent?: FocusIntent;
+  moveFocus?: boolean;
+}
+
+type FocusZoneRegistration = {
+  id: FocusZoneId;
+  ref: React.RefObject<HTMLElement | null>;
+  focusFirst?: () => void;
+};
+
+type FocusState = {
+  zone: FocusZoneId | null;
+  intent: FocusIntent | null;
+  shouldMoveDOMFocus: boolean;
+};
+
+type FocusContextValue = {
+  focusState: FocusState;
+  registerZone: (zone: FocusZoneRegistration) => void;
+  unregisterZone: (id: FocusZoneId) => void;
+  focusZone: (id: FocusZoneId, options?: FocusZoneOptions) => void;
+  focusNextZone: () => void;
+  focusPreviousZone: () => void;
+  isZoneFocused: (id: FocusZoneId) => boolean;
+};
+
+const ZONE_ORDER: FocusZoneId[] = ['sidebar', 'navigator', 'chat'];
+
+const FocusContext = createContext<FocusContextValue | null>(null);
+
+export function SidebarFocusProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const zonesRef = useRef(new Map<FocusZoneId, FocusZoneRegistration>());
+  const [focusState, setFocusState] = useState<FocusState>({
+    zone: null,
+    intent: null,
+    shouldMoveDOMFocus: false,
+  });
+
+  const registerZone = useCallback((zone: FocusZoneRegistration) => {
+    zonesRef.current.set(zone.id, zone);
+  }, []);
+
+  const unregisterZone = useCallback((id: FocusZoneId) => {
+    zonesRef.current.delete(id);
+  }, []);
+
+  const focusZone = useCallback((id: FocusZoneId, options?: FocusZoneOptions) => {
+    const zone = zonesRef.current.get(id);
+    if (!zone) {
+      return;
+    }
+
+    const intent = options?.intent ?? 'programmatic';
+    const shouldMoveDOMFocus = options?.moveFocus ?? (intent !== 'click');
+
+    setFocusState({ zone: id, intent, shouldMoveDOMFocus });
+
+    if (shouldMoveDOMFocus) {
+      if (zone.focusFirst) {
+        zone.focusFirst();
+      } else {
+        zone.ref.current?.focus();
+      }
+
+      queueMicrotask(() => {
+        setFocusState((current) => ({ ...current, shouldMoveDOMFocus: false }));
+      });
+    }
+  }, []);
+
+  const focusNextZone = useCallback(() => {
+    const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : -1;
+    const nextZone = ZONE_ORDER[(currentIndex + 1 + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
+    focusZone(nextZone, { intent: 'keyboard', moveFocus: true });
+  }, [focusState.zone, focusZone]);
+
+  const focusPreviousZone = useCallback(() => {
+    const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : 0;
+    const prevZone = ZONE_ORDER[(currentIndex - 1 + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
+    focusZone(prevZone, { intent: 'keyboard', moveFocus: true });
+  }, [focusState.zone, focusZone]);
+
+  const value = useMemo<FocusContextValue>(
+    () => ({
+      focusState,
+      registerZone,
+      unregisterZone,
+      focusZone,
+      focusNextZone,
+      focusPreviousZone,
+      isZoneFocused: (id) => focusState.zone === id,
+    }),
+    [focusState, registerZone, unregisterZone, focusZone, focusNextZone, focusPreviousZone]
+  );
+
+  return <FocusContext.Provider value={value}>{children}</FocusContext.Provider>;
+}
+
+export function useSidebarFocusContext(): FocusContextValue {
+  const context = useContext(FocusContext);
+  if (!context) {
+    throw new Error('useSidebarFocusContext must be used within SidebarFocusProvider.');
+  }
+  return context;
+}
+
+export function useFocusZone({
+  zoneId,
+  enabled = true,
+  onFocus,
+  onBlur,
+  focusFirst,
+}: {
+  zoneId: FocusZoneId;
+  enabled?: boolean;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  focusFirst?: () => void;
+}) {
+  const zoneRef = useRef<HTMLDivElement>(null);
+  const { focusState, registerZone, unregisterZone, focusZone, isZoneFocused } = useSidebarFocusContext();
+  const isFocused = enabled && isZoneFocused(zoneId);
+  const shouldMoveDOMFocus = enabled && focusState.zone === zoneId && focusState.shouldMoveDOMFocus;
+  const intent = focusState.zone === zoneId ? focusState.intent : null;
+  const previousIsFocused = useRef(isFocused);
+
+  useEffect(() => {
+    if (!enabled) {
+      unregisterZone(zoneId);
+      return;
+    }
+
+    if (zoneRef.current) {
+      zoneRef.current.dataset.focusZone = zoneId;
+    }
+
+    registerZone({
+      id: zoneId,
+      ref: zoneRef,
+      focusFirst,
+    });
+
+    return () => unregisterZone(zoneId);
+  }, [enabled, focusFirst, registerZone, unregisterZone, zoneId]);
+
+  useEffect(() => {
+    if (isFocused && !previousIsFocused.current) {
+      onFocus?.();
+    }
+
+    if (!isFocused && previousIsFocused.current) {
+      onBlur?.();
+    }
+
+    previousIsFocused.current = isFocused;
+  }, [isFocused, onBlur, onFocus]);
+
+  return {
+    zoneRef,
+    isFocused,
+    shouldMoveDOMFocus,
+    intent,
+    focus: useCallback((options?: FocusZoneOptions) => focusZone(zoneId, options), [focusZone, zoneId]),
+  };
+}

--- a/frontend/features/nav-chats/sidebar-focus.tsx
+++ b/frontend/features/nav-chats/sidebar-focus.tsx
@@ -1,24 +1,50 @@
+/**
+ * @file sidebar-focus.tsx
+ *
+ * Manages keyboard focus across the three major UI regions: sidebar,
+ * navigator (conversation list), and chat panel. Without this, Tab/Shift+Tab
+ * would walk through every focusable element on the page sequentially. This
+ * system lets us treat each region as a "zone" that can be jumped between
+ * with a single keystroke, similar to how VS Code handles sidebar/editor/panel
+ * focus cycling.
+ *
+ * Each zone registers itself (with a ref and an optional focusFirst callback)
+ * and the provider tracks which zone is currently active. Navigation skips
+ * unregistered zones so conditionally-rendered regions don't block the cycle.
+ */
 'use client';
 
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
+/** Identifies one of the three focusable regions. */
 export type FocusZoneId = 'sidebar' | 'navigator' | 'chat';
+
+/**
+ * How the focus change was triggered. Keyboard navigation should move DOM focus;
+ * click-initiated focus changes should not (the click itself already focused the element).
+ */
 export type FocusIntent = 'keyboard' | 'click' | 'programmatic';
 
+/** Options passed when requesting focus on a zone. */
 export interface FocusZoneOptions {
   intent?: FocusIntent;
+  /** If true, actually move DOM focus to the zone root or its first focusable child. */
   moveFocus?: boolean;
 }
 
+/** Internal registration record for a mounted focus zone. */
 type FocusZoneRegistration = {
   id: FocusZoneId;
   ref: React.RefObject<HTMLElement | null>;
+  /** Optional callback to focus the first interactive child instead of the zone root. */
   focusFirst?: () => void;
 };
 
+/** Tracks which zone is focused, how it got focused, and whether DOM focus needs to move. */
 type FocusState = {
   zone: FocusZoneId | null;
   intent: FocusIntent | null;
+  /** True for one microtask after a keyboard/programmatic focus change. */
   shouldMoveDOMFocus: boolean;
 };
 
@@ -32,10 +58,18 @@ type FocusContextValue = {
   isZoneFocused: (id: FocusZoneId) => boolean;
 };
 
+/**
+ * Defines the Tab-order cycle. Zones are visited in this order for
+ * focusNextZone and reversed for focusPreviousZone.
+ */
 const ZONE_ORDER: FocusZoneId[] = ['sidebar', 'navigator', 'chat'];
 
 const FocusContext = createContext<FocusContextValue | null>(null);
 
+/**
+ * Wraps the app layout and provides focus-zone coordination to all children.
+ * Mount this once above the sidebar + chat layout.
+ */
 export function SidebarFocusProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
   const zonesRef = useRef(new Map<FocusZoneId, FocusZoneRegistration>());
   const [focusState, setFocusState] = useState<FocusState>({
@@ -52,6 +86,10 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
     zonesRef.current.delete(id);
   }, []);
 
+  /**
+   * Move logical focus to a zone. If moveFocus is true (default for keyboard),
+   * also moves DOM focus via focusFirst() or the zone root element.
+   */
   const focusZone = useCallback((id: FocusZoneId, options?: FocusZoneOptions) => {
     const zone = zonesRef.current.get(id);
     if (!zone) {
@@ -59,6 +97,7 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
     }
 
     const intent = options?.intent ?? 'programmatic';
+    // Click-initiated changes don't need to move DOM focus (the click already did).
     const shouldMoveDOMFocus = options?.moveFocus ?? (intent !== 'click');
 
     setFocusState({ zone: id, intent, shouldMoveDOMFocus });
@@ -68,6 +107,7 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
         zone.focusFirst();
       } else {
         // Ensure the zone root is focusable before attempting focus.
+        // Plain divs without tabindex silently ignore .focus() calls.
         const el = zone.ref.current;
         if (el && !el.hasAttribute('tabindex')) {
           el.setAttribute('tabindex', '-1');
@@ -75,15 +115,19 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
         el?.focus();
       }
 
+      // Clear the flag after one microtask so consumers only see it for one render.
       queueMicrotask(() => {
         setFocusState((current) => ({ ...current, shouldMoveDOMFocus: false }));
       });
     }
   }, []);
 
+  /**
+   * Cycle to the next zone in ZONE_ORDER, skipping any that aren't currently
+   * registered (conditionally rendered or feature-flagged out).
+   */
   const focusNextZone = useCallback(() => {
     const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : -1;
-    // Skip unregistered zones so navigation doesn't get stuck.
     for (let i = 1; i <= ZONE_ORDER.length; i++) {
       const candidate = ZONE_ORDER[(currentIndex + i) % ZONE_ORDER.length] as FocusZoneId;
       if (zonesRef.current.has(candidate)) {
@@ -93,9 +137,9 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
     }
   }, [focusState.zone, focusZone]);
 
+  /** Cycle to the previous zone, same skip logic as focusNextZone. */
   const focusPreviousZone = useCallback(() => {
     const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : 0;
-    // Skip unregistered zones so navigation doesn't get stuck.
     for (let i = 1; i <= ZONE_ORDER.length; i++) {
       const candidate = ZONE_ORDER[(currentIndex - i + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
       if (zonesRef.current.has(candidate)) {
@@ -121,6 +165,7 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
   return <FocusContext.Provider value={value}>{children}</FocusContext.Provider>;
 }
 
+/** Access the focus context. Throws if called outside SidebarFocusProvider. */
 export function useSidebarFocusContext(): FocusContextValue {
   const context = useContext(FocusContext);
   if (!context) {
@@ -129,6 +174,17 @@ export function useSidebarFocusContext(): FocusContextValue {
   return context;
 }
 
+/**
+ * Hook for a component to participate in the focus zone system.
+ * Returns a ref to attach to the zone's root element, plus focus state
+ * and a manual focus trigger.
+ *
+ * @param zoneId - Which zone this component represents.
+ * @param enabled - Set false to unregister (e.g. when the panel is hidden).
+ * @param onFocus - Called when this zone becomes the active zone.
+ * @param onBlur - Called when this zone loses active status.
+ * @param focusFirst - Optional: focus the first interactive child instead of the root.
+ */
 export function useFocusZone({
   zoneId,
   enabled = true,
@@ -149,12 +205,14 @@ export function useFocusZone({
   const intent = focusState.zone === zoneId ? focusState.intent : null;
   const previousIsFocused = useRef(isFocused);
 
+  // Register/unregister this zone as it mounts, unmounts, or toggles enabled.
   useEffect(() => {
     if (!enabled) {
       unregisterZone(zoneId);
       return;
     }
 
+    // Stamp a data attribute for debugging/testing.
     if (zoneRef.current) {
       zoneRef.current.dataset.focusZone = zoneId;
     }
@@ -168,6 +226,7 @@ export function useFocusZone({
     return () => unregisterZone(zoneId);
   }, [enabled, focusFirst, registerZone, unregisterZone, zoneId]);
 
+  // Fire onFocus/onBlur callbacks when the zone's active state changes.
   useEffect(() => {
     if (isFocused && !previousIsFocused.current) {
       onFocus?.();
@@ -185,6 +244,7 @@ export function useFocusZone({
     isFocused,
     shouldMoveDOMFocus,
     intent,
+    /** Manually request focus on this zone. */
     focus: useCallback((options?: FocusZoneOptions) => focusZone(zoneId, options), [focusZone, zoneId]),
   };
 }

--- a/frontend/features/nav-chats/sidebar-focus.tsx
+++ b/frontend/features/nav-chats/sidebar-focus.tsx
@@ -67,7 +67,12 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
       if (zone.focusFirst) {
         zone.focusFirst();
       } else {
-        zone.ref.current?.focus();
+        // Ensure the zone root is focusable before attempting focus.
+        const el = zone.ref.current;
+        if (el && !el.hasAttribute('tabindex')) {
+          el.setAttribute('tabindex', '-1');
+        }
+        el?.focus();
       }
 
       queueMicrotask(() => {
@@ -78,14 +83,26 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
 
   const focusNextZone = useCallback(() => {
     const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : -1;
-    const nextZone = ZONE_ORDER[(currentIndex + 1 + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
-    focusZone(nextZone, { intent: 'keyboard', moveFocus: true });
+    // Skip unregistered zones so navigation doesn't get stuck.
+    for (let i = 1; i <= ZONE_ORDER.length; i++) {
+      const candidate = ZONE_ORDER[(currentIndex + i) % ZONE_ORDER.length] as FocusZoneId;
+      if (zonesRef.current.has(candidate)) {
+        focusZone(candidate, { intent: 'keyboard', moveFocus: true });
+        return;
+      }
+    }
   }, [focusState.zone, focusZone]);
 
   const focusPreviousZone = useCallback(() => {
     const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : 0;
-    const prevZone = ZONE_ORDER[(currentIndex - 1 + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
-    focusZone(prevZone, { intent: 'keyboard', moveFocus: true });
+    // Skip unregistered zones so navigation doesn't get stuck.
+    for (let i = 1; i <= ZONE_ORDER.length; i++) {
+      const candidate = ZONE_ORDER[(currentIndex - i + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
+      if (zonesRef.current.has(candidate)) {
+        focusZone(candidate, { intent: 'keyboard', moveFocus: true });
+        return;
+      }
+    }
   }, [focusState.zone, focusZone]);
 
   const value = useMemo<FocusContextValue>(

--- a/frontend/features/nav-chats/use-conversation-search.ts
+++ b/frontend/features/nav-chats/use-conversation-search.ts
@@ -1,0 +1,197 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAuthedFetch } from '@/hooks/use-authed-fetch';
+import { API_ENDPOINTS } from '@/lib/api';
+import type { AgnoMessage, Conversation } from '@/lib/types';
+
+export type ContentSearchResult = {
+  matchCount: number;
+  snippet: string;
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countOccurrences(content: string, query: string): number {
+  if (!query) {
+    return 0;
+  }
+
+  const matches = content.match(new RegExp(escapeRegExp(query), 'gi'));
+  return matches?.length ?? 0;
+}
+
+function buildSnippet(content: string, query: string): string {
+  const matchIndex = content.toLowerCase().indexOf(query.toLowerCase());
+  if (matchIndex < 0) {
+    return '';
+  }
+
+  const start = Math.max(0, matchIndex - 40);
+  const end = Math.min(content.length, matchIndex + query.length + 40);
+  return content.slice(start, end).trim();
+}
+
+function extractSearchableText(messages: AgnoMessage[]): string {
+  return messages.map((message) => message.content).join('\n');
+}
+
+function fuzzyScore(title: string, query: string): number {
+  const lowerTitle = title.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  if (lowerTitle.includes(lowerQuery)) {
+    return lowerQuery.length * 10;
+  }
+
+  let queryIndex = 0;
+  let score = 0;
+
+  for (const char of lowerTitle) {
+    if (char === lowerQuery[queryIndex]) {
+      queryIndex += 1;
+      score += 2;
+      if (queryIndex === lowerQuery.length) {
+        return score;
+      }
+    }
+  }
+
+  return 0;
+}
+
+export function rankConversationsForSearch(
+  conversations: Conversation[],
+  query: string,
+  contentSearchResults: Map<string, ContentSearchResult>,
+  _activeChatMatchInfo?: { sessionId: string; count: number } | null
+): Conversation[] {
+  return [...conversations].sort((left, right) => {
+    const leftScore = fuzzyScore(left.title, query);
+    const rightScore = fuzzyScore(right.title, query);
+
+    if (leftScore > 0 && rightScore === 0) {
+      return -1;
+    }
+
+    if (leftScore === 0 && rightScore > 0) {
+      return 1;
+    }
+
+    if (leftScore !== rightScore) {
+      return rightScore - leftScore;
+    }
+
+    const leftCount = contentSearchResults.get(left.id)?.matchCount ?? 0;
+    const rightCount = contentSearchResults.get(right.id)?.matchCount ?? 0;
+
+    if (leftCount !== rightCount) {
+      return rightCount - leftCount;
+    }
+
+    return new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime();
+  });
+}
+
+export function useConversationSearch({
+  conversations,
+  searchQuery,
+  activeConversationId,
+  activeChatHistory,
+}: {
+  conversations: Conversation[];
+  searchQuery: string;
+  activeConversationId?: string | null;
+  activeChatHistory?: AgnoMessage[];
+}) {
+  const fetcher = useAuthedFetch();
+  const cacheRef = useRef(new Map<string, AgnoMessage[]>());
+  const [contentSearchResults, setContentSearchResults] = useState<
+    Map<string, ContentSearchResult>
+  >(new Map());
+  const trimmedQuery = searchQuery.trim();
+  const isSearchActive = trimmedQuery.length >= 2;
+
+  useEffect(() => {
+    if (!isSearchActive) {
+      setContentSearchResults(new Map());
+      return;
+    }
+
+    let cancelled = false;
+
+    const computeResults = async () => {
+      const missingConversationIds = conversations
+        .map((conversation) => conversation.id)
+        .filter((conversationId) => !cacheRef.current.has(conversationId));
+
+      if (missingConversationIds.length > 0) {
+        await Promise.all(
+          missingConversationIds.map(async (conversationId) => {
+            try {
+              const response = await fetcher(
+                API_ENDPOINTS.conversations.getMessages(conversationId)
+              );
+              const payload = (await response.json()) as AgnoMessage[];
+              cacheRef.current.set(conversationId, payload);
+            } catch {
+              cacheRef.current.set(conversationId, []);
+            }
+          })
+        );
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      const nextResults = new Map<string, ContentSearchResult>();
+      for (const conversation of conversations) {
+        const chatHistory = cacheRef.current.get(conversation.id) ?? [];
+        const searchableText = extractSearchableText(chatHistory);
+        const titleCount = countOccurrences(conversation.title, trimmedQuery);
+        const contentCount = countOccurrences(searchableText, trimmedQuery);
+        const matchCount = titleCount + contentCount;
+
+        if (
+          matchCount > 0 ||
+          conversation.title.toLowerCase().includes(trimmedQuery.toLowerCase())
+        ) {
+          nextResults.set(conversation.id, {
+            matchCount,
+            snippet: buildSnippet(searchableText || conversation.title, trimmedQuery),
+          });
+        }
+      }
+
+      setContentSearchResults(nextResults);
+    };
+
+    void computeResults();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversations, fetcher, isSearchActive, trimmedQuery]);
+
+  const activeChatMatchInfo = useMemo(() => {
+    if (!isSearchActive || !activeConversationId || !activeChatHistory) {
+      return null;
+    }
+
+    const searchableText = extractSearchableText(activeChatHistory);
+    const count = countOccurrences(searchableText, trimmedQuery);
+    return {
+      sessionId: activeConversationId,
+      count,
+    };
+  }, [activeChatHistory, activeConversationId, isSearchActive, trimmedQuery]);
+
+  return {
+    contentSearchResults,
+    activeChatMatchInfo,
+    isSearchActive,
+  };
+}

--- a/frontend/features/nav-chats/use-conversation-search.ts
+++ b/frontend/features/nav-chats/use-conversation-search.ts
@@ -5,6 +5,9 @@ import { useAuthedFetch } from '@/hooks/use-authed-fetch';
 import { API_ENDPOINTS } from '@/lib/api';
 import type { AgnoMessage, Conversation } from '@/lib/types';
 
+/** Maximum number of conversation message caches to retain. Oldest entries are evicted first. */
+const MAX_CACHE_SIZE = 100;
+
 export type ContentSearchResult = {
   matchCount: number;
   snippet: string;
@@ -62,11 +65,11 @@ function fuzzyScore(title: string, query: string): number {
   return 0;
 }
 
+// TODO: Wire activeChatMatchInfo into ranking logic (boost active chat when it has content matches).
 export function rankConversationsForSearch(
   conversations: Conversation[],
   query: string,
   contentSearchResults: Map<string, ContentSearchResult>,
-  _activeChatMatchInfo?: { sessionId: string; count: number } | null
 ): Conversation[] {
   return [...conversations].sort((left, right) => {
     const leftScore = fuzzyScore(left.title, query);
@@ -114,6 +117,10 @@ export function useConversationSearch({
   const trimmedQuery = searchQuery.trim();
   const isSearchActive = trimmedQuery.length >= 2;
 
+  // TODO: Cache keys by conversation.id only. If message content can change under
+  // the same ID (edits, deletions), stale results will be returned. Consider keying
+  // by id+updated_at or invalidating on mutation if this becomes an issue.
+
   useEffect(() => {
     if (!isSearchActive) {
       setContentSearchResults(new Map());
@@ -127,6 +134,9 @@ export function useConversationSearch({
         .map((conversation) => conversation.id)
         .filter((conversationId) => !cacheRef.current.has(conversationId));
 
+      // TODO: Promise.all fetches all uncached conversations concurrently. If the
+      // conversation list grows large (hundreds+), consider adding a concurrency
+      // limiter to avoid overwhelming the backend.
       if (missingConversationIds.length > 0) {
         await Promise.all(
           missingConversationIds.map(async (conversationId) => {
@@ -136,8 +146,16 @@ export function useConversationSearch({
               );
               const payload = (await response.json()) as AgnoMessage[];
               cacheRef.current.set(conversationId, payload);
+
+              // Evict oldest entries if cache exceeds the cap.
+              if (cacheRef.current.size > MAX_CACHE_SIZE) {
+                const firstKey = cacheRef.current.keys().next().value;
+                if (firstKey !== undefined) {
+                  cacheRef.current.delete(firstKey);
+                }
+              }
             } catch {
-              cacheRef.current.set(conversationId, []);
+              // Don't cache failed fetches so the next search retries.
             }
           })
         );

--- a/frontend/features/nav-chats/use-conversation-search.ts
+++ b/frontend/features/nav-chats/use-conversation-search.ts
@@ -1,3 +1,17 @@
+/**
+ * @file use-conversation-search.ts
+ *
+ * Full-text search across conversation titles and message content.
+ *
+ * Title matching uses fuzzy scoring so partial/misspelled queries still surface
+ * relevant conversations. Content matching fetches each conversation's message
+ * history on-demand and caches it locally so repeated searches don't re-fetch.
+ *
+ * The cache is capped at MAX_CACHE_SIZE to prevent unbounded memory growth
+ * in long-running sessions. Failed fetches are intentionally not cached so
+ * transient network errors don't permanently block a conversation from being
+ * searchable.
+ */
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -5,7 +19,11 @@ import { useAuthedFetch } from '@/hooks/use-authed-fetch';
 import { API_ENDPOINTS } from '@/lib/api';
 import type { AgnoMessage, Conversation } from '@/lib/types';
 
-/** Maximum number of conversation message caches to retain. Oldest entries are evicted first. */
+/**
+ * Maximum cached conversation histories. When exceeded, the oldest entry
+ * (first inserted) is evicted. Keeps memory bounded in sessions where the
+ * user searches many different conversations over time.
+ */
 const MAX_CACHE_SIZE = 100;
 
 export type ContentSearchResult = {
@@ -65,7 +83,14 @@ function fuzzyScore(title: string, query: string): number {
   return 0;
 }
 
-// TODO: Wire activeChatMatchInfo into ranking logic (boost active chat when it has content matches).
+/**
+ * Sort conversations by search relevance: title fuzzy score first, then
+ * content match count, then recency as a tiebreaker.
+ *
+ * TODO: Wire activeChatMatchInfo into ranking to boost the active chat
+ * when it has content matches (avoids it dropping below closed conversations
+ * that happen to mention the query more often).
+ */
 export function rankConversationsForSearch(
   conversations: Conversation[],
   query: string,
@@ -98,6 +123,17 @@ export function rankConversationsForSearch(
   });
 }
 
+/**
+ * Hook that powers the sidebar search bar. Manages the fetch/cache lifecycle
+ * for conversation message histories and computes per-conversation match
+ * counts and snippets.
+ *
+ * @param conversations - The full list of conversations visible in the sidebar.
+ * @param searchQuery - Raw text from the search input (trimmed internally).
+ * @param activeConversationId - The conversation open in the chat panel (if any).
+ * @param activeChatHistory - Messages already loaded for the active chat
+ *   (avoids a redundant fetch since the chat panel already has them).
+ */
 export function useConversationSearch({
   conversations,
   searchQuery,


### PR DESCRIPTION
### Stack 2/3 — Hooks, Contexts & Label Badge

Adds the supporting infrastructure for the session list features:

- **`ChatActivityProvider`** (`chat-activity-context.tsx`) — tracks active conversation state (loading, history) for sidebar indicators
- **`SidebarFocusProvider`** + **`useFocusZone`** (`sidebar-focus.tsx`) — keyboard focus zone system (sidebar ↔ navigator ↔ chat)
- **`conversation-selection.ts`** — pure multi-select state machine (single, toggle, range, clear)
- **`useConversationSearch`** (`use-conversation-search.ts`) — content search with fuzzy matching and result ranking
- **`ConversationLabelBadge`** — colored label pill component

Stacked on #74 (types & docs).

**Stack order:** #74 → This PR → #(integration)

## Summary by Sourcery

Introduce navigation chat infrastructure for search, focus management, activity tracking, multi-select, and labeling.

New Features:
- Add content-based conversation search hook with fuzzy title matching and ranked results.
- Add shared focus management context and hook for coordinating keyboard focus across sidebar, navigator, and chat panes.
- Add pure multi-select state utilities for conversation selection, supporting single, toggle, range, and clear behaviors.
- Add conversation label badge component for displaying normalized, colorized label pills in the UI.
- Add chat activity context for tracking the active conversation, its history, and loading state for sidebar indicators.