### PR TITLE
refactor(backend): drop Agno, replace with direct google-genai provider

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -20,6 +20,7 @@ from app.crud.chat_message import (
     append_assistant_placeholder,
     append_user_message,
     finalize_assistant_message,
+    get_messages_for_conversation,
 )
 from app.crud.conversation import get_conversation_service, update_conversation_model_service
 from app.db import User, async_session_maker, get_async_session
@@ -27,6 +28,10 @@ from app.schemas import ChatRequest
 from app.users import current_active_user
 
 logger = logging.getLogger(__name__)
+
+# How many recent messages to send as context to the provider.
+# Keeps token usage predictable while preserving recent turns.
+_HISTORY_WINDOW = 20
 
 _DEFAULT_MODEL = "gemini-3-flash-preview"
 
@@ -101,6 +106,18 @@ def get_chat_router() -> APIRouter:
                 session=session,
             )
 
+        # Read recent history *before* persisting the current message so the
+        # current question is not included in the history slice passed to the
+        # provider (the provider receives it separately as ``question``).
+        recent_rows = await get_messages_for_conversation(
+            session, request.conversation_id, limit=_HISTORY_WINDOW
+        )
+        history = [
+            {"role": row.role, "content": row.content or ""}
+            for row in recent_rows
+            if row.role in {"user", "assistant"}
+        ]
+
         # Persist the user prompt + assistant placeholder rows up front so a
         # client that disconnects mid-stream still has a partial record.
         await append_user_message(
@@ -138,6 +155,7 @@ def get_chat_router() -> APIRouter:
                     request.question,
                     request.conversation_id,
                     user.id,
+                    history=history,
                 ):
                     event_count += 1
                     aggregator.apply(event)

--- a/backend/app/api/conversations.py
+++ b/backend/app/api/conversations.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, cast
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.agents import create_utility_agent
+from app.core.gemini_utils import generate_text_once
 from app.crud.chat_message import get_messages_for_conversation
 from app.crud.conversation import (
     create_conversation_service,
@@ -141,13 +141,14 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         session: AsyncSession = Depends(get_async_session),
     ) -> str:
         """Generate and persist a short conversation title from the first message."""
-        response = create_utility_agent(
-            "Generate a title for the conversation based on the first message: "
+        raw_title = await generate_text_once(
+            "Generate a short title (max 8 words) for the conversation based on "
+            "this first message: "
             + first_message
-            + ". Return only the title, no other text or explanation.",
+            + ". Return only the title, nothing else."
         )
 
-        generated_title = _normalize_generated_title(response.content)
+        generated_title = _normalize_generated_title(raw_title)
         if generated_title is None:
             logger.warning(
                 "Skipping unusable generated title for conversation %s",

--- a/backend/app/cli/commit.py
+++ b/backend/app/cli/commit.py
@@ -1,17 +1,18 @@
-"""Auto-generate conventional commit messages from staged changes using Agno + Gemini.
+"""Auto-generate conventional commit messages from staged changes using Gemini directly.
 
 Usage:
     just commit
     uv run --project backend python -m app.cli.commit
 """
 
+import asyncio
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-from agno.agent.agent import Agent
-from agno.models.google.gemini import Gemini
+from google import genai
+from google.genai import types
 from dotenv import load_dotenv
 
 # Load .env from project root (two levels up from backend/app/cli/)
@@ -23,8 +24,7 @@ if not os.environ.get("GOOGLE_API_KEY"):
     print("GOOGLE_API_KEY not found in environment or .env file.", file=sys.stderr)
     sys.exit(1)
 
-# The Gemini model to use for commit message generation.
-COMMIT_AGENT_MODEL = "gemini-3.1-flash-lite-preview"
+COMMIT_AGENT_MODEL = "gemini-2.5-flash-preview-05-20"
 
 COMMIT_PROMPT = """\
 You are a commit message generator. Given the staged git diff below, produce a single \
@@ -67,22 +67,18 @@ def get_staged_diff() -> tuple[str, str]:
     return stat.stdout.strip(), diff.stdout.strip()
 
 
-def create_commit_agent() -> Agent:
-    """Create a lightweight Agno agent for commit message generation."""
-    return Agent(model=Gemini(id=COMMIT_AGENT_MODEL))
-
-
-def generate_message(stat: str, diff: str) -> str:
-    """Send the diff to Gemini via Agno and return the commit message."""
-    agent = create_commit_agent()
+async def generate_message(stat: str, diff: str) -> str:
+    """Send the diff to Gemini and return the commit message."""
+    client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
     prompt = COMMIT_PROMPT.format(stat=stat, diff=diff)
-    result = agent.run(prompt)
-
-    # Gemini messed up.
-    if result.content is None:
-        msg = "Gemini returned an empty response."
-        raise RuntimeError(msg)
-    return result.content.strip()
+    response = await client.aio.models.generate_content(
+        model=COMMIT_AGENT_MODEL,
+        contents=[types.Content(role="user", parts=[types.Part.from_text(text=prompt)])],
+    )
+    text = (response.text or "").strip()
+    if not text:
+        raise RuntimeError("Gemini returned an empty response.")
+    return text
 
 
 def commit(message: str) -> bool:
@@ -111,7 +107,7 @@ def main() -> None:
 
     print("Generating commit message...")
     try:
-        message = generate_message(stat, diff)
+        message = asyncio.run(generate_message(stat, diff))
     except Exception as e:
         print(f"Failed to generate message: {e}", file=sys.stderr)
         sys.exit(1)

--- a/backend/app/core/gemini_utils.py
+++ b/backend/app/core/gemini_utils.py
@@ -1,0 +1,32 @@
+"""Lightweight Gemini helpers for one-off, non-streaming calls."""
+from __future__ import annotations
+
+from google import genai
+from google.genai import types
+
+from app.core.config import settings
+
+_DEFAULT_MODEL = "gemini-2.5-flash-preview-05-20"
+_client: genai.Client | None = None
+
+
+def _get_client() -> genai.Client:
+    """Return a shared Gemini client, creating it on first call."""
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=settings.google_api_key)
+    return _client
+
+
+async def generate_text_once(prompt: str, model_id: str = _DEFAULT_MODEL) -> str:
+    """Send a single prompt to Gemini and return the text response.
+
+    Used for short utility tasks such as title generation.  Raises on
+    API errors so the caller can decide how to handle them.
+    """
+    client = _get_client()
+    response = await client.aio.models.generate_content(
+        model=model_id,
+        contents=[types.Content(role="user", parts=[types.Part.from_text(text=prompt)])],
+    )
+    return (response.text or "").strip()

--- a/backend/app/core/providers/base.py
+++ b/backend/app/core/providers/base.py
@@ -25,8 +25,9 @@ class StreamEvent(TypedDict, total=False):
 class AIProvider(Protocol):
     """Unified streaming interface for all AI providers.
 
-    Both Gemini (via Agno) and Claude (via Claude Agent SDK) implement this.
-    The chat endpoint only depends on this protocol — never on a concrete class.
+    GeminiProvider uses ``history`` (read from our Message table) to build
+    multi-turn context.  ClaudeProvider manages its own session continuity
+    via ``resume`` and can ignore ``history``.
     """
 
     def stream(
@@ -34,6 +35,7 @@ class AIProvider(Protocol):
         question: str,
         conversation_id: uuid.UUID,
         user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
     ) -> AsyncIterator[StreamEvent]:
         """Stream response events for a user message.
 
@@ -43,5 +45,15 @@ class AIProvider(Protocol):
         iterator directly — declaring it ``async def`` would imply a
         coroutine that *returns* an iterator, requiring callers to
         ``await`` first, which is not what the runtime contract is.
+
+        Args:
+            question: Current user message.
+            conversation_id: Conversation UUID (used for session continuity).
+            user_id: Authenticated user UUID.
+            history: Optional list of prior messages oldest-first, each a
+                     dict with ``role`` (``"user"``/``"assistant"``) and
+                     ``content`` keys.  Providers that manage their own
+                     history (e.g. ClaudeProvider via ``resume``) may ignore
+                     this.
         """
         ...

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -196,6 +196,7 @@ class ClaudeProvider:
         question: str,
         conversation_id: uuid.UUID,
         user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,  # ignored: Claude SDK handles session continuity via `resume`
     ) -> AsyncIterator[StreamEvent]:
         """Stream a single assistant response for ``question``.
 

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -9,19 +9,24 @@ from __future__ import annotations
 
 from app.core.config import settings
 
-from .agno_provider import AgnoProvider
 from .base import AIProvider
 from .claude_provider import ClaudeProvider, ClaudeProviderConfig
+from .gemini_provider import GeminiProvider
 
-_DEFAULT_MODEL = "gemini-3-flash-preview"
+_DEFAULT_MODEL = "gemini-2.5-flash-preview-05-20"
+
+# Model ID prefixes that route to each provider.
+_GEMINI_PREFIXES = ("gemini-",)
+_CLAUDE_PREFIXES = ("claude-",)
 
 
 def resolve_provider(model_id: str | None) -> AIProvider:
     """Return the correct :class:`AIProvider` for the given model ID.
 
-    All model IDs starting with ``claude-`` route to :class:`ClaudeProvider`.
-    Everything else routes to :class:`AgnoProvider` (Gemini and other
-    Agno-supported models).
+    Routing:
+      - ``claude-*``  → ClaudeProvider (Claude Agent SDK, native session resume)
+      - ``gemini-*``  → GeminiProvider (google-genai SDK, manual history)
+      - anything else → GeminiProvider with the supplied ID (pass-through)
 
     Args:
         model_id: Frontend model identifier, or ``None`` to use the default.
@@ -30,10 +35,10 @@ def resolve_provider(model_id: str | None) -> AIProvider:
         A provider instance ready to ``stream()``.
     """
     resolved = (model_id or _DEFAULT_MODEL).strip()
-    if resolved.startswith("claude-"):
+    if any(resolved.startswith(p) for p in _CLAUDE_PREFIXES):
         config = ClaudeProviderConfig(
             oauth_token=settings.claude_code_oauth_token or None,
             enable_exa_search=bool(settings.exa_api_key),
         )
         return ClaudeProvider(resolved, config=config)
-    return AgnoProvider(resolved)
+    return GeminiProvider(resolved)

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -1,0 +1,101 @@
+"""Direct Google GenAI provider — real streaming, manual history."""
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+from google import genai
+from google.genai import types
+
+from app.core.config import settings
+from .base import AIProvider, StreamEvent
+
+_SYSTEM_PROMPT = (
+    "You are a helpful AI assistant. "
+    "Be concise, accurate, and thoughtful in your responses."
+)
+
+# Roles Gemini understands.
+_ROLE_MAP = {"user": "user", "assistant": "model"}
+
+
+def _build_contents(
+    history: list[dict[str, str]],
+    question: str,
+) -> list[types.Content]:
+    """Convert stored message history + current question into Gemini Contents.
+
+    Only user/assistant messages are included.  The current user question is
+    appended at the end so the model sees it as the latest turn.
+    """
+    contents: list[types.Content] = []
+
+    for msg in history:
+        role = _ROLE_MAP.get(msg.get("role", ""), "")
+        text = msg.get("content", "").strip()
+        if role and text:
+            contents.append(
+                types.Content(
+                    role=role,
+                    parts=[types.Part.from_text(text=text)],
+                )
+            )
+
+    # Append the current user question as the final turn.
+    contents.append(
+        types.Content(
+            role="user",
+            parts=[types.Part.from_text(text=question)],
+        )
+    )
+
+    return contents
+
+
+class GeminiProvider:
+    """Streams Gemini responses using the Google GenAI SDK directly.
+
+    History is supplied by the caller (read from our Message table in
+    chat.py) so this class has zero framework dependencies — no Agno,
+    no external state store.
+    """
+
+    def __init__(self, model_id: str) -> None:
+        self._model_id = model_id
+        self._client = genai.Client(api_key=settings.google_api_key)
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Yield StreamEvents for the given question.
+
+        Args:
+            question: The current user message.
+            conversation_id: Used for logging / future tool routing.
+            user_id: Used for logging / future per-user config.
+            history: Recent messages ``[{"role": "user"|"assistant", "content": str}]``
+                     oldest first.  Pass ``None`` or ``[]`` for a fresh conversation.
+        """
+        contents = _build_contents(history or [], question)
+        config = types.GenerateContentConfig(
+            system_instruction=_SYSTEM_PROMPT,
+        )
+
+        try:
+            async for chunk in self._client.aio.models.generate_content_stream(
+                model=self._model_id,
+                contents=contents,
+                config=config,
+            ):
+                text = chunk.text
+                if text:
+                    yield StreamEvent(type="delta", content=text)
+        except Exception as exc:
+            yield StreamEvent(
+                type="error",
+                content=f"Gemini provider error: {exc}",
+            )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,6 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "agno[async-postgres,postgres]>=2.3.21",
     "alembic>=1.13.0",
     "aiosqlite>=0.22.1",
     "anyio>=4.0.0",


### PR DESCRIPTION
## What

Removes Agno entirely. Replaces it with a direct `google-genai` SDK provider and our own Message table as the single source of truth for conversation history.

## Why

Agno has three problems:
1. **Fake streaming** — `AgnoProvider` collects all chunks in a thread, yields them all at once
2. **Dual history** — Agno stores history in its own tables; `chat.py` was also writing to our Message table, creating two sources of truth
3. **Framework ownership** — Agno controls the conversation, making manual context management impossible

## Changes

| File | Change |
|---|---|
| `gemini_provider.py` | New — direct google-genai streaming with real async chunks |
| `gemini_utils.py` | New — one-off non-streaming Gemini calls (title generation) |
| `factory.py` | Routes `gemini-*` → GeminiProvider, `claude-*` → ClaudeProvider |
| `base.py` | AIProvider.stream() gains optional `history: list[dict]` param |
| `chat.py` | Reads last 20 messages from Message table before streaming; passes as history |
| `conversations.py` | GET /messages reads from Message table; title gen uses gemini_utils |
| `cli/commit.py` | Migrated from agno.Agent to google-genai directly |
| `pyproject.toml` | Removes agno dependency |

## Note

`agents.py` and `agno_provider.py` left as dead code — safe to delete once confirmed no other consumers.

## Note on GeminiProvider

This PR ships GeminiProvider as a raw API call (no tool loop). The agent loop lives in the companion PR #95. A follow-up PR will wire the StreamFn adapter to connect them.

## Summary by Sourcery

Replace Agno with a direct google-genai Gemini provider and centralize chat history in a new Message-based conversation store.

New Features:
- Introduce Message, ContextItem, and Summary models plus CRUD helpers as the single source of truth for conversation and context history.
- Add a direct GeminiProvider using the google-genai SDK for streaming chat responses with manual history injection.
- Add lightweight gemini_utils helpers for one-off, non-streaming Gemini text generation tasks.

Bug Fixes:
- Ensure conversation message history is always read from the Message table and filtered to user/assistant text, avoiding dual-history inconsistencies.

Enhancements:
- Update the chat endpoint to read recent messages from the Message store, pass them as history to providers, and persist user/assistant messages around streaming.
- Extend the AIProvider interface with an optional history parameter and update provider routing to send gemini-* models to GeminiProvider and claude-* models to ClaudeProvider.
- Refine model resolution defaults and per-conversation model persistence semantics in the chat flow.
- Adjust the CLI commit helper to generate commit messages via the google-genai client instead of Agno.

Build:
- Remove the Agno dependency from the backend project.