### PR TITLE
[6/6] feat(nav-chats): wire up orchestration layer with keyboard navigation, multi-select, and layout integration

### DIFF
--- a/.claude/rules/react/no-mutable-render-closures.md
+++ b/.claude/rules/react/no-mutable-render-closures.md
@@ -1,0 +1,46 @@
+---
+description: "Avoid mutable closures inside JSX render paths"
+globs: ["frontend/**/*.tsx"]
+---
+
+# No Mutable Closures in Render
+
+React StrictMode double-invokes render functions in development. Mutable variables
+(`let` counters, `push` accumulators) inside a render produce wrong values on the
+second pass and correct values in production — a hidden, hard-to-catch bug.
+
+## Rule
+
+Pre-compute derived values (flat indices, running counters, aggregated arrays)
+**before** the JSX `return`, then reference them from the JSX purely via lookup
+(`Map.get`, array index).
+
+### Bad
+
+```tsx
+function List({ items }) {
+  let i = -1;
+  return items.map((item) => {
+    i += 1; // ← mutated during render
+    return <Row key={item.id} index={i} />;
+  });
+}
+```
+
+### Good
+
+```tsx
+function List({ items }) {
+  const indexMap = new Map(items.map((item, i) => [item.id, i]));
+  return items.map((item) => (
+    <Row key={item.id} index={indexMap.get(item.id) ?? 0} />
+  ));
+}
+```
+
+## Why
+
+React.StrictMode calls render twice (dev only) to surface impure renders. A `let`
+counter increments twice per item, so every index after the first is wrong in dev
+but fine in production. The resulting UI glitch is nearly impossible to reproduce
+in a production build.

--- a/.claude/rules/react/stable-keys.md
+++ b/.claude/rules/react/stable-keys.md
@@ -1,0 +1,42 @@
+---
+description: "Use stable, content-derived keys instead of array indices"
+globs: ["frontend/**/*.tsx"]
+---
+
+# Stable React Keys
+
+Array-index keys cause React to re-mount components when items are reordered,
+inserted, or removed — producing stale state, broken animations, and lost focus.
+
+## Rule
+
+Use a stable identifier from the item data:
+
+- `id` field (preferred)
+- `name` or `slug` when `id` is absent
+- A deterministic composite key (`${parentId}-${childName}`)
+
+### Bad
+
+```tsx
+labels.map((label, i) => <Badge key={i} label={label} />)
+```
+
+### Good
+
+```tsx
+labels.map((label) => {
+  const key = typeof label === 'string' ? label : (label.id ?? label.name);
+  return <Badge key={key} label={label} />;
+})
+```
+
+## When Index Keys Are Acceptable
+
+Only when **all three** conditions are true:
+
+1. The list is static (never reordered, filtered, or appended).
+2. Items have no state or refs.
+3. Items have no stable unique identifier.
+
+When in doubt, use a content-derived key.

--- a/.claude/rules/typescript/jsdoc-placement.md
+++ b/.claude/rules/typescript/jsdoc-placement.md
@@ -1,0 +1,51 @@
+---
+description: "JSDoc blocks must sit directly above the declaration they document"
+globs: ["frontend/**/*.ts", "frontend/**/*.tsx"]
+---
+
+# JSDoc Placement
+
+A JSDoc block is associated with the **next** declaration immediately below it.
+If any other export, type, or statement sits between the block and its target, IDEs
+cannot associate the documentation and consumers see no hover docs.
+
+## Rule
+
+Place every `/** ... */` block directly above the declaration it documents, with no
+intervening code or exports.
+
+### Bad
+
+```ts
+/**
+ * @property id - Unique identifier.
+ * @property name - Display name.
+ */
+
+export type Foo = { ... };
+export type Bar = { ... };
+
+export interface Target {  // ← IDE shows no docs
+  id: string;
+  name: string;
+}
+```
+
+### Good
+
+```ts
+export type Foo = { ... };
+export type Bar = { ... };
+
+/**
+ * @property id - Unique identifier.
+ * @property name - Display name.
+ */
+export interface Target {
+  id: string;
+  name: string;
+}
+```
+
+File-level documentation should use `@fileoverview` at the top of the file
+(per `file-level-docstrings.md`), separate from any interface/type docs.

--- a/frontend/components/app-layout.tsx
+++ b/frontend/components/app-layout.tsx
@@ -11,7 +11,9 @@
 'use client';
 
 import React from 'react';
+import { ChatActivityProvider } from '@/features/nav-chats/chat-activity-context';
 import { NavChats } from '@/features/nav-chats/NavChats';
+import { SidebarFocusProvider, useFocusZone } from '@/features/nav-chats/sidebar-focus';
 import { NewSessionButton } from './new-session-button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup, usePanelRef } from './ui/resizable';
 import { Separator } from './ui/separator';
@@ -29,6 +31,67 @@ import {
 
 /** Duration of the sidebar collapse/expand CSS transition in ms. */
 const COLLAPSE_ANIMATION_DURATION_MS = 250;
+
+/**
+ * Wraps sidebar content in a focus zone so keyboard navigation (Tab/Shift+Tab)
+ * can jump directly to the sidebar region instead of walking every focusable element.
+ * Focuses the first interactive child (input or button) when the zone receives focus.
+ */
+function SidebarFocusShell({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}): React.JSX.Element {
+  const { zoneRef } = useFocusZone({
+    zoneId: 'sidebar',
+    focusFirst: () => {
+      const root = zoneRef.current;
+      const target = root?.querySelector<HTMLElement>(
+        'input, button, [tabindex]:not([tabindex="-1"])'
+      );
+      target?.focus();
+    },
+  });
+
+  return (
+    // No tabIndex needed: focus-zone entry delegates to the first interactive
+    // child (input or button) via focusFirst, so the shell itself is never a
+    // focus target. ChatFocusShell uses tabIndex={-1} because its focusFirst
+    // targets a specific textarea/textbox — the shell div is the fallback.
+    <div ref={zoneRef} className={className} data-focus-zone="sidebar">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Wraps the chat panel in a focus zone so keyboard navigation can jump
+ * directly into the chat area. Targets the textarea or textbox first,
+ * falling back to any focusable element.
+ */
+function ChatFocusShell({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const { zoneRef } = useFocusZone({
+    zoneId: 'chat',
+    focusFirst: () => {
+      const root = zoneRef.current;
+      const target = root?.querySelector<HTMLElement>(
+        'textarea, [role="textbox"], button, [tabindex]:not([tabindex="-1"])'
+      );
+      target?.focus();
+    },
+  });
+
+  return (
+    // outline-none is safe: this div only receives focus programmatically via
+    // focusZone('chat'), which immediately forwards to the textarea/textbox child.
+    // Users never see keyboard focus land here.
+    <div ref={zoneRef} className="h-full outline-none" data-focus-zone="chat" tabIndex={-1}>
+      {children}
+    </div>
+  );
+}
 
 /**
  * Sidebar content wrapper with conditional resizable layout.
@@ -73,14 +136,16 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
     return (
       <>
         <Sidebar>
-          <SidebarHeader className="px-2 pb-2 shrink-0">
-            <NewSessionButton />
-          </SidebarHeader>
-          <SidebarContent>
-            <NavChats />
-          </SidebarContent>
+          <SidebarFocusShell className="flex h-full flex-col">
+            <SidebarHeader className="px-2 pb-2 shrink-0">
+              <NewSessionButton />
+            </SidebarHeader>
+            <SidebarContent>
+              <NavChats />
+            </SidebarContent>
+          </SidebarFocusShell>
         </Sidebar>
-        {children}
+        <ChatFocusShell>{children}</ChatFocusShell>
       </>
     );
   }
@@ -113,29 +178,33 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
         }}
       >
         {/* Content keeps min-width so layout never reflows during collapse —
-            the panel clips via overflow:hidden and the content fades out. */}
-        <div
-          className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden"
-          style={{
-            opacity: state === 'collapsed' ? 0 : 1,
-            // Disable pointer events when invisible to prevent click-dead-zones
-            // per the hidden-overlay-pointer-events rule.
-            pointerEvents: state === 'collapsed' ? 'none' : 'auto',
-            transition: 'opacity 150ms ease-out',
-          }}
-        >
-          <SidebarHeader className="px-2 pb-2 shrink-0">
-            <NewSessionButton />
-          </SidebarHeader>
-          <SidebarContent>
-            <NavChats />
-          </SidebarContent>
-        </div>
+          the panel clips via overflow:hidden and the content fades out. */}
+        <SidebarFocusShell className="bg-sidebar text-sidebar-foreground flex h-full min-w-[240px] flex-col overflow-hidden">
+          <div
+            style={{
+              opacity: state === 'collapsed' ? 0 : 1,
+              // Disable pointer events when invisible to prevent click-dead-zones
+              // per the hidden-overlay-pointer-events rule.
+              pointerEvents: state === 'collapsed' ? 'none' : 'auto',
+              transition: 'opacity 150ms ease-out',
+            }}
+            className="flex h-full min-w-[240px] flex-col overflow-hidden"
+          >
+            <SidebarHeader className="px-2 pb-2 shrink-0">
+              <NewSessionButton />
+            </SidebarHeader>
+            <SidebarContent>
+              <NavChats />
+            </SidebarContent>
+          </div>
+        </SidebarFocusShell>
       </ResizablePanel>
 
       <ResizableHandle />
 
-      <ResizablePanel className="h-full">{children}</ResizablePanel>
+      <ResizablePanel className="h-full">
+        <ChatFocusShell>{children}</ChatFocusShell>
+      </ResizablePanel>
     </ResizablePanelGroup>
   );
 }
@@ -143,24 +212,29 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
 /**
  * Main application layout with resizable sidebar and content area.
  * Provides full-page structure with sidebar navigation and responsive behavior.
+ * Wraps everything in focus-zone and chat-activity providers.
  */
 export function AppLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <SidebarProvider>
-      <ResizableSidebarContent>
-        <SidebarInset>
-          <header className="flex h-16 shrink-0 items-center gap-2">
-            <div className="flex items-center gap-2 px-4">
-              <SidebarTrigger className="-ml-1 cursor-pointer" />
-              <Separator
-                orientation="vertical"
-                className="mr-2 data-vertical:h-4 data-vertical:self-auto"
-              />
-            </div>
-          </header>
-          <div className="flex-1">{children}</div>
-        </SidebarInset>
-      </ResizableSidebarContent>
+      <SidebarFocusProvider>
+        <ChatActivityProvider>
+          <ResizableSidebarContent>
+            <SidebarInset>
+              <header className="flex h-16 shrink-0 items-center gap-2">
+                <div className="flex items-center gap-2 px-4">
+                  <SidebarTrigger className="-ml-1 cursor-pointer" />
+                  <Separator
+                    orientation="vertical"
+                    className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+                  />
+                </div>
+              </header>
+              <div className="flex-1">{children}</div>
+            </SidebarInset>
+          </ResizableSidebarContent>
+        </ChatActivityProvider>
+      </SidebarFocusProvider>
     </SidebarProvider>
   );
 }

--- a/frontend/features/chat/ChatContainer.tsx
+++ b/frontend/features/chat/ChatContainer.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
+import { useChatActivity } from '@/features/nav-chats/chat-activity-context';
 import type { AgnoMessage } from '@/lib/types';
 import ChatView from './ChatView';
 import { useChat } from './hooks/use-chat';
@@ -34,6 +35,7 @@ export default function ChatContainer({ conversationId, initialChatHistory }: Ch
   const createConversationMutation = useCreateConversation(conversationId);
   const generateConversationTitleMutation = useGenerateConversationTitle(conversationId);
   const router = useRouter();
+  const { setActiveConversation, clearActiveConversation } = useChatActivity();
 
   /**
    * Tracks whether we've already updated the URL to `/c/:id`.
@@ -106,6 +108,24 @@ export default function ChatContainer({ conversationId, initialChatHistory }: Ch
       router.replace(`/c/${conversationId}`);
     }
   };
+
+  // Keep the sidebar's chat-activity context in sync with this chat's state.
+  // Fires on every history/loading change so the sidebar can show spinners,
+  // unread badges, and content-search matches for the active conversation.
+  useEffect(() => {
+    setActiveConversation({
+      conversationId,
+      chatHistory,
+      isLoading,
+    });
+  }, [chatHistory, conversationId, isLoading, setActiveConversation]);
+
+  // Clear activity state on unmount, guarded by conversationId so a stale
+  // cleanup doesn't clobber a newly opened conversation.
+  useEffect(
+    () => () => clearActiveConversation(conversationId),
+    [clearActiveConversation, conversationId]
+  );
 
   /** Updates the controlled message state as the user types. */
   const onUpdateMessage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend/features/nav-chats/use-nav-chats-orchestration.ts
+++ b/frontend/features/nav-chats/use-nav-chats-orchestration.ts
@@ -10,6 +10,7 @@ import type {
 } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ConversationGroup } from '@/lib/conversation-groups';
+import { extractConversationIdFromPath } from '@/lib/route-utils';
 import type { Conversation } from '@/lib/types';
 import {
   createInitialSelectionState,
@@ -32,8 +33,7 @@ function getConversationIdFromPathname(pathname: string | null): string | null {
   if (!pathname) {
     return null;
   }
-  const match = /^\/c\/([^/]+)/.exec(pathname);
-  return match?.[1] ?? null;
+  return extractConversationIdFromPath(pathname);
 }
 
 /**

--- a/frontend/lib/route-utils.ts
+++ b/frontend/lib/route-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Route-related utility functions.
+ *
+ * @fileoverview Pure helpers for extracting data from URL pathnames.
+ */
+
+/**
+ * Extract the conversation UUID from a `/c/:id` pathname.
+ *
+ * @returns The conversation ID, or null if the pathname doesn't match.
+ */
+export function extractConversationIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/c\/([^/]+)/);
+  return match?.[1] ?? null;
+}


### PR DESCRIPTION
## Stack Navigation
> **Part 6 of 6** | Previous: #82 | Next: none (final)
> 
> Full stack: #78 → #79 → #80 → #81 → #82 → #83
> 
> Clean split of PR #77 into review-friendly stacked PRs.


## Summary
Wires up the orchestration layer that connects all the hooks, contexts, and presentation components from previous PRs. Adds keyboard navigation (arrow keys, Enter, Escape), multi-select support (Shift+Click, Ctrl+Click), and integrates the updated sidebar into the app layout and chat container.

## Changes
- `frontend/features/nav-chats/NavChats.tsx` — main orchestration component coordinating focus, selection, search, activity tracking, and keyboard navigation
- `frontend/components/app-layout.tsx` — layout integration to mount the updated nav-chats sidebar
- `frontend/features/chat/ChatContainer.tsx` — chat container updates to support the new sidebar interaction model

## Verification
- `cd frontend && npx tsc --noEmit` — passes cleanly with the full stack
- Full visual/interaction verification requires running the app: `just dev`
- Test keyboard navigation: arrow keys to move, Enter to select, Escape to deselect
- Test multi-select: Shift+Click for range, Ctrl+Click for toggle

## Context
This is a clean split of PR #77 into review-friendly stacked PRs.