### PR TITLE
feat: channel abstraction layer (SSEChannel, registry, chat.py delegation)

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -1,17 +1,17 @@
-"""Chat API — provider-agnostic streaming endpoint."""
+"""Chat API — channel-routed, provider-agnostic streaming endpoint."""
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from collections.abc import AsyncGenerator
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, Header, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRouter
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.channels import resolve_channel, surface_from_header
 from app.core.chat_aggregator import ChatTurnAggregator
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
@@ -50,6 +50,7 @@ def get_chat_router() -> APIRouter:
         request: ChatRequest,
         user: User = Depends(current_active_user),
         session: AsyncSession = Depends(get_async_session),
+        x_nexus_surface: str | None = Header(default=None),
     ) -> StreamingResponse:
         """Stream an AI response as Server-Sent Events.
 
@@ -74,13 +75,17 @@ def get_chat_router() -> APIRouter:
         """
         # Entry log — pairs with REQ_IN/REQ_OUT from the request middleware via rid.
         # Question length, not contents, to avoid leaking PII into the log file.
+        surface = surface_from_header(x_nexus_surface)
+        channel = resolve_channel(surface)
+
         rid = get_request_id()
         logger.info(
-            "CHAT_IN  rid=%s user_id=%s conversation_id=%s model_id=%s question_len=%d",
+            "CHAT_IN  rid=%s user_id=%s conversation_id=%s model_id=%s surface=%s question_len=%d",
             rid,
             user.id,
             request.conversation_id,
             request.model_id or "<default>",
+            surface,
             len(request.question),
         )
 
@@ -139,46 +144,58 @@ def get_chat_router() -> APIRouter:
 
         provider = resolve_llm(model_id)
 
-        async def event_stream() -> AsyncGenerator[str]:
-            """Yield SSE-framed events from the provider stream.
+        async def event_stream() -> AsyncGenerator[bytes]:
+            """Yield channel-encoded bytes for each LLM event, then done.
 
-            Wraps the provider's async iterator with timing, event counting,
-            and structured ``CHAT_OUT`` / ``CHAT_ERR`` log markers so a
-            single user message produces exactly one entry/exit pair in
-            ``backend/app.log`` per request ID.
+            Builds a raw provider stream, wraps it with error handling and
+            aggregation, then hands it to ``channel.deliver()`` which
+            encodes each event for the surface (SSE frames for web/Electron,
+            message edits for Telegram, etc.).
             """
             stream_start = time.perf_counter()
             event_count = 0
             aggregator = ChatTurnAggregator()
+
+            async def _guarded_stream():
+                """Wrap the provider stream with error capture + aggregation."""
+                nonlocal event_count
+                try:
+                    async for event in provider.stream(
+                        request.question,
+                        request.conversation_id,
+                        user.id,
+                        history=history,
+                    ):
+                        event_count += 1
+                        aggregator.apply(event)
+                        yield event
+                except Exception as exc:
+                    logger.exception(
+                        "CHAT_ERR rid=%s conversation_id=%s model_id=%s after %d events",
+                        rid,
+                        request.conversation_id,
+                        model_id,
+                        event_count,
+                    )
+                    error_event: StreamEvent = {"type": "error", "content": str(exc)}
+                    aggregator.apply(error_event)
+                    yield error_event
+
+            from app.channels.base import ChannelMessage  # noqa: PLC0415
+            channel_message: ChannelMessage = {
+                "user_id": user.id,
+                "conversation_id": request.conversation_id,
+                "text": request.question,
+                "surface": surface,
+                "model_id": model_id,
+                "metadata": {},
+            }
+
             try:
-                async for event in provider.stream(
-                    request.question,
-                    request.conversation_id,
-                    user.id,
-                    history=history,
-                ):
-                    event_count += 1
-                    aggregator.apply(event)
-                    yield f"data: {json.dumps(event)}\n\n"
-            except Exception as exc:
-                # Logged with full traceback so the file has enough info to triage
-                # without needing to also tail stdout. Always pair with a CHAT_ERR
-                # marker so the corresponding REQ_OUT can be matched by rid.
-                logger.exception(
-                    "CHAT_ERR rid=%s conversation_id=%s model_id=%s after %d events",
-                    rid,
-                    request.conversation_id,
-                    model_id,
-                    event_count,
-                )
-                error_event: StreamEvent = {"type": "error", "content": str(exc)}
-                aggregator.apply(error_event)
-                yield f"data: {json.dumps(error_event)}\n\n"
+                async for chunk in channel.deliver(_guarded_stream(), channel_message):
+                    yield chunk
             finally:
                 duration_ms = (time.perf_counter() - stream_start) * 1000
-                # Persist the final assistant snapshot. Open a fresh session —
-                # the request-scoped one was committed and may have been closed
-                # by the time this finally runs in the streaming task.
                 final_status = "failed" if aggregator.error_text else "complete"
                 snapshot = aggregator.to_persisted_shape(status=final_status)
                 try:
@@ -190,23 +207,20 @@ def get_chat_router() -> APIRouter:
                         )
                         await persist_session.commit()
                 except Exception:
-                    # Persistence failure must not break the SSE response; the
-                    # client already saw every event live and the recovery hook
-                    # can replay if needed.
                     logger.exception(
                         "CHAT_PERSIST_ERR rid=%s message_id=%s",
                         rid,
                         assistant_message_id,
                     )
                 logger.info(
-                    "CHAT_OUT rid=%s conversation_id=%s model_id=%s events=%d duration_ms=%.1f",
+                    "CHAT_OUT rid=%s conversation_id=%s model_id=%s surface=%s events=%d duration_ms=%.1f",
                     rid,
                     request.conversation_id,
                     model_id,
+                    surface,
                     event_count,
                     duration_ms,
                 )
-                yield "data: [DONE]\n\n"
 
         return StreamingResponse(
             event_stream(),

--- a/backend/app/channels/__init__.py
+++ b/backend/app/channels/__init__.py
@@ -1,0 +1,24 @@
+"""Channel abstraction layer for AI Nexus.
+
+Every surface that can send a message and receive a response is a Channel.
+This package provides:
+
+- ``Channel`` — protocol that all adapters implement.
+- ``ChannelMessage`` / ``ChannelResponse`` — normalized inbound/outbound types.
+- ``SSEChannel`` — HTTP SSE adapter (web + Electron).
+- ``resolve_channel(surface)`` — look up a Channel by surface name.
+- ``registered_surfaces()`` — introspect active channel registrations.
+"""
+from .base import Channel, ChannelMessage, ChannelResponse
+from .registry import registered_surfaces, resolve_channel
+from .sse import SSEChannel, surface_from_header
+
+__all__ = [
+    "Channel",
+    "ChannelMessage",
+    "ChannelResponse",
+    "SSEChannel",
+    "registered_surfaces",
+    "resolve_channel",
+    "surface_from_header",
+]

--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -1,0 +1,134 @@
+"""Channel abstraction — base protocol and shared message types.
+
+Every surface that can send a message to Nexus and receive a response is a
+Channel.  Channels are equal peers; there is no "default" channel.
+
+Architecture
+------------
+- ``ChannelMessage`` — normalized inbound shape produced by any channel.
+- ``ChannelResponse`` — normalized outbound shape consumed by any channel.
+- ``Channel`` — protocol that every adapter must implement.
+
+The split between *inbound normalization* and *outbound delivery* maps to
+the two directions of data flow:
+
+    raw surface event
+        → Channel.receive()          ← normalize to ChannelMessage
+        → resolve_llm() / agent_loop ← core is channel-agnostic
+        → Channel.deliver()          ← surface-specific delivery
+        → raw surface output
+
+Current implementations
+-----------------------
+- ``SSEChannel`` (app.channels.sse) — HTTP Server-Sent Events; used by the
+  web frontend and the Electron desktop shell.
+
+Planned
+-------
+- ``TelegramChannel`` — aiogram polling/webhook + progressive message edits.
+- ``MobileChannel`` — SSE + APNs/FCM push for background delivery.
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any, Literal, Protocol, TypedDict
+
+from app.core.providers.base import StreamEvent
+
+
+# ---------------------------------------------------------------------------
+# Normalized message types
+# ---------------------------------------------------------------------------
+
+
+class ChannelMessage(TypedDict):
+    """Normalized inbound message produced by ``Channel.receive()``.
+
+    Every channel reduces its raw event (HTTP body, Telegram Update, IPC
+    payload, …) to this common shape before the message enters the core
+    turn pipeline.
+    """
+
+    user_id: uuid.UUID
+    """Nexus user UUID — resolved from auth token or channel binding."""
+
+    conversation_id: uuid.UUID
+    """Nexus conversation UUID — created or looked up by the channel."""
+
+    text: str
+    """The user's message text."""
+
+    surface: str
+    """Identifies the originating surface, e.g. ``"web"``, ``"electron"``,
+    ``"telegram"``.  Used for logging, analytics, and any surface-specific
+    behaviour the core layer needs to branch on."""
+
+    model_id: str | None
+    """Optional LLM model override requested by the client."""
+
+    metadata: dict[str, Any]
+    """Catch-all for surface-specific extras (e.g. Telegram chat_id, message_id)
+    that the delivery layer needs but the core layer should never inspect."""
+
+
+class ChannelResponse(TypedDict, total=False):
+    """Normalized outbound event produced by the core and consumed by
+    ``Channel.deliver()``.
+
+    This is a thin wrapper around ``StreamEvent`` that adds routing context
+    so the delivery layer knows *where* to send the response.
+    """
+
+    event: StreamEvent
+    """The LLM-layer stream event to deliver."""
+
+    done: bool
+    """True on the final event of a turn (signals ``[DONE]`` or equivalent)."""
+
+
+# ---------------------------------------------------------------------------
+# Channel protocol
+# ---------------------------------------------------------------------------
+
+
+class Channel(Protocol):
+    """Streaming chat channel adapter.
+
+    Implementations translate between a surface's native protocol and the
+    Nexus core pipeline.  Each implementation is responsible for:
+
+    1. **Normalization** (``receive``): converting the raw inbound event
+       into a ``ChannelMessage``.
+    2. **Delivery** (``deliver``): consuming ``StreamEvent`` s from the LLM
+       pipeline and pushing them back to the surface in whatever format it
+       expects (SSE frames, Telegram message edits, push payloads, …).
+
+    Implementations are *not* responsible for authentication, LLM routing,
+    or history management — those belong to the core layer.
+    """
+
+    surface: str
+    """Canonical surface name, e.g. ``"web"``, ``"electron"``, ``"telegram"``."""
+
+    def deliver(
+        self,
+        stream: AsyncIterator[StreamEvent],
+        message: ChannelMessage,
+    ) -> AsyncIterator[bytes]:
+        """Consume LLM stream events and yield surface-appropriate bytes.
+
+        For SSE channels this is newline-framed JSON.  For Telegram this
+        would drive ``edit_message_text`` calls and yield nothing (delivery
+        is a side-effect).  The protocol uses ``bytes`` as the common
+        denominator; channels that deliver via side-effect yield nothing.
+
+        Args:
+            stream: Async iterator of ``StreamEvent`` dicts from the LLM.
+            message: The originating ``ChannelMessage`` — delivery may need
+                     metadata from it (e.g. Telegram ``chat_id``).
+
+        Yields:
+            Surface-encoded bytes to hand to the transport layer.
+        """
+        ...

--- a/backend/app/channels/registry.py
+++ b/backend/app/channels/registry.py
@@ -1,0 +1,59 @@
+"""Channel registry — maps surface names to Channel implementations.
+
+The registry is a lightweight lookup table.  It is intentionally not a
+global singleton that auto-discovers implementations; channels are registered
+explicitly so the set of active channels is always visible in one place.
+
+Usage
+-----
+::
+
+    from app.channels.registry import resolve_channel
+
+    channel = resolve_channel("web")      # SSEChannel(surface="web")
+    channel = resolve_channel("electron") # SSEChannel(surface="electron")
+    channel = resolve_channel("telegram") # TelegramChannel (future)
+
+Extending
+---------
+When a new channel adapter is added, import it here and register it via
+``_REGISTRY``.  No other file needs to change.
+"""
+from __future__ import annotations
+
+from .base import Channel
+from .sse import SURFACE_ELECTRON, SURFACE_WEB, SSEChannel
+
+# ---------------------------------------------------------------------------
+# Registry — explicit mapping of surface name → Channel instance.
+#
+# Channels are stateless singletons: they hold no per-request state, so one
+# instance per surface is safe and cheap.
+# ---------------------------------------------------------------------------
+
+_REGISTRY: dict[str, Channel] = {
+    SURFACE_WEB: SSEChannel(surface=SURFACE_WEB),
+    SURFACE_ELECTRON: SSEChannel(surface=SURFACE_ELECTRON),
+    # "telegram": TelegramChannel(),  ← next PR
+}
+
+
+def resolve_channel(surface: str) -> Channel:
+    """Return the ``Channel`` registered for *surface*.
+
+    Falls back to the web SSE channel for unrecognized surface names so that
+    new clients that haven't registered their surface yet don't crash.
+
+    Args:
+        surface: Canonical surface name, e.g. ``"web"``, ``"electron"``,
+                 ``"telegram"``.
+
+    Returns:
+        The registered ``Channel`` instance.
+    """
+    return _REGISTRY.get(surface, _REGISTRY[SURFACE_WEB])
+
+
+def registered_surfaces() -> list[str]:
+    """Return the list of registered surface names (for introspection/tests)."""
+    return list(_REGISTRY.keys())

--- a/backend/app/channels/sse.py
+++ b/backend/app/channels/sse.py
@@ -1,0 +1,98 @@
+"""SSEChannel — HTTP Server-Sent Events delivery for web and Electron.
+
+Both the web frontend and the Electron desktop shell connect over HTTP and
+consume the same SSE stream format, so a single ``SSEChannel`` implementation
+covers both surfaces.  The ``surface`` field on ``ChannelMessage`` records
+which one originated the request (``"web"`` vs ``"electron"``), but the
+delivery path is identical.
+
+SSE frame format
+----------------
+Each event is serialized as::
+
+    data: <json>\n\n
+
+A turn is terminated by::
+
+    data: [DONE]\n\n
+
+This matches the existing format the frontend's ``EventSource`` parser
+expects, so the channel is a drop-in replacement for the previous inline
+``event_stream()`` generator in ``chat.py``.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+from app.core.providers.base import StreamEvent
+
+from .base import Channel, ChannelMessage
+
+# Sentinel surface names recognized by the registry.
+SURFACE_WEB = "web"
+SURFACE_ELECTRON = "electron"
+
+# HTTP header the frontend sets to identify itself.
+# If absent, the channel defaults to SURFACE_WEB.
+NEXUS_SURFACE_HEADER = "X-Nexus-Surface"
+
+
+def _frame(event: StreamEvent) -> bytes:
+    """Serialize a ``StreamEvent`` as a single SSE data frame."""
+    return f"data: {json.dumps(event)}\n\n".encode()
+
+
+_DONE_FRAME = b"data: [DONE]\n\n"
+
+
+class SSEChannel:
+    """``Channel`` implementation for HTTP SSE (web + Electron).
+
+    Instantiated once and shared across requests — it holds no per-request
+    state.
+    """
+
+    def __init__(self, surface: str = SURFACE_WEB) -> None:
+        self.surface = surface
+
+    async def deliver(
+        self,
+        stream: AsyncIterator[StreamEvent],
+        message: ChannelMessage,  # noqa: ARG002 — reserved for future metadata use
+    ) -> AsyncIterator[bytes]:
+        """Yield SSE-framed bytes for every event in *stream*, then ``[DONE]``.
+
+        The caller wraps the returned iterator in a ``StreamingResponse``
+        with ``media_type="text/event-stream"``.
+
+        Args:
+            stream: Async iterator of ``StreamEvent`` dicts from the LLM.
+            message: Originating ``ChannelMessage`` (unused by SSE delivery
+                     but required by the ``Channel`` protocol for surfaces
+                     that need it, e.g. Telegram).
+
+        Yields:
+            UTF-8 encoded SSE frames.
+        """
+        async for event in stream:
+            yield _frame(event)
+        yield _DONE_FRAME
+
+
+def surface_from_header(header_value: str | None) -> str:
+    """Resolve the surface name from the ``X-Nexus-Surface`` request header.
+
+    Accepts ``"web"`` and ``"electron"``; defaults to ``"web"`` for any
+    unrecognized or absent value so existing clients that don't send the
+    header keep working.
+
+    Args:
+        header_value: Raw header string, or ``None`` if the header is absent.
+
+    Returns:
+        Canonical surface name — either ``SURFACE_WEB`` or ``SURFACE_ELECTRON``.
+    """
+    if header_value and header_value.lower() == SURFACE_ELECTRON:
+        return SURFACE_ELECTRON
+    return SURFACE_WEB

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1,0 +1,199 @@
+"""Tests for the channel abstraction layer.
+
+Covers:
+- ``surface_from_header`` — header parsing + defaults
+- ``resolve_channel`` — registry lookup + unknown-surface fallback
+- ``registered_surfaces`` — introspection
+- ``SSEChannel.deliver`` — SSE frame encoding
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+from app.channels import (
+    SSEChannel,
+    registered_surfaces,
+    resolve_channel,
+    surface_from_header,
+)
+from app.channels.sse import SURFACE_ELECTRON, SURFACE_WEB
+
+
+# ---------------------------------------------------------------------------
+# surface_from_header
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceFromHeader:
+    def test_none_defaults_to_web(self) -> None:
+        assert surface_from_header(None) == SURFACE_WEB
+
+    def test_empty_string_defaults_to_web(self) -> None:
+        assert surface_from_header("") == SURFACE_WEB
+
+    def test_web_returns_web(self) -> None:
+        assert surface_from_header("web") == SURFACE_WEB
+
+    def test_electron_returns_electron(self) -> None:
+        assert surface_from_header("electron") == SURFACE_ELECTRON
+
+    def test_electron_case_insensitive(self) -> None:
+        assert surface_from_header("Electron") == SURFACE_ELECTRON
+        assert surface_from_header("ELECTRON") == SURFACE_ELECTRON
+
+    def test_unknown_value_defaults_to_web(self) -> None:
+        assert surface_from_header("mobile") == SURFACE_WEB
+        assert surface_from_header("telegram") == SURFACE_WEB
+
+
+# ---------------------------------------------------------------------------
+# resolve_channel
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChannel:
+    def test_web_returns_sse_channel(self) -> None:
+        ch = resolve_channel("web")
+        assert isinstance(ch, SSEChannel)
+        assert ch.surface == SURFACE_WEB
+
+    def test_electron_returns_sse_channel(self) -> None:
+        ch = resolve_channel("electron")
+        assert isinstance(ch, SSEChannel)
+        assert ch.surface == SURFACE_ELECTRON
+
+    def test_unknown_surface_falls_back_to_web(self) -> None:
+        ch = resolve_channel("unknown-surface")
+        assert isinstance(ch, SSEChannel)
+        assert ch.surface == SURFACE_WEB
+
+    def test_web_and_electron_are_same_type_but_distinct_instances(self) -> None:
+        web = resolve_channel("web")
+        electron = resolve_channel("electron")
+        assert type(web) is type(electron)
+        assert web is not electron
+
+
+# ---------------------------------------------------------------------------
+# registered_surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestRegisteredSurfaces:
+    def test_contains_web(self) -> None:
+        assert "web" in registered_surfaces()
+
+    def test_contains_electron(self) -> None:
+        assert "electron" in registered_surfaces()
+
+    def test_returns_list(self) -> None:
+        assert isinstance(registered_surfaces(), list)
+
+
+# ---------------------------------------------------------------------------
+# SSEChannel.deliver
+# ---------------------------------------------------------------------------
+
+
+async def _make_stream(events: list) -> AsyncIterator:
+    """Helper — yield a list of events as an async iterator."""
+    for event in events:
+        yield event
+
+
+class TestSSEChannelDeliver:
+    @pytest.mark.anyio
+    async def test_yields_json_frames(self) -> None:
+        channel = SSEChannel(surface="web")
+        events = [
+            {"type": "delta", "content": "Hello"},
+            {"type": "delta", "content": " world"},
+        ]
+        from app.channels.base import ChannelMessage
+        import uuid
+
+        msg: ChannelMessage = {
+            "user_id": uuid.uuid4(),
+            "conversation_id": uuid.uuid4(),
+            "text": "hi",
+            "surface": "web",
+            "model_id": None,
+            "metadata": {},
+        }
+
+        chunks = []
+        async for chunk in channel.deliver(_make_stream(events), msg):
+            chunks.append(chunk)
+
+        # Two data frames + the [DONE] sentinel
+        assert len(chunks) == 3
+
+        # Each event frame must be valid SSE and deserialize to the original dict
+        for chunk, event in zip(chunks[:2], events, strict=True):
+            assert chunk.startswith(b"data: ")
+            assert chunk.endswith(b"\n\n")
+            payload = json.loads(chunk[len("data: "):].strip())
+            assert payload == event
+
+    @pytest.mark.anyio
+    async def test_done_frame_is_last(self) -> None:
+        channel = SSEChannel(surface="electron")
+        from app.channels.base import ChannelMessage
+        import uuid
+
+        msg: ChannelMessage = {
+            "user_id": uuid.uuid4(),
+            "conversation_id": uuid.uuid4(),
+            "text": "hi",
+            "surface": "electron",
+            "model_id": None,
+            "metadata": {},
+        }
+
+        chunks = []
+        async for chunk in channel.deliver(_make_stream([{"type": "delta", "content": "x"}]), msg):
+            chunks.append(chunk)
+
+        assert chunks[-1] == b"data: [DONE]\n\n"
+
+    @pytest.mark.anyio
+    async def test_empty_stream_only_yields_done(self) -> None:
+        channel = SSEChannel(surface="web")
+        from app.channels.base import ChannelMessage
+        import uuid
+
+        msg: ChannelMessage = {
+            "user_id": uuid.uuid4(),
+            "conversation_id": uuid.uuid4(),
+            "text": "hi",
+            "surface": "web",
+            "model_id": None,
+            "metadata": {},
+        }
+
+        chunks = []
+        async for chunk in channel.deliver(_make_stream([]), msg):
+            chunks.append(chunk)
+
+        assert chunks == [b"data: [DONE]\n\n"]
+
+    @pytest.mark.anyio
+    async def test_yields_bytes(self) -> None:
+        channel = SSEChannel(surface="web")
+        from app.channels.base import ChannelMessage
+        import uuid
+
+        msg: ChannelMessage = {
+            "user_id": uuid.uuid4(),
+            "conversation_id": uuid.uuid4(),
+            "text": "hi",
+            "surface": "web",
+            "model_id": None,
+            "metadata": {},
+        }
+
+        async for chunk in channel.deliver(_make_stream([{"type": "delta", "content": "y"}]), msg):
+            assert isinstance(chunk, bytes)


### PR DESCRIPTION
## What

Introduces the `app/channels/` package — the foundation for treating every surface (web, Electron, Telegram, mobile) as an equal-peer channel rather than having SSE baked into the endpoint logic.

## New: `app/channels/`

| File | Responsibility |
|------|---------------|
| `base.py` | `Channel` protocol; `ChannelMessage` / `ChannelResponse` TypedDicts |
| `sse.py` | `SSEChannel` — HTTP SSE delivery for web + Electron; `surface_from_header()` |
| `registry.py` | `_REGISTRY`, `resolve_channel()`, `registered_surfaces()` |
| `__init__.py` | Public re-exports |

Key design decisions:
- **No default channel** — `web` and `electron` are both explicit registry entries backed by distinct `SSEChannel` instances, even though they share the same delivery format. Every surface is a peer.
- **`X-Nexus-Surface` header** — clients declare their surface; unknown values fall back to `web` for backward compat without treating web as structurally special.
- **`Channel.deliver(stream, message) → AsyncIterator[bytes]`** — the protocol common denominator. SSE yields framed bytes; future Telegram channel will drive `edit_message_text` as a side-effect and yield nothing.

## Refactored: `app/api/chat.py`

- Accepts `X-Nexus-Surface` header; resolves `surface` + `channel` once at request start
- `event_stream()` now returns `AsyncGenerator[bytes]` (was `str`)
- Inner `_guarded_stream()` isolates error capture + aggregation
- Delegates to `channel.deliver()` — the endpoint is now fully channel-agnostic
- `CHAT_IN` / `CHAT_OUT` log entries include `surface` field

## Tests

`tests/test_channels.py` — 17 tests, all passing:
- `surface_from_header`: `None`, empty, known values, unknown values, case-insensitivity
- `resolve_channel`: web, electron, unknown-surface fallback, instance identity
- `registered_surfaces`: list type + expected surface names
- `SSEChannel.deliver`: frame format, `[DONE]` sentinel, empty stream, bytes type

## Stack position

`development` → **this PR** → `feat/telegram-channel-routing` (next)

## Summary by Sourcery

Introduce a channel abstraction layer and update the chat streaming endpoint to route responses through surface-specific channels instead of hard-coded SSE framing.

New Features:
- Add a generic Channel protocol with normalized ChannelMessage and ChannelResponse types to support multiple chat surfaces.
- Provide an SSEChannel implementation and surface header parsing for web and Electron clients.
- Add a channel registry that maps surface names to shared Channel instances and exposes registered surfaces for introspection.

Enhancements:
- Refactor the chat API endpoint to resolve the client surface from the X-Nexus-Surface header and delegate streaming delivery to the resolved channel.
- Include the originating surface in CHAT_IN and CHAT_OUT log records for better observability.

Tests:
- Add channel-layer tests covering surface header parsing, channel resolution and registry behavior, and SSEChannel streaming semantics.