### PR TITLE
feat(nav-chats): integrate session list features into views and layout

### DIFF
--- a/.beans/ai-nexus-mgm1--fix-sidebar-hydration-mismatch.md
+++ b/.beans/ai-nexus-mgm1--fix-sidebar-hydration-mismatch.md
@@ -1,0 +1,10 @@
+---
+# ai-nexus-mgm1
+title: Fix Sidebar Hydration Mismatch
+status: todo
+type: bug
+created_at: 2026-04-09T15:05:48Z
+updated_at: 2026-04-09T15:05:48Z
+---
+
+## Context\nWhen running Next.js in development, a hydration mismatch error occurs:\n```\nA tree hydrated but some attributes of the server rendered HTML didn't match the client properties.\n```\n\nThis happens because `SidebarProvider` (`frontend/components/ui/sidebar.tsx`) initializes its state using `loadDesktopSidebarWidth` which checks `window.localStorage`. On the server (SSR), `window` is undefined, so it returns the default 300px. On the client (hydration), it reads `localStorage` and might return 361px. Since `300px \!== 361px`, React throws a hydration error. The same issue exists with the sidebar `state` ("expanded" vs "collapsed").\n\n## Requirements\n- [ ] Fix the React hydration mismatch in `SidebarProvider` (`frontend/components/ui/sidebar.tsx`).\n- [ ] Initialize `desktopWidth` and `state` to their server defaults on the first render.\n- [ ] Update them from `localStorage` inside a `useEffect` to ensure the client's first render matches the server perfectly.

--- a/.claude/rules/clean-code/python-strict-typing.md
+++ b/.claude/rules/clean-code/python-strict-typing.md
@@ -1,0 +1,19 @@
+---
+description: Python specific clean code rules (Pydantic, typing)
+globs: **/*.py
+---
+# Clean Code: Python
+
+## Pydantic Settings & Enums
+
+1. **Use `Literal` instead of `str` for constrained values.**
+   If a setting or payload field only accepts a specific set of strings (e.g. `"lax" | "strict" | "none"`), type it as `Literal["lax", "strict", "none"]`. Do not use `str` and rely on manual string checking.
+
+2. **Enforce cross-field security invariants at startup.**
+   If one setting depends on another for security (e.g. `SameSite=none` requires `Secure=True` or `is_production=True`), enforce it immediately in a `@model_validator(mode="after")`. Do not let the app boot in an insecure or broken state.
+
+## Typing
+
+1. **Do not use `cast(Any, ...)`.**
+   This is a type-suppression pattern that violates the project's strict typing rules. If you find yourself needing to cast to `Any` to make a library happy, your underlying types are usually wrong (e.g., using `str` instead of `Literal`). Fix the source type.
+

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.15"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.15.tgz",
+      "integrity": "sha512-jZJbuvUXc5Limz8pacQl+ffATjjKGlq+xaA4wTUeW+/spwOf7Yr5Ryyvan8eNlYM8wy6h5SLfznl1rlFpjYC8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.15",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.15.tgz",
+      "integrity": "sha512-Uk59C7wsK20wpdr277yx7Xz7TqG5jGqlZUpSW3wDH/7a2K2iBg0lXc2wskHuCXLRXMhXpPZtb4a3SOpPENkkbg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - **Backend (`backend/`)**: Python FastAPI application. API routes in `backend/app/api/`, database models in `backend/app/models/`, CRUD operations in `backend/app/crud/`.
 - **Docs (`docs/`)**: Project documentation, migration plans, and design specs.
 - **Tasks (`.beans/`)**: Markdown-based task tracking. Update the status of `.beans` files as work is completed.
+- **Rule**: Always use the `beans` CLI (e.g. `beans create`, `beans update`) to manage `.beans` files. Never create or edit them manually.
 - **AI Rules (`.claude/rules/`)**: Strict context and design patterns to follow. Always read and abide by the rules inside `.claude/rules/react/`, `.claude/rules/typescript/`, and `.claude/rules/github-actions/, and .claude/rules/clean-code/` when modifying or creating new code.
 - **Rule**: Frontend code must only communicate with the backend via the established API endpoints (using `useAuthedFetch` or TanStack Query mutations). Do not mix frontend and backend responsibilities.
 - **Rule**: UI components should follow the established Craft Agents design language (e.g., `popover-styled` classes, exact radius matching).
@@ -29,8 +30,8 @@ We rely on `just` as our primary task runner for the repository.
 - **Auto-commit**: `just commit` (auto-generates conventional commit).
 - **Push**: `just push` (runs push with auth switching).
 - **Terminology**:
-  - "gate" means a verification command or command set that must be green for the decision you are making.
-  - A local dev gate is the fast default loop, usually `bun run typecheck` and `just check` plus any scoped test you actually need.
+    - "gate" means a verification command or command set that must be green for the decision you are making.
+    - A local dev gate is the fast default loop, usually `bun run typecheck` and `just check` plus any scoped test you actually need.
 
 ## Coding Style & Naming Conventions
 
@@ -65,9 +66,9 @@ We rely on `just` as our primary task runner for the repository.
 - **Multi-agent safety:** running multiple agents is OK as long as each agent has its own session.
 - **Multi-agent safety:** when you see unrecognized files, keep going; focus on your changes and commit only those.
 - Lint/format churn:
-  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
-  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit.
-  - Only ask when changes are semantic (logic/data/behavior).
+    - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
+    - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit.
+    - Only ask when changes are semantic (logic/data/behavior).
 - **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
 - Bug investigations: read source code of relevant dependencies and all related local code before concluding; aim for high-confidence root cause.
 - Code style: add brief comments for tricky logic.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -7,9 +7,11 @@ for its dependency chain.
 """
 
 from collections.abc import AsyncGenerator
+import asyncio
 
 from fastapi import Depends
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
@@ -44,6 +46,20 @@ async def create_db_and_tables() -> None:
     from . import models  # noqa: F401 — side-effect import to register models
 
     async with engine.begin() as conn:
+
+        # We're running the backend serverless on Raiwaly, so it's possible that the database connection isn't immediately available when the app starts.
+        for i in range(5):
+            try:
+                await conn.execute(text("SELECT 1"))  # Test the connection
+                break  # If successful, exit the loop
+            except Exception as e:
+                if i < 4:  # If it's not the last attempt, wait and retry
+                    print(f"Database connection failed (attempt {i + 1}/5): {e}. Retrying in 5 seconds...")
+                    await asyncio.sleep(5)
+                else:
+                    print(f"Database connection failed after 5 attempts: {e}. Exiting.")
+                    raise
+
         await conn.run_sync(Base.metadata.create_all)
 
 

--- a/dev.ts
+++ b/dev.ts
@@ -24,7 +24,7 @@ const backendPromise =
 // Auto-open browser after servers have had time to initialize
 // Wait 2-3 seconds to ensure Next.js is fully ready before opening
 setTimeout(() => {
-  const frontendUrl = 'http://app.nexus-ai.localhost:3001';
+  const frontendUrl = 'https://app.nexus-ai.localhost';
   const shouldAutoOpen = process.env.NO_AUTO_OPEN !== '1';
 
   if (shouldAutoOpen) {

--- a/docs/craft-resizable-panels.md
+++ b/docs/craft-resizable-panels.md
@@ -1,0 +1,1115 @@
+# Craft resizable multi-panel app shell: extracted code + analysis
+
+Source tree analyzed: `apps/electron/src/renderer` in `~/.openclaw/workspace/_local/ai-nexus-craft-source`
+
+This document extracts the exact components and logic Craft uses for its split-pane shell. The important bit: Craft does **not** use a single static CSS grid for the whole app. It combines:
+
+- **fixed-width left rails** managed directly in `AppShell.tsx`
+- a **horizontal content panel stack** managed by Jotai atoms + flex proportions
+- **drag sashes** that convert DOM-measured pixel widths into updated flex proportions
+- a **compact/mobile mode** driven by `useContainerWidth`
+
+---
+
+## 1) Top-level composition: `AppShell.tsx`
+
+The shell is composed as:
+
+- **Left sidebar** → fixed px width (`sidebarWidth`)
+- **Navigator / Session list** → fixed px width (`sessionListWidth`)
+- **Main content panel(s)** → proportional flex layout inside `PanelStackContainer`
+
+### Core shell state
+
+```tsx
+const [isSidebarVisible, setIsSidebarVisible] = React.useState(() => {
+  return storage.get(storage.KEYS.sidebarVisible, !defaultCollapsed)
+})
+const [sidebarWidth, setSidebarWidth] = React.useState(() => {
+  return storage.get(storage.KEYS.sidebarWidth, 220)
+})
+// Session list width in pixels (min 240, max 480)
+const [sessionListWidth, setSessionListWidth] = React.useState(() => {
+  return storage.get(storage.KEYS.sessionListWidth, 300)
+})
+
+const [isSidebarAndNavigatorHidden, setIsSidebarAndNavigatorHidden] = React.useState(() => {
+  return isFocusedMode || storage.get(storage.KEYS.focusModeEnabled, false)
+})
+```
+
+### Auto-compact / mobile collapse
+
+This is how Craft switches to single-panel mode on narrow widths:
+
+```tsx
+const shellRef = useRef<HTMLDivElement>(null)
+const shellWidth = useContainerWidth(shellRef)
+const MOBILE_THRESHOLD = 768
+const isAutoCompact = shellWidth > 0 && shellWidth < MOBILE_THRESHOLD
+
+const effectiveSidebarAndNavigatorHidden = isSidebarAndNavigatorHidden || isAutoCompact
+```
+
+### Shell composition with `PanelStackContainer`
+
+This is the key composition point. `PanelStackContainer` receives the left sidebar slot, navigator slot, and content panel stack.
+
+```tsx
+<div
+  ref={shellRef}
+  className="flex items-stretch relative"
+  style={{ height: '100%', paddingRight: PANEL_EDGE_INSET, paddingBottom: PANEL_EDGE_INSET, paddingLeft: 0, gap: PANEL_GAP }}
+>
+  <PanelStackContainer
+    sidebarSlot={
+      <div
+        ref={sidebarRef}
+        style={{ width: sidebarWidth }}
+        className="h-full font-sans relative"
+        data-focus-zone="sidebar"
+        tabIndex={sidebarFocused ? 0 : -1}
+        onKeyDown={handleSidebarKeyDown}
+      >
+        ...
+        <LeftSidebar ... />
+      </div>
+    }
+    sidebarWidth={effectiveSidebarAndNavigatorHidden ? 0 : (isSidebarVisible ? sidebarWidth : 0)}
+    navigatorSlot={
+      <div
+        style={{ width: isAutoCompact ? '100%' : sessionListWidth }}
+        className="h-full flex flex-col min-w-0 relative z-panel"
+      >
+        ...
+        <SessionList ... />
+      </div>
+    }
+    navigatorWidth={isAutoCompact ? sessionListWidth : (effectiveSidebarAndNavigatorHidden ? 0 : sessionListWidth)}
+    isSidebarAndNavigatorHidden={effectiveSidebarAndNavigatorHidden}
+    isRightSidebarVisible={false}
+    isCompact={isAutoCompact}
+    isResizing={!!isResizing}
+  />
+```
+
+### What this means structurally
+
+Craft’s effective layout is:
+
+```text
+[ LeftSidebar px width ] [ SessionList/Navigator px width ] [ PanelStack flex panels... ]
+```
+
+Notably:
+
+- the **sidebar** and **session list** are **not** part of the proportional content-panel flex math
+- only the **main content area** is split into panel proportions
+- compact mode can hide sidebar/navigator and show either list or content
+
+---
+
+## 2) The resizable left rails in `AppShell.tsx`
+
+Craft has **two absolute resize handles** in `AppShell.tsx`:
+
+- one for the **sidebar**
+- one for the **session list**
+
+### Resize state
+
+```tsx
+const [isResizing, setIsResizing] = React.useState<'sidebar' | 'session-list' | null>(null)
+const [sidebarHandleY, setSidebarHandleY] = React.useState<number | null>(null)
+const [sessionListHandleY, setSessionListHandleY] = React.useState<number | null>(null)
+const resizeHandleRef = React.useRef<HTMLDivElement>(null)
+const sessionListHandleRef = React.useRef<HTMLDivElement>(null)
+```
+
+### Drag logic for sidebar + session list
+
+This is the exact mousemove math Craft uses:
+
+```tsx
+React.useEffect(() => {
+  if (!isResizing) return
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (isResizing === 'sidebar') {
+      const newWidth = Math.min(Math.max(e.clientX, 180), 320)
+      setSidebarWidth(newWidth)
+      if (resizeHandleRef.current) {
+        const rect = resizeHandleRef.current.getBoundingClientRect()
+        setSidebarHandleY(e.clientY - rect.top)
+      }
+    } else if (isResizing === 'session-list') {
+      const offset = isSidebarVisible ? sidebarWidth : 0
+      const newWidth = Math.min(Math.max(e.clientX - offset, 240), 480)
+      setSessionListWidth(newWidth)
+      if (sessionListHandleRef.current) {
+        const rect = sessionListHandleRef.current.getBoundingClientRect()
+        setSessionListHandleY(e.clientY - rect.top)
+      }
+    }
+  }
+
+  const handleMouseUp = () => {
+    if (isResizing === 'sidebar') {
+      storage.set(storage.KEYS.sidebarWidth, sidebarWidth)
+      setSidebarHandleY(null)
+    } else if (isResizing === 'session-list') {
+      storage.set(storage.KEYS.sessionListWidth, sessionListWidth)
+      setSessionListHandleY(null)
+    }
+    setIsResizing(null)
+  }
+
+  document.addEventListener('mousemove', handleMouseMove)
+  document.addEventListener('mouseup', handleMouseUp)
+
+  return () => {
+    document.removeEventListener('mousemove', handleMouseMove)
+    document.removeEventListener('mouseup', handleMouseUp)
+  }
+}, [
+  isResizing,
+  sidebarWidth,
+  sessionListWidth,
+  isSidebarVisible,
+])
+```
+
+### The actual constraints
+
+- **Sidebar width**: clamped to `180..320`
+- **Session list width**: clamped to `240..480`
+- session-list drag subtracts sidebar width when sidebar is visible:
+  - `e.clientX - offset`
+
+That means the navigator sash is positioned in **window coordinates**, but the final width is computed relative to the left rail already occupying space.
+
+### The two absolute sash elements
+
+#### Sidebar sash
+
+```tsx
+<div
+  ref={resizeHandleRef}
+  onMouseDown={(e) => { e.preventDefault(); setIsResizing('sidebar') }}
+  onMouseMove={(e) => {
+    if (resizeHandleRef.current) {
+      const rect = resizeHandleRef.current.getBoundingClientRect()
+      setSidebarHandleY(e.clientY - rect.top)
+    }
+  }}
+  onMouseLeave={() => { if (!isResizing) setSidebarHandleY(null) }}
+  className="absolute cursor-col-resize z-panel flex justify-center"
+  style={{
+    width: PANEL_SASH_HIT_WIDTH,
+    top: PANEL_STACK_VERTICAL_OVERFLOW,
+    bottom: PANEL_STACK_VERTICAL_OVERFLOW,
+    left: isSidebarVisible
+      ? sidebarWidth + (PANEL_GAP / 2) - PANEL_SASH_HALF_HIT_WIDTH
+      : -PANEL_GAP,
+    transition: isResizing === 'sidebar' ? undefined : 'left 0.15s ease-out',
+  }}
+>
+  <div
+    className="h-full"
+    style={{
+      ...getResizeGradientStyle(sidebarHandleY, resizeHandleRef.current?.clientHeight ?? null),
+      width: PANEL_SASH_LINE_WIDTH,
+    }}
+  />
+</div>
+```
+
+#### Session-list sash
+
+```tsx
+<div
+  ref={sessionListHandleRef}
+  onMouseDown={(e) => { e.preventDefault(); setIsResizing('session-list') }}
+  onMouseMove={(e) => {
+    if (sessionListHandleRef.current) {
+      const rect = sessionListHandleRef.current.getBoundingClientRect()
+      setSessionListHandleY(e.clientY - rect.top)
+    }
+  }}
+  onMouseLeave={() => { if (isResizing !== 'session-list') setSessionListHandleY(null) }}
+  className="absolute cursor-col-resize z-panel flex justify-center"
+  style={{
+    width: PANEL_SASH_HIT_WIDTH,
+    top: PANEL_STACK_VERTICAL_OVERFLOW,
+    bottom: PANEL_STACK_VERTICAL_OVERFLOW,
+    left:
+      (isSidebarVisible ? sidebarWidth + PANEL_GAP : PANEL_EDGE_INSET) +
+      sessionListWidth +
+      (PANEL_GAP / 2) -
+      PANEL_SASH_HALF_HIT_WIDTH,
+    transition: isResizing === 'session-list' ? undefined : 'left 0.15s ease-out',
+  }}
+>
+  <div
+    className="h-full"
+    style={{
+      ...getResizeGradientStyle(sessionListHandleY, sessionListHandleRef.current?.clientHeight ?? null),
+      width: PANEL_SASH_LINE_WIDTH,
+    }}
+  />
+</div>
+```
+
+### Why this is not a simple CSS layout
+
+The shell rails are positioned by:
+
+- persisted React state (`sidebarWidth`, `sessionListWidth`)
+- absolute seam math using `PANEL_GAP`, `PANEL_EDGE_INSET`, and sash hit widths
+- document-level drag listeners
+- visual gradient tracking via pointer Y
+
+So the shell is interactive, stateful, and geometry-driven rather than static.
+
+---
+
+## 3) `useContainerWidth.ts`: compact-mode width observer
+
+This hook is tiny but central to Craft’s responsive shell.
+
+```tsx
+export function useContainerWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const ro = new ResizeObserver(([entry]) => {
+      setWidth(entry.contentBoxSize[0].inlineSize)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [ref])
+
+  return width
+}
+```
+
+### Purpose
+
+`AppShell.tsx` uses this width to determine:
+
+- when to collapse sidebar + navigator automatically
+- when to switch from a multi-column shell to compact list/content behavior
+
+---
+
+## 4) The real multi-panel engine: `PanelStackContainer.tsx`
+
+This file is the actual split-pane content layout engine.
+
+### High-level comment from the file
+
+```tsx
+/**
+ * Horizontal layout container for ALL panels:
+ * Sidebar → Navigator → Content Panel(s) with resize sashes.
+ *
+ * Content panels use CSS flex-grow with their proportions as weights:
+ * - Each panel gets `flex: <proportion> 1 0px` with `min-width: PANEL_MIN_WIDTH`
+ * - Flex distributes available space proportionally — panels fill the viewport
+ * - When panels hit min-width, overflow-x: auto kicks in naturally
+ *
+ * Sidebar and Navigator are NOT part of the proportional layout —
+ * they have their own fixed/user-resizable widths managed by AppShell.
+ */
+```
+
+That comment is dead-on: the split-pane system only governs **content panels**.
+
+### Important derived layout flags
+
+```tsx
+const panelStack = useAtomValue(panelStackAtom)
+const focusedPanelId = useAtomValue(focusedPanelIdAtom)
+const focusedSessionId = useAtomValue(focusedSessionIdAtom)
+
+const contentPanels = panelStack
+
+const hasSelectedContent = isCompact && !!focusedSessionId
+const visiblePanels = isCompact
+  ? contentPanels.filter(e => e.id === focusedPanelId).slice(0, 1)
+  : contentPanels
+
+const hasSidebar = sidebarWidth > 0
+const hasNavigator = isCompact ? (navigatorWidth > 0 && !hasSelectedContent) : navigatorWidth > 0
+const isMultiPanel = visiblePanels.length > 1
+const isLeftEdge = !hasSidebar && !hasNavigator
+```
+
+### Compact mode behavior
+
+In compact mode, Craft shows **either**:
+
+- navigator/list, or
+- the focused content panel
+
+not both.
+
+This is the key toggle:
+
+```tsx
+const hasSelectedContent = isCompact && !!focusedSessionId
+```
+
+### Auto-scroll when a new panel is pushed
+
+```tsx
+useEffect(() => {
+  if (contentPanels.length > prevCountRef.current && scrollRef.current) {
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({
+        left: scrollRef.current.scrollWidth,
+        behavior: 'smooth',
+      })
+    })
+  }
+  prevCountRef.current = contentPanels.length
+}, [contentPanels.length])
+```
+
+So the content strip itself is horizontally scrollable if panels overflow.
+
+### Animated shell slots
+
+Sidebar slot:
+
+```tsx
+<motion.div
+  data-panel-role="sidebar"
+  initial={false}
+  animate={{
+    width: hasSidebar ? sidebarWidth : 0,
+    marginRight: hasSidebar ? 0 : -PANEL_GAP,
+    opacity: hasSidebar ? 1 : 0,
+  }}
+  transition={transition}
+  className="h-full relative shrink-0"
+  style={{ overflowX: 'clip', overflowY: 'visible' }}
+>
+  <div className="h-full" style={{ width: sidebarWidth }}>
+    {sidebarSlot}
+  </div>
+</motion.div>
+```
+
+Navigator slot:
+
+```tsx
+<motion.div
+  data-panel-role="navigator"
+  initial={false}
+  animate={{
+    width: hasNavigator ? navigatorWidth : 0,
+    marginRight: hasNavigator ? 0 : -PANEL_GAP,
+    opacity: hasNavigator ? 1 : 0,
+  }}
+  transition={transition}
+  className={cn(
+    'h-full overflow-hidden relative shrink-0 z-[2]',
+    'bg-background shadow-middle',
+  )}
+  style={{
+    ...(isCompact && hasNavigator && !hasSelectedContent ? { flex: '1 1 auto' } : {}),
+    borderTopLeftRadius: RADIUS_INNER,
+    borderBottomLeftRadius: !hasSidebar ? RADIUS_EDGE : RADIUS_INNER,
+    borderTopRightRadius: RADIUS_INNER,
+    borderBottomRightRadius: RADIUS_INNER,
+  }}
+>
+  <div className="h-full" style={{ width: isCompact && hasNavigator && !hasSelectedContent ? '100%' : navigatorWidth }}>
+    {navigatorSlot}
+  </div>
+</motion.div>
+```
+
+### Rendering the content panel stack
+
+```tsx
+{visiblePanels.map((entry, index) => (
+  <PanelSlot
+    key={entry.id}
+    entry={entry}
+    isOnly={visiblePanels.length === 1}
+    isFocusedPanel={isMultiPanel ? entry.id === focusedPanelId : true}
+    isSidebarAndNavigatorHidden={isSidebarAndNavigatorHidden}
+    isAtLeftEdge={index === 0 && isLeftEdge}
+    isAtRightEdge={index === visiblePanels.length - 1 && !isRightSidebarVisible}
+    proportion={entry.proportion}
+    isCompact={isCompact}
+    sash={index > 0 ? (
+      <PanelResizeSash
+        leftIndex={index - 1}
+        rightIndex={index}
+      />
+    ) : undefined}
+  />
+))}
+```
+
+This is the exact split-pane chain:
+
+- first content panel: no sash before it
+- every later panel: gets a `PanelResizeSash` inserted before it
+
+---
+
+## 5) Individual content panels: `PanelSlot.tsx`
+
+`PanelSlot` is where each main panel gets its **flex sizing contract**.
+
+### The key sizing rule
+
+```tsx
+style={{
+  ...(isOnly
+    ? { flexGrow: 1, minWidth: 0 }
+    : { flexGrow: proportion, flexShrink: 1, flexBasis: 0, minWidth: PANEL_MIN_WIDTH }
+  ),
+}}
+```
+
+### What that means
+
+If there is only one panel:
+
+- it just fills available space
+
+If there are multiple panels:
+
+- `flex-grow = proportion`
+- `flex-basis = 0`
+- `flex-shrink = 1`
+- `min-width = PANEL_MIN_WIDTH`
+
+So panel widths are not stored as pixels. They are stored as **weights**.
+
+That weight is `entry.proportion` from the panel stack atom.
+
+### Exact wrapper with focus styling and edge radii
+
+```tsx
+<div
+  onPointerDown={handlePointerDown}
+  data-panel-role="content"
+  data-compact={isCompact || undefined}
+  className={cn(
+    'h-full overflow-hidden relative @container/panel',
+    !isOnly && isFocusedPanel ? 'shadow-panel-focused z-[1]' : 'shadow-middle z-0',
+    'bg-foreground-2',
+  )}
+  style={{
+    ...(!isFocusedPanel && !isOnly
+      ? {
+          '--background': 'var(--background-elevated)',
+          '--shadow-minimal': 'var(--shadow-minimal-flat)',
+          '--user-message-bubble': 'var(--user-message-bubble-dimmed)',
+        } as React.CSSProperties
+      : {}
+    ),
+    borderTopLeftRadius: RADIUS_INNER,
+    borderBottomLeftRadius: isAtLeftEdge ? RADIUS_EDGE : RADIUS_INNER,
+    borderTopRightRadius: RADIUS_INNER,
+    borderBottomRightRadius: isAtRightEdge ? RADIUS_EDGE : RADIUS_INNER,
+    ...(isOnly
+      ? { flexGrow: 1, minWidth: 0 }
+      : { flexGrow: proportion, flexShrink: 1, flexBasis: 0, minWidth: PANEL_MIN_WIDTH }
+    ),
+  }}
+>
+```
+
+### Panel focus behavior
+
+Clicking a panel focuses it:
+
+```tsx
+const handlePointerDown = useCallback(() => {
+  if (!isFocusedPanel) {
+    setFocusedPanel(entry.id)
+  }
+}, [isFocusedPanel, setFocusedPanel, entry.id])
+```
+
+This matters because Craft’s compact mode and keyboard behavior key off the focused panel.
+
+---
+
+## 6) The drag sash between content panels: `PanelResizeSash.tsx`
+
+This is the exact split-pane drag logic for the main content area.
+
+### Core refs used during drag
+
+```tsx
+const startXRef = useRef(0)
+const startLeftWidthRef = useRef(0)
+const startRightWidthRef = useRef(0)
+const combinedProportionRef = useRef(0)
+```
+
+### Exact drag algorithm
+
+```tsx
+const handleMouseDown = useCallback((e: React.MouseEvent) => {
+  e.preventDefault()
+  handlers.onMouseDown()
+
+  const sashEl = ref.current
+  if (!sashEl) return
+
+  const leftPanel = sashEl.previousElementSibling as HTMLElement | null
+  const rightPanel = sashEl.nextElementSibling as HTMLElement | null
+  if (!leftPanel || !rightPanel) return
+
+  startXRef.current = e.clientX
+  startLeftWidthRef.current = leftPanel.getBoundingClientRect().width
+  startRightWidthRef.current = rightPanel.getBoundingClientRect().width
+
+  const leftProp = panelStack[leftIndex]?.proportion ?? 0.5
+  const rightProp = panelStack[rightIndex]?.proportion ?? 0.5
+  combinedProportionRef.current = leftProp + rightProp
+
+  const handleMouseMove = (e: MouseEvent) => {
+    const delta = e.clientX - startXRef.current
+    const combinedWidth = startLeftWidthRef.current + startRightWidthRef.current
+
+    let newLeftWidth = startLeftWidthRef.current + delta
+    let newRightWidth = startRightWidthRef.current - delta
+
+    if (newLeftWidth < PANEL_MIN_WIDTH) {
+      newLeftWidth = PANEL_MIN_WIDTH
+      newRightWidth = combinedWidth - PANEL_MIN_WIDTH
+    }
+    if (newRightWidth < PANEL_MIN_WIDTH) {
+      newRightWidth = PANEL_MIN_WIDTH
+      newLeftWidth = combinedWidth - PANEL_MIN_WIDTH
+    }
+
+    const combined = combinedProportionRef.current
+    const total = newLeftWidth + newRightWidth
+    const leftProportion = (newLeftWidth / total) * combined
+    const rightProportion = combined - leftProportion
+
+    resizePanels({ leftIndex, rightIndex, leftProportion, rightProportion })
+  }
+
+  const handleMouseUp = () => {
+    document.removeEventListener('mousemove', handleMouseMove)
+    document.removeEventListener('mouseup', handleMouseUp)
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }
+
+  document.body.style.userSelect = 'none'
+  document.body.style.cursor = 'col-resize'
+  document.addEventListener('mousemove', handleMouseMove)
+  document.addEventListener('mouseup', handleMouseUp)
+}, [leftIndex, rightIndex, panelStack, resizePanels, handlers, ref])
+```
+
+### The important math
+
+Craft’s panel-resize math works like this:
+
+1. **Measure current pixel widths** of the left and right DOM siblings.
+2. Compute pointer delta:
+   - `delta = e.clientX - startX`
+3. Apply delta:
+   - `newLeftWidth = startLeftWidth + delta`
+   - `newRightWidth = startRightWidth - delta`
+4. Clamp both to `PANEL_MIN_WIDTH`.
+5. Convert those pixels back into **relative proportions**, preserving the pair’s total proportion.
+
+That conversion is the heart of the system:
+
+```tsx
+const combined = combinedProportionRef.current
+const total = newLeftWidth + newRightWidth
+const leftProportion = (newLeftWidth / total) * combined
+const rightProportion = combined - leftProportion
+```
+
+### Why preserving combined proportion matters
+
+If two adjacent panels previously had proportions:
+
+- left = `0.3`
+- right = `0.7`
+
+then their combined share is `1.0`.
+
+After dragging, Craft redistributes only that `1.0` between the two panels. It does **not** disturb other panels in the stack.
+
+That gives local resizing behavior instead of recomputing the whole row.
+
+### Double-click reset behavior
+
+```tsx
+const handleDoubleClick = useCallback(() => {
+  const left = panelStack[leftIndex]
+  const right = panelStack[rightIndex]
+  if (!left || !right) return
+  const combined = left.proportion + right.proportion
+  const half = combined / 2
+  resizePanels({
+    leftIndex,
+    rightIndex,
+    leftProportion: half,
+    rightProportion: half,
+  })
+}, [leftIndex, rightIndex, panelStack, resizePanels])
+```
+
+So double-click equalizes the two neighboring panels while keeping their total share stable.
+
+### Sash rendering
+
+```tsx
+return (
+  <div
+    ref={ref}
+    className="relative w-0 h-full cursor-col-resize flex justify-center shrink-0"
+    style={{ margin: `0 ${PANEL_SASH_FLEX_MARGIN}px` }}
+    onMouseDown={handleMouseDown}
+    onMouseMove={handlers.onMouseMove}
+    onMouseLeave={handlers.onMouseLeave}
+    onDoubleClick={handleDoubleClick}
+  >
+    <div
+      className="absolute inset-y-0 flex justify-center cursor-col-resize"
+      style={{ left: -PANEL_SASH_HALF_HIT_WIDTH, right: -PANEL_SASH_HALF_HIT_WIDTH }}
+    >
+      <div
+        className="absolute left-1/2 -translate-x-1/2"
+        style={{
+          ...gradientStyle,
+          width: PANEL_SASH_LINE_WIDTH,
+          top: PANEL_STACK_VERTICAL_OVERFLOW,
+          bottom: PANEL_STACK_VERTICAL_OVERFLOW,
+        }}
+      />
+    </div>
+  </div>
+)
+```
+
+The sash itself is `w-0`; the actual grab zone is an absolutely positioned hit area centered on the seam.
+
+---
+
+## 7) Resize visuals: `useResizeGradient.ts`
+
+Craft uses the same gradient logic for:
+
+- sidebar sash
+- session-list sash
+- content-panel sash
+
+### Exact gradient math
+
+```tsx
+const RESIZE_GRADIENT_EDGE_BUFFER_PX = 64
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function getResizeGradientStyle(
+  mouseY: number | null,
+  handleHeight: number | null,
+): React.CSSProperties {
+  if (mouseY === null || !handleHeight || handleHeight <= 0) {
+    return {
+      transition: 'opacity 150ms ease-out',
+      opacity: 0,
+      background: 'none',
+    }
+  }
+
+  const height = handleHeight
+  const edgeBuffer = Math.min(RESIZE_GRADIENT_EDGE_BUFFER_PX, Math.max(0, Math.floor(height / 2)))
+  const centerY = clamp(mouseY, edgeBuffer, height - edgeBuffer)
+
+  const nearCenterDelta = Math.max(20, Math.round(edgeBuffer * 0.22))
+  const farCenterDelta = Math.max(56, Math.round(edgeBuffer * 0.75))
+
+  const stopTopNear = clamp(centerY - nearCenterDelta, 0, height)
+  const stopTopFar = clamp(centerY - farCenterDelta, 0, height)
+  const stopBottomNear = clamp(centerY + nearCenterDelta, 0, height)
+  const stopBottomFar = clamp(centerY + farCenterDelta, 0, height)
+
+  return {
+    transition: 'opacity 150ms ease-out',
+    opacity: 1,
+    background: `linear-gradient(
+      to bottom,
+      transparent 0px,
+      color-mix(in oklch, var(--foreground) 10%, transparent) ${stopTopFar}px,
+      color-mix(in oklch, var(--foreground) 18%, transparent) ${stopTopNear}px,
+      color-mix(in oklch, var(--foreground) 36%, transparent) ${centerY}px,
+      color-mix(in oklch, var(--foreground) 18%, transparent) ${stopBottomNear}px,
+      color-mix(in oklch, var(--foreground) 10%, transparent) ${stopBottomFar}px,
+      transparent ${height}px
+    )`,
+  }
+}
+```
+
+### Interaction hook
+
+```tsx
+export function useResizeGradient() {
+  const [mouseY, setMouseY] = React.useState<number | null>(null)
+  const [isDragging, setIsDragging] = React.useState(false)
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  const onMouseMove = React.useCallback((e: React.MouseEvent) => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect()
+      setMouseY(e.clientY - rect.top)
+    }
+  }, [])
+
+  const onMouseLeave = React.useCallback(() => {
+    if (!isDragging) {
+      setMouseY(null)
+    }
+  }, [isDragging])
+
+  const onMouseDown = React.useCallback(() => {
+    setIsDragging(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!isDragging) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (ref.current) {
+        const rect = ref.current.getBoundingClientRect()
+        setMouseY(e.clientY - rect.top)
+      }
+    }
+
+    const handleMouseUp = () => {
+      setIsDragging(false)
+      setMouseY(null)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDragging])
+
+  return {
+    ref,
+    mouseY,
+    isDragging,
+    handlers: { onMouseMove, onMouseLeave, onMouseDown },
+    gradientStyle: getResizeGradientStyle(mouseY, ref.current?.clientHeight ?? null),
+  }
+}
+```
+
+This is purely visual, but it is part of why the sash feels alive instead of being a dead border.
+
+---
+
+## 8) Panel state and resize persistence: `atoms/panel-stack.ts`
+
+The main content panel layout is stored in Jotai.
+
+### Panel stack shape
+
+```tsx
+export interface PanelStackEntry {
+  id: string
+  route: ViewRoute
+  proportion: number
+  panelType: PanelType
+  laneId: PanelLaneId
+}
+
+export const panelStackAtom = atom<PanelStackEntry[]>([])
+export const focusedPanelIdAtom = atom<string | null>(null)
+```
+
+### Proportion normalization
+
+Whenever panels are pushed/reconciled, proportions are normalized.
+
+```tsx
+function normalizeProportions(stack: PanelStackEntry[]): PanelStackEntry[] {
+  if (stack.length === 0) return stack
+  const total = stack.reduce((sum, p) => sum + p.proportion, 0)
+  if (total <= 0) {
+    const equal = 1 / stack.length
+    return stack.map(p => ({ ...p, proportion: equal }))
+  }
+  return stack.map(p => ({ ...p, proportion: p.proportion / total }))
+}
+```
+
+### Resize atom
+
+This is the destination of `PanelResizeSash` drag updates:
+
+```tsx
+export const resizePanelsAtom = atom(
+  null,
+  (get, set, { leftIndex, rightIndex, leftProportion, rightProportion }: {
+    leftIndex: number
+    rightIndex: number
+    leftProportion: number
+    rightProportion: number
+  }) => {
+    const stack = get(panelStackAtom)
+    if (leftIndex < 0 || rightIndex >= stack.length) return
+    const newStack = stack.map((p, i) => {
+      if (i === leftIndex) return { ...p, proportion: leftProportion }
+      if (i === rightIndex) return { ...p, proportion: rightProportion }
+      return p
+    })
+    set(panelStackAtom, newStack)
+  }
+)
+```
+
+Notice: during drag, Craft does **not** renormalize the entire stack. It just updates the two neighboring proportions. Since `PanelResizeSash` preserves the pair’s sum, the whole stack stays coherent.
+
+### Focused session derivation
+
+Compact mode depends on this derived session selection:
+
+```tsx
+export function parseSessionIdFromRoute(route: ViewRoute): string | null {
+  const segments = route.split('/')
+  const idx = segments.indexOf('session')
+  if (idx >= 0 && idx + 1 < segments.length) {
+    return segments[idx + 1]
+  }
+  return null
+}
+
+export const focusedSessionIdAtom = atom((get) => {
+  const route = get(focusedPanelRouteAtom)
+  if (!route) return null
+  return parseSessionIdFromRoute(route)
+})
+```
+
+That is how `PanelStackContainer` knows whether compact mode should show list or content.
+
+---
+
+## 9) `AppShellContext.tsx`: layout-related context behavior
+
+`AppShellContext` is not directly doing the resize math, but it is part of how each panel behaves as an equal citizen in the shell.
+
+### Relevant context fields
+
+```tsx
+export interface AppShellContextType {
+  ...
+  rightSidebarButton?: React.ReactNode
+  leadingAction?: React.ReactNode
+  isFocusedPanel?: boolean
+  ...
+}
+```
+
+### Provider use in `AppShell.tsx`
+
+`AppShell` wraps the shell with:
+
+```tsx
+<AppShellProvider value={appShellContextValue}>
+  ...
+</AppShellProvider>
+```
+
+### Per-panel context override in `PanelSlot.tsx`
+
+Each content panel overrides the context so `MainContentPanel` can render panel-specific controls and focus state.
+
+```tsx
+const contextOverride = useMemo(() => ({
+  ...parentContext,
+  rightSidebarButton: closeButton,
+  leadingAction: backButton,
+  isFocusedPanel,
+}), [parentContext, closeButton, backButton, isFocusedPanel])
+
+<AppShellProvider value={contextOverride}>
+  <MainContentPanel
+    navStateOverride={navState}
+    isSidebarAndNavigatorHidden={isSidebarAndNavigatorHidden}
+  />
+</AppShellProvider>
+```
+
+So the shell is not just visual split panes; each pane also gets contextual behavior:
+
+- close button
+- compact-mode back button
+- focused/unfocused styling state
+
+---
+
+## 10) Supporting layout constants: `panel-constants.ts`
+
+These constants are used to keep all seams aligned.
+
+```tsx
+export const PANEL_GAP = 6
+export const PANEL_EDGE_INSET = 6
+export const RADIUS_EDGE = isMac ? 14 : 8
+export const RADIUS_INNER = 10
+export const PANEL_MIN_WIDTH = 440
+export const PANEL_STACK_VERTICAL_OVERFLOW = 8
+export const PANEL_SASH_HIT_WIDTH = 8
+export const PANEL_SASH_LINE_WIDTH = 2
+export const PANEL_SASH_FLEX_MARGIN = -(PANEL_GAP / 2)
+export const PANEL_SASH_HALF_HIT_WIDTH = PANEL_SASH_HIT_WIDTH / 2
+```
+
+Two especially important ones:
+
+- `PANEL_MIN_WIDTH = 440` for content panes
+- `PANEL_SASH_FLEX_MARGIN = -(PANEL_GAP / 2)` so inserting a sash between flex items does not visually double the gap
+
+---
+
+## 11) Where the three main panes come from
+
+If you want the exact top-level composition of the classic Craft shell, it is:
+
+### Left pane: sidebar navigation
+
+Implemented via `LeftSidebar` inside the `sidebarSlot`.
+
+```tsx
+<LeftSidebar
+  isCollapsed={false}
+  getItemProps={getSidebarItemProps}
+  focusedItemId={focusedSidebarItemId}
+  links={[ ... ]}
+/>
+```
+
+### Middle pane: navigator / session list
+
+Implemented by the `navigatorSlot`, typically with `SessionList` when in sessions navigation.
+
+```tsx
+{isSessionsNavigation(navState) && (
+  <SessionList
+    key={sessionFilter?.kind}
+    items={searchActive ? workspaceSessionMetas : filteredSessionMetas}
+    ...
+  />
+)}
+```
+
+### Right/main pane: chat/content panels
+
+Implemented by `PanelStackContainer` rendering one or more `PanelSlot`s, each wrapping `MainContentPanel`, which in session routes includes `ChatDisplay`.
+
+```tsx
+<PanelSlot
+  ...
+>
+```
+
+Inside `PanelSlot`:
+
+```tsx
+<MainContentPanel
+  navStateOverride={navState}
+  isSidebarAndNavigatorHidden={isSidebarAndNavigatorHidden}
+/>
+```
+
+And `ChatDisplay` is the actual chat pane UI used by the main content path.
+
+---
+
+## 12) Role of `WorkspaceSwitcher.tsx`
+
+`WorkspaceSwitcher.tsx` is **not** part of the resize math. It is just a workspace dropdown trigger used in topbar/sidebar UI.
+
+It matters to shell composition only in the sense that it is part of the surrounding app chrome, not the split-pane system.
+
+There is **no drag-resize logic** in `WorkspaceSwitcher.tsx`.
+
+---
+
+## 13) Condensed architectural summary
+
+### What actually implements Craft’s resizable app shell
+
+**Fixed left rails**
+- `AppShell.tsx`
+  - `sidebarWidth`
+  - `sessionListWidth`
+  - absolute resize handles
+  - document mouse listeners
+
+**Responsive shell mode switching**
+- `useContainerWidth.ts`
+  - `ResizeObserver`
+  - `isAutoCompact`
+
+**Resizable content split panes**
+- `PanelStackContainer.tsx`
+  - arranges sidebar, navigator, and content panel strip
+- `PanelSlot.tsx`
+  - applies `flex-grow: proportion; flex-basis: 0; min-width: PANEL_MIN_WIDTH`
+- `PanelResizeSash.tsx`
+  - DOM width measurement + drag delta + proportion conversion
+
+**State backing the split panes**
+- `atoms/panel-stack.ts`
+  - `panelStackAtom`
+  - `focusedPanelIdAtom`
+  - `resizePanelsAtom`
+  - normalized proportions
+
+**Per-panel behavior**
+- `AppShellContext.tsx`
+- `PanelSlot.tsx` context override for `isFocusedPanel`, close/back buttons
+
+---
+
+## 14) The key design trick Craft uses
+
+The nastiest useful little trick in this whole beast:
+
+- during drag, Craft measures panel widths in **pixels**
+- but it stores layout in **proportions**
+- and it preserves only the **combined proportion of the two adjacent panels**
+
+That gives it:
+
+- natural flexbox filling
+- local resize behavior
+- stable multi-panel layout
+- horizontal overflow when min widths are hit
+- no global layout explosion every time a sash moves
+
+In short: **DOM pixels for input, flex proportions for state**. Clean knife-work.

--- a/docs/plan-resizable-panels.md
+++ b/docs/plan-resizable-panels.md
@@ -1,0 +1,688 @@
+# Craft-style Resizable Three-Panel Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ai-nexus`’s current desktop two-pane sidebar/chat layout with a Craft-style three-panel shell: `LeftSidebar` (fixed px, resizable), `SessionList` (fixed px, resizable), and `MainContent` (fills remaining width), while preserving a compact/mobile experience.
+
+**Architecture:** Do **not** blindly port Craft’s entire multi-content panel stack. `ai-nexus` only needs the **left-rail portion** of Craft right now: two persisted pixel widths, two absolute drag sashes, a compact-mode width observer, and a main content panel that flexes into the remaining space. Introduce Jotai for layout state and persistence, extract the shell into focused layout components, and adapt current `NavChats`/`ChatContainer` pages so they fill the new shell cleanly.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind v4, Jotai (new dependency), existing `motion` dependency only if animated width transitions are wanted, existing `SidebarFocusProvider` for keyboard zone navigation.
+
+---
+
+## Current State Analysis
+
+### What exists today
+
+- `frontend/components/app-layout.tsx`
+  - Desktop layout is a **two-pane** `ResizablePanelGroup`:
+    - left: current `Sidebar` containing `NewSessionButton` + `NavChats`
+    - right: `children` (chat/dashboard content)
+  - Mobile uses the current `Sidebar` sheet overlay.
+- `frontend/components/ui/sidebar.tsx`
+  - Owns desktop sidebar width/state (`desktopWidth`, `state`) and mobile open state.
+  - Is tightly coupled to the old “one sidebar + one content area” layout.
+- `frontend/features/nav-chats/NavChats.tsx`
+  - Already behaves like a **session/navigator panel**, not a global app sidebar.
+  - Registers as focus zone `navigator`.
+- `frontend/features/nav-chats/sidebar-focus.tsx`
+  - Already has the exact three focus zones we need conceptually: `sidebar`, `navigator`, `chat`.
+- `frontend/app/(app)/page.tsx` and `frontend/app/(app)/c/[conversationId]/page.tsx`
+  - Wrap chat pages in extra `<div>` elements; the conversation route also renders an unnecessary `<h1>`.
+- `frontend/features/chat/ChatView.tsx`
+  - Assumes a viewport-driven layout (`h-[90vh]`) instead of filling a parent shell panel.
+- `frontend/app/(app)/dashboard/page.tsx`
+  - Still mounts its **own** `SidebarProvider` / `AppSidebar`, which will conflict with the new shared shell.
+
+### What Craft does that matters here
+
+From `docs/craft-resizable-panels.md`, the useful parts for `ai-nexus` are:
+
+1. **Two left rails are pixel-sized and independently resizable**
+   - `sidebarWidth`: clamped and persisted
+   - `sessionListWidth`: clamped and persisted
+2. **Desktop shell is `flex` + absolute sash geometry**, not `react-resizable-panels`
+3. **Compact mode is derived from container width** (`ResizeObserver`)
+4. **Only the main content strip uses proportional panel math** in Craft
+   - `ai-nexus` does **not** need Craft’s `panelStackAtom` / `PanelResizeSash` for multiple content panes yet
+   - For `ai-nexus` today, `MainContent` can just be `flex: 1 1 auto`
+
+### Direct mapping from Craft to `ai-nexus`
+
+| Craft concept | `ai-nexus` equivalent | Port now? | Notes |
+|---|---|---:|---|
+| `sidebarWidth` | `LeftSidebar` width | Yes | New desktop-only px width state |
+| `sessionListWidth` | `NavChats` container width | Yes | Move `NewSessionButton` + `NavChats` into dedicated session panel |
+| `useContainerWidth` | shell compact-mode observer | Yes | Needed to auto-collapse to mobile/compact |
+| absolute left rail sashes | `LeftSidebar` / `SessionList` drag handles | Yes | This is the real desktop resize behavior to copy |
+| `panelStackAtom` | multi-chat/content tabs | No (not yet) | Overkill until `ai-nexus` can open multiple main panels |
+| `PanelResizeSash` between content panels | future main-content multi-panel split | No (not yet) | Mention as future extension only |
+| `flexGrow: proportion` content widths | `MainContent` | No (not yet) | Single main panel only |
+
+---
+
+## File Structure / Ownership
+
+### Create
+
+- `frontend/store/layout-atoms.ts`
+  - Jotai atoms for desktop layout preferences and shell UI state.
+  - Persist `leftSidebarWidth`, `sessionListWidth`, `leftSidebarVisible`, and optional compact override state.
+- `frontend/components/layout/layout-constants.ts`
+  - Centralize Craft-derived geometry constants (`PANEL_GAP`, hit widths, edge inset, min/max widths).
+- `frontend/components/layout/use-container-width.ts`
+  - `ResizeObserver` hook for shell width and compact mode.
+- `frontend/components/layout/use-resize-gradient.ts`
+  - Shared hover/drag gradient visuals for sashes.
+- `frontend/components/layout/resizable-sash.tsx`
+  - Generic visual sash used for the two desktop drag seams.
+- `frontend/components/layout/left-sidebar-panel.tsx`
+  - Global app navigation / collapse control / future workspace or user chrome.
+- `frontend/components/layout/session-list-panel.tsx`
+  - Header + `NewSessionButton` + `NavChats`; this is Craft’s navigator equivalent.
+- `frontend/components/layout/desktop-three-panel-shell.tsx`
+  - Desktop-only flex shell with two resizable left rails and `children` as main content.
+- `frontend/components/layout/mobile-shell.tsx`
+  - Compact/mobile fallback that reuses existing sheet behavior or a simplified overlay.
+- `frontend/components/layout/main-content-shell.tsx`
+  - Optional wrapper for the right panel surface (`h-full`, shadows, rounded edges, header slot if needed).
+
+### Modify
+
+- `frontend/package.json`
+  - Add `jotai`.
+- `frontend/app/providers.tsx`
+  - Add `<Provider>` from Jotai around the app.
+- `frontend/components/app-layout.tsx`
+  - Replace current `ResizablePanelGroup` implementation with a shell orchestrator that chooses desktop vs compact/mobile.
+- `frontend/components/ui/sidebar.tsx`
+  - Reduce responsibilities or stop using its desktop width logic from `AppLayout`.
+  - Keep only what still matters for mobile sheet behavior if reused.
+- `frontend/components/new-session-button.tsx`
+  - Stop coupling to the old sidebar desktop behavior; only close compact/mobile sheet if present.
+- `frontend/features/nav-chats/sidebar-focus.tsx`
+  - Keep zone model, but verify `sidebar -> navigator -> chat` order still works with the new physical layout.
+- `frontend/features/nav-chats/NavChats.tsx`
+  - Keep `navigator` zone registration; may only need container/focus cleanup.
+- `frontend/features/nav-chats/NavChatsView.tsx`
+  - Ensure it fills the new session panel (`min-h-0`, overflow behavior, no hidden height assumptions).
+- `frontend/features/chat/ChatView.tsx`
+  - Remove viewport height hacks and make it fill the main panel.
+- `frontend/app/(app)/page.tsx`
+  - Return a height-filling chat surface without extra wrappers.
+- `frontend/app/(app)/c/[conversationId]/page.tsx`
+  - Remove the extra `<h1>` / wrapper so the conversation view fills the panel.
+- `frontend/app/(app)/dashboard/page.tsx`
+  - Remove nested sidebar shell so dashboard renders inside the global three-panel layout.
+- `frontend/components/app-sidebar.tsx`
+  - Delete or deprecate once `SessionListPanel` replaces it.
+
+---
+
+## Target Layout Contract
+
+### Desktop
+
+```text
+[ LeftSidebar width:px ] [ SessionList width:px ] [ MainContent flex:1 ]
+```
+
+- Outer shell: `display: flex; position: relative; height: 100%`
+- Left sidebar width: persisted px, clamped
+- Session list width: persisted px, clamped
+- Main content: `flex: 1 1 auto; min-width: 0`
+- Two absolute drag handles rendered on top of the seams
+
+### Compact/mobile
+
+Mimic Craft’s compact behavior without porting the content panel stack:
+
+- If shell width `< MOBILE_THRESHOLD` (start with `768` to match Craft), hide the desktop three-panel shell.
+- Show either:
+  - a mobile sheet/drawer for navigation, and
+  - main content full-width
+- The current `Sidebar` mobile sheet is good enough as the first compact implementation.
+
+### Width clamps to start with
+
+Use Craft’s same starting clamps unless the product calls for different numbers:
+
+- `LEFT_SIDEBAR_MIN_WIDTH = 180`
+- `LEFT_SIDEBAR_MAX_WIDTH = 320`
+- `SESSION_LIST_MIN_WIDTH = 240`
+- `SESSION_LIST_MAX_WIDTH = 480`
+- `MOBILE_THRESHOLD = 768`
+
+If product wants a narrower icon rail later, change only the left sidebar constants and component content — not the resize architecture.
+
+---
+
+## State Design
+
+## Chunk 1: Layout state and shell geometry
+
+### Task 1: Add Jotai-based layout state
+
+**Files:**
+- Create: `frontend/store/layout-atoms.ts`
+- Modify: `frontend/package.json`
+- Modify: `frontend/app/providers.tsx`
+
+- [ ] **Step 1: Add Jotai dependency**
+
+Run: `bun --cwd frontend add jotai`
+Expected: `frontend/package.json` gains `jotai`
+
+- [ ] **Step 2: Create layout atoms**
+
+Define atoms for:
+
+- `leftSidebarVisibleAtom` → boolean, default `true`
+- `leftSidebarWidthAtom` → number, default `220`
+- `sessionListWidthAtom` → number, default `300`
+- `isDesktopChromeHiddenAtom` (optional) → boolean, default `false`
+
+Use either `atomWithStorage` from `jotai/utils` or a tiny custom persistence wrapper. If using `atomWithStorage`, keep the storage keys explicit:
+
+- `layout.leftSidebarVisible`
+- `layout.leftSidebarWidth`
+- `layout.sessionListWidth`
+
+- [ ] **Step 3: Add width clamp helpers in the same module or constants module**
+
+Include exact helpers:
+
+- `clampLeftSidebarWidth(width)`
+- `clampSessionListWidth(width)`
+
+These must be used by all drag code and hydration code so persisted garbage cannot break the shell.
+
+- [ ] **Step 4: Add Jotai provider**
+
+Wrap `Providers` output with Jotai’s root provider so layout atoms are available in `AppLayout` and child panels.
+
+- [ ] **Step 5: Validate dependency + types**
+
+Run: `bun --cwd frontend typecheck`
+Expected: PASS
+
+### Task 2: Add Craft-style geometry primitives
+
+**Files:**
+- Create: `frontend/components/layout/layout-constants.ts`
+- Create: `frontend/components/layout/use-container-width.ts`
+- Create: `frontend/components/layout/use-resize-gradient.ts`
+- Create: `frontend/components/layout/resizable-sash.tsx`
+
+- [ ] **Step 1: Create layout constants**
+
+Add a focused constants file with:
+
+- `PANEL_GAP = 6`
+- `PANEL_EDGE_INSET = 6`
+- `PANEL_SASH_HIT_WIDTH = 8`
+- `PANEL_SASH_LINE_WIDTH = 2`
+- `PANEL_SASH_HALF_HIT_WIDTH = PANEL_SASH_HIT_WIDTH / 2`
+- `PANEL_STACK_VERTICAL_OVERFLOW = 8`
+- width min/max constants listed above
+- `MOBILE_THRESHOLD = 768`
+
+- [ ] **Step 2: Create `useContainerWidth`**
+
+Port the tiny `ResizeObserver` hook from Craft almost verbatim. This is the right tool here; do not poll `window.innerWidth`.
+
+- [ ] **Step 3: Create `useResizeGradient` + shared gradient math**
+
+Use Craft’s hover/drag Y-tracking pattern so both left rail sashes feel alive and consistent.
+
+- [ ] **Step 4: Create `ResizableSash`**
+
+This component should only handle:
+
+- hit area rendering
+- gradient visuals
+- mouse down callback
+- optional `left` style positioning from parent
+- optional `onDoubleClick` for future reset behavior
+
+It should **not** own width state. The shell owns geometry and drag math.
+
+- [ ] **Step 5: Validate**
+
+Run: `bun --cwd frontend typecheck`
+Expected: PASS
+
+---
+
+## Chunk 2: Replace the desktop shell
+
+### Task 3: Build the new desktop three-panel shell
+
+**Files:**
+- Create: `frontend/components/layout/desktop-three-panel-shell.tsx`
+- Create: `frontend/components/layout/left-sidebar-panel.tsx`
+- Create: `frontend/components/layout/session-list-panel.tsx`
+- Create: `frontend/components/layout/main-content-shell.tsx`
+- Modify: `frontend/components/app-layout.tsx`
+
+- [ ] **Step 1: Extract the left sidebar panel**
+
+Create `left-sidebar-panel.tsx` for the **global** sidebar, not the session list.
+
+Initial contents should be minimal but structurally correct:
+
+- collapse/expand button
+- app-level nav links (e.g. `Chats`, `Dashboard`)
+- optional footer/user area placeholder
+
+Important: this panel is the target for focus zone `sidebar`.
+
+- [ ] **Step 2: Extract the session list panel**
+
+Create `session-list-panel.tsx` that contains:
+
+- `NewSessionButton` in header
+- `NavChats` in body
+- shell classes like `h-full flex min-h-0 flex-col`
+
+This becomes Craft’s `navigatorSlot` equivalent.
+
+- [ ] **Step 3: Create main content shell wrapper**
+
+Create a thin wrapper that gives `children`:
+
+- `h-full`
+- `min-w-0`
+- `min-h-0`
+- panel surface/shadow/radius classes if wanted
+
+The right panel should own overflow behavior cleanly so route pages do not have to guess at height.
+
+- [ ] **Step 4: Implement desktop shell flex layout**
+
+In `desktop-three-panel-shell.tsx`, render:
+
+```tsx
+<div ref={shellRef} className="relative flex h-full items-stretch" style={{ gap: PANEL_GAP, paddingRight: PANEL_EDGE_INSET, paddingBottom: PANEL_EDGE_INSET }}>
+  <div style={{ width: leftSidebarVisible ? leftSidebarWidth : 0 }} />
+  <div style={{ width: sessionListWidth }} />
+  <div className="min-w-0 flex-1">...</div>
+
+  <ResizableSash ... />
+  <ResizableSash ... />
+</div>
+```
+
+Use real panel content, not placeholders.
+
+- [ ] **Step 5: Implement drag math for the left sidebar seam**
+
+Mirror Craft’s document-level listeners:
+
+- on mouse down, store active handle = `'left-sidebar'`
+- on `mousemove`, compute:
+
+```ts
+const newWidth = clampLeftSidebarWidth(e.clientX)
+```
+
+or, if shell-relative coordinates are cleaner:
+
+```ts
+const newWidth = clampLeftSidebarWidth(e.clientX - shellRect.left)
+```
+
+Pick one coordinate system and use it consistently. Shell-relative math is safer if the app is not flush with the viewport.
+
+Persist width on mouse up.
+
+- [ ] **Step 6: Implement drag math for the session list seam**
+
+Mirror Craft’s offset logic:
+
+```ts
+const leftOffset = leftSidebarVisible ? leftSidebarWidth + PANEL_GAP : PANEL_EDGE_INSET
+const newWidth = clampSessionListWidth(e.clientX - shellRect.left - leftOffset)
+```
+
+This is the crucial mapping from Craft’s `e.clientX - offset` math into `ai-nexus`’s shell.
+
+- [ ] **Step 7: Position the absolute sashes exactly from state**
+
+Use `left` positions derived from current widths:
+
+Left sidebar sash:
+
+```ts
+leftSidebarVisible
+  ? leftSidebarWidth + PANEL_GAP / 2 - PANEL_SASH_HALF_HIT_WIDTH
+  : -PANEL_GAP
+```
+
+Session list sash:
+
+```ts
+(leftSidebarVisible ? leftSidebarWidth + PANEL_GAP : PANEL_EDGE_INSET)
++ sessionListWidth
++ PANEL_GAP / 2
+- PANEL_SASH_HALF_HIT_WIDTH
+```
+
+If the shell uses different padding than Craft, adjust both formulas together.
+
+- [ ] **Step 8: Replace the old `ResizablePanelGroup` in `app-layout.tsx`**
+
+`AppLayout` should become an orchestrator:
+
+- desktop → `DesktopThreePanelShell`
+- compact/mobile → `MobileShell`
+
+Delete the old `ResizablePanel`, `ResizableHandle`, `ResizablePanelGroup`, and `usePanelRef` usage from `app-layout.tsx`.
+
+- [ ] **Step 9: Validate**
+
+Run:
+- `bun --cwd frontend typecheck`
+- `bun --cwd frontend build`
+
+Expected: PASS
+
+### Task 4: Decide what survives from `components/ui/sidebar.tsx`
+
+**Files:**
+- Modify: `frontend/components/ui/sidebar.tsx`
+- Modify: `frontend/components/app-layout.tsx`
+- Modify: `frontend/components/new-session-button.tsx`
+
+- [ ] **Step 1: Stop using `Sidebar` desktop width logic from `AppLayout`**
+
+The old sidebar component is coupled to one desktop sidebar gap and fixed container positioning. That machinery will fight the new three-panel shell.
+
+- [ ] **Step 2: Keep only mobile behavior you still need**
+
+Recommended path:
+
+- keep `SidebarProvider` if you still want:
+  - mobile sheet open state
+  - `⌘/Ctrl + b` toggle shortcut
+- stop reading `desktopWidth` / desktop `state` from it in the new shell
+
+- [ ] **Step 3: Update `NewSessionButton`**
+
+It currently imports `useSidebar()` only to close the mobile sheet.
+
+Keep that behavior, but make sure the button does **not** assume the old desktop sidebar still exists.
+
+- [ ] **Step 4: Validate**
+
+Run: `bun --cwd frontend typecheck`
+Expected: PASS
+
+---
+
+## Chunk 3: Compact mode and route cleanup
+
+### Task 5: Add compact/mobile shell switching
+
+**Files:**
+- Create: `frontend/components/layout/mobile-shell.tsx`
+- Modify: `frontend/components/app-layout.tsx`
+
+- [ ] **Step 1: Measure shell width with `useContainerWidth`**
+
+Use a ref on the shell container in `AppLayout` or `DesktopThreePanelShell` and compute:
+
+```ts
+const isAutoCompact = shellWidth > 0 && shellWidth < MOBILE_THRESHOLD
+```
+
+- [ ] **Step 2: Choose compact behavior**
+
+Recommended first implementation for `ai-nexus`:
+
+- compact/mobile: no persistent desktop three-panel shell
+- show `children` full-width
+- expose `SessionListPanel` through the current mobile sheet/drawer
+- optionally hide `LeftSidebar` entirely on compact widths
+
+This is simpler than Craft’s “navigator or focused content” switching and matches the current app better.
+
+- [ ] **Step 3: Wire trigger/collapse controls to compact shell**
+
+The current top-bar trigger should open the compact drawer rather than attempt desktop collapse behavior.
+
+- [ ] **Step 4: Manual validation**
+
+In devtools responsive mode, verify:
+
+- desktop widths drag correctly
+- below threshold, the desktop shell disappears cleanly
+- the session list remains reachable on mobile/compact
+
+### Task 6: Make route content fill the new main panel
+
+**Files:**
+- Modify: `frontend/app/(app)/page.tsx`
+- Modify: `frontend/app/(app)/c/[conversationId]/page.tsx`
+- Modify: `frontend/features/chat/ChatView.tsx`
+- Modify: `frontend/app/(app)/dashboard/page.tsx`
+- Modify: `frontend/components/app-sidebar.tsx`
+
+- [ ] **Step 1: Strip extra wrappers from the root conversation route**
+
+Change `/app/(app)/page.tsx` so it renders `ChatContainer` inside a panel-filling wrapper only if required:
+
+```tsx
+return <ChatContainer key={uuid} conversationId={uuid} />
+```
+
+or:
+
+```tsx
+return <div className="h-full min-h-0"><ChatContainer ... /></div>
+```
+
+No bare wrapper divs with no layout purpose.
+
+- [ ] **Step 2: Strip extra wrappers from the conversation detail route**
+
+Remove the `Conversation {id}` heading and wrapper div from `/app/(app)/c/[conversationId]/page.tsx` so the main content panel is not polluted by route-level chrome.
+
+- [ ] **Step 3: Make `ChatView` fill its parent instead of the viewport**
+
+Replace this shape:
+
+- `sm:max-w-[80%] lg:max-w-[60%] xl:max-w-[50%] mx-auto`
+- nested `h-[90vh]`
+
+with parent-filling structure, for example:
+
+- outer wrapper: `flex h-full min-h-0 flex-col`
+- inner centered content container: `mx-auto flex h-full w-full max-w-4xl min-h-0 flex-col`
+- conversation area: `flex-1 min-h-0 overflow-y-auto`
+
+This is mandatory; otherwise the new shell will feel broken.
+
+- [ ] **Step 4: Remove nested shelling from dashboard**
+
+`frontend/app/(app)/dashboard/page.tsx` must stop creating its own `SidebarProvider`, `AppSidebar`, and `SidebarInset`. Let `AppLayout` provide the shell once, globally.
+
+- [ ] **Step 5: Delete or deprecate `AppSidebar`**
+
+If nothing imports `frontend/components/app-sidebar.tsx` after the migration, remove it or leave a short comment marking it dead code to clean up next.
+
+- [ ] **Step 6: Validate**
+
+Run:
+- `bun --cwd frontend typecheck`
+- `bun --cwd frontend build`
+
+Expected: PASS
+
+---
+
+## Chunk 4: Focus, polish, and verification
+
+### Task 7: Preserve keyboard focus behavior across the new three-panel shell
+
+**Files:**
+- Modify: `frontend/features/nav-chats/sidebar-focus.tsx`
+- Modify: `frontend/components/layout/left-sidebar-panel.tsx`
+- Modify: `frontend/components/layout/session-list-panel.tsx`
+- Modify: `frontend/components/app-layout.tsx`
+
+- [ ] **Step 1: Keep the existing zone model**
+
+The current zone order already matches the new shell:
+
+- `sidebar`
+- `navigator`
+- `chat`
+
+Do **not** rename zones unless absolutely necessary.
+
+- [ ] **Step 2: Register the new left sidebar correctly**
+
+`LeftSidebarPanel` should use the `sidebar` zone and focus its first actionable control.
+
+- [ ] **Step 3: Keep `NavChats` as the navigator zone**
+
+No new focus abstraction is needed; just verify it still receives keyboard focus after extraction.
+
+- [ ] **Step 4: Keep the main content shell as `chat` zone**
+
+The old `ChatFocusShell` behavior can survive with minimal changes.
+
+- [ ] **Step 5: Manual validation**
+
+Verify:
+
+- `ArrowLeft` from a conversation goes to `navigator`
+- another left move can go to `sidebar` if intended
+- `ArrowRight` returns to `chat`
+- clicking each panel updates zone ownership cleanly
+
+### Task 8: Add resize polish and persistence checks
+
+**Files:**
+- Modify: `frontend/components/layout/desktop-three-panel-shell.tsx`
+- Modify: `frontend/components/layout/resizable-sash.tsx`
+- Modify: `frontend/store/layout-atoms.ts`
+
+- [ ] **Step 1: Disable text selection while dragging**
+
+Mirror Craft:
+
+```ts
+document.body.style.userSelect = 'none'
+document.body.style.cursor = 'col-resize'
+```
+
+and always reset them on mouse up / cleanup.
+
+- [ ] **Step 2: Animate sash position changes only when not actively dragging**
+
+Use the same pattern Craft uses:
+
+- no transition during drag
+- `left 0.15s ease-out` when widths update from persisted state or collapse toggles
+
+- [ ] **Step 3: Confirm persistence**
+
+Reload the page and verify:
+
+- left sidebar width restored
+- session list width restored
+- collapsed/visible state restored if implemented
+
+- [ ] **Step 4: Optional double-click behavior**
+
+If desired, double-click on a sash can reset to default width. This is not required for the first pass, but the sash component should leave room for it.
+
+---
+
+## Explicit Non-Goals for This Pass
+
+These are tempting rabbit holes. Leave them in the wall for later.
+
+- [ ] Do **not** port Craft’s full `panelStackAtom` / `PanelSlot` / `PanelResizeSash` content-strip engine yet.
+- [ ] Do **not** rebuild `ChatContainer` into true multi-panel chat tabs yet.
+- [ ] Do **not** mix `react-resizable-panels` desktop behavior with the new Craft-style manual shell.
+  - Pick one system on desktop: the Craft-style shell.
+- [ ] Do **not** leave nested shell providers (`SidebarProvider`, `SidebarInset`, `AppSidebar`) inside route pages.
+
+---
+
+## Implementation Notes / Decision Log
+
+### Why Jotai goes into `ai-nexus` now
+
+The Craft blueprint uses Jotai as the shell’s backing store. Even though `ai-nexus` only needs the left-rail subset today, adding Jotai now gives a clean home for layout state instead of stuffing more desktop shell state into `SidebarProvider` or `localStorage` helper functions.
+
+### Why not use `react-resizable-panels` for this
+
+`react-resizable-panels` is fine for the current 2-pane split, but Craft’s layout is not just “three panels in a group.” It depends on:
+
+- fixed pixel left rails
+- custom seam placement math
+- document-level drag listeners
+- compact-mode hiding rules
+- a future path toward a separate content panel stack
+
+That is a different beast.
+
+### Why `NavChats` belongs in the middle panel
+
+`NavChats` already behaves like a session navigator:
+
+- search
+- grouping
+- selection
+- keyboard list navigation
+
+So it maps directly to Craft’s `SessionList`, not to the app-level left sidebar.
+
+### What should go in `LeftSidebar`
+
+Start small:
+
+- `Chats` route shortcut
+- `Dashboard` route shortcut
+- collapse button
+- optional brand/user footer
+
+The important thing is to create the **layout slot** now. The exact app-nav content can evolve later.
+
+---
+
+## Verification Checklist
+
+After implementation, verify all of this manually:
+
+- [ ] Desktop shows three visible panels: `LeftSidebar`, `SessionList`, `MainContent`
+- [ ] Left sidebar seam drags and persists
+- [ ] Session list seam drags and persists
+- [ ] Main content always fills remaining width
+- [ ] `NavChats` still selects and focuses conversations correctly
+- [ ] Chat page fills the right panel without `90vh` hacks
+- [ ] Dashboard renders inside the shared shell, not a nested one
+- [ ] Compact/mobile mode swaps to the fallback shell below the threshold
+- [ ] Keyboard focus still moves `sidebar -> navigator -> chat`
+- [ ] `bun --cwd frontend typecheck` passes
+- [ ] `bun --cwd frontend build` passes
+
+---
+
+## Recommended Commit Sequence
+
+1. `feat: add layout atoms and shell constants`
+2. `feat: add craft-style desktop three-panel shell`
+3. `refactor: move nav chats into session list panel`
+4. `refactor: make chat routes fill main content shell`
+5. `refactor: remove old desktop sidebar/resizable-panel wiring`
+6. `feat: add compact shell fallback`
+7. `chore: remove obsolete app sidebar shell`
+
+---
+
+Plan complete and saved to `docs/plan-resizable-panels.md`. Ready to execute?

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -11,7 +11,9 @@
 'use client';
 
 import React from 'react';
+import { ChatActivityProvider } from '@/features/nav-chats/chat-activity-context';
 import { NavChats } from '@/features/nav-chats/NavChats';
+import { SidebarFocusProvider, useFocusZone } from '@/features/nav-chats/sidebar-focus';
 import { NewSessionButton } from './new-session-button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup, usePanelRef } from './ui/resizable';
 import { Separator } from './ui/separator';
@@ -29,6 +31,60 @@ import {
 
 /** Duration of the sidebar collapse/expand CSS transition in ms. */
 const COLLAPSE_ANIMATION_DURATION_MS = 250;
+
+/**
+ * Wraps sidebar content in a focus zone so keyboard navigation (Tab/Shift+Tab)
+ * can jump directly to the sidebar region instead of walking every focusable element.
+ * Focuses the first interactive child (input or button) when the zone receives focus.
+ */
+function SidebarFocusShell({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { zoneRef } = useFocusZone({
+    zoneId: 'sidebar',
+    focusFirst: () => {
+      const root = zoneRef.current;
+      const target = root?.querySelector<HTMLElement>(
+        'input, button, [tabindex]:not([tabindex="-1"])'
+      );
+      target?.focus();
+    },
+  });
+
+  return (
+    <div ref={zoneRef} className={className} data-focus-zone="sidebar">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Wraps the chat panel in a focus zone so keyboard navigation can jump
+ * directly into the chat area. Targets the textarea or textbox first,
+ * falling back to any focusable element.
+ */
+function ChatFocusShell({ children }: { children: React.ReactNode }) {
+  const { zoneRef } = useFocusZone({
+    zoneId: 'chat',
+    focusFirst: () => {
+      const root = zoneRef.current;
+      const target = root?.querySelector<HTMLElement>(
+        'textarea, [role="textbox"], button, [tabindex]:not([tabindex="-1"])'
+      );
+      target?.focus();
+    },
+  });
+
+  return (
+    <div ref={zoneRef} className="h-full outline-none" data-focus-zone="chat" tabIndex={-1}>
+      {children}
+    </div>
+  );
+}
 
 /**
  * Sidebar content wrapper with conditional resizable layout.
@@ -73,14 +129,16 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
     return (
       <>
         <Sidebar>
-          <SidebarHeader className="px-2 pb-2 shrink-0">
-            <NewSessionButton />
-          </SidebarHeader>
-          <SidebarContent>
-            <NavChats />
-          </SidebarContent>
+          <SidebarFocusShell className="flex h-full flex-col">
+            <SidebarHeader className="px-2 pb-2 shrink-0">
+              <NewSessionButton />
+            </SidebarHeader>
+            <SidebarContent>
+              <NavChats />
+            </SidebarContent>
+          </SidebarFocusShell>
         </Sidebar>
-        {children}
+        <ChatFocusShell>{children}</ChatFocusShell>
       </>
     );
   }
@@ -113,29 +171,33 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         }}
       >
         {/* Content keeps min-width so layout never reflows during collapse —
-            the panel clips via overflow:hidden and the content fades out. */}
-        <div
-          className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden"
-          style={{
-            opacity: state === 'collapsed' ? 0 : 1,
-            // Disable pointer events when invisible to prevent click-dead-zones
-            // per the hidden-overlay-pointer-events rule.
-            pointerEvents: state === 'collapsed' ? 'none' : 'auto',
-            transition: 'opacity 150ms ease-out',
-          }}
-        >
-          <SidebarHeader className="px-2 pb-2 shrink-0">
-            <NewSessionButton />
-          </SidebarHeader>
-          <SidebarContent>
-            <NavChats />
-          </SidebarContent>
-        </div>
+          the panel clips via overflow:hidden and the content fades out. */}
+        <SidebarFocusShell className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden">
+          <div
+            style={{
+              opacity: state === 'collapsed' ? 0 : 1,
+              // Disable pointer events when invisible to prevent click-dead-zones
+              // per the hidden-overlay-pointer-events rule.
+              pointerEvents: state === 'collapsed' ? 'none' : 'auto',
+              transition: 'opacity 150ms ease-out',
+            }}
+            className="flex h-full min-w-[240px] flex-col overflow-hidden"
+          >
+            <SidebarHeader className="px-2 pb-2 shrink-0">
+              <NewSessionButton />
+            </SidebarHeader>
+            <SidebarContent>
+              <NavChats />
+            </SidebarContent>
+          </div>
+        </SidebarFocusShell>
       </ResizablePanel>
 
       <ResizableHandle />
 
-      <ResizablePanel className="h-full">{children}</ResizablePanel>
+      <ResizablePanel className="h-full">
+        <ChatFocusShell>{children}</ChatFocusShell>
+      </ResizablePanel>
     </ResizablePanelGroup>
   );
 }
@@ -143,24 +205,29 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
 /**
  * Main application layout with resizable sidebar and content area.
  * Provides full-page structure with sidebar navigation and responsive behavior.
+ * Wraps everything in focus-zone and chat-activity providers.
  */
 export function AppLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>
-      <ResizableSidebarContent>
-        <SidebarInset>
-          <header className="flex h-16 shrink-0 items-center gap-2">
-            <div className="flex items-center gap-2 px-4">
-              <SidebarTrigger className="-ml-1 cursor-pointer" />
-              <Separator
-                orientation="vertical"
-                className="mr-2 data-vertical:h-4 data-vertical:self-auto"
-              />
-            </div>
-          </header>
-          <div className="flex-1">{children}</div>
-        </SidebarInset>
-      </ResizableSidebarContent>
+      <SidebarFocusProvider>
+        <ChatActivityProvider>
+          <ResizableSidebarContent>
+            <SidebarInset>
+              <header className="flex h-16 shrink-0 items-center gap-2">
+                <div className="flex items-center gap-2 px-4">
+                  <SidebarTrigger className="-ml-1 cursor-pointer" />
+                  <Separator
+                    orientation="vertical"
+                    className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+                  />
+                </div>
+              </header>
+              <div className="flex-1">{children}</div>
+            </SidebarInset>
+          </ResizableSidebarContent>
+        </ChatActivityProvider>
+      </SidebarFocusProvider>
     </SidebarProvider>
   );
 }

--- a/frontend/features/chat/ChatContainer.tsx
+++ b/frontend/features/chat/ChatContainer.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
+import { useChatActivity } from '@/features/nav-chats/chat-activity-context';
 import type { AgnoMessage } from '@/lib/types';
 import ChatView from './ChatView';
 import { useChat } from './hooks/use-chat';
@@ -34,6 +35,7 @@ export default function ChatContainer({ conversationId, initialChatHistory }: Ch
   const createConversationMutation = useCreateConversation(conversationId);
   const generateConversationTitleMutation = useGenerateConversationTitle(conversationId);
   const router = useRouter();
+  const { setActiveConversation, clearActiveConversation } = useChatActivity();
 
   /**
    * Tracks whether we've already updated the URL to `/c/:id`.
@@ -106,6 +108,24 @@ export default function ChatContainer({ conversationId, initialChatHistory }: Ch
       router.replace(`/c/${conversationId}`);
     }
   };
+
+  // Keep the sidebar's chat-activity context in sync with this chat's state.
+  // Fires on every history/loading change so the sidebar can show spinners,
+  // unread badges, and content-search matches for the active conversation.
+  useEffect(() => {
+    setActiveConversation({
+      conversationId,
+      chatHistory,
+      isLoading,
+    });
+  }, [chatHistory, conversationId, isLoading, setActiveConversation]);
+
+  // Clear activity state on unmount, guarded by conversationId so a stale
+  // cleanup doesn't clobber a newly opened conversation.
+  useEffect(
+    () => () => clearActiveConversation(conversationId),
+    [clearActiveConversation, conversationId]
+  );
 
   /** Updates the controlled message state as the user types. */
   const onUpdateMessage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend/features/nav-chats/ConversationLabelBadge.tsx
+++ b/frontend/features/nav-chats/ConversationLabelBadge.tsx
@@ -15,6 +15,7 @@
 
 import type { ConversationLabel } from '@/lib/types';
 
+/** Derive badge background/text colors from the label's color, falling back to theme defaults. */
 function resolveBadgeColor(label: ConversationLabel): { backgroundColor: string; color: string } {
   if (label.color) {
     return {

--- a/frontend/features/nav-chats/ConversationSidebarItem.tsx
+++ b/frontend/features/nav-chats/ConversationSidebarItem.tsx
@@ -20,6 +20,20 @@ interface ConversationSidebarItemProps {
   onRename: (conversationId: string) => void;
   /** Called to open the delete confirmation for this conversation. */
   onDelete: (conversationId: string) => void;
+  /** Icon shown before the title (e.g. processing spinner, unread dot). */
+  icon?: ReactNode;
+  /** Label badges shown after the title. */
+  badges?: ReactNode;
+  /** Content shown after the title (e.g. search match count badge). */
+  titleTrailing?: ReactNode;
+  /** True when this item is part of an active multi-select. */
+  isInMultiSelect?: boolean;
+  /** Called when the row is clicked. */
+  onClick?: () => void;
+  /** Called on mouse down on the row. */
+  onMouseDown?: (e: React.MouseEvent) => void;
+  /** Extra button props for the row's interactive element. */
+  buttonProps?: Record<string, unknown>;
 }
 
 /**
@@ -37,6 +51,13 @@ export function ConversationSidebarItem({
   onNavigate,
   onRename,
   onDelete,
+  icon,
+  badges,
+  titleTrailing,
+  isInMultiSelect,
+  onClick,
+  onMouseDown,
+  buttonProps,
 }: ConversationSidebarItemProps): React.JSX.Element {
   const pathname = usePathname();
   const href = `/c/${id}`;
@@ -56,10 +77,17 @@ export function ConversationSidebarItem({
       age={age}
       href={href}
       absoluteHref={absoluteHref}
-      onClick={() => onNavigate(href)}
+      icon={icon}
+      badges={badges}
+      titleTrailing={titleTrailing}
+      isInMultiSelect={isInMultiSelect}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+      onClickMenuItem={() => onNavigate(href)}
       onNavigate={onNavigate}
       onRename={() => onRename(id)}
       onDelete={() => onDelete(id)}
+      buttonProps={buttonProps}
     />
   );
 }

--- a/frontend/features/nav-chats/ConversationSidebarItemView.tsx
+++ b/frontend/features/nav-chats/ConversationSidebarItemView.tsx
@@ -34,13 +34,27 @@ export interface ConversationSidebarItemViewProps {
   /** Absolute URL for clipboard copy. */
   absoluteHref: string;
   /** Called when the row is clicked. */
-  onClick: () => void;
+  onClick?: () => void;
   /** Called to navigate in a menu item. */
   onNavigate: (href: string) => void;
   /** Opens the rename flow for this conversation. */
   onRename: () => void;
   /** Opens the delete confirmation for this conversation. */
   onDelete: () => void;
+  /** Icon shown before the title (e.g. processing spinner, unread dot). */
+  icon?: ReactNode;
+  /** Label badges shown after the title. */
+  badges?: ReactNode;
+  /** Content shown after the title (e.g. search match count badge). */
+  titleTrailing?: ReactNode;
+  /** True when this item is part of an active multi-select. */
+  isInMultiSelect?: boolean;
+  /** Called on mouse down on the row. */
+  onMouseDown?: (e: React.MouseEvent) => void;
+  /** Called when a menu item triggers navigation (separate from onClick). */
+  onClickMenuItem?: () => void;
+  /** Extra button props for the row's interactive element. */
+  buttonProps?: Record<string, unknown>;
 }
 
 /** Placeholder status icon for a conversation row (empty circle). */
@@ -229,30 +243,44 @@ export function ConversationSidebarItemView({
   onNavigate,
   onRename,
   onDelete,
+  icon,
+  badges,
+  titleTrailing,
+  isInMultiSelect,
+  onMouseDown,
+  onClickMenuItem,
+  buttonProps,
 }: ConversationSidebarItemViewProps): React.JSX.Element {
   return (
     <SidebarMenuItem>
       <EntityRow
-        icon={<ConversationStatusIcon />}
+        icon={icon ?? <ConversationStatusIcon />}
         showSeparator={showSeparator}
         isSelected={isSelected}
+        isInMultiSelect={isInMultiSelect}
         onClick={onClick}
+        onMouseDown={onMouseDown}
         title={title}
         titleClassName="text-[13px]"
         titleTrailing={
-          age ? (
-            <span className="text-[11px] text-foreground/40 whitespace-nowrap">{age}</span>
-          ) : undefined
+          <div className="flex items-center gap-1">
+            {titleTrailing}
+            {badges}
+            {age ? (
+              <span className="text-[11px] text-foreground/40 whitespace-nowrap">{age}</span>
+            ) : undefined}
+          </div>
         }
         menuContent={
           <ConversationMenuContent
             href={href}
             absoluteHref={absoluteHref}
-            onNavigate={onNavigate}
+            onNavigate={onClickMenuItem ?? onNavigate}
             onRename={onRename}
             onDelete={onDelete}
           />
         }
+        buttonProps={buttonProps}
       />
     </SidebarMenuItem>
   );

--- a/frontend/features/nav-chats/NavChats.tsx
+++ b/frontend/features/nav-chats/NavChats.tsx
@@ -1,16 +1,29 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useGetConversations from '@/hooks/get-conversations';
-import {
-  buildConversationGroups,
-  countGroupItems,
-  filterConversationGroups,
-} from '@/lib/conversation-groups';
+import type { ConversationGroup } from '@/lib/conversation-groups';
+import { buildConversationGroups, countGroupItems } from '@/lib/conversation-groups';
+import type { Conversation } from '@/lib/types';
 import { ConversationDeleteDialog } from './ConversationDeleteDialog';
 import { ConversationRenameDialog } from './ConversationRenameDialog';
+import { useChatActivity } from './chat-activity-context';
+import type { MultiSelectState } from './conversation-selection';
+import {
+  clearMultiSelect,
+  createInitialSelectionState,
+  isMultiSelectActive,
+  rangeSelect,
+  singleSelect,
+  toggleSelect,
+} from './conversation-selection';
 import { NavChatsView } from './NavChatsView';
+import { useFocusZone, useSidebarFocusContext } from './sidebar-focus';
 import { useConversationActions } from './UseConversationActions';
+import type { ContentSearchResult } from './use-conversation-search';
+import { rankConversationsForSearch, useConversationSearch } from './use-conversation-search';
 
 /** localStorage key used to persist which date groups the user has collapsed. */
 const COLLAPSED_GROUPS_STORAGE_KEY = 'nav-chats-collapsed-groups';
@@ -39,29 +52,21 @@ function loadCollapsedGroups(): Set<string> {
   }
 }
 
+/** Extract the conversation UUID from a `/c/:id` pathname, or null if not on a conversation route. */
+function extractConversationIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/c\/([^/]+)/);
+  return match?.[1] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Extracted hooks — keep NavChats itself under the 120-line Biome limit.
+// ---------------------------------------------------------------------------
+
 /**
- * Container for the sidebar conversation list.
- *
- * Owns data fetching (conversations), search state, group computation,
- * collapsed-group persistence, navigation, and conversation rename/delete operations.
- * Delegates all rendering to `NavChatsView`.
+ * Manages collapsed group state with localStorage persistence.
+ * Returns the current collapsed set and a toggle callback.
  */
-export function NavChats(): React.JSX.Element {
-  const { data: conversations, isLoading } = useGetConversations();
-
-  // --- search ---
-  const [searchQuery, setSearchQuery] = useState('');
-  const isSearchActive = searchQuery.trim().length >= 2;
-
-  // --- grouping & filtering ---
-  const groups = useMemo(() => buildConversationGroups(conversations ?? []), [conversations]);
-  const filteredGroups = useMemo(
-    () => filterConversationGroups(groups, searchQuery),
-    [groups, searchQuery]
-  );
-  const resultCount = useMemo(() => countGroupItems(filteredGroups), [filteredGroups]);
-
-  // --- collapsed state (persisted in localStorage) ---
+function useCollapsedGroups() {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(loadCollapsedGroups);
 
   useEffect(() => {
@@ -79,7 +84,7 @@ export function NavChats(): React.JSX.Element {
     }
   }, [collapsedGroups]);
 
-  const toggleGroupCollapse = (groupKey: string): void => {
+  const toggleGroupCollapse = useCallback((groupKey: string): void => {
     setCollapsedGroups((currentGroups) => {
       const nextGroups = new Set(currentGroups);
       if (nextGroups.has(groupKey)) {
@@ -89,9 +94,485 @@ export function NavChats(): React.JSX.Element {
       }
       return nextGroups;
     });
-  };
+  }, []);
 
-  // --- conversation actions ---
+  return { collapsedGroups, toggleGroupCollapse };
+}
+
+/**
+ * Derives grouped and filtered conversation lists from raw conversations.
+ *
+ * When a search is active the conversations are flattened into a single
+ * "Matches" group sorted by relevance. Otherwise date-based grouping is used.
+ * Also computes the flat list of visible conversation IDs (respecting collapsed groups).
+ */
+function useConversationGrouping(
+  conversationsWithActivity: Conversation[],
+  isSearchActive: boolean,
+  searchQuery: string,
+  contentSearchResults: Map<string, ContentSearchResult>,
+  collapsedGroups: Set<string>
+) {
+  const baseGroups = useMemo(
+    () => buildConversationGroups(conversationsWithActivity ?? []),
+    [conversationsWithActivity]
+  );
+
+  // When searching, flatten results into a single "Matches" group sorted by relevance.
+  // Otherwise use the default date-based grouping.
+  const displayedGroups: ConversationGroup[] = useMemo(() => {
+    if (!isSearchActive) {
+      return baseGroups;
+    }
+
+    const matches = rankConversationsForSearch(
+      conversationsWithActivity.filter((conversation) => contentSearchResults.has(conversation.id)),
+      searchQuery,
+      contentSearchResults
+    );
+
+    return [
+      {
+        key: 'search-results',
+        label: 'Matches',
+        items: matches,
+      },
+    ];
+  }, [baseGroups, contentSearchResults, conversationsWithActivity, isSearchActive, searchQuery]);
+
+  // Flat list of conversation IDs currently visible in the DOM (respects collapsed groups).
+  // Used for keyboard navigation index calculations and range-select boundaries.
+  const visibleConversationIds = useMemo(
+    () =>
+      displayedGroups.flatMap((group) => {
+        const isCollapsible = !isSearchActive && displayedGroups.length > 1;
+        if (isCollapsible && collapsedGroups.has(group.key)) {
+          return [];
+        }
+
+        return group.items.map((conversation) => conversation.id);
+      }),
+    [collapsedGroups, displayedGroups, isSearchActive]
+  );
+
+  return { displayedGroups, visibleConversationIds };
+}
+
+/**
+ * Syncs selection state when the route changes (e.g. user clicks a link or
+ * navigates via browser back/forward). Skips when multi-select is active so
+ * route changes from clicking a selected item don't collapse the selection.
+ */
+function useRouteSelectionSync(
+  routeConversationId: string | null,
+  visibleConversationIds: string[],
+  selectionState: MultiSelectState,
+  setSelectionState: React.Dispatch<React.SetStateAction<MultiSelectState>>
+) {
+  useEffect(() => {
+    if (!routeConversationId) {
+      return;
+    }
+
+    const routeIndex = visibleConversationIds.indexOf(routeConversationId);
+    if (routeIndex >= 0 && !isMultiSelectActive(selectionState)) {
+      setSelectionState((current) =>
+        current.selected === routeConversationId && current.selectedIds.size === 1
+          ? current
+          : singleSelect(routeConversationId, routeIndex)
+      );
+    }
+  }, [routeConversationId, selectionState, visibleConversationIds, setSelectionState]);
+}
+
+/**
+ * Manages the focus-zone registration and DOM focus synchronisation for the
+ * conversation navigator. Returns the zone ref, focused ID, and element
+ * registration callback.
+ */
+function useFocusManagement(
+  selectionState: MultiSelectState,
+  routeConversationId: string | null,
+  visibleConversationIds: string[]
+) {
+  /** Maps conversation IDs to their DOM elements for programmatic focus management. */
+  const conversationElementRefs = useRef(new Map<string, HTMLDivElement>());
+
+  // Resolve which conversation should appear focused: explicit selection > route > first visible.
+  const focusedConversationId =
+    selectionState.selected ?? routeConversationId ?? visibleConversationIds[0] ?? null;
+
+  const { zoneRef, shouldMoveDOMFocus } = useFocusZone({
+    zoneId: 'navigator',
+    focusFirst: () => {
+      const focusTargetId = focusedConversationId ?? visibleConversationIds[0];
+      if (focusTargetId) {
+        conversationElementRefs.current.get(focusTargetId)?.focus();
+      }
+    },
+  });
+
+  // Move DOM focus to the focused conversation when the focus-zone system
+  // signals that a keyboard-initiated focus change occurred.
+  useEffect(() => {
+    if (!shouldMoveDOMFocus) {
+      return;
+    }
+
+    const targetId = focusedConversationId ?? visibleConversationIds[0];
+    if (targetId) {
+      conversationElementRefs.current.get(targetId)?.focus();
+    }
+  }, [focusedConversationId, shouldMoveDOMFocus, visibleConversationIds]);
+
+  /** Move DOM focus to the conversation at a given index in the visible list. */
+  const focusConversationAtIndex = useCallback(
+    (index: number) => {
+      const clampedIndex = Math.max(0, Math.min(index, visibleConversationIds.length - 1));
+      const conversationId = visibleConversationIds[clampedIndex];
+      if (!conversationId) {
+        return;
+      }
+
+      conversationElementRefs.current.get(conversationId)?.focus();
+    },
+    [visibleConversationIds]
+  );
+
+  /** Ref callback to register/unregister a conversation row's DOM element for focus management. */
+  const registerConversationElement = useCallback(
+    (conversationId: string, element: HTMLDivElement | null) => {
+      if (element) {
+        conversationElementRefs.current.set(conversationId, element);
+        return;
+      }
+
+      conversationElementRefs.current.delete(conversationId);
+    },
+    []
+  );
+
+  return {
+    zoneRef,
+    focusedConversationId,
+    focusConversationAtIndex,
+    registerConversationElement,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard handler helpers — extracted to reduce cognitive complexity of
+// handleConversationKeyDown below the Biome threshold (max 20).
+// ---------------------------------------------------------------------------
+
+/** Handle ArrowLeft: move focus to the sidebar zone. */
+function handleArrowLeft(
+  event: ReactKeyboardEvent,
+  focusZone: ReturnType<typeof useSidebarFocusContext>['focusZone']
+) {
+  event.preventDefault();
+  focusZone('sidebar', { intent: 'keyboard', moveFocus: true });
+}
+
+/** Handle ArrowRight: move focus to the chat zone. */
+function handleArrowRight(
+  event: ReactKeyboardEvent,
+  focusZone: ReturnType<typeof useSidebarFocusContext>['focusZone']
+) {
+  event.preventDefault();
+  focusZone('chat', { intent: 'keyboard', moveFocus: true });
+}
+
+/** Handle Cmd/Ctrl+A: select all visible conversations. */
+function handleSelectAll(
+  event: ReactKeyboardEvent,
+  visibleConversationIds: string[],
+  setSelectionState: React.Dispatch<React.SetStateAction<MultiSelectState>>
+) {
+  event.preventDefault();
+  const firstConversationId = visibleConversationIds[0];
+  const lastConversationId = visibleConversationIds[visibleConversationIds.length - 1];
+  if (firstConversationId && lastConversationId) {
+    setSelectionState({
+      selected: lastConversationId,
+      selectedIds: new Set(visibleConversationIds),
+      anchorId: firstConversationId,
+      anchorIndex: 0,
+    });
+  }
+}
+
+/** Handle Escape: clear multi-select when active. Returns true if handled. */
+function handleEscape(
+  event: ReactKeyboardEvent,
+  selectionState: MultiSelectState,
+  setSelectionState: React.Dispatch<React.SetStateAction<MultiSelectState>>
+): boolean {
+  if (!isMultiSelectActive(selectionState)) {
+    return false;
+  }
+  event.preventDefault();
+  setSelectionState((current) => clearMultiSelect(current));
+  return true;
+}
+
+/** Handle Enter/Space: navigate to the conversation. */
+function handleActivate(
+  event: ReactKeyboardEvent,
+  conversation: Conversation,
+  index: number,
+  onClick: (id: string, idx: number, href: string) => void
+) {
+  event.preventDefault();
+  onClick(conversation.id, index, `/c/${conversation.id}`);
+}
+
+/**
+ * Resolves a movement key to the target index, or null if the key isn't a movement key.
+ * Covers ArrowUp, ArrowDown, Home, and End.
+ */
+function resolveMovementIndex(key: string, currentIndex: number, maxIndex: number): number | null {
+  switch (key) {
+    case 'ArrowUp':
+      return currentIndex - 1;
+    case 'ArrowDown':
+      return currentIndex + 1;
+    case 'Home':
+      return 0;
+    case 'End':
+      return maxIndex;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Encapsulates selection state and all conversation interaction handlers
+ * (click, mouseDown, keyDown). Keeps NavChats under the line-count limit.
+ */
+function useConversationInteraction(
+  focusZone: ReturnType<typeof useSidebarFocusContext>['focusZone'],
+  navigateTo: (href: string) => void,
+  visibleConversationIds: string[],
+  focusConversationAtIndex: (index: number) => void,
+  selectionState: MultiSelectState,
+  setSelectionState: React.Dispatch<React.SetStateAction<MultiSelectState>>
+) {
+  /** Select exactly one conversation and update the selection anchor. */
+  const updateSingleSelection = useCallback(
+    (conversationId: string, index: number) => {
+      setSelectionState(singleSelect(conversationId, index));
+    },
+    [setSelectionState]
+  );
+
+  /** Handle a normal click on a conversation row: select it, navigate to it. */
+  const handleConversationClick = useCallback(
+    (conversationId: string, index: number, href: string) => {
+      focusZone('navigator', { intent: 'click', moveFocus: false });
+      updateSingleSelection(conversationId, index);
+      navigateTo(href);
+    },
+    [focusZone, navigateTo, updateSingleSelection]
+  );
+
+  /**
+   * Handle mouseDown with modifier detection for multi-select.
+   * - Right-click (button 2): add to selection if multi-select is active.
+   * - Cmd/Ctrl+Click: toggle individual item.
+   * - Shift+Click: range-select from anchor to target.
+   * - Plain click: single-select (handled on click, not mouseDown).
+   */
+  const handleConversationMouseDown = useCallback(
+    (event: ReactMouseEvent, conversationId: string, index: number) => {
+      focusZone('navigator', { intent: 'click', moveFocus: false });
+
+      if (event.button === 2) {
+        setSelectionState((current) => {
+          if (isMultiSelectActive(current) && !current.selectedIds.has(conversationId)) {
+            return toggleSelect(current, conversationId, index);
+          }
+          return current;
+        });
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey) {
+        event.preventDefault();
+        setSelectionState((current) => toggleSelect(current, conversationId, index));
+        return;
+      }
+
+      if (event.shiftKey) {
+        event.preventDefault();
+        setSelectionState((current) => rangeSelect(current, index, visibleConversationIds));
+        return;
+      }
+
+      updateSingleSelection(conversationId, index);
+    },
+    [focusZone, setSelectionState, updateSingleSelection, visibleConversationIds]
+  );
+
+  /**
+   * Keyboard navigation handler for the conversation list.
+   *
+   * Delegates to extracted helper functions per key to keep cognitive complexity
+   * under the Biome threshold. Arrow Up/Down move focus; Shift+Arrow extends
+   * range selection; Arrow Left/Right jump focus zones; Cmd+A selects all;
+   * Escape clears multi-select; Enter/Space navigates.
+   */
+  const handleConversationKeyDown = useCallback(
+    (event: ReactKeyboardEvent, conversation: Conversation, index: number) => {
+      const { key } = event;
+
+      if (key === 'ArrowLeft') {
+        return handleArrowLeft(event, focusZone);
+      }
+      if (key === 'ArrowRight') {
+        return handleArrowRight(event, focusZone);
+      }
+      if ((event.metaKey || event.ctrlKey) && key.toLowerCase() === 'a') {
+        return handleSelectAll(event, visibleConversationIds, setSelectionState);
+      }
+      if (key === 'Escape') {
+        handleEscape(event, selectionState, setSelectionState);
+        return;
+      }
+      if (key === 'Enter' || key === ' ') {
+        return handleActivate(event, conversation, index, handleConversationClick);
+      }
+
+      const moveToIndex = resolveMovementIndex(key, index, visibleConversationIds.length - 1);
+      if (moveToIndex == null) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextIndex = Math.max(0, Math.min(moveToIndex, visibleConversationIds.length - 1));
+      const nextConversationId = visibleConversationIds[nextIndex];
+      if (!nextConversationId) {
+        return;
+      }
+
+      if (event.shiftKey) {
+        setSelectionState((current) => rangeSelect(current, nextIndex, visibleConversationIds));
+      } else {
+        updateSingleSelection(nextConversationId, nextIndex);
+      }
+
+      focusConversationAtIndex(nextIndex);
+    },
+    [
+      focusConversationAtIndex,
+      focusZone,
+      handleConversationClick,
+      selectionState,
+      setSelectionState,
+      updateSingleSelection,
+      visibleConversationIds,
+    ]
+  );
+
+  return {
+    handleConversationClick,
+    handleConversationMouseDown,
+    handleConversationKeyDown,
+  };
+}
+
+/** Renders the rename + delete confirmation dialogs for conversation management. */
+function ConversationDialogs({
+  renameDialogConversationId,
+  deleteDialogConversationId,
+  draftTitle,
+  isRenamePending,
+  isDeletePending,
+  setDraftTitle,
+  handleRenameDialogOpenChange,
+  handleDeleteDialogOpenChange,
+  handleRenameSubmit,
+  handleDeleteConfirm,
+}: {
+  renameDialogConversationId: string | null;
+  deleteDialogConversationId: string | null;
+  draftTitle: string;
+  isRenamePending: boolean;
+  isDeletePending: boolean;
+  setDraftTitle: (title: string) => void;
+  handleRenameDialogOpenChange: (open: boolean) => void;
+  handleDeleteDialogOpenChange: (open: boolean) => void;
+  handleRenameSubmit: () => Promise<void>;
+  handleDeleteConfirm: () => Promise<void>;
+}) {
+  return (
+    <>
+      <ConversationRenameDialog
+        isOpen={!!renameDialogConversationId}
+        isPending={isRenamePending}
+        draftTitle={draftTitle}
+        onDraftTitleChange={setDraftTitle}
+        onOpenChange={handleRenameDialogOpenChange}
+        onSubmit={() => void handleRenameSubmit()}
+      />
+      <ConversationDeleteDialog
+        isOpen={!!deleteDialogConversationId}
+        isPending={isDeletePending}
+        onOpenChange={handleDeleteDialogOpenChange}
+        onConfirm={() => void handleDeleteConfirm()}
+      />
+    </>
+  );
+}
+
+/**
+ * Container for the sidebar conversation list.
+ *
+ * Owns data fetching (conversations), search state, group computation,
+ * collapsed-group persistence, navigation, conversation rename/delete operations,
+ * multi-select functionality, and keyboard focus management.
+ * Delegates all rendering to `NavChatsView`.
+ */
+export function NavChats(): React.JSX.Element {
+  const { data: conversations, isLoading } = useGetConversations();
+  const pathname = usePathname();
+  const routeConversationId = extractConversationIdFromPath(pathname);
+  const {
+    conversationId: activeConversationId,
+    chatHistory: activeChatHistory,
+    isLoading: isChatLoading,
+  } = useChatActivity();
+  const { focusZone } = useSidebarFocusContext();
+  const [searchQuery, setSearchQuery] = useState('');
+  const { collapsedGroups, toggleGroupCollapse } = useCollapsedGroups();
+
+  // Merge real-time chat loading state into the conversation list so the sidebar
+  // can show a spinner on the active conversation row without waiting for a refetch.
+  const conversationsWithActivity = useMemo(
+    () =>
+      (conversations ?? []).map((conversation) =>
+        conversation.id === activeConversationId
+          ? { ...conversation, is_processing: conversation.is_processing || isChatLoading }
+          : conversation
+      ),
+    [activeConversationId, conversations, isChatLoading]
+  );
+
+  const { contentSearchResults, activeChatMatchInfo, isSearchActive } = useConversationSearch({
+    conversations: conversationsWithActivity,
+    searchQuery,
+    activeConversationId,
+    activeChatHistory,
+  });
+
+  const { displayedGroups, visibleConversationIds } = useConversationGrouping(
+    conversationsWithActivity,
+    isSearchActive,
+    searchQuery,
+    contentSearchResults,
+    collapsedGroups
+  );
+
   const {
     renameDialogConversationId,
     deleteDialogConversationId,
@@ -108,37 +589,70 @@ export function NavChats(): React.JSX.Element {
     handleDeleteDialogOpenChange,
   } = useConversationActions(conversations);
 
+  const [selectionState, setSelectionState] = useState(createInitialSelectionState);
+
+  // --- focus management ---
+  const { zoneRef, focusedConversationId, focusConversationAtIndex, registerConversationElement } =
+    useFocusManagement(selectionState, routeConversationId, visibleConversationIds);
+
+  // --- interaction handlers (click, mouseDown, keyDown) ---
+  const { handleConversationClick, handleConversationMouseDown, handleConversationKeyDown } =
+    useConversationInteraction(
+      focusZone,
+      navigateTo,
+      visibleConversationIds,
+      focusConversationAtIndex,
+      selectionState,
+      setSelectionState
+    );
+
+  // --- route sync ---
+  useRouteSelectionSync(
+    routeConversationId,
+    visibleConversationIds,
+    selectionState,
+    setSelectionState
+  );
+
   return (
     <>
       <NavChatsView
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         onSearchClose={() => setSearchQuery('')}
-        resultCount={resultCount}
+        resultCount={countGroupItems(displayedGroups)}
         isLoading={isLoading}
-        isEmpty={!conversations?.length}
+        isEmpty={!conversationsWithActivity.length}
         isSearchActive={isSearchActive}
-        filteredGroups={filteredGroups}
+        filteredGroups={displayedGroups}
         collapsedGroups={collapsedGroups}
         onToggleGroup={toggleGroupCollapse}
         onNewSession={() => navigateTo('/')}
         onNavigate={navigateTo}
         onRename={handleRenameClick}
         onDelete={handleDeleteClick}
+        navigatorRef={zoneRef}
+        contentSearchResults={contentSearchResults}
+        activeChatMatchInfo={activeChatMatchInfo}
+        multiSelectedIds={selectionState.selectedIds}
+        focusedConversationId={focusedConversationId}
+        onConversationClick={handleConversationClick}
+        onConversationMouseDown={handleConversationMouseDown}
+        onConversationKeyDown={handleConversationKeyDown}
+        registerConversationElement={registerConversationElement}
+        onNavigatorMouseDown={() => focusZone('navigator', { intent: 'click', moveFocus: false })}
       />
-      <ConversationRenameDialog
-        isOpen={!!renameDialogConversationId}
-        isPending={isRenamePending}
+      <ConversationDialogs
+        renameDialogConversationId={renameDialogConversationId}
+        deleteDialogConversationId={deleteDialogConversationId}
         draftTitle={draftTitle}
-        onDraftTitleChange={setDraftTitle}
-        onOpenChange={handleRenameDialogOpenChange}
-        onSubmit={() => void handleRenameSubmit()}
-      />
-      <ConversationDeleteDialog
-        isOpen={!!deleteDialogConversationId}
-        isPending={isDeletePending}
-        onOpenChange={handleDeleteDialogOpenChange}
-        onConfirm={() => void handleDeleteConfirm()}
+        isRenamePending={isRenamePending}
+        isDeletePending={isDeletePending}
+        setDraftTitle={setDraftTitle}
+        handleRenameDialogOpenChange={handleRenameDialogOpenChange}
+        handleDeleteDialogOpenChange={handleDeleteDialogOpenChange}
+        handleRenameSubmit={handleRenameSubmit}
+        handleDeleteConfirm={handleDeleteConfirm}
       />
     </>
   );

--- a/frontend/features/nav-chats/NavChatsView.tsx
+++ b/frontend/features/nav-chats/NavChatsView.tsx
@@ -1,13 +1,22 @@
 import { Calligraph } from 'calligraph';
-import { Inbox, Search } from 'lucide-react';
+import { Circle, Inbox, LoaderCircle, Search, ShieldAlert } from 'lucide-react';
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  RefObject,
+} from 'react';
 import { Fragment } from 'react';
 import type { ConversationGroup } from '@/lib/conversation-groups';
 import { highlightMatch } from '@/lib/highlight-match';
+import type { Conversation } from '@/lib/types';
+import { cn } from '@/lib/utils';
 import { CollapsibleGroupHeader } from './CollapsibleGroupHeader';
+import { ConversationLabelBadge } from './ConversationLabelBadge';
 import { ConversationSearchHeader } from './ConversationSearchHeader';
 import { ConversationSidebarItem } from './ConversationSidebarItem';
 import { ConversationsEmptyState } from './ConversationsEmptyState';
 import { SectionHeader } from './SectionHeader';
+import type { ContentSearchResult } from './use-conversation-search';
 
 export interface NavChatsViewProps {
   /** Current search input value. */
@@ -38,6 +47,355 @@ export interface NavChatsViewProps {
   onRename: (conversationId: string) => void;
   /** Opens the delete confirmation for a conversation. */
   onDelete: (conversationId: string) => void;
+  /** Ref attached to the navigator (listbox) root for focus-zone registration. */
+  navigatorRef: RefObject<HTMLDivElement | null>;
+  /** Per-conversation search results from content matching. */
+  contentSearchResults: Map<string, ContentSearchResult>;
+  /** Match info for the currently open chat (searched against loaded messages). */
+  activeChatMatchInfo?: { sessionId: string; count: number } | null;
+  /** Set of conversation IDs in the current multi-selection. */
+  multiSelectedIds: Set<string>;
+  /** The conversation ID that should appear keyboard-focused. */
+  focusedConversationId: string | null;
+  /** Called when a conversation row is clicked (select + navigate). */
+  onConversationClick: (conversationId: string, index: number, href: string) => void;
+  /** Called on mouseDown for modifier-key multi-select handling. */
+  onConversationMouseDown: (event: ReactMouseEvent, conversationId: string, index: number) => void;
+  /** Keyboard handler for arrow navigation, range-select, and zone switching. */
+  onConversationKeyDown: (
+    event: ReactKeyboardEvent,
+    conversation: Conversation,
+    index: number
+  ) => void;
+  /** Ref callback to register conversation row elements for programmatic focus. */
+  registerConversationElement: (conversationId: string, element: HTMLDivElement | null) => void;
+  /** Claims navigator focus zone on mouseDown (before click fires). */
+  onNavigatorMouseDown: () => void;
+}
+
+/**
+ * Renders status indicators for a conversation row: a base circle icon plus
+ * contextual badges for loading, unread messages, pending plans, and queued prompts.
+ * Secondary indicators animate in/out via width + opacity transitions.
+ */
+function ConversationIndicators({
+  conversation,
+  isProcessing,
+}: {
+  conversation: Conversation;
+  isProcessing: boolean;
+}) {
+  const hasUnreadMeta = Boolean(conversation.has_unread_meta);
+  const hasPlan = conversation.last_message_role === 'plan';
+  const hasPendingPrompt = (conversation.pending_prompt_count ?? 0) > 0;
+
+  return (
+    <>
+      <div className="flex items-center justify-center text-muted-foreground/75">
+        <Circle className="h-3.5 w-3.5" strokeWidth={1.5} />
+      </div>
+      <div
+        className={cn(
+          'flex items-center justify-center overflow-hidden gap-1 transition-all duration-200 ease-out',
+          isProcessing || hasUnreadMeta || hasPlan || hasPendingPrompt
+            ? 'opacity-100 ml-0'
+            : '!w-0 opacity-0 -ml-[10px]'
+        )}
+      >
+        {isProcessing ? <LoaderCircle className="h-3.5 w-3.5 animate-spin text-[10px]" /> : null}
+        {hasUnreadMeta ? (
+          <svg
+            className="text-accent h-3.5 w-3.5"
+            viewBox="0 0 25 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <g transform="translate(1.748, 0.7832)">
+              <path
+                fillRule="nonzero"
+                d="M10.9952443,22 C8.89638276,22 7.01311428,21.5426195 5.34543882,20.6278586 C4.85718403,21.0547471 4.29283758,21.3901594 3.65239948,21.6340956 C3.01196138,21.8780319 2.3651823,22 1.71206226,22 C1.5028102,22 1.34111543,21.9466389 1.22697795,21.8399168 C1.11284047,21.7331947 1.05735697,21.6016979 1.06052745,21.4454262 C1.06369794,21.2891545 1.13820435,21.1347886 1.28404669,20.9823285 C1.5693904,20.6621622 1.77547197,20.3400901 1.9022914,20.0161123 C2.02911082,19.6921344 2.09252054,19.3090783 2.09252054,18.8669439 C2.09252054,18.4553015 2.02276985,18.0646223 1.88326848,17.6949064 C1.74376711,17.3251906 1.5693904,16.9383229 1.36013835,16.5343035 C1.15088629,16.1302841 0.941634241,15.6748094 0.732382188,15.1678794 C0.523130134,14.6609494 0.348753423,14.0682606 0.209252054,13.3898129 C0.0697506845,12.7113652 0,11.9147609 0,11 C0,9.40679141 0.271076524,7.93936244 0.813229572,6.5977131 C1.35538262,5.25606376 2.11946966,4.09164934 3.1054907,3.10446985 C4.09151175,2.11729037 5.25507998,1.35308385 6.59619542,0.811850312 C7.93731085,0.270616771 9.40366047,0 10.9952443,0 C12.5868281,0 14.0531777,0.270616771 15.3942931,0.811850312 C16.7354086,1.35308385 17.900562,2.11729037 18.8897536,3.10446985 C19.8789451,4.09164934 20.6446174,5.25606376 21.1867704,6.5977131 C21.7289235,7.93936244 22,9.40679141 22,11 C22,12.5932086 21.7289235,14.0606376 21.1867704,15.4022869 C20.6446174,16.7439362 19.8805303,17.9083507 18.8945093,18.8955301 C17.9084883,19.8827096 16.74492,20.6469161 15.4038046,21.1881497 C14.0626891,21.7293832 12.593169,22 10.9952443,22 Z"
+              />
+            </g>
+          </svg>
+        ) : null}
+        {hasPlan ? (
+          <svg
+            className="text-success h-3.5 w-3.5"
+            viewBox="0 0 25 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="nonzero"
+              d="M13.7207031,22.6523438 C13.264974,22.6523438 12.9361979,22.4895833 12.734375,22.1640625 C12.5325521,21.8385417 12.360026,21.4316406 12.2167969,20.9433594 L10.6640625,15.7871094 C10.5729167,15.4615885 10.5403646,15.1995443 10.5664062,15.0009766 C10.5924479,14.8024089 10.6998698,14.6022135 10.8886719,14.4003906 L20.859375,3.6484375 C20.9179688,3.58984375 20.9472656,3.52473958 20.9472656,3.453125 C20.9472656,3.38151042 20.921224,3.32291667 20.8691406,3.27734375 C20.8170573,3.23177083 20.7568359,3.20735677 20.6884766,3.20410156 C20.6201172,3.20084635 20.5566406,3.22851562 20.4980469,3.28710938 L9.78515625,13.296875 C9.5703125,13.4921875 9.36197917,13.601237 9.16015625,13.6240234 C8.95833333,13.6468099 8.70117188,13.609375 8.38867188,13.5117188 L3.11523438,11.9101562 C2.64648438,11.7669271 2.25911458,11.5960286 1.953125,11.3974609 C1.64713542,11.1988932 1.49414062,10.875 1.49414062,10.4257812 C1.49414062,10.0742188 1.63411458,9.77148438 1.9140625,9.51757812 C2.19401042,9.26367188 2.5390625,9.05859375 2.94921875,8.90234375 L19.7460938,2.46679688 C19.9739583,2.38216146 20.1871745,2.31542969 20.3857422,2.26660156 C20.5843099,2.21777344 20.764974,2.19335938 20.9277344,2.19335938 C21.2467448,2.19335938 21.4973958,2.28450521 21.6796875,2.46679688 C21.8619792,2.64908854 21.953125,2.89973958 21.953125,3.21875 C21.953125,3.38802083 21.9287109,3.5703125 21.8798828,3.765625 C21.8310547,3.9609375 21.7643229,4.17252604 21.6796875,4.40039062 L15.2832031,21.109375 C15.1009115,21.578125 14.8828125,21.952474 14.6289062,22.2324219 C14.375,22.5123698 14.0722656,22.6523438 13.7207031,22.6523438 Z"
+            />
+          </svg>
+        ) : null}
+        {hasPendingPrompt ? <ShieldAlert className="h-3.5 w-3.5 text-sky-500" /> : null}
+      </div>
+    </>
+  );
+}
+
+/** Renders a single conversation row within a group, computing derived state from search results. */
+function ConversationRow({
+  conversation,
+  index,
+  visibleIndex,
+  isSearchActive,
+  searchQuery,
+  multiSelectedIds,
+  contentSearchResults,
+  activeChatMatchInfo,
+  onConversationClick,
+  onConversationMouseDown,
+  onConversationKeyDown,
+  registerConversationElement,
+  onNavigate,
+  onRename,
+  onDelete,
+}: {
+  conversation: Conversation;
+  index: number;
+  visibleIndex: number;
+  isSearchActive: boolean;
+  searchQuery: string;
+  multiSelectedIds: Set<string>;
+  contentSearchResults: Map<string, ContentSearchResult>;
+  activeChatMatchInfo?: { sessionId: string; count: number } | null;
+  onConversationClick: (conversationId: string, index: number, href: string) => void;
+  onConversationMouseDown: (event: ReactMouseEvent, conversationId: string, index: number) => void;
+  onConversationKeyDown: (
+    event: ReactKeyboardEvent,
+    conversation: Conversation,
+    index: number
+  ) => void;
+  registerConversationElement: (conversationId: string, element: HTMLDivElement | null) => void;
+  onNavigate: (href: string) => void;
+  onRename: (conversationId: string) => void;
+  onDelete: (conversationId: string) => void;
+}) {
+  const href = `/c/${conversation.id}`;
+  const isSelected = multiSelectedIds.has(conversation.id);
+  const searchCount =
+    activeChatMatchInfo?.sessionId === conversation.id
+      ? activeChatMatchInfo.count
+      : contentSearchResults.get(conversation.id)?.matchCount;
+  const labels = conversation.labels ?? [];
+  const isProcessing = Boolean(conversation.is_processing);
+
+  return (
+    <ConversationSidebarItem
+      key={conversation.id}
+      id={conversation.id}
+      title={
+        isSearchActive ? (
+          highlightMatch(conversation.title, searchQuery)
+        ) : (
+          <Calligraph>{conversation.title}</Calligraph>
+        )
+      }
+      updatedAt={conversation.updated_at}
+      icon={<ConversationIndicators conversation={conversation} isProcessing={isProcessing} />}
+      badges={
+        labels.length > 0
+          ? labels.map((label, labelIndex) => (
+              <ConversationLabelBadge key={`${conversation.id}-${labelIndex}`} label={label} />
+            ))
+          : undefined
+      }
+      titleTrailing={
+        searchCount && searchCount > 0 ? (
+          <SearchCountBadge count={searchCount} isSelected={isSelected} />
+        ) : undefined
+      }
+      isInMultiSelect={multiSelectedIds.size > 1 && multiSelectedIds.has(conversation.id)}
+      showSeparator={index > 0}
+      onClick={() => onConversationClick(conversation.id, visibleIndex, href)}
+      onMouseDown={(event) => onConversationMouseDown(event, conversation.id, visibleIndex)}
+      buttonProps={{
+        ref: (element: HTMLDivElement | null) =>
+          registerConversationElement(conversation.id, element),
+        tabIndex: isSelected ? 0 : -1,
+        role: 'option',
+        'aria-selected': isSelected,
+        onKeyDown: (event: ReactKeyboardEvent) =>
+          onConversationKeyDown(event, conversation, visibleIndex),
+      }}
+      onNavigate={onNavigate}
+      onRename={onRename}
+      onDelete={onDelete}
+    />
+  );
+}
+
+/** Small pill showing the number of search matches found in a conversation's history. */
+function SearchCountBadge({ count, isSelected }: { count: number; isSelected: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center min-w-[24px] px-1 py-0.5 rounded-[6px] text-[10px] font-medium tabular-nums leading-tight whitespace-nowrap shadow-tinted',
+        isSelected
+          ? 'bg-yellow-300/50 border border-yellow-500 text-yellow-900'
+          : 'bg-yellow-300/10 border border-yellow-600/20 text-yellow-800'
+      )}
+      style={{
+        ['--shadow-color' as string]: isSelected ? '234, 179, 8' : '133, 77, 14',
+      }}
+      title="Matches found"
+    >
+      {count}
+    </span>
+  );
+}
+
+/**
+ * Pure presentation layer for the sidebar conversation list.
+ *
+ * Renders the search header, empty states, and grouped conversation items.
+ * All data and callbacks are received via props — no hooks.
+ */
+/**
+ * Builds the inner content of the conversation list: loading placeholder,
+ * empty states, or the grouped conversation rows. Extracted from NavChatsView
+ * to keep the main component under the Biome line-count threshold.
+ */
+function NavChatsContent({
+  isLoading,
+  isEmpty,
+  isSearchActive,
+  resultCount,
+  filteredGroups,
+  collapsedGroups,
+  navigatorRef,
+  searchQuery,
+  multiSelectedIds,
+  contentSearchResults,
+  activeChatMatchInfo,
+  onToggleGroup,
+  onNewSession,
+  onNavigate,
+  onRename,
+  onDelete,
+  onConversationClick,
+  onConversationMouseDown,
+  onConversationKeyDown,
+  registerConversationElement,
+  onNavigatorMouseDown,
+}: Pick<
+  NavChatsViewProps,
+  | 'isLoading'
+  | 'isEmpty'
+  | 'isSearchActive'
+  | 'resultCount'
+  | 'filteredGroups'
+  | 'collapsedGroups'
+  | 'navigatorRef'
+  | 'searchQuery'
+  | 'multiSelectedIds'
+  | 'contentSearchResults'
+  | 'activeChatMatchInfo'
+  | 'onToggleGroup'
+  | 'onNewSession'
+  | 'onNavigate'
+  | 'onRename'
+  | 'onDelete'
+  | 'onConversationClick'
+  | 'onConversationMouseDown'
+  | 'onConversationKeyDown'
+  | 'registerConversationElement'
+  | 'onNavigatorMouseDown'
+>): React.JSX.Element | null {
+  if (isLoading) {
+    return null;
+  }
+
+  if (isEmpty) {
+    return (
+      <ConversationsEmptyState
+        icon={<Inbox className="h-4 w-4" />}
+        title="No sessions yet"
+        description="Sessions with your agent appear here. Start one to get going."
+        buttonLabel="New Session"
+        onAction={onNewSession}
+      />
+    );
+  }
+
+  if (isSearchActive && resultCount === 0) {
+    return (
+      <ConversationsEmptyState
+        icon={<Search className="h-4 w-4" />}
+        title="No matching sessions"
+        description="Try a different title fragment. Search also digs through loaded chat history once you have at least two characters."
+      />
+    );
+  }
+
+  let flatIndex = -1;
+
+  return (
+    <div
+      ref={navigatorRef}
+      className="pt-1 outline-none"
+      role="listbox"
+      aria-label="Sessions"
+      aria-multiselectable="true"
+      onMouseDown={onNavigatorMouseDown}
+    >
+      <ul className="flex w-full min-w-0 flex-col gap-0">
+        {filteredGroups.map((group) => {
+          // Only allow collapsing when there are multiple groups and
+          // the user is not searching (search always shows all matches).
+          const isCollapsible = !isSearchActive && filteredGroups.length > 1;
+
+          // Gate on isCollapsible so a persisted key can't hide items
+          // when only one group remains.
+          const isCollapsed = isCollapsible && collapsedGroups.has(group.key);
+
+          return (
+            <Fragment key={group.key}>
+              {isCollapsible ? (
+                <CollapsibleGroupHeader
+                  label={group.label}
+                  isCollapsed={isCollapsed}
+                  itemCount={group.items.length}
+                  onToggle={() => onToggleGroup(group.key)}
+                />
+              ) : (
+                <SectionHeader label={group.label} />
+              )}
+              {isCollapsed
+                ? null
+                : group.items.map((conversation, index) => {
+                    flatIndex += 1;
+                    return (
+                      <ConversationRow
+                        key={conversation.id}
+                        conversation={conversation}
+                        index={index}
+                        visibleIndex={flatIndex}
+                        isSearchActive={isSearchActive}
+                        searchQuery={searchQuery}
+                        multiSelectedIds={multiSelectedIds}
+                        contentSearchResults={contentSearchResults}
+                        activeChatMatchInfo={activeChatMatchInfo}
+                        onConversationClick={onConversationClick}
+                        onConversationMouseDown={onConversationMouseDown}
+                        onConversationKeyDown={onConversationKeyDown}
+                        registerConversationElement={registerConversationElement}
+                        onNavigate={onNavigate}
+                        onRename={onRename}
+                        onDelete={onDelete}
+                      />
+                    );
+                  })}
+            </Fragment>
+          );
+        })}
+      </ul>
+    </div>
+  );
 }
 
 /**
@@ -61,84 +419,19 @@ export function NavChatsView({
   onNavigate,
   onRename,
   onDelete,
+  navigatorRef,
+  contentSearchResults,
+  activeChatMatchInfo,
+  multiSelectedIds,
+  // focusedConversationId is part of the public interface for consumers but
+  // not used directly by this view component — rendering delegates handle it.
+  focusedConversationId: _focusedConversationId,
+  onConversationClick,
+  onConversationMouseDown,
+  onConversationKeyDown,
+  registerConversationElement,
+  onNavigatorMouseDown,
 }: NavChatsViewProps): React.JSX.Element {
-  // --- content resolution ---
-  // Computed outside JSX to avoid hard-to-read nested ternaries.
-  let content: React.JSX.Element | null = null;
-
-  if (isLoading) {
-    content = null;
-  } else if (isEmpty) {
-    content = (
-      <ConversationsEmptyState
-        icon={<Inbox className="h-4 w-4" />}
-        title="No sessions yet"
-        description="Sessions with your agent appear here. Start one to get going."
-        buttonLabel="New Session"
-        onAction={onNewSession}
-      />
-    );
-  } else if (isSearchActive && resultCount === 0) {
-    content = (
-      <ConversationsEmptyState
-        icon={<Search className="h-4 w-4" />}
-        title="No matching sessions"
-        description="Try a different title fragment. Search lights up once you have at least two characters."
-      />
-    );
-  } else {
-    content = (
-      <div className="pt-1">
-        <ul className="flex w-full min-w-0 flex-col gap-0">
-          {filteredGroups.map((group) => {
-            // Only allow collapsing when there are multiple groups and
-            // the user is not searching (search always shows all matches).
-            const isCollapsible = !isSearchActive && filteredGroups.length > 1;
-
-            // Gate on isCollapsible so a persisted key can't hide items
-            // when only one group remains.
-            const isCollapsed = isCollapsible && collapsedGroups.has(group.key);
-
-            return (
-              <Fragment key={group.key}>
-                {isCollapsible ? (
-                  <CollapsibleGroupHeader
-                    label={group.label}
-                    isCollapsed={isCollapsed}
-                    itemCount={group.items.length}
-                    onToggle={() => onToggleGroup(group.key)}
-                  />
-                ) : (
-                  <SectionHeader label={group.label} />
-                )}
-                {isCollapsed
-                  ? null
-                  : group.items.map((conversation, index) => (
-                      <ConversationSidebarItem
-                        key={conversation.id}
-                        id={conversation.id}
-                        title={
-                          isSearchActive ? (
-                            highlightMatch(conversation.title, searchQuery)
-                          ) : (
-                            <Calligraph>{conversation.title}</Calligraph>
-                          )
-                        }
-                        updatedAt={conversation.updated_at}
-                        showSeparator={index > 0}
-                        onNavigate={onNavigate}
-                        onRename={onRename}
-                        onDelete={onDelete}
-                      />
-                    ))}
-              </Fragment>
-            );
-          })}
-        </ul>
-      </div>
-    );
-  }
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <ConversationSearchHeader
@@ -147,7 +440,29 @@ export function NavChatsView({
         onSearchClose={onSearchClose}
         resultCount={resultCount}
       />
-      {content}
+      <NavChatsContent
+        isLoading={isLoading}
+        isEmpty={isEmpty}
+        isSearchActive={isSearchActive}
+        resultCount={resultCount}
+        filteredGroups={filteredGroups}
+        collapsedGroups={collapsedGroups}
+        navigatorRef={navigatorRef}
+        searchQuery={searchQuery}
+        multiSelectedIds={multiSelectedIds}
+        contentSearchResults={contentSearchResults}
+        activeChatMatchInfo={activeChatMatchInfo}
+        onToggleGroup={onToggleGroup}
+        onNewSession={onNewSession}
+        onNavigate={onNavigate}
+        onRename={onRename}
+        onDelete={onDelete}
+        onConversationClick={onConversationClick}
+        onConversationMouseDown={onConversationMouseDown}
+        onConversationKeyDown={onConversationKeyDown}
+        registerConversationElement={registerConversationElement}
+        onNavigatorMouseDown={onNavigatorMouseDown}
+      />
     </div>
   );
 }

--- a/frontend/features/nav-chats/chat-activity-context.tsx
+++ b/frontend/features/nav-chats/chat-activity-context.tsx
@@ -13,7 +13,8 @@
  */
 'use client';
 
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import type React from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 import type { AgnoMessage } from '@/lib/types';
 
 /** Snapshot of the conversation currently open in the chat panel. */
@@ -41,7 +42,11 @@ const ChatActivityContext = createContext<ChatActivityContextValue | null>(null)
  * Provides chat activity state to the sidebar and any other component
  * that needs to know which conversation is currently open.
  */
-export function ChatActivityProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+export function ChatActivityProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
   const [state, setState] = useState<ActiveConversationState>({
     conversationId: null,
     chatHistory: [],

--- a/frontend/features/nav-chats/conversation-selection.ts
+++ b/frontend/features/nav-chats/conversation-selection.ts
@@ -67,7 +67,7 @@ export function toggleSelect(state: MultiSelectState, id: string, index: number)
 
     nextIds.delete(id);
     return {
-      selected: state.selected === id ? [...nextIds][0] ?? null : state.selected,
+      selected: state.selected === id ? ([...nextIds][0] ?? null) : state.selected,
       selectedIds: nextIds,
       anchorId: id,
       anchorIndex: index,
@@ -90,7 +90,11 @@ export function toggleSelect(state: MultiSelectState, id: string, index: number)
  * if the cached `anchorIndex` no longer matches. This prevents stale index
  * references from selecting the wrong range after the list is re-sorted.
  */
-export function rangeSelect(state: MultiSelectState, toIndex: number, items: string[]): MultiSelectState {
+export function rangeSelect(
+  state: MultiSelectState,
+  toIndex: number,
+  items: string[]
+): MultiSelectState {
   if (items.length === 0) {
     return state;
   }
@@ -99,7 +103,11 @@ export function rangeSelect(state: MultiSelectState, toIndex: number, items: str
 
   // Re-resolve the anchor by ID if the cached index is stale.
   let anchorIndex = clampedIndex;
-  if (state.anchorIndex >= 0 && state.anchorIndex < items.length && items[state.anchorIndex] === state.anchorId) {
+  if (
+    state.anchorIndex >= 0 &&
+    state.anchorIndex < items.length &&
+    items[state.anchorIndex] === state.anchorId
+  ) {
     anchorIndex = state.anchorIndex;
   } else if (state.anchorId) {
     const foundIndex = items.indexOf(state.anchorId);

--- a/frontend/features/nav-chats/sidebar-focus.tsx
+++ b/frontend/features/nav-chats/sidebar-focus.tsx
@@ -14,7 +14,16 @@
  */
 'use client';
 
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 /** Identifies one of the three focusable regions. */
 export type FocusZoneId = 'sidebar' | 'navigator' | 'chat';
@@ -48,6 +57,7 @@ type FocusState = {
   shouldMoveDOMFocus: boolean;
 };
 
+/** Context value exposing focus-zone state and navigation methods to consumers. */
 type FocusContextValue = {
   focusState: FocusState;
   registerZone: (zone: FocusZoneRegistration) => void;
@@ -70,7 +80,11 @@ const FocusContext = createContext<FocusContextValue | null>(null);
  * Wraps the app layout and provides focus-zone coordination to all children.
  * Mount this once above the sidebar + chat layout.
  */
-export function SidebarFocusProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+export function SidebarFocusProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
   const zonesRef = useRef(new Map<FocusZoneId, FocusZoneRegistration>());
   const [focusState, setFocusState] = useState<FocusState>({
     zone: null,
@@ -98,7 +112,7 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
 
     const intent = options?.intent ?? 'programmatic';
     // Click-initiated changes don't need to move DOM focus (the click already did).
-    const shouldMoveDOMFocus = options?.moveFocus ?? (intent !== 'click');
+    const shouldMoveDOMFocus = options?.moveFocus ?? intent !== 'click';
 
     setFocusState({ zone: id, intent, shouldMoveDOMFocus });
 
@@ -141,7 +155,9 @@ export function SidebarFocusProvider({ children }: { children: React.ReactNode }
   const focusPreviousZone = useCallback(() => {
     const currentIndex = focusState.zone ? ZONE_ORDER.indexOf(focusState.zone) : 0;
     for (let i = 1; i <= ZONE_ORDER.length; i++) {
-      const candidate = ZONE_ORDER[(currentIndex - i + ZONE_ORDER.length) % ZONE_ORDER.length] as FocusZoneId;
+      const candidate = ZONE_ORDER[
+        (currentIndex - i + ZONE_ORDER.length) % ZONE_ORDER.length
+      ] as FocusZoneId;
       if (zonesRef.current.has(candidate)) {
         focusZone(candidate, { intent: 'keyboard', moveFocus: true });
         return;
@@ -199,7 +215,8 @@ export function useFocusZone({
   focusFirst?: () => void;
 }) {
   const zoneRef = useRef<HTMLDivElement>(null);
-  const { focusState, registerZone, unregisterZone, focusZone, isZoneFocused } = useSidebarFocusContext();
+  const { focusState, registerZone, unregisterZone, focusZone, isZoneFocused } =
+    useSidebarFocusContext();
   const isFocused = enabled && isZoneFocused(zoneId);
   const shouldMoveDOMFocus = enabled && focusState.zone === zoneId && focusState.shouldMoveDOMFocus;
   const intent = focusState.zone === zoneId ? focusState.intent : null;
@@ -245,6 +262,9 @@ export function useFocusZone({
     shouldMoveDOMFocus,
     intent,
     /** Manually request focus on this zone. */
-    focus: useCallback((options?: FocusZoneOptions) => focusZone(zoneId, options), [focusZone, zoneId]),
+    focus: useCallback(
+      (options?: FocusZoneOptions) => focusZone(zoneId, options),
+      [focusZone, zoneId]
+    ),
   };
 }

--- a/frontend/features/nav-chats/use-conversation-search.ts
+++ b/frontend/features/nav-chats/use-conversation-search.ts
@@ -26,15 +26,18 @@ import type { AgnoMessage, Conversation } from '@/lib/types';
  */
 const MAX_CACHE_SIZE = 100;
 
+/** Per-conversation search result with match count and a context snippet. */
 export type ContentSearchResult = {
   matchCount: number;
   snippet: string;
 };
 
+/** Escape special regex characters so user input can be used in a RegExp safely. */
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** Count case-insensitive occurrences of `query` within `content`. */
 function countOccurrences(content: string, query: string): number {
   if (!query) {
     return 0;
@@ -44,6 +47,7 @@ function countOccurrences(content: string, query: string): number {
   return matches?.length ?? 0;
 }
 
+/** Extract a ~80-char context window around the first match of `query` in `content`. */
 function buildSnippet(content: string, query: string): string {
   const matchIndex = content.toLowerCase().indexOf(query.toLowerCase());
   if (matchIndex < 0) {
@@ -55,10 +59,16 @@ function buildSnippet(content: string, query: string): string {
   return content.slice(start, end).trim();
 }
 
+/** Concatenate all message contents into a single searchable string. */
 function extractSearchableText(messages: AgnoMessage[]): string {
   return messages.map((message) => message.content).join('\n');
 }
 
+/**
+ * Compute a simple fuzzy match score between a title and query.
+ * Returns a higher score for exact substring matches, a lower score for
+ * subsequence matches, and 0 if the query can't be matched at all.
+ */
 function fuzzyScore(title: string, query: string): number {
   const lowerTitle = title.toLowerCase();
   const lowerQuery = query.toLowerCase();
@@ -94,7 +104,7 @@ function fuzzyScore(title: string, query: string): number {
 export function rankConversationsForSearch(
   conversations: Conversation[],
   query: string,
-  contentSearchResults: Map<string, ContentSearchResult>,
+  contentSearchResults: Map<string, ContentSearchResult>
 ): Conversation[] {
   return [...conversations].sort((left, right) => {
     const leftScore = fuzzyScore(left.title, query);

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -13,31 +13,41 @@
  * @property labels - Tags or categories assigned to the conversation.
  */
 
-export type MessageRole = "user" | "assistant" | "plan";
+/** The role of a message sender: human user, AI assistant, or a plan artifact. */
+export type MessageRole = 'user' | 'assistant' | 'plan';
 
+/**
+ * Structured label attached to a conversation (e.g. status tags, categories).
+ *
+ * @property id - Machine-readable slug derived from the label name.
+ * @property name - Human-readable label text.
+ * @property color - Optional hex color for badge rendering.
+ * @property value - Optional freeform value associated with the label.
+ * @property valueType - Optional type hint for the value (e.g. "string", "number").
+ */
 export type ConversationLabel = {
-	id?: string;
-	name: string;
-	color?: string;
-	value?: string;
-	valueType?: string;
+  id?: string;
+  name: string;
+  color?: string;
+  value?: string;
+  valueType?: string;
 };
 
 /** A label that is either a structured object or a legacy plain string. */
 export type ConversationLabelLike = ConversationLabel | string;
 
 export interface Conversation {
-	id: string;
-	user_id: string;
-	title: string;
-	created_at: string;
-	updated_at: string;
-	// Optional sidebar metadata ported from Craft-style session rows.
-	is_processing?: boolean;
-	has_unread_meta?: boolean;
-	last_message_role?: MessageRole | null;
-	pending_prompt_count?: number;
-	labels?: ConversationLabelLike[];
+  id: string;
+  user_id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  // Optional sidebar metadata ported from Craft-style session rows.
+  is_processing?: boolean;
+  has_unread_meta?: boolean;
+  last_message_role?: MessageRole | null;
+  pending_prompt_count?: number;
+  labels?: ConversationLabelLike[];
 }
 
 /**
@@ -46,6 +56,6 @@ export interface Conversation {
  * @property content - Plain-text message body.
  */
 export interface AgnoMessage {
-	role: "user" | "assistant";
-	content: string;
+  role: 'user' | 'assistant';
+  content: string;
 }


### PR DESCRIPTION
Clean copy of #76.

Wires up all session list features into the main views:

- **NavChats.tsx** — search, multi-select, keyboard navigation, focus zones, activity tracking
- **NavChatsView.tsx** — activity indicators, search count badges, label badges, multi-select highlighting, keyboard-navigable items
- **app-layout.tsx** — SidebarFocusProvider, ChatActivityProvider, focus zone shells
- **ChatContainer.tsx** — reports active conversation state to ChatActivityProvider

Also includes hooks, contexts, types, docs, and supporting changes (db retry logic, Biome fixes, AGENTS.md cleanup).

## Summary by Sourcery

Integrate the enhanced chat session navigator into the main app layout with keyboard focus zones and chat-activity tracking, while tightening backend reliability and developer docs.

New Features:
- Add rich session list interactions including multi-select, keyboard navigation, search ranking, label badges, and activity indicators in the NavChats sidebar.
- Introduce sidebar and chat focus zones so keyboard users can jump between sidebar, navigator, and chat regions predictably.
- Propagate active chat state from the chat container to a shared chat-activity context so the session list can reflect live loading and search results.

Bug Fixes:
- Improve database startup robustness by adding retry logic for transient connection failures in the async DB initialization.

Enhancements:
- Refine NavChats and NavChatsView into smaller focused hooks and components to stay within linting limits and simplify interaction logic.
- Extend conversation UI components to support icons, badges, multi-select styling, and ARIA roles for accessibility.
- Update the main app layout to wrap content in SidebarFocusProvider and ChatActivityProvider and to use new focus shells for sidebar and chat panels.
- Tighten TypeScript types for conversations, labels, and messages and add clarifying comments across nav-chats utilities and hooks.
- Document Craft-style resizable panel architecture and a step-by-step plan for adopting a three-panel shell in the project.
- Add stricter clean-code rules for Python typing and Pydantic usage in the AI agent ruleset.
- Adjust dev tooling to open the frontend on the HTTPS localhost domain by default.

Documentation:
- Clarify CONTRIBUTING-style rules around managing `.beans` task files with the CLI and document future layout work in new design docs for resizable panels.

Chores:
- Add a tracked `.beans` task describing a Sidebar hydration mismatch bug for future work.