### PR TITLE
feat(backend): wire ClaudeProvider → agent_loop via StreamFn

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     google_api_key: str
     # Fernet Encryption Key (used to encrypt API keys)
     fernet_key: str
+    # Anthropic API key for direct Messages API calls (ClaudeStreamFnProvider).
+    # Required when any claude-* model is selected. Get one from
+    # https://console.anthropic.com/account/keys
+    anthropic_api_key: str = ""
     # OAuth token used by the Claude Agent SDK to authenticate the bundled
     # Claude Code CLI subprocess. Optional — only required when a chat
     # request resolves to a Claude model. Generate with `claude setup-token`.

--- a/backend/app/core/providers/claude_stream_fn_provider.py
+++ b/backend/app/core/providers/claude_stream_fn_provider.py
@@ -1,0 +1,341 @@
+"""Claude provider — StreamFn adapter for the agent loop.
+
+Mirrors the structure of ``gemini_provider.py``: a ``make_claude_stream_fn()``
+factory builds a ``StreamFn`` backed by the raw Anthropic Python SDK, and
+``ClaudeStreamFnProvider`` wires it into ``agent_loop()`` so every provider
+shares the same turn lifecycle.
+
+Unlike ``ClaudeProvider`` (which delegates to the Claude Code CLI via
+``claude_agent_sdk``), this provider calls the Anthropic Messages API
+directly.  That means:
+
+- Full streaming with ``AsyncAnthropic.messages.stream()``.
+- Tool calls accumulated from ``input_json_delta`` chunks — same pattern the
+  Anthropic docs recommend.
+- History injected per-turn from ``AgentContext.messages`` rather than
+  relying on CLI session transcripts.
+
+Design decisions that mirror ``gemini_provider.py``:
+- ``make_claude_stream_fn(model_id)`` is a closure so it can be unit-tested
+  independently of the full provider class.
+- ``_build_anthropic_messages()`` converts ``AgentMessage`` list to the dict
+  format the Anthropic API expects (role + content).
+- ``_build_anthropic_tools()`` converts ``AgentTool`` → Anthropic tool schema.
+- ``ClaudeStreamFnProvider.stream()`` translates ``AgentEvent``→``StreamEvent``
+  using the same projection as ``GeminiProvider``.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import anthropic
+
+from app.core.agent_loop import (
+    AgentContext,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    StreamFn,
+    UserMessage,
+    agent_loop,
+)
+from app.core.config import settings
+
+from .base import AIProvider, StreamEvent
+
+_SYSTEM_PROMPT = (
+    "You are a helpful AI assistant inside the AI Nexus chat application. "
+    "Be concise, accurate, and thoughtful in your responses."
+)
+
+_MAX_TOKENS = 8096
+
+_ANTHROPIC_ROLE = {"user": "user", "assistant": "assistant"}
+
+
+# ---------------------------------------------------------------------------
+# Message / tool converters
+# ---------------------------------------------------------------------------
+
+
+def _build_anthropic_messages(
+    messages: list[AgentMessage],
+) -> list[dict[str, Any]]:
+    """Convert ``AgentMessage`` list to Anthropic Messages API format.
+
+    Rules:
+    - ``user`` / ``assistant`` roles map 1-to-1.
+    - ``toolResult`` messages become a ``user`` turn with a
+      ``tool_result`` content block — the format the API expects.
+    - Empty or whitespace-only text messages are skipped to avoid API errors.
+    """
+    result: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+
+        if role == "user":
+            text = msg.get("content", "")
+            if isinstance(text, str) and text.strip():
+                result.append({"role": "user", "content": text})
+
+        elif role == "assistant":
+            content = msg.get("content", [])
+            if isinstance(content, str):
+                if content.strip():
+                    result.append({"role": "assistant", "content": content})
+            elif isinstance(content, list):
+                blocks: list[dict[str, Any]] = []
+                for block in content:
+                    btype = block.get("type", "")
+                    if btype == "text":
+                        blocks.append({"type": "text", "text": block.get("text", "")})
+                    elif btype == "toolCall":
+                        blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": block.get("tool_call_id", ""),
+                                "name": block.get("name", ""),
+                                "input": block.get("arguments", {}),
+                            }
+                        )
+                if blocks:
+                    result.append({"role": "assistant", "content": blocks})
+
+        elif role == "toolResult":
+            tool_call_id = msg.get("tool_call_id", "")
+            content_list = msg.get("content", [])
+            text_parts = [
+                c.get("text", "") for c in content_list if c.get("type") == "text"
+            ]
+            result.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_call_id,
+                            "content": "\n".join(text_parts),
+                            "is_error": msg.get("is_error", False),
+                        }
+                    ],
+                }
+            )
+
+    return result
+
+
+def _build_anthropic_tools(tools: list[AgentTool]) -> list[dict[str, Any]]:
+    """Convert ``AgentTool`` list to Anthropic tool definitions."""
+    return [
+        {
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.parameters,
+        }
+        for t in tools
+    ]
+
+
+# ---------------------------------------------------------------------------
+# StreamFn factory
+# ---------------------------------------------------------------------------
+
+
+def make_claude_stream_fn(model_id: str) -> StreamFn:
+    """Build a ``StreamFn`` backed by the Anthropic Messages streaming API.
+
+    The returned async generator:
+    1. Converts ``AgentMessage`` → Anthropic message dicts.
+    2. Streams from ``AsyncAnthropic.messages.stream()``.
+    3. Yields ``LLMTextDeltaEvent`` for each text chunk.
+    4. Accumulates ``input_json_delta`` chunks to reconstruct tool call
+       arguments, then emits ``LLMToolCallEvent`` on ``content_block_stop``.
+    5. Emits ``LLMDoneEvent`` with ``stop_reason`` and full content list.
+    """
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+
+    async def stream_fn(
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+    ) -> AsyncIterator[LLMEvent]:
+        anthropic_messages = _build_anthropic_messages(messages)
+        anthropic_tools = _build_anthropic_tools(tools)
+
+        # Per-stream accumulators
+        full_text = ""
+        tool_calls: list[dict[str, Any]] = []
+
+        # In-progress tool call state (built up across delta events)
+        current_tool: dict[str, Any] | None = None
+        current_tool_json_buf: str = ""
+
+        try:
+            kwargs: dict[str, Any] = {
+                "model": model_id,
+                "max_tokens": _MAX_TOKENS,
+                "system": _SYSTEM_PROMPT,
+                "messages": anthropic_messages,
+            }
+            if anthropic_tools:
+                kwargs["tools"] = anthropic_tools
+
+            async with client.messages.stream(**kwargs) as stream:
+                async for event in stream:
+                    etype = event.type
+
+                    # --- start of a new content block ---
+                    if etype == "content_block_start":
+                        block = event.content_block  # type: ignore[attr-defined]
+                        if block.type == "tool_use":
+                            current_tool = {
+                                "tool_call_id": block.id,
+                                "name": block.name,
+                            }
+                            current_tool_json_buf = ""
+
+                    # --- delta within a content block ---
+                    elif etype == "content_block_delta":
+                        delta = event.delta  # type: ignore[attr-defined]
+                        if delta.type == "text_delta":
+                            yield LLMTextDeltaEvent(type="text_delta", text=delta.text)
+                            full_text += delta.text
+                        elif delta.type == "input_json_delta":
+                            current_tool_json_buf += delta.partial_json
+
+                    # --- end of a content block ---
+                    elif etype == "content_block_stop":
+                        if current_tool is not None:
+                            try:
+                                arguments = (
+                                    json.loads(current_tool_json_buf)
+                                    if current_tool_json_buf.strip()
+                                    else {}
+                                )
+                            except json.JSONDecodeError:
+                                arguments = {"_raw": current_tool_json_buf}
+
+                            tool_call = {
+                                "tool_call_id": current_tool["tool_call_id"],
+                                "name": current_tool["name"],
+                                "arguments": arguments,
+                            }
+                            yield LLMToolCallEvent(
+                                type="tool_call",
+                                tool_call_id=tool_call["tool_call_id"],
+                                name=tool_call["name"],
+                                arguments=arguments,
+                            )
+                            tool_calls.append(tool_call)
+                            current_tool = None
+                            current_tool_json_buf = ""
+
+        except anthropic.APIError as exc:
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="error",
+                content=[{"type": "text", "text": f"Anthropic API error: {exc}"}],
+            )
+            return
+
+        # Determine stop reason and emit done event
+        stop_reason = "tool_use" if tool_calls else "stop"
+
+        from app.core.agent_loop.types import TextContent, ToolCallContent
+
+        content: list[TextContent | ToolCallContent] = []
+        if full_text:
+            content.append(TextContent(type="text", text=full_text))
+        for tc in tool_calls:
+            content.append(
+                ToolCallContent(
+                    type="toolCall",
+                    tool_call_id=tc["tool_call_id"],
+                    name=tc["name"],
+                    arguments=tc["arguments"],
+                )
+            )
+
+        yield LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+
+    return stream_fn
+
+
+# ---------------------------------------------------------------------------
+# Provider class
+# ---------------------------------------------------------------------------
+
+
+def _identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Pass through messages the Anthropic API understands; strip UI-only types."""
+    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
+
+
+class ClaudeStreamFnProvider:
+    """``AIProvider`` backed by ``agent_loop`` + a Claude ``StreamFn``.
+
+    Matches the interface of ``GeminiProvider`` exactly — same constructor
+    signature, same ``stream()`` signature, same ``AgentEvent``→``StreamEvent``
+    projection.  The only provider-specific code is in ``make_claude_stream_fn()``.
+    """
+
+    def __init__(self, model_id: str) -> None:
+        self._model_id = model_id
+        self._stream_fn = make_claude_stream_fn(model_id)
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Run the agent loop and translate ``AgentEvent``s → ``StreamEvent``s."""
+        prior: list[AgentMessage] = [
+            AgentMessage(role=m["role"], content=m["content"])  # type: ignore[call-overload]
+            for m in (history or [])
+            if m.get("role") in {"user", "assistant"}
+        ]
+
+        context = AgentContext(
+            system_prompt=_SYSTEM_PROMPT,
+            messages=prior,
+            tools=[],  # TODO: wire Exa + MCP tools here
+        )
+        prompt = UserMessage(role="user", content=question)
+        config = AgentLoopConfig(convert_to_llm=_identity_convert)
+
+        try:
+            async for event in agent_loop([prompt], context, config, self._stream_fn):
+                etype = event["type"]
+
+                if etype == "text_delta":
+                    yield StreamEvent(type="delta", content=event.get("text", ""))  # type: ignore[arg-type]
+
+                elif etype == "tool_call_start":
+                    yield StreamEvent(
+                        type="tool_use",
+                        name=event.get("name", ""),  # type: ignore[arg-type]
+                        input={},
+                        tool_use_id=event.get("tool_call_id", ""),  # type: ignore[arg-type]
+                    )
+
+                elif etype == "tool_result":
+                    yield StreamEvent(
+                        type="tool_result",
+                        content=event.get("content", ""),  # type: ignore[arg-type]
+                        tool_use_id=event.get("tool_call_id", ""),  # type: ignore[arg-type]
+                    )
+
+                elif etype == "agent_end":
+                    pass  # loop complete — chat.py sends [DONE]
+
+        except Exception as exc:
+            yield StreamEvent(type="error", content=f"Claude provider error: {exc}")

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 
 from .base import AIProvider
 from .claude_provider import ClaudeProvider, ClaudeProviderConfig
+from .claude_stream_fn_provider import ClaudeStreamFnProvider
 from .gemini_provider import GeminiProvider
 
 _DEFAULT_MODEL = "gemini-2.5-flash-preview-05-20"
@@ -36,6 +37,12 @@ def resolve_provider(model_id: str | None) -> AIProvider:
     """
     resolved = (model_id or _DEFAULT_MODEL).strip()
     if any(resolved.startswith(p) for p in _CLAUDE_PREFIXES):
+        # Use ClaudeStreamFnProvider (raw Anthropic SDK + agent_loop) when an
+        # API key is configured.  Fall back to ClaudeProvider (Claude Code CLI
+        # + claude_agent_sdk) otherwise, so existing OAuth-token setups still
+        # work without an API key.
+        if settings.anthropic_api_key:
+            return ClaudeStreamFnProvider(resolved)
         config = ClaudeProviderConfig(
             oauth_token=settings.claude_code_oauth_token or None,
             enable_exa_search=bool(settings.exa_api_key),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "alembic>=1.13.0",
     "aiosqlite>=0.22.1",
     "anyio>=4.0.0",
+    "anthropic>=0.40.0",
     "claude-agent-sdk",
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.127.0",

--- a/backend/tests/test_claude_stream_fn.py
+++ b/backend/tests/test_claude_stream_fn.py
@@ -1,0 +1,309 @@
+"""Tests for the Claude StreamFn adapter (``claude_stream_fn_provider.py``).
+
+Mirrors the structure of ``test_gemini_stream_fn.py``:
+- ``make_claude_stream_fn`` is unit-tested against a mocked Anthropic client.
+- ``ClaudeStreamFnProvider`` is smoke-tested with a mocked stream_fn.
+
+Anthropic streaming uses server-sent events with typed objects; we mock the
+``client.messages.stream`` async context manager to yield fake event objects.
+"""
+from __future__ import annotations
+
+import json
+import types
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.agent_loop.types import (
+    AgentContext,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    UserMessage,
+)
+from app.core.providers.claude_stream_fn_provider import (
+    ClaudeStreamFnProvider,
+    _build_anthropic_messages,
+    _build_anthropic_tools,
+    make_claude_stream_fn,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake Anthropic stream events
+# ---------------------------------------------------------------------------
+
+
+def _text_event(text: str) -> MagicMock:
+    ev = MagicMock()
+    ev.type = "content_block_delta"
+    ev.delta = MagicMock()
+    ev.delta.type = "text_delta"
+    ev.delta.text = text
+    return ev
+
+
+def _tool_start_event(tool_id: str, name: str) -> MagicMock:
+    ev = MagicMock()
+    ev.type = "content_block_start"
+    ev.content_block = MagicMock()
+    ev.content_block.type = "tool_use"
+    ev.content_block.id = tool_id
+    ev.content_block.name = name
+    return ev
+
+
+def _json_delta_event(partial_json: str) -> MagicMock:
+    ev = MagicMock()
+    ev.type = "content_block_delta"
+    ev.delta = MagicMock()
+    ev.delta.type = "input_json_delta"
+    ev.delta.partial_json = partial_json
+    return ev
+
+
+def _block_stop_event() -> MagicMock:
+    ev = MagicMock()
+    ev.type = "content_block_stop"
+    return ev
+
+
+def _unhandled_event(etype: str) -> MagicMock:
+    ev = MagicMock()
+    ev.type = etype
+    return ev
+
+
+async def _fake_stream(events: list[MagicMock]) -> AsyncIterator[MagicMock]:
+    for ev in events:
+        yield ev
+
+
+class _FakeStreamContext:
+    """Async context manager that yields a fake stream iterator."""
+
+    def __init__(self, events: list[MagicMock]) -> None:
+        self._events = events
+
+    async def __aenter__(self) -> AsyncIterator[MagicMock]:
+        return _fake_stream(self._events)
+
+    async def __aexit__(self, *_: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _build_anthropic_messages
+# ---------------------------------------------------------------------------
+
+
+def test_build_messages_user_only() -> None:
+    msgs: list[AgentMessage] = [UserMessage(role="user", content="Hello")]
+    result = _build_anthropic_messages(msgs)
+    assert result == [{"role": "user", "content": "Hello"}]
+
+
+def test_build_messages_skips_empty_user() -> None:
+    msgs: list[AgentMessage] = [UserMessage(role="user", content="  ")]
+    result = _build_anthropic_messages(msgs)
+    assert result == []
+
+
+def test_build_messages_assistant_string() -> None:
+    msgs: list[AgentMessage] = [
+        {"role": "assistant", "content": "Hi there", "stop_reason": "stop"}  # type: ignore[typeddict-item]
+    ]
+    result = _build_anthropic_messages(msgs)
+    assert result == [{"role": "assistant", "content": "Hi there"}]
+
+
+def test_build_messages_tool_result() -> None:
+    msgs: list[AgentMessage] = [
+        {
+            "role": "toolResult",  # type: ignore[typeddict-item]
+            "tool_call_id": "tc-1",
+            "content": [{"type": "text", "text": "search result"}],
+            "is_error": False,
+        }
+    ]
+    result = _build_anthropic_messages(msgs)
+    assert len(result) == 1
+    assert result[0]["role"] == "user"
+    assert result[0]["content"][0]["type"] == "tool_result"
+    assert result[0]["content"][0]["tool_use_id"] == "tc-1"
+    assert result[0]["content"][0]["content"] == "search result"
+
+
+# ---------------------------------------------------------------------------
+# _build_anthropic_tools
+# ---------------------------------------------------------------------------
+
+
+def test_build_anthropic_tools_empty() -> None:
+    assert _build_anthropic_tools([]) == []
+
+
+def test_build_anthropic_tools_single() -> None:
+    async def noop(**_: Any) -> str:
+        return ""
+
+    tool = AgentTool(
+        name="my_tool",
+        description="Does a thing",
+        parameters={"type": "object", "properties": {"x": {"type": "string"}}},
+        execute=noop,
+    )
+    result = _build_anthropic_tools([tool])
+    assert result == [
+        {
+            "name": "my_tool",
+            "description": "Does a thing",
+            "input_schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# make_claude_stream_fn — text-only turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_fn_text_only() -> None:
+    events = [
+        _text_event("Hello"),
+        _text_event(" world"),
+        _unhandled_event("message_start"),
+        _unhandled_event("message_stop"),
+    ]
+    stream_ctx = _FakeStreamContext(events)
+
+    with patch("app.core.providers.claude_stream_fn_provider.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.AsyncAnthropic.return_value = mock_client
+        mock_anthropic.APIError = Exception
+        mock_client.messages.stream.return_value = stream_ctx
+
+        stream_fn = make_claude_stream_fn("claude-sonnet-4-5")
+        msgs: list[AgentMessage] = [UserMessage(role="user", content="Hi")]
+        collected = [ev async for ev in stream_fn(msgs, [])]
+
+    text_events = [e for e in collected if e["type"] == "text_delta"]
+    done_events = [e for e in collected if e["type"] == "done"]
+
+    assert len(text_events) == 2
+    assert text_events[0]["text"] == "Hello"
+    assert text_events[1]["text"] == " world"
+    assert len(done_events) == 1
+    assert done_events[0]["stop_reason"] == "stop"
+    full = "".join(e["text"] for e in text_events)
+    assert full == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# make_claude_stream_fn — tool call turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_fn_tool_call() -> None:
+    tool_args = json.dumps({"query": "latest AI news"})
+    events = [
+        _tool_start_event("tc-abc", "exa_search"),
+        _json_delta_event(tool_args[:10]),
+        _json_delta_event(tool_args[10:]),
+        _block_stop_event(),
+    ]
+    stream_ctx = _FakeStreamContext(events)
+
+    with patch("app.core.providers.claude_stream_fn_provider.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.AsyncAnthropic.return_value = mock_client
+        mock_anthropic.APIError = Exception
+        mock_client.messages.stream.return_value = stream_ctx
+
+        stream_fn = make_claude_stream_fn("claude-sonnet-4-5")
+        msgs: list[AgentMessage] = [UserMessage(role="user", content="Search for news")]
+        collected = [ev async for ev in stream_fn(msgs, [])]
+
+    tool_events = [e for e in collected if e["type"] == "tool_call"]
+    done_events = [e for e in collected if e["type"] == "done"]
+
+    assert len(tool_events) == 1
+    assert tool_events[0]["name"] == "exa_search"
+    assert tool_events[0]["arguments"] == {"query": "latest AI news"}
+    assert tool_events[0]["tool_call_id"] == "tc-abc"
+
+    assert len(done_events) == 1
+    assert done_events[0]["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# make_claude_stream_fn — API error path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_fn_api_error() -> None:
+    class FakeAPIError(Exception):
+        pass
+
+    async def bad_stream(*_: Any, **__: Any) -> None:
+        raise FakeAPIError("rate limited")
+
+    # We need the context manager to raise on __aenter__
+    class _ErrorStreamCtx:
+        async def __aenter__(self) -> None:
+            raise FakeAPIError("rate limited")
+
+        async def __aexit__(self, *_: Any) -> None:
+            pass
+
+    with patch("app.core.providers.claude_stream_fn_provider.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.AsyncAnthropic.return_value = mock_client
+        mock_anthropic.APIError = FakeAPIError
+        mock_client.messages.stream.return_value = _ErrorStreamCtx()
+
+        stream_fn = make_claude_stream_fn("claude-sonnet-4-5")
+        msgs: list[AgentMessage] = [UserMessage(role="user", content="Hi")]
+        collected = [ev async for ev in stream_fn(msgs, [])]
+
+    done_events = [e for e in collected if e["type"] == "done"]
+    assert len(done_events) == 1
+    assert done_events[0]["stop_reason"] == "error"
+    assert "rate limited" in done_events[0]["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# ClaudeStreamFnProvider — smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_stream_delegates_to_agent_loop() -> None:
+    """Provider.stream() should translate text_delta AgentEvents → StreamEvents."""
+
+    async def fake_agent_loop(*_: Any, **__: Any) -> AsyncIterator[dict]:
+        yield {"type": "text_delta", "text": "Hi from Claude"}
+        yield {"type": "agent_end", "messages": []}
+
+    with patch(
+        "app.core.providers.claude_stream_fn_provider.agent_loop",
+        side_effect=fake_agent_loop,
+    ):
+        with patch("app.core.providers.claude_stream_fn_provider.anthropic"):
+            provider = ClaudeStreamFnProvider("claude-sonnet-4-5")
+            events = [
+                e
+                async for e in provider.stream(
+                    "Hello", __import__("uuid").uuid4(), __import__("uuid").uuid4()
+                )
+            ]
+
+    delta_events = [e for e in events if e["type"] == "delta"]
+    assert len(delta_events) == 1
+    assert delta_events[0]["content"] == "Hi from Claude"


### PR DESCRIPTION
## What

Wires Claude into the same `agent_loop()` infrastructure as Gemini (PR #97), using a `make_claude_stream_fn()` adapter over the raw Anthropic Python SDK.

## Changes

- **`claude_stream_fn_provider.py`** — new file
  - `make_claude_stream_fn(model_id)`: StreamFn adapter using `AsyncAnthropic.messages.stream()`
  - Accumulates `input_json_delta` chunks to reconstruct tool arguments
  - Yields `LLMTextDeltaEvent`, `LLMToolCallEvent`, `LLMDoneEvent`
  - `ClaudeStreamFnProvider`: same interface as `GeminiProvider`, same `AgentEvent → StreamEvent` projection
- **`factory.py`** — prefer `ClaudeStreamFnProvider` when `ANTHROPIC_API_KEY` is set; fall back to legacy `ClaudeProvider` (CLI/OAuth) otherwise
- **`config.py`** — add optional `anthropic_api_key` field
- **`pyproject.toml`** — add `anthropic>=0.40.0`
- **`test_claude_stream_fn.py`** — 5 tests: message builder, tool schema builder, text-only turn, tool-call turn, API error path

## Why

All three providers now share the same turn lifecycle via `agent_loop()`. Adding a new provider means writing a StreamFn — nothing else changes.

## Summary by Sourcery

Integrate Claude via a new StreamFn-based provider that plugs into the shared agent_loop lifecycle and prefer it when an Anthropic API key is configured.

New Features:
- Add ClaudeStreamFnProvider and make_claude_stream_fn adapter to stream from the Anthropic Messages API into the agent_loop event model.

Enhancements:
- Route Claude model requests through ClaudeStreamFnProvider when an anthropic_api_key is set, falling back to the legacy ClaudeProvider otherwise.
- Convert internal agent messages and tools into Anthropic-compatible message and tool schemas for consistent multi-turn interactions.

Build:
- Add anthropic>=0.40.0 as a backend dependency.

Documentation:
- Document the new anthropic_api_key setting and its purpose for direct Claude API usage.

Tests:
- Add unit tests for the message and tool schema builders, text-only and tool-call streaming flows, Anthropic API error handling, and a smoke test for ClaudeStreamFnProvider.stream().