### PR TITLE
feat(backend): message persistence — Message, ContextItem, Summary models + CRUD

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.providers import resolve_provider
 from app.crud.conversation import get_conversation_service, update_conversation_model_service
+from app.crud.message import create_message
 from app.db import User, get_async_session
 from app.schemas import ChatRequest
 from app.users import current_active_user
@@ -61,18 +62,42 @@ def get_chat_router() -> APIRouter:
 
         provider = resolve_provider(model_id)
 
+        # Persist the user message before streaming begins
+        await create_message(
+            session,
+            conversation_id=request.conversation_id,
+            user_id=user.id,
+            role="user",
+            content=request.question,
+        )
+        await session.commit()
+
         async def event_stream():
+            full_response_parts: list[str] = []
             try:
                 async for event in provider.stream(
                     request.question,
                     request.conversation_id,
                     user.id,
                 ):
+                    # Collect assistant text chunks for persistence
+                    if isinstance(event, dict) and event.get("type") == "delta":
+                        full_response_parts.append(event.get("content", ""))
                     yield f"data: {json.dumps(event)}\n\n"
             except Exception as exc:
                 error_event = {"type": "error", "content": str(exc)}
                 yield f"data: {json.dumps(error_event)}\n\n"
             finally:
+                # Persist assistant message after stream completes
+                if full_response_parts:
+                    await create_message(
+                        session,
+                        conversation_id=request.conversation_id,
+                        user_id=None,
+                        role="assistant",
+                        content="".join(full_response_parts),
+                    )
+                    await session.commit()
                 yield "data: [DONE]\n\n"
 
         return StreamingResponse(

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -1,17 +1,13 @@
 """
 Chat API — provider-agnostic streaming endpoint.
 
-All AI providers (Claude via Agent SDK, Gemini via Agno, …) expose the
-same ``AIProvider.stream()`` interface and emit ``StreamEvent`` TypedDicts.
-This module contains exactly one route: ``POST /api/v1/chat/``.
+All AI providers expose the same ``AIProvider.stream()`` interface and
+emit ``StreamEvent`` TypedDicts.  This module has one route:
+``POST /api/v1/chat/``.
 
-Message persistence
--------------------
-The endpoint persists every user and assistant message to the
-``messages`` / ``context_items`` tables (Phase 1 LCM foundation).
-The user message is written *before* the stream starts so it survives
-network errors; the assistant message is written inside the ``finally``
-block so it is persisted even when an error event ends the stream early.
+The user message is saved before streaming starts; the assistant reply
+is saved after streaming ends (in a ``finally`` block so partial replies
+are still recorded on error).
 """
 from __future__ import annotations
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -1,4 +1,18 @@
-"""Chat API — provider-agnostic streaming endpoint."""
+"""
+Chat API — provider-agnostic streaming endpoint.
+
+All AI providers (Claude via Agent SDK, Gemini via Agno, …) expose the
+same ``AIProvider.stream()`` interface and emit ``StreamEvent`` TypedDicts.
+This module contains exactly one route: ``POST /api/v1/chat/``.
+
+Message persistence
+-------------------
+The endpoint persists every user and assistant message to the
+``messages`` / ``context_items`` tables (Phase 1 LCM foundation).
+The user message is written *before* the stream starts so it survives
+network errors; the assistant message is written inside the ``finally``
+block so it is persisted even when an error event ends the stream early.
+"""
 from __future__ import annotations
 
 import json
@@ -48,10 +62,12 @@ def get_chat_router() -> APIRouter:
         if conversation is None:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
-        # Resolve model: request overrides stored model, stored model overrides default
+        # Resolve model: request > stored > global default.
+        # This allows per-message model switching without a separate PATCH.
         model_id = request.model_id or conversation.model_id or _DEFAULT_MODEL
 
-        # Persist model change if it differs from what is stored
+        # Persist model change so the next request inherits it without
+        # the client having to re-send model_id every turn.
         if model_id != conversation.model_id:
             await update_conversation_model_service(
                 model_id=model_id,
@@ -62,7 +78,9 @@ def get_chat_router() -> APIRouter:
 
         provider = resolve_provider(model_id)
 
-        # Persist the user message before streaming begins
+        # Persist the user message *before* streaming starts.  Writing it
+        # here (outside the generator) ensures it is committed even if the
+        # client disconnects before the first SSE frame is sent.
         await create_message(
             session,
             conversation_id=request.conversation_id,
@@ -73,6 +91,15 @@ def get_chat_router() -> APIRouter:
         await session.commit()
 
         async def event_stream():
+            """Async generator that streams SSE frames to the client.
+
+            Yields one ``data: ...\n\n`` frame per provider event, then
+            a final ``data: [DONE]\n\n`` sentinel.  The assistant message
+            is persisted inside ``finally`` so it is written regardless of
+            whether the stream completes cleanly or raises an exception.
+            """
+            # Accumulate delta chunks so we can write the full assistant
+            # reply as a single Message row once streaming is done.
             full_response_parts: list[str] = []
             try:
                 async for event in provider.stream(
@@ -80,20 +107,25 @@ def get_chat_router() -> APIRouter:
                     request.conversation_id,
                     user.id,
                 ):
-                    # Collect assistant text chunks for persistence
+                    # Only "delta" events carry text we want to persist;
+                    # thinking / tool_use / tool_result are forwarded as-is.
                     if isinstance(event, dict) and event.get("type") == "delta":
                         full_response_parts.append(event.get("content", ""))
                     yield f"data: {json.dumps(event)}\n\n"
             except Exception as exc:
+                # Surface provider errors to the client as a typed event
+                # so the frontend can display them rather than silently hang.
                 error_event = {"type": "error", "content": str(exc)}
                 yield f"data: {json.dumps(error_event)}\n\n"
             finally:
-                # Persist assistant message after stream completes
+                # Persist the full assistant reply.  Running in ``finally``
+                # guarantees this executes even when an error interrupted
+                # the stream mid-way, preserving partial responses.
                 if full_response_parts:
                     await create_message(
                         session,
                         conversation_id=request.conversation_id,
-                        user_id=None,
+                        user_id=None,  # assistant messages have no user owner
                         role="assistant",
                         content="".join(full_response_parts),
                     )

--- a/backend/app/crud/message.py
+++ b/backend/app/crud/message.py
@@ -1,0 +1,77 @@
+"""CRUD helpers for Message, ContextItem, and Summary models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ContextItem, Message, Summary
+
+
+async def get_next_ordinal(db: AsyncSession, conversation_id: uuid.UUID) -> int:
+    """Return the next ordinal value for a new message in a conversation."""
+    result = await db.execute(
+        select(func.coalesce(func.max(Message.ordinal), -1)).where(
+            Message.conversation_id == conversation_id
+        )
+    )
+    return (result.scalar() or -1) + 1
+
+
+async def create_message(
+    db: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID | None,
+    role: str,
+    content: str,
+    token_count: int | None = None,
+) -> Message:
+    """Persist a single message and add a matching ContextItem."""
+    ordinal = await get_next_ordinal(db, conversation_id)
+
+    msg = Message(
+        id=uuid.uuid4(),
+        conversation_id=conversation_id,
+        user_id=user_id,
+        role=role,
+        content=content,
+        token_count=token_count,
+        ordinal=ordinal,
+        created_at=datetime.utcnow(),
+    )
+    db.add(msg)
+
+    ctx = ContextItem(
+        id=uuid.uuid4(),
+        conversation_id=conversation_id,
+        item_type="message",
+        item_id=msg.id,
+        ordinal=ordinal,
+        token_count=token_count,
+    )
+    db.add(ctx)
+
+    await db.flush()  # get IDs without committing
+    return msg
+
+
+async def get_messages(
+    db: AsyncSession,
+    conversation_id: uuid.UUID,
+    *,
+    limit: int | None = None,
+) -> list[Message]:
+    """Return messages for a conversation in ordinal order."""
+    q = (
+        select(Message)
+        .where(Message.conversation_id == conversation_id)
+        .order_by(Message.ordinal)
+    )
+    if limit is not None:
+        q = q.limit(limit)
+    result = await db.execute(q)
+    return list(result.scalars().all())

--- a/backend/app/crud/message.py
+++ b/backend/app/crud/message.py
@@ -1,19 +1,9 @@
 """
 CRUD helpers for Message, ContextItem, and Summary models.
 
-Every public function enforces the invariant that a ``Message`` row is
-always accompanied by a matching ``ContextItem`` row in the same flush.
-This keeps the context window table authoritative: the context assembler
-(Phase 2) only needs to read ``context_items`` to reconstruct history —
-it never has to join or guess at message ordering.
-
-Caller contract
----------------
-- Pass an uncommitted ``AsyncSession``.  Functions call ``flush()`` but
-  **never** ``commit()``.  The caller is responsible for committing after
-  all related side-effects (e.g. updating the conversation's
-  ``updated_at``) have been applied.
-- ``user_id`` should be ``None`` for assistant/system messages.
+Callers pass an open ``AsyncSession``.  Functions call ``flush()`` but
+never ``commit()``; the caller commits after any remaining work.
+``user_id`` should be ``None`` for assistant or system messages.
 """
 
 from __future__ import annotations
@@ -28,27 +18,23 @@ from app.models import ContextItem, Message, Summary
 
 
 async def get_next_ordinal(db: AsyncSession, conversation_id: uuid.UUID) -> int:
-    """Return the next monotonically-increasing ordinal for a conversation.
+    """Return the next ordinal for a new message in this conversation.
 
-    Ordinals start at 0.  When the conversation has no messages yet,
-    ``MAX(ordinal)`` is ``NULL``; ``COALESCE`` maps that to ``-1`` so the
-    first message gets ordinal ``0``.
+    The first message gets ordinal 0.  Each subsequent message gets
+    one higher than the current maximum.
 
     Args:
-        db: Async database session (read-only — no flush or commit).
+        db: Async database session.
         conversation_id: UUID of the conversation to query.
 
     Returns:
-        An integer one greater than the current maximum ordinal, or ``0``
-        if the conversation contains no messages yet.
+        The next available ordinal (0 when the conversation is empty).
     """
     result = await db.execute(
         select(func.coalesce(func.max(Message.ordinal), -1)).where(
             Message.conversation_id == conversation_id
         )
     )
-    # scalar() returns None when the row set is empty, but COALESCE above
-    # guarantees at least -1, so the `or -1` guard is purely defensive.
     return (result.scalar() or -1) + 1
 
 
@@ -61,27 +47,23 @@ async def create_message(
     content: str,
     token_count: int | None = None,
 ) -> Message:
-    """Persist a single message and its matching context-window entry.
+    """Save a message and a matching position entry to the database.
 
-    Atomically creates one ``Message`` row and one ``ContextItem`` row that
-    points to it.  Both share the same ``ordinal`` so the context assembler
-    can order context items without joining the messages table.
-
-    The session is flushed (but not committed) so that the new rows are
-    visible within the same transaction for any subsequent operations.
+    Creates a ``Message`` row and a ``ContextItem`` row pointing to it
+    in the same flush, so the two are always in sync.
 
     Args:
         db: Async database session.
         conversation_id: UUID of the owning conversation.
-        user_id: UUID of the user who authored the message, or ``None``
-            for assistant / system messages.
-        role: Message role — one of ``"user"``, ``"assistant"``,
-            ``"thinking"``, ``"tool_use"``, or ``"tool_result"``.
-        content: Raw text content of the message.
-        token_count: Pre-computed token count, or ``None`` if unknown.
+        user_id: UUID of the user who sent the message, or ``None``
+            for assistant messages.
+        role: One of ``"user"``, ``"assistant"``, ``"thinking"``,
+            ``"tool_use"``, or ``"tool_result"``.
+        content: Text content of the message.
+        token_count: Token count if already known, otherwise ``None``.
 
     Returns:
-        The newly flushed ``Message`` ORM instance (ID is populated).
+        The saved ``Message`` instance.
     """
     ordinal = await get_next_ordinal(db, conversation_id)
 
@@ -97,8 +79,8 @@ async def create_message(
     )
     db.add(msg)
 
-    # Mirror every message with a ContextItem so the context assembler
-    # only needs to walk context_items — it never reads messages directly.
+    # Each message gets a matching ContextItem that records its position.
+    # This makes it easy to fetch the ordered history without extra joins.
     ctx = ContextItem(
         id=uuid.uuid4(),
         conversation_id=conversation_id,
@@ -109,8 +91,7 @@ async def create_message(
     )
     db.add(ctx)
 
-    # Flush to materialise IDs without ending the transaction; the caller
-    # commits after any remaining side-effects (e.g. updating updated_at).
+    # Flush so the IDs are available within the transaction; the caller commits.
     await db.flush()
     return msg
 
@@ -121,26 +102,20 @@ async def get_messages(
     *,
     limit: int | None = None,
 ) -> list[Message]:
-    """Return all messages for a conversation, sorted by ordinal.
-
-    Used by the context assembler (Phase 2) to reconstruct conversation
-    history before writing the JSONL file for the Claude Agent SDK.
+    """Return messages for a conversation in order, oldest first.
 
     Args:
-        db: Async database session (read-only — no flush or commit).
+        db: Async database session.
         conversation_id: UUID of the conversation to fetch.
-        limit: If provided, return only the most-recent ``limit`` messages
-            (the query orders ascending so the caller receives the tail).
-            Pass ``None`` to fetch the full history.
+        limit: Return at most this many messages. ``None`` fetches all.
 
     Returns:
-        A list of ``Message`` instances ordered by ``ordinal`` ascending.
-        Returns an empty list when the conversation has no messages.
+        Messages ordered by ``ordinal`` ascending. Empty list if none.
     """
     q = (
         select(Message)
         .where(Message.conversation_id == conversation_id)
-        .order_by(Message.ordinal)  # ascending — oldest first
+        .order_by(Message.ordinal)
     )
     if limit is not None:
         q = q.limit(limit)

--- a/backend/app/crud/message.py
+++ b/backend/app/crud/message.py
@@ -1,4 +1,20 @@
-"""CRUD helpers for Message, ContextItem, and Summary models."""
+"""
+CRUD helpers for Message, ContextItem, and Summary models.
+
+Every public function enforces the invariant that a ``Message`` row is
+always accompanied by a matching ``ContextItem`` row in the same flush.
+This keeps the context window table authoritative: the context assembler
+(Phase 2) only needs to read ``context_items`` to reconstruct history —
+it never has to join or guess at message ordering.
+
+Caller contract
+---------------
+- Pass an uncommitted ``AsyncSession``.  Functions call ``flush()`` but
+  **never** ``commit()``.  The caller is responsible for committing after
+  all related side-effects (e.g. updating the conversation's
+  ``updated_at``) have been applied.
+- ``user_id`` should be ``None`` for assistant/system messages.
+"""
 
 from __future__ import annotations
 
@@ -12,12 +28,27 @@ from app.models import ContextItem, Message, Summary
 
 
 async def get_next_ordinal(db: AsyncSession, conversation_id: uuid.UUID) -> int:
-    """Return the next ordinal value for a new message in a conversation."""
+    """Return the next monotonically-increasing ordinal for a conversation.
+
+    Ordinals start at 0.  When the conversation has no messages yet,
+    ``MAX(ordinal)`` is ``NULL``; ``COALESCE`` maps that to ``-1`` so the
+    first message gets ordinal ``0``.
+
+    Args:
+        db: Async database session (read-only — no flush or commit).
+        conversation_id: UUID of the conversation to query.
+
+    Returns:
+        An integer one greater than the current maximum ordinal, or ``0``
+        if the conversation contains no messages yet.
+    """
     result = await db.execute(
         select(func.coalesce(func.max(Message.ordinal), -1)).where(
             Message.conversation_id == conversation_id
         )
     )
+    # scalar() returns None when the row set is empty, but COALESCE above
+    # guarantees at least -1, so the `or -1` guard is purely defensive.
     return (result.scalar() or -1) + 1
 
 
@@ -30,7 +61,28 @@ async def create_message(
     content: str,
     token_count: int | None = None,
 ) -> Message:
-    """Persist a single message and add a matching ContextItem."""
+    """Persist a single message and its matching context-window entry.
+
+    Atomically creates one ``Message`` row and one ``ContextItem`` row that
+    points to it.  Both share the same ``ordinal`` so the context assembler
+    can order context items without joining the messages table.
+
+    The session is flushed (but not committed) so that the new rows are
+    visible within the same transaction for any subsequent operations.
+
+    Args:
+        db: Async database session.
+        conversation_id: UUID of the owning conversation.
+        user_id: UUID of the user who authored the message, or ``None``
+            for assistant / system messages.
+        role: Message role — one of ``"user"``, ``"assistant"``,
+            ``"thinking"``, ``"tool_use"``, or ``"tool_result"``.
+        content: Raw text content of the message.
+        token_count: Pre-computed token count, or ``None`` if unknown.
+
+    Returns:
+        The newly flushed ``Message`` ORM instance (ID is populated).
+    """
     ordinal = await get_next_ordinal(db, conversation_id)
 
     msg = Message(
@@ -45,17 +97,21 @@ async def create_message(
     )
     db.add(msg)
 
+    # Mirror every message with a ContextItem so the context assembler
+    # only needs to walk context_items — it never reads messages directly.
     ctx = ContextItem(
         id=uuid.uuid4(),
         conversation_id=conversation_id,
-        item_type="message",
+        item_type="message",  # distinguishes from "summary" entries
         item_id=msg.id,
         ordinal=ordinal,
         token_count=token_count,
     )
     db.add(ctx)
 
-    await db.flush()  # get IDs without committing
+    # Flush to materialise IDs without ending the transaction; the caller
+    # commits after any remaining side-effects (e.g. updating updated_at).
+    await db.flush()
     return msg
 
 
@@ -65,11 +121,26 @@ async def get_messages(
     *,
     limit: int | None = None,
 ) -> list[Message]:
-    """Return messages for a conversation in ordinal order."""
+    """Return all messages for a conversation, sorted by ordinal.
+
+    Used by the context assembler (Phase 2) to reconstruct conversation
+    history before writing the JSONL file for the Claude Agent SDK.
+
+    Args:
+        db: Async database session (read-only — no flush or commit).
+        conversation_id: UUID of the conversation to fetch.
+        limit: If provided, return only the most-recent ``limit`` messages
+            (the query orders ascending so the caller receives the tail).
+            Pass ``None`` to fetch the full history.
+
+    Returns:
+        A list of ``Message`` instances ordered by ``ordinal`` ascending.
+        Returns an empty list when the conversation has no messages.
+    """
     q = (
         select(Message)
         .where(Message.conversation_id == conversation_id)
-        .order_by(Message.ordinal)
+        .order_by(Message.ordinal)  # ascending — oldest first
     )
     if limit is not None:
         q = q.limit(limit)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -87,15 +87,10 @@ class APIKey(Base):
 
 class Message(Base):
     """
-    A single message turn in a conversation.
+    A single message in a conversation.
 
-    Persisted by the application layer (not the Claude Agent SDK) so that
-    the LCM context assembler (Phase 2) can read and compact history before
-    passing it to the SDK via JSONL intercept.
-
-    ``ordinal`` is a per-conversation monotonic counter starting at 0;
-    it determines display and compaction order.  ``token_count`` is
-    populated lazily — ``None`` until the caller counts tokens.
+    ``ordinal`` is a per-conversation counter starting at 0 that sets the
+    display order.  ``token_count`` is optional and can be filled in later.
 
     Allowed roles: ``"user"``, ``"assistant"``, ``"thinking"``,
     ``"tool_use"``, ``"tool_result"``.
@@ -119,16 +114,10 @@ class Message(Base):
 
 class ContextItem(Base):
     """
-    An ordered entry in the active context window for a conversation.
+    An ordered pointer to a message or summary in a conversation.
 
-    Acts as an indirection layer between the context assembler and the
-    underlying storage (``messages`` or ``summaries`` tables).  When the
-    compaction engine replaces a range of messages with a summary it
-    deletes the old ``ContextItem`` rows and inserts a new one pointing to
-    the summary — the ordinal sequence is then re-indexed from 0.
-
-    ``item_type`` is either ``"message"`` or ``"summary"``;
-    ``item_id`` is the UUID primary key of the referenced row.
+    ``item_type`` is ``"message"`` or ``"summary"``.
+    ``item_id`` is the primary key of the referenced row.
     """
 
     __tablename__ = "context_items"
@@ -145,20 +134,11 @@ class ContextItem(Base):
 
 class Summary(Base):
     """
-    A compacted summary produced by the LCM summary engine.
+    A condensed summary that replaces a range of messages in a conversation.
 
-    Summaries are created by ``summary_engine.leaf_pass()`` (Phase 3) when
-    a conversation’s message count exceeds the compaction threshold.  Each
-    summary captures the semantic content of the ``source_ids`` messages it
-    replaces.
-
-    ``depth`` tracks DAG level: ``0`` for leaf summaries (directly over
-    raw messages), ``1`` for summaries-of-summaries, etc.  The multi-level
-    DAG (depth > 0) is a Phase 6 concern.
-
-    ``source_ids`` lists the UUIDs of the ``Message`` rows that were
-    compacted into this summary, enabling lossless expansion for recall
-    tools (``lcm_expand``).
+    ``source_ids`` records which messages were summarised so they can be
+    retrieved later.  ``depth`` starts at 0 for direct message summaries
+    and increases for summaries of summaries.
     """
 
     __tablename__ = "summaries"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -86,7 +86,20 @@ class APIKey(Base):
 
 
 class Message(Base):
-    """A single message in a conversation (user, assistant, thinking, tool_use, tool_result)."""
+    """
+    A single message turn in a conversation.
+
+    Persisted by the application layer (not the Claude Agent SDK) so that
+    the LCM context assembler (Phase 2) can read and compact history before
+    passing it to the SDK via JSONL intercept.
+
+    ``ordinal`` is a per-conversation monotonic counter starting at 0;
+    it determines display and compaction order.  ``token_count`` is
+    populated lazily — ``None`` until the caller counts tokens.
+
+    Allowed roles: ``"user"``, ``"assistant"``, ``"thinking"``,
+    ``"tool_use"``, ``"tool_result"``.
+    """
 
     __tablename__ = "messages"
 
@@ -105,7 +118,18 @@ class Message(Base):
 
 
 class ContextItem(Base):
-    """Ordered context window entry — points to a Message or Summary."""
+    """
+    An ordered entry in the active context window for a conversation.
+
+    Acts as an indirection layer between the context assembler and the
+    underlying storage (``messages`` or ``summaries`` tables).  When the
+    compaction engine replaces a range of messages with a summary it
+    deletes the old ``ContextItem`` rows and inserts a new one pointing to
+    the summary — the ordinal sequence is then re-indexed from 0.
+
+    ``item_type`` is either ``"message"`` or ``"summary"``;
+    ``item_id`` is the UUID primary key of the referenced row.
+    """
 
     __tablename__ = "context_items"
 
@@ -120,7 +144,22 @@ class ContextItem(Base):
 
 
 class Summary(Base):
-    """A compacted summary that replaces a range of messages in the context window."""
+    """
+    A compacted summary produced by the LCM summary engine.
+
+    Summaries are created by ``summary_engine.leaf_pass()`` (Phase 3) when
+    a conversation’s message count exceeds the compaction threshold.  Each
+    summary captures the semantic content of the ``source_ids`` messages it
+    replaces.
+
+    ``depth`` tracks DAG level: ``0`` for leaf summaries (directly over
+    raw messages), ``1`` for summaries-of-summaries, etc.  The multi-level
+    DAG (depth > 0) is a Phase 6 concern.
+
+    ``source_ids`` lists the UUIDs of the ``Message`` rows that were
+    compacted into this summary, enabling lossless expansion for recall
+    tools (``lcm_expand``).
+    """
 
     __tablename__ = "summaries"
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,8 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Uuid
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Text
 from sqlalchemy_utils import StringEncryptedType
@@ -82,3 +83,53 @@ class APIKey(Base):
         StringEncryptedType(String, config.settings.fernet_key, FernetEngine)
     )
     is_active: Mapped[bool] = mapped_column(default=True)
+
+
+class Message(Base):
+    """A single message in a conversation (user, assistant, thinking, tool_use, tool_result)."""
+
+    __tablename__ = "messages"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class ContextItem(Base):
+    """Ordered context window entry — points to a Message or Summary."""
+
+    __tablename__ = "context_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False
+    )
+    item_type: Mapped[str] = mapped_column(String(10), nullable=False)  # message | summary
+    item_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False)
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class Summary(Base):
+    """A compacted summary that replaces a range of messages in the context window."""
+
+    __tablename__ = "summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False
+    )
+    depth: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source_ids: Mapped[list[uuid.UUID] | None] = mapped_column(ARRAY(Uuid), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## What

Saves every user and assistant message to the database so we have a full conversation history to work with.

## Changes

### `backend/app/models.py`
- **`Message`** — one row per message, with `role`, `content`, `ordinal`, `token_count`
- **`ContextItem`** — ordered pointer to each message (or future summary), makes fetching history simple
- **`Summary`** — stores condensed summaries that can replace message ranges later

### `backend/app/crud/message.py` *(new)*
- `create_message()` — saves a Message and matching ContextItem in one flush
- `get_messages()` — fetches messages in order, with optional limit
- `get_next_ordinal()` — returns the next position counter for a conversation

### `backend/app/api/chat.py`
- Saves the **user message** before the stream starts
- Accumulates assistant chunks during streaming, saves the **full assistant reply** in a `finally` block so even errored turns are recorded

## Notes
- No Alembic needed — `create_all()` handles table creation on startup
- Purely additive, no breaking changes