### PR TITLE
feat(frontend): wire thinking SSE events into animated chat UI + TS fixes

### DIFF
--- a/frontend/components/ai-elements/reasoning.tsx
+++ b/frontend/components/ai-elements/reasoning.tsx
@@ -172,7 +172,7 @@ export const ReasoningContent = memo(({ className, children, ...props }: Reasoni
 		)}
 		{...props}
 	>
-		<Streamdown {...props}>{children}</Streamdown>
+				<Streamdown>{children}</Streamdown>
 	</CollapsibleContent>
 ));
 

--- a/frontend/components/ai-elements/thinking-dots.tsx
+++ b/frontend/components/ai-elements/thinking-dots.tsx
@@ -1,14 +1,33 @@
 'use client';
 
 /**
- * Animated thinking indicator — three dots that bounce in sequence.
+ * Animated loading indicator for in-progress AI responses.
  *
  * @fileoverview AI Elements — `thinking-dots`.
+ *
+ * Renders three small circles that bounce in a staggered sequence
+ * (150 ms apart) to communicate that the assistant is generating a
+ * response.  Uses Tailwind’s `animate-bounce` utility with inline
+ * `animationDelay` overrides — no additional CSS required.
+ *
+ * Replace the static “Thinking...” text in `ChatView` with this
+ * component whenever `isLoading` is true.
  */
 
+/**
+ * Three staggered bouncing dots that signal an in-progress AI response.
+ *
+ * The dots share a 1 s animation cycle but are offset by 0 ms, 150 ms,
+ * and 300 ms so they ripple left-to-right rather than bouncing in sync.
+ *
+ * The wrapping `<span>` carries `aria-label="Thinking"` so screen
+ * readers announce the loading state without reading out three empty
+ * elements.
+ */
 export function ThinkingDots() {
 	return (
 		<span className="inline-flex items-center gap-[3px]" aria-label="Thinking">
+			{/* Each dot is a filled circle; delay staggers the bounce phase. */}
 			{[0, 150, 300].map((delay) => (
 				<span
 					key={delay}

--- a/frontend/components/ai-elements/thinking-dots.tsx
+++ b/frontend/components/ai-elements/thinking-dots.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+/**
+ * Animated thinking indicator — three dots that bounce in sequence.
+ *
+ * @fileoverview AI Elements — `thinking-dots`.
+ */
+
+export function ThinkingDots() {
+	return (
+		<span className="inline-flex items-center gap-[3px]" aria-label="Thinking">
+			{[0, 150, 300].map((delay) => (
+				<span
+					key={delay}
+					className="size-1.5 rounded-full bg-muted-foreground animate-bounce"
+					style={{ animationDelay: `${delay}ms`, animationDuration: '1s' }}
+				/>
+			))}
+		</span>
+	);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
 		"@browserbasehq/stagehand": "^3.3.0",
 		"@playwright/test": "^1.59.1",
 		"@tailwindcss/postcss": "^4.1.18",
-		"@tanstack/react-query-devtools": "^5.100.8",
+		"@tanstack/react-query-devtools": "^5.100.9",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Summary\n\nSurfaces backend chain-of-thought SSE events in the chat UI: replaces the static Loader+Thinking placeholder with animated ThinkingDots and a live ChainOfThought collapsible when reasoning content is available. Also fixes three pre-existing TypeScript errors.\n\n## What Changed\n\n### frontend/components/ai-elements/thinking-dots.tsx (new)\nThree staggered bouncing dots rendered via animate-bounce + animationDelay (0 / 150 / 300 ms). No new runtime dependencies.\n\n### frontend/features/chat/hooks/use-chat.ts\n- Exports new ThinkingChunk type: { type: thinking; content: string }\n- parseSseMessage now returns ThinkingChunk for SSE frames with type:thinking instead of silently dropping them\n- resolveParsedFrame passes ThinkingChunk objects through to callers\n- streamMessage generator signature changed to AsyncGenerator<string | ThinkingChunk>\n\n### frontend/features/chat/ChatContainer.tsx\n- Adds thinkingContent state (string) that accumulates thinking chunks during a stream and resets to empty string on each new send\n- Stream loop now branches: thinking chunks go to setThinkingContent; text chunks go to the assistantMessage accumulator\n- Passes thinkingContent down to ChatView\n\n### frontend/features/chat/ChatView.tsx\n- Adds thinkingContent?: string to ChatProps\n- When isLoading && thinkingContent: renders ChainOfThought with ChainOfThoughtStep (label = accumulated text) plus ThinkingDots\n- When isLoading && !thinkingContent: renders bare ThinkingDots\n- Removes Loader import (no longer used)\n\n### frontend/features/chat/hooks/use-chat.test.ts\n- collectStream signature updated to AsyncGenerator<string | ThinkingChunk>; ThinkingChunk items are intentionally skipped in string-only collection\n\n### Pre-existing TS fixes\n\n| File | Fix |\n|------|-----|\n| reasoning.tsx | Removed bad spread into Streamdown (caused dir type mismatch) |\n| app-layout.tsx | Typed onResize callback param as PanelSize from react-resizable-panels |\n\n### frontend/package.json\n- @tanstack/react-query-devtools bumped 5.100.8 to 5.100.9 (patch)\n\n## What Users Will Notice\n\n- The static Thinking... text and spinner is replaced with three animated bouncing dots\n- When the backend emits chain-of-thought content, a collapsible Reasoning section appears above the dots during streaming\n- Once the assistant response arrives, the thinking indicator disappears\n\n## Manual Testing\n\nNot run - this PR was assembled in an automated agent session. Recommended checks:\n\n- Send a message with a reasoning-capable model; verify ThinkingDots appear while waiting\n- If the backend emits type:thinking SSE events, verify the ChainOfThought panel renders and accumulates content\n- Verify ThinkingDots disappears once the assistant message is complete\n- Run npx tsc --noEmit in frontend/ - should report 0 errors\n- Run bun run check in frontend/ - Biome should pass\n\n## Automated Testing\n\nuse-chat.test.ts was updated to compile against the new AsyncGenerator<string | ThinkingChunk> signature. Tests were not executed in this session.\n\n## Coverage Gaps\n\n- No new tests cover ThinkingDots rendering or the thinking-chunk branch in ChatContainer\n- ChainOfThought integration with live streaming is untested