### PR TITLE
feat(backend): Pi-inspired provider-agnostic agent loop (TDD)

### DIFF
--- a/backend/app/core/agent_loop/__init__.py
+++ b/backend/app/core/agent_loop/__init__.py
@@ -1,0 +1,34 @@
+"""Pi-inspired provider-agnostic agent loop."""
+from .loop import agent_loop
+from .types import (
+    AgentContext,
+    AgentEvent,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    StreamFn,
+    ToolResultMessage,
+    UserMessage,
+)
+
+__all__ = [
+    "agent_loop",
+    "AgentContext",
+    "AgentEvent",
+    "AgentLoopConfig",
+    "AgentMessage",
+    "AgentTool",
+    "AssistantMessage",
+    "LLMDoneEvent",
+    "LLMEvent",
+    "LLMTextDeltaEvent",
+    "LLMToolCallEvent",
+    "StreamFn",
+    "ToolResultMessage",
+    "UserMessage",
+]

--- a/backend/app/core/agent_loop/loop.py
+++ b/backend/app/core/agent_loop/loop.py
@@ -1,0 +1,236 @@
+"""
+Pi-inspired provider-agnostic agent loop.
+
+Architecture mirrors @mariozechner/pi-agent-core from pi-mono:
+  https://github.com/badlogic/pi-mono/blob/main/packages/agent/src/agent-loop.ts
+
+The loop owns:
+  - Turn lifecycle (agent_start → turn_start → ... → turn_end → agent_end)
+  - Tool call execution (sequential, with before/after hooks TBD)
+  - Context transform before each LLM call
+  - shouldStopAfterTurn early exit
+
+Each provider supplies a StreamFn — the only provider-specific code.
+The loop never imports any provider SDK directly.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from copy import deepcopy
+
+from .types import (
+    AgentContext,
+    AgentEndEvent,
+    AgentEvent,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentStartEvent,
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    StreamFn,
+    TextContent,
+    TextDeltaEvent,
+    ToolCallContent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+    ToolResultContent,
+    ToolResultEvent,
+    ToolResultMessage,
+    TurnEndEvent,
+    TurnStartEvent,
+)
+
+
+async def agent_loop(
+    prompts: list[AgentMessage],
+    context: AgentContext,
+    config: AgentLoopConfig,
+    stream_fn: StreamFn,
+) -> AsyncIterator[AgentEvent]:
+    """Run the agent loop and yield AgentEvents.
+
+    Args:
+        prompts: The new user message(s) for this turn.
+        context: Shared context — system prompt, prior messages, tools.
+                 Mutated in place as the loop accumulates messages.
+        config: Loop configuration — convert_to_llm, transform_context,
+                should_stop_after_turn.
+        stream_fn: Provider-specific streaming function.  Accepts the
+                   current message list (after transform + convert) and
+                   tool list; yields LLMEvents.
+
+    Yields:
+        AgentEvents in the sequence:
+          agent_start
+            turn_start
+              message_start / message_end  (for each prompt)
+              text_delta*                  (streamed text)
+              tool_call_start / tool_call_end / tool_result  (when tools used)
+            turn_end
+          [more turns if tool calls triggered a loop-back]
+          agent_end
+    """
+    # Build up the list of all new messages produced in this invocation.
+    new_messages: list[AgentMessage] = list(prompts)
+
+    # Add prompts to context so the LLM sees them in the first call.
+    current_messages = list(context.messages) + list(prompts)
+
+    yield AgentStartEvent(type="agent_start")
+    yield TurnStartEvent(type="turn_start")
+
+    # Emit start/end events for the incoming prompt(s).
+    for prompt in prompts:
+        yield MessageStartEvent(type="message_start", message=prompt)
+        yield MessageEndEvent(type="message_end", message=prompt)
+
+    async for event in _run_loop(current_messages, context.tools, new_messages, config, stream_fn):
+        yield event
+
+
+async def _run_loop(
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+    new_messages: list[AgentMessage],
+    config: AgentLoopConfig,
+    stream_fn: StreamFn,
+) -> AsyncIterator[AgentEvent]:
+    """Inner loop — handles multiple turns when tool calls require looping back."""
+    first_turn = True
+
+    while True:
+        if not first_turn:
+            yield TurnStartEvent(type="turn_start")
+        first_turn = False
+
+        # ── Context transform (e.g. sliding window, compaction) ──────────
+        transformed = messages
+        if config.transform_context is not None:
+            transformed = await config.transform_context(list(messages))
+
+        # ── Convert to LLM-compatible format ─────────────────────────────
+        llm_messages = config.convert_to_llm(transformed)
+
+        # ── Stream the assistant response ─────────────────────────────────
+        assistant_content: list[TextContent | ToolCallContent] = []
+        stop_reason = "stop"
+
+        async for llm_event in stream_fn(llm_messages, tools):
+            if llm_event["type"] == "text_delta":
+                assert isinstance(llm_event, dict)
+                typed_delta: LLMTextDeltaEvent = llm_event  # type: ignore[assignment]
+                yield TextDeltaEvent(type="text_delta", text=typed_delta["text"])
+
+            elif llm_event["type"] == "tool_call":
+                assert isinstance(llm_event, dict)
+                typed_tc: LLMToolCallEvent = llm_event  # type: ignore[assignment]
+                yield ToolCallStartEvent(
+                    type="tool_call_start",
+                    tool_call_id=typed_tc["tool_call_id"],
+                    name=typed_tc["name"],
+                )
+                yield ToolCallEndEvent(
+                    type="tool_call_end",
+                    tool_call_id=typed_tc["tool_call_id"],
+                    name=typed_tc["name"],
+                    arguments=typed_tc["arguments"],
+                )
+
+            elif llm_event["type"] == "done":
+                assert isinstance(llm_event, dict)
+                typed_done: LLMDoneEvent = llm_event  # type: ignore[assignment]
+                assistant_content = typed_done["content"]
+                stop_reason = typed_done["stop_reason"]
+
+        # Build the AssistantMessage for this turn.
+        assistant_msg = AssistantMessage(
+            role="assistant",
+            content=assistant_content,
+            stop_reason=stop_reason,
+        )
+        messages.append(assistant_msg)
+        new_messages.append(assistant_msg)
+
+        # ── Execute tool calls if any ─────────────────────────────────────
+        tool_calls = [b for b in assistant_content if b["type"] == "toolCall"]
+        tool_results: list[ToolResultMessage] = []
+
+        if tool_calls:
+            tool_map = {t.name: t for t in tools}
+
+            for tc in tool_calls:
+                assert tc["type"] == "toolCall"
+                tool = tool_map.get(tc["name"])
+                is_error = False
+                result_text: str
+
+                if tool is None:
+                    result_text = f"Tool '{tc['name']}' not found."
+                    is_error = True
+                else:
+                    try:
+                        result_text = await tool.execute(
+                            tc["tool_call_id"], **tc["arguments"]
+                        )
+                    except Exception as exc:
+                        result_text = f"Tool error: {exc}"
+                        is_error = True
+
+                yield ToolResultEvent(
+                    type="tool_result",
+                    tool_call_id=tc["tool_call_id"],
+                    content=result_text,
+                    is_error=is_error,
+                )
+
+                tool_result_msg = ToolResultMessage(
+                    role="toolResult",
+                    tool_call_id=tc["tool_call_id"],
+                    content=[ToolResultContent(type="text", text=result_text)],
+                    is_error=is_error,
+                )
+                tool_results.append(tool_result_msg)
+                messages.append(tool_result_msg)
+                new_messages.append(tool_result_msg)
+
+        yield TurnEndEvent(
+            type="turn_end",
+            message=assistant_msg,
+            tool_results=tool_results,
+        )
+
+        # ── Check stop conditions ─────────────────────────────────────────
+        if stop_reason in {"error", "aborted"}:
+            break
+
+        if config.should_stop_after_turn is not None:
+            fake_ctx = _make_context_snapshot(messages, tools)
+            if config.should_stop_after_turn(fake_ctx):
+                break
+
+        # Loop back only if there were tool calls (and no stop triggered).
+        if not tool_calls:
+            break
+
+    yield AgentEndEvent(type="agent_end", messages=new_messages)
+
+
+def _make_context_snapshot(
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+) -> object:
+    """Lightweight stand-in for AgentContext passed to shouldStopAfterTurn."""
+    # Avoid importing AgentContext circularly; just return an object with
+    # the fields shouldStopAfterTurn callbacks typically inspect.
+    class _Snapshot:
+        def __init__(self) -> None:
+            self.messages = messages
+            self.tools = tools
+
+    return _Snapshot()

--- a/backend/app/core/agent_loop/types.py
+++ b/backend/app/core/agent_loop/types.py
@@ -1,0 +1,221 @@
+"""
+Types for the Pi-inspired agent loop.
+
+Architecture mirrors @mariozechner/pi-agent-core from pi-mono:
+  https://github.com/badlogic/pi-mono/blob/main/packages/agent/src/types.ts
+
+Key separation:
+  - AgentMessage: what the loop works with (can include UI-only messages)
+  - LLMEvent: what providers emit while streaming
+  - AgentEvent: what the loop emits to callers
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Coroutine
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypedDict
+
+
+# ---------------------------------------------------------------------------
+# Content blocks (inside messages)
+# ---------------------------------------------------------------------------
+
+class TextContent(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class ToolCallContent(TypedDict):
+    type: Literal["toolCall"]
+    tool_call_id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class ToolResultContent(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+# ---------------------------------------------------------------------------
+# Agent-level messages (what the loop accumulates)
+# ---------------------------------------------------------------------------
+
+class UserMessage(TypedDict):
+    role: Literal["user"]
+    content: str
+
+
+class AssistantMessage(TypedDict):
+    role: Literal["assistant"]
+    content: list[TextContent | ToolCallContent]
+    stop_reason: str  # "stop" | "tool_use" | "error" | "aborted"
+
+
+class ToolResultMessage(TypedDict):
+    role: Literal["toolResult"]
+    tool_call_id: str
+    content: list[ToolResultContent]
+    is_error: bool
+
+
+AgentMessage = UserMessage | AssistantMessage | ToolResultMessage
+
+
+# ---------------------------------------------------------------------------
+# LLM-level events (what StreamFn implementations yield)
+# ---------------------------------------------------------------------------
+
+class LLMTextDeltaEvent(TypedDict):
+    type: Literal["text_delta"]
+    text: str
+
+
+class LLMToolCallEvent(TypedDict):
+    type: Literal["tool_call"]
+    tool_call_id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class LLMDoneEvent(TypedDict):
+    type: Literal["done"]
+    stop_reason: str
+    content: list[TextContent | ToolCallContent]
+
+
+LLMEvent = LLMTextDeltaEvent | LLMToolCallEvent | LLMDoneEvent
+
+
+# ---------------------------------------------------------------------------
+# Agent-level events (what agent_loop() yields to callers)
+# ---------------------------------------------------------------------------
+
+class AgentStartEvent(TypedDict):
+    type: Literal["agent_start"]
+
+
+class TurnStartEvent(TypedDict):
+    type: Literal["turn_start"]
+
+
+class MessageStartEvent(TypedDict):
+    type: Literal["message_start"]
+    message: AgentMessage
+
+
+class MessageEndEvent(TypedDict):
+    type: Literal["message_end"]
+    message: AgentMessage
+
+
+class TextDeltaEvent(TypedDict):
+    type: Literal["text_delta"]
+    text: str
+
+
+class ToolCallStartEvent(TypedDict):
+    type: Literal["tool_call_start"]
+    tool_call_id: str
+    name: str
+
+
+class ToolCallEndEvent(TypedDict):
+    type: Literal["tool_call_end"]
+    tool_call_id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class ToolResultEvent(TypedDict):
+    type: Literal["tool_result"]
+    tool_call_id: str
+    content: str
+    is_error: bool
+
+
+class TurnEndEvent(TypedDict):
+    type: Literal["turn_end"]
+    message: AssistantMessage
+    tool_results: list[ToolResultMessage]
+
+
+class AgentEndEvent(TypedDict):
+    type: Literal["agent_end"]
+    messages: list[AgentMessage]
+
+
+AgentEvent = (
+    AgentStartEvent
+    | TurnStartEvent
+    | MessageStartEvent
+    | MessageEndEvent
+    | TextDeltaEvent
+    | ToolCallStartEvent
+    | ToolCallEndEvent
+    | ToolResultEvent
+    | TurnEndEvent
+    | AgentEndEvent
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentTool:
+    """A callable tool the agent can invoke.
+
+    ``execute`` receives the tool_call_id and keyword arguments matching
+    the JSON schema parameters.  It must return a string result.
+    """
+    name: str
+    description: str
+    parameters: dict[str, Any]  # JSON schema object
+    execute: Callable[..., Coroutine[Any, Any, str]]
+
+
+# ---------------------------------------------------------------------------
+# Agent context and loop config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentContext:
+    """Shared state passed into and mutated by the agent loop."""
+    system_prompt: str
+    messages: list[AgentMessage]
+    tools: list[AgentTool] = field(default_factory=list)
+
+
+# StreamFn: what each provider implements.
+# Takes messages (after transform + convert) and tools; yields LLMEvents.
+StreamFn = Callable[
+    [list[AgentMessage], list[AgentTool]],
+    AsyncIterator[LLMEvent],
+]
+
+# TransformContextFn: prune/summarise messages before the LLM call.
+TransformContextFn = Callable[
+    [list[AgentMessage]],
+    Coroutine[Any, Any, list[AgentMessage]],
+]
+
+# ShouldStopFn: return True to exit after the current turn.
+ShouldStopFn = Callable[[AgentContext], bool]
+
+
+@dataclass
+class AgentLoopConfig:
+    """Configuration for a single agent_loop invocation.
+
+    convert_to_llm: required — filters/converts AgentMessage[] to the
+        subset the LLM provider understands (strips UI-only messages).
+    transform_context: optional — async function that prunes or compresses
+        the message list before every LLM call (e.g. sliding window).
+    should_stop_after_turn: optional — sync predicate; return True to stop
+        the loop after the current turn even if more tool calls are pending.
+    """
+    convert_to_llm: Callable[[list[AgentMessage]], list[AgentMessage]]
+    transform_context: TransformContextFn | None = None
+    should_stop_after_turn: ShouldStopFn | None = None

--- a/backend/tests/test_agent_loop.py
+++ b/backend/tests/test_agent_loop.py
@@ -1,0 +1,321 @@
+"""
+TDD tests for the Pi-inspired agent loop.
+
+Test structure mirrors pi-mono/packages/agent/test/agent-loop.test.ts
+(https://github.com/badlogic/pi-mono/blob/main/packages/agent/test/agent-loop.test.ts)
+
+RED phase: all tests fail until loop.py and types.py are implemented.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from app.core.agent_loop.types import (
+    AgentContext,
+    AgentEvent,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    TextContent,
+    ToolCallContent,
+    ToolResultContent,
+    UserMessage,
+)
+from app.core.agent_loop.loop import agent_loop
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock primitives matching Pi's test helpers
+# ---------------------------------------------------------------------------
+
+def make_user_message(text: str) -> UserMessage:
+    return UserMessage(role="user", content=text)
+
+
+def make_assistant_message(
+    content: list[TextContent | ToolCallContent],
+    stop_reason: str = "stop",
+) -> AssistantMessage:
+    return AssistantMessage(role="assistant", content=content, stop_reason=stop_reason)
+
+
+def make_text_content(text: str) -> TextContent:
+    return TextContent(type="text", text=text)
+
+
+def make_tool_call_content(tool_call_id: str, name: str, arguments: dict[str, Any]) -> ToolCallContent:
+    return ToolCallContent(type="toolCall", tool_call_id=tool_call_id, name=name, arguments=arguments)
+
+
+def make_tool_result_content(text: str) -> ToolResultContent:
+    return ToolResultContent(type="text", text=text)
+
+
+def identity_converter(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Pass through only roles the LLM understands (mirrors Pi's identityConverter)."""
+    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
+
+
+def make_mock_stream(*responses: AssistantMessage):
+    """Build a StreamFn that yields pre-scripted AssistantMessages in order."""
+    call_count = 0
+
+    async def stream_fn(
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+    ) -> AsyncIterator[LLMEvent]:
+        nonlocal call_count
+        msg = responses[min(call_count, len(responses) - 1)]
+        call_count += 1
+
+        # Emit text deltas for any text content
+        for block in msg["content"]:
+            if block["type"] == "text":
+                yield LLMTextDeltaEvent(type="text_delta", text=block["text"])
+            elif block["type"] == "toolCall":
+                yield LLMToolCallEvent(
+                    type="tool_call",
+                    tool_call_id=block["tool_call_id"],
+                    name=block["name"],
+                    arguments=block["arguments"],
+                )
+
+        yield LLMDoneEvent(
+            type="done",
+            stop_reason=msg["stop_reason"],
+            content=msg["content"],
+        )
+
+    return stream_fn
+
+
+# ---------------------------------------------------------------------------
+# Test 1: basic turn, no tools (mirrors "should emit events with AgentMessage types")
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_emits_full_event_sequence_for_simple_turn() -> None:
+    """A single user prompt with no tool calls emits the full lifecycle event sequence."""
+    context = AgentContext(system_prompt="You are helpful.", messages=[], tools=[])
+    prompt = make_user_message("Hello")
+    config = AgentLoopConfig(convert_to_llm=identity_converter)
+    stream_fn = make_mock_stream(
+        make_assistant_message([make_text_content("Hi there!")])
+    )
+
+    events: list[AgentEvent] = []
+    returned_messages: list[AgentMessage] = []
+
+    async for event in agent_loop([prompt], context, config, stream_fn):
+        events.append(event)
+        if event["type"] == "agent_end":
+            returned_messages = event["messages"]
+
+    event_types = [e["type"] for e in events]
+
+    assert "agent_start" in event_types
+    assert "turn_start" in event_types
+    assert "message_start" in event_types
+    assert "message_end" in event_types
+    assert "turn_end" in event_types
+    assert "agent_end" in event_types
+
+    # Prompt + assistant response
+    assert len(returned_messages) == 2
+    assert returned_messages[0]["role"] == "user"
+    assert returned_messages[1]["role"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: text deltas stream through during turn
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_streams_text_deltas() -> None:
+    """Text delta events from the stream_fn are forwarded as agent events."""
+    context = AgentContext(system_prompt="You are helpful.", messages=[], tools=[])
+    prompt = make_user_message("Hi")
+    config = AgentLoopConfig(convert_to_llm=identity_converter)
+    stream_fn = make_mock_stream(
+        make_assistant_message([make_text_content("Hello world")])
+    )
+
+    events: list[AgentEvent] = []
+    async for event in agent_loop([prompt], context, config, stream_fn):
+        events.append(event)
+
+    text_deltas = [e for e in events if e["type"] == "text_delta"]
+    assert len(text_deltas) >= 1
+    assert any("Hello world" in e.get("text", "") for e in text_deltas)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: transformContext is applied before convert_to_llm
+# (mirrors "should apply transformContext before convertToLlm")
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_applies_transform_context_before_convert() -> None:
+    """transformContext prunes history before the LLM sees it."""
+    old_messages: list[AgentMessage] = [
+        make_user_message("old 1"),
+        make_assistant_message([make_text_content("old reply 1")]),
+        make_user_message("old 2"),
+        make_assistant_message([make_text_content("old reply 2")]),
+    ]
+    context = AgentContext(system_prompt="You are helpful.", messages=old_messages, tools=[])
+    prompt = make_user_message("new message")
+
+    seen_by_llm: list[list[AgentMessage]] = []
+
+    async def recording_stream_fn(
+        messages: list[AgentMessage], tools: list[AgentTool]
+    ) -> AsyncIterator[LLMEvent]:
+        seen_by_llm.append(list(messages))
+        msg = make_assistant_message([make_text_content("response")])
+        yield LLMTextDeltaEvent(type="text_delta", text="response")
+        yield LLMDoneEvent(type="done", stop_reason="stop", content=msg["content"])
+
+    async def prune_to_last_two(messages: list[AgentMessage]) -> list[AgentMessage]:
+        return messages[-2:]
+
+    config = AgentLoopConfig(
+        convert_to_llm=identity_converter,
+        transform_context=prune_to_last_two,
+    )
+
+    async for _ in agent_loop([prompt], context, config, recording_stream_fn):
+        pass
+
+    # After pruning, LLM should only see the 2 most recent messages + the new prompt
+    assert len(seen_by_llm) == 1
+    # The pruned context (last 2) + new prompt = 3 messages max
+    assert len(seen_by_llm[0]) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Test 4: tool calls trigger execution and a second LLM turn
+# (mirrors "should handle tool calls and results")
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_executes_tool_calls_and_loops() -> None:
+    """When the assistant returns a tool call, the loop executes it and calls the LLM again."""
+    executed: list[str] = []
+
+    async def echo_execute(tool_call_id: str, **kwargs: Any) -> str:
+        executed.append(kwargs["value"])
+        return f"echoed: {kwargs['value']}"
+
+    echo_tool = AgentTool(
+        name="echo",
+        description="Echoes a value",
+        parameters={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        execute=echo_execute,
+    )
+
+    context = AgentContext(system_prompt="You are helpful.", messages=[], tools=[echo_tool])
+    prompt = make_user_message("Echo hello")
+    config = AgentLoopConfig(convert_to_llm=identity_converter)
+
+    # First LLM call: request a tool call. Second: plain text response.
+    stream_fn = make_mock_stream(
+        make_assistant_message(
+            [make_tool_call_content("call-1", "echo", {"value": "hello"})],
+            stop_reason="tool_use",
+        ),
+        make_assistant_message([make_text_content("Done!")]),
+    )
+
+    events: list[AgentEvent] = []
+    returned_messages: list[AgentMessage] = []
+
+    async for event in agent_loop([prompt], context, config, stream_fn):
+        events.append(event)
+        if event["type"] == "agent_end":
+            returned_messages = event["messages"]
+
+    # Tool should have been called
+    assert executed == ["hello"]
+
+    event_types = [e["type"] for e in events]
+    assert "tool_call_start" in event_types
+    assert "tool_call_end" in event_types
+    assert "tool_result" in event_types
+
+    # Two full turns: one with tool call, one with final response
+    turn_starts = [e for e in events if e["type"] == "turn_start"]
+    assert len(turn_starts) == 2
+
+    # Messages: user prompt, assistant (tool call), tool result, assistant (final)
+    assert len(returned_messages) == 4
+
+
+# ---------------------------------------------------------------------------
+# Test 5: shouldStopAfterTurn stops the loop early
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_respects_should_stop_after_turn() -> None:
+    """shouldStopAfterTurn returning True exits after the first turn."""
+    context = AgentContext(system_prompt="You are helpful.", messages=[], tools=[])
+    prompt = make_user_message("Hello")
+    config = AgentLoopConfig(
+        convert_to_llm=identity_converter,
+        should_stop_after_turn=lambda ctx: True,  # always stop
+    )
+    stream_fn = make_mock_stream(
+        make_assistant_message([make_text_content("Turn 1")]),
+        make_assistant_message([make_text_content("Turn 2 — should not reach")]),
+    )
+
+    events: list[AgentEvent] = []
+    async for event in agent_loop([prompt], context, config, stream_fn):
+        events.append(event)
+
+    turn_starts = [e for e in events if e["type"] == "turn_start"]
+    assert len(turn_starts) == 1  # stopped after first turn
+
+
+# ---------------------------------------------------------------------------
+# Test 6: existing messages in context are included in LLM call
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_agent_loop_includes_existing_context_messages() -> None:
+    """Prior messages in context are passed to the LLM (multi-turn continuity)."""
+    prior_messages: list[AgentMessage] = [
+        make_user_message("What is 2+2?"),
+        make_assistant_message([make_text_content("4")]),
+    ]
+    context = AgentContext(system_prompt="You are helpful.", messages=prior_messages, tools=[])
+    prompt = make_user_message("And 3+3?")
+    config = AgentLoopConfig(convert_to_llm=identity_converter)
+
+    messages_seen_by_llm: list[list[AgentMessage]] = []
+
+    async def recording_stream_fn(
+        messages: list[AgentMessage], tools: list[AgentTool]
+    ) -> AsyncIterator[LLMEvent]:
+        messages_seen_by_llm.append(list(messages))
+        msg = make_assistant_message([make_text_content("6")])
+        yield LLMTextDeltaEvent(type="text_delta", text="6")
+        yield LLMDoneEvent(type="done", stop_reason="stop", content=msg["content"])
+
+    async for _ in agent_loop([prompt], context, config, recording_stream_fn):
+        pass
+
+    # LLM should have received: 2 prior messages + new prompt = 3 total
+    assert len(messages_seen_by_llm[0]) == 3


### PR DESCRIPTION
## What

Adds a self-owned Pi-style agent harness — no third-party port dependency, no Agno.

Modelled directly on [@mariozechner/pi-agent-core](https://github.com/badlogic/pi-mono/blob/main/packages/agent/src/agent-loop.ts) from pi-mono, translated faithfully to Python.

## Why

Agno owns the agent loop behind our back. Pi SDK is TypeScript-only. pi-agents-py is a Beta third-party port that lags the original (v0.58 vs v0.72). The loop itself is ~80 meaningful lines — owning it costs less than the risk of a stale dependency.

## Architecture

```
Providers supply StreamFn → agent_loop() owns the rest
```

**`types.py`** — AgentMessage, LLMEvent, AgentEvent, AgentTool, AgentContext, AgentLoopConfig, StreamFn

**`loop.py`** — agent_loop() async generator:
- Full Pi lifecycle: agent_start → turn_start → text_delta* → tool_call_start/end → tool_result → turn_end → agent_end
- Tool call execution (sequential, error-safe)
- `transform_context` hook — prune/compress history before each LLM call
- `convert_to_llm` hook — filter AgentMessage[] to what the provider understands
- `should_stop_after_turn` hook — early exit predicate
- Multi-turn loop-back when tool calls are present

## Tests

6 tests mirroring pi-mono's own test suite, all using a mock StreamFn (no real LLM calls):
1. Full event sequence for a simple turn
2. Text deltas forwarded
3. transformContext applied before convert_to_llm
4. Tool calls executed + loop-back for second turn
5. shouldStopAfterTurn respected
6. Existing context messages included

## Next

Wire StreamFn adapters for GeminiProvider + update factory.

## Summary by Sourcery

Introduce a provider-agnostic, Pi-inspired agent loop core with accompanying types and tests for streaming LLM interactions and tool execution.

New Features:
- Add a reusable agent loop generator that orchestrates turn lifecycle, LLM streaming, and tool execution independently of specific providers.
- Define shared agent loop types for messages, events, tools, and configuration to standardize provider integrations.
- Expose a public agent_loop API and related types via a new app.core.agent_loop package.

Tests:
- Add an integration-style test suite validating the agent loop lifecycle, text streaming, context transformation, tool call handling, stop conditions, and context continuity.