### PR TITLE
feat: OpenClaw-style multi-workspace backend

### DIFF
--- a/backend/alembic/versions/008_add_workspaces.py
+++ b/backend/alembic/versions/008_add_workspaces.py
@@ -1,0 +1,53 @@
+"""add workspaces table
+
+Revision ID: 008_add_workspaces
+Revises: 007_add_user_appearance
+Create Date: 2026-05-06
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "008_add_workspaces"
+down_revision: Union[str, None] = "007_add_user_appearance"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the workspaces table.
+
+    One user can own many workspaces.  Each workspace is a named agent home
+    directory on the host filesystem following the OpenClaw standard layout
+    (AGENTS.md, SOUL.md, IDENTITY.md, USER.md, TOOLS.md, memory/, skills/,
+    artifacts/).
+
+    The ``path`` column stores the absolute filesystem path so agents and API
+    endpoints can resolve files without reconstructing the path from user IDs.
+
+    ``is_default`` flags the workspace that was created at onboarding — users
+    start with exactly one default workspace; additional workspaces (work,
+    personal, project-specific, etc.) are created on demand and have
+    ``is_default=False``.
+    """
+    op.create_table(
+        "workspaces",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False, server_default="Main"),
+        sa.Column("slug", sa.String(255), nullable=False, server_default="main"),
+        sa.Column("path", sa.String(4096), nullable=False),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_workspaces_user_id", "workspaces", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workspaces_user_id", table_name="workspaces")
+    op.drop_table("workspaces")

--- a/backend/app/api/personalization.py
+++ b/backend/app/api/personalization.py
@@ -1,8 +1,11 @@
 """HTTP endpoints for the home-page personalization wizard."""
 
+import logging
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.workspace import ensure_default_workspace
 from app.crud.personalization import (
     get_personalization_service,
     upsert_personalization_service,
@@ -11,6 +14,8 @@ from app.db import User, get_async_session
 from app.models import UserPersonalization
 from app.schemas import PersonalizationProfile
 from app.users import current_active_user
+
+log = logging.getLogger(__name__)
 
 
 def _to_profile(row: UserPersonalization | None) -> PersonalizationProfile:
@@ -53,10 +58,29 @@ def get_personalization_router() -> APIRouter:
         user: User = Depends(current_active_user),
         session: AsyncSession = Depends(get_async_session),
     ) -> PersonalizationProfile:
-        """Create or replace the authenticated user's personalization profile."""
+        """Create or replace the authenticated user's personalization profile.
+
+        Also seeds the user's default workspace the first time this endpoint
+        is called (idempotent — subsequent calls are a no-op for the workspace).
+        """
         row = await upsert_personalization_service(
             user_id=user.id, payload=payload, session=session
         )
+
+        # Seed the default workspace on first personalization save.  This is
+        # the natural trigger for "onboarding complete" since the wizard writes
+        # the full profile before calling finish().
+        try:
+            await ensure_default_workspace(
+                user_id=user.id,
+                session=session,
+                personalization=row,
+            )
+            await session.commit()
+        except Exception:
+            log.exception("Failed to ensure default workspace for user %s", user.id)
+            # Non-fatal — workspace seeding must not break the personalization save.
+
         return _to_profile(row)
 
     return router

--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -1,0 +1,241 @@
+"""HTTP endpoints for workspace management.
+
+Workspaces are OpenClaw-style agent home directories.  Each user can own
+multiple workspaces; the frontend shows the file tree and lets users read,
+write, and delete files inside their workspace.
+
+Agents access the filesystem directly via tools — these endpoints exist
+purely to surface workspace data in the UI.
+
+Mounted at: /api/v1/workspaces
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.workspace import list_workspaces, get_default_workspace
+from app.db import User, get_async_session
+from app.models import Workspace
+from app.schemas import (
+    WorkspaceFileContent,
+    WorkspaceFileNode,
+    WorkspaceFileWrite,
+    WorkspaceRead,
+    WorkspaceTreeResponse,
+)
+from app.users import current_active_user
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _get_owned_workspace(
+    workspace_id: uuid.UUID,
+    user: User,
+    session: AsyncSession,
+) -> Workspace:
+    """Fetch a workspace by ID and verify it belongs to the authenticated user."""
+    result = await session.execute(
+        select(Workspace).where(
+            Workspace.id == workspace_id,
+            Workspace.user_id == user.id,
+        )
+    )
+    ws = result.scalar_one_or_none()
+    if ws is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
+    return ws
+
+
+def _safe_child(root: Path, relative: str) -> Path:
+    """Resolve a workspace-relative path and verify it stays inside the root.
+
+    Raises 400 if the path escapes the workspace root (directory traversal).
+    """
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path must be inside the workspace",
+        )
+    return resolved
+
+
+def _build_tree(root: Path, relative_root: Path | None = None) -> list[WorkspaceFileNode]:
+    """Recursively build a flat list of file-tree nodes.
+
+    ``relative_root`` is the workspace root used to compute workspace-relative
+    paths; it defaults to ``root`` on the first call.
+    """
+    if relative_root is None:
+        relative_root = root
+
+    nodes: list[WorkspaceFileNode] = []
+    try:
+        entries = sorted(root.iterdir(), key=lambda p: (p.is_file(), p.name))
+    except PermissionError:
+        return nodes
+
+    for entry in entries:
+        rel = entry.relative_to(relative_root).as_posix()
+        if entry.is_dir():
+            nodes.append(WorkspaceFileNode(name=entry.name, path=rel, is_dir=True))
+            nodes.extend(_build_tree(entry, relative_root))
+        else:
+            nodes.append(
+                WorkspaceFileNode(
+                    name=entry.name,
+                    path=rel,
+                    is_dir=False,
+                    size=entry.stat().st_size,
+                )
+            )
+    return nodes
+
+
+# ---------------------------------------------------------------------------
+# Router factory
+# ---------------------------------------------------------------------------
+
+def get_workspace_router() -> APIRouter:
+    """Build the workspace router (mounted at /api/v1/workspaces)."""
+    router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
+
+    # ------------------------------------------------------------------
+    # List workspaces
+    # ------------------------------------------------------------------
+
+    @router.get("", response_model=list[WorkspaceRead])
+    async def list_user_workspaces(
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> list[WorkspaceRead]:
+        """Return all workspaces owned by the authenticated user."""
+        workspaces = await list_workspaces(user.id, session)
+        return [WorkspaceRead.model_validate(ws) for ws in workspaces]
+
+    # ------------------------------------------------------------------
+    # File tree
+    # ------------------------------------------------------------------
+
+    @router.get("/{workspace_id}/tree", response_model=WorkspaceTreeResponse)
+    async def get_workspace_tree(
+        workspace_id: uuid.UUID,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> WorkspaceTreeResponse:
+        """Return the full file tree of a workspace as a flat node list."""
+        ws = await _get_owned_workspace(workspace_id, user, session)
+        root = Path(ws.path)
+        if not root.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Workspace directory not found on disk",
+            )
+        return WorkspaceTreeResponse(
+            workspace_id=ws.id,
+            nodes=_build_tree(root),
+        )
+
+    # ------------------------------------------------------------------
+    # Read file
+    # ------------------------------------------------------------------
+
+    @router.get("/{workspace_id}/files/{file_path:path}", response_model=WorkspaceFileContent)
+    async def read_workspace_file(
+        workspace_id: uuid.UUID,
+        file_path: str,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> WorkspaceFileContent:
+        """Read a file's text content from the workspace."""
+        ws = await _get_owned_workspace(workspace_id, user, session)
+        target = _safe_child(Path(ws.path), file_path)
+
+        if not target.exists():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        if target.is_dir():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Path is a directory, not a file",
+            )
+
+        try:
+            content = target.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="File is not valid UTF-8 text",
+            )
+
+        return WorkspaceFileContent(path=file_path, content=content)
+
+    # ------------------------------------------------------------------
+    # Write file
+    # ------------------------------------------------------------------
+
+    @router.put(
+        "/{workspace_id}/files/{file_path:path}",
+        response_model=WorkspaceFileContent,
+        status_code=status.HTTP_200_OK,
+    )
+    async def write_workspace_file(
+        workspace_id: uuid.UUID,
+        file_path: str,
+        payload: WorkspaceFileWrite,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> WorkspaceFileContent:
+        """Create or replace a text file inside the workspace."""
+        ws = await _get_owned_workspace(workspace_id, user, session)
+        target = _safe_child(Path(ws.path), file_path)
+
+        if target.is_dir():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Path resolves to a directory",
+            )
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(payload.content, encoding="utf-8")
+
+        return WorkspaceFileContent(path=file_path, content=payload.content)
+
+    # ------------------------------------------------------------------
+    # Delete file
+    # ------------------------------------------------------------------
+
+    @router.delete(
+        "/{workspace_id}/files/{file_path:path}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def delete_workspace_file(
+        workspace_id: uuid.UUID,
+        file_path: str,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> None:
+        """Delete a file from the workspace.  Does not delete directories."""
+        ws = await _get_owned_workspace(workspace_id, user, session)
+        target = _safe_child(Path(ws.path), file_path)
+
+        if not target.exists():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        if target.is_dir():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Use a dedicated endpoint to delete directories",
+            )
+
+        target.unlink()
+
+    return router

--- a/backend/app/core/workspace.py
+++ b/backend/app/core/workspace.py
@@ -1,11 +1,329 @@
+"""Workspace management service.
+
+A workspace is an OpenClaw-style agent home directory.  Each user can have
+multiple workspaces; each workspace is a self-contained directory tree that
+holds the agent's identity, memory, skills, and generated artifacts.
+
+Standard file layout (inspired by the official OpenClaw workspace structure):
+
+    {workspace_root}/
+    ├── AGENTS.md       # Operating instructions / entry point
+    ├── SOUL.md         # Agent persona and tone
+    ├── IDENTITY.md     # Agent name, emoji, vibe
+    ├── USER.md         # Who the human is (from onboarding)
+    ├── TOOLS.md        # Local tool conventions
+    ├── memory/         # Memory files (daily notes, long-term)
+    │   └── .gitkeep
+    ├── skills/         # Workspace-scoped skills
+    │   └── .gitkeep
+    └── artifacts/      # Files the agent has generated
+        └── .gitkeep
+
+Seeding happens once: when the user completes the onboarding wizard and the
+``PUT /api/v1/personalization`` endpoint is called for the first time.  The
+service is idempotent — calling it again on an existing workspace is a no-op.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
-from uuid import UUID
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 
+if TYPE_CHECKING:
+    from app.models import UserPersonalization, Workspace
 
-def get_user_workspace(user_id: UUID) -> str:
-    """Get the workspace directory for a given user. This function constructs a path based on the `workspace_base_dir` setting and the user's UUID. It ensures that the directory exists by creating it if necessary."""
-    workspace = settings.workspace_base_dir + "/" + str(user_id)
-    Path(workspace).mkdir(parents=True, exist_ok=True)
-    return workspace
+
+# ---------------------------------------------------------------------------
+# File templates
+# ---------------------------------------------------------------------------
+
+_AGENTS_MD = """\
+# AGENTS.md — Workspace Entry Point
+
+This folder is the agent's home for this workspace.
+
+## Purpose
+
+`AGENTS.md` is the cognitive entry point.  It tells the agent:
+- Who it is in this workspace
+- How to collaborate with the user
+- Where to find deeper operational docs
+
+## Session Startup
+
+On every session start, read:
+1. `SOUL.md` — who you are
+2. `USER.md` — who you're helping
+3. `memory/` — recent daily notes for context
+
+## Memory
+
+Write to `memory/YYYY-MM-DD.md` constantly — every decision, lesson,
+build event, or correction goes in before anything else.
+
+## Skills
+
+Custom skills live in `skills/`.  Each skill is a markdown file describing
+a repeatable workflow.
+
+## Artifacts
+
+Files the agent generates for the user live in `artifacts/`.
+
+## Scope Discipline
+
+Do exactly what's asked.  Propose adjacent work; never execute it silently.
+A question is not an instruction.
+"""
+
+_IDENTITY_MD = """\
+# IDENTITY.md — Who Am I?
+
+- **Name:** _(set a name for your agent)_
+- **Vibe:** _(describe the agent's personality in a few words)_
+- **Emoji:** _(pick one)_
+
+---
+
+This file is yours to fill in.  Give your agent a name and a vibe that
+feels right for how you work.
+"""
+
+_TOOLS_MD = """\
+# TOOLS.md — Tool Conventions
+
+Local tool conventions for this workspace.
+
+## File Access
+
+The agent has direct read/write access to this workspace directory.
+
+## Memory
+
+- Daily notes: `memory/YYYY-MM-DD.md`
+- Long-term memory index: `memory/MEMORY.md` _(created automatically)_
+
+## Skills
+
+- List available skills with the skill workshop tool.
+- Workspace-scoped skills live in `skills/`.
+"""
+
+_PERSONALITY_SOULS: dict[str, str] = {
+    "analytical": """\
+# SOUL.md — Who You Are
+
+You are a precise, analytical assistant.  You think in systems, surface
+trade-offs, and lead with evidence.  Your default mode is structured and
+calm — bullet points when they help, prose when it flows better.
+
+You are direct.  You flag uncertainty clearly.  You do not pad answers
+with enthusiasm or filler.  You are here to help the user think, decide,
+and ship.
+""",
+    "creative": """\
+# SOUL.md — Who You Are
+
+You are an imaginative, generative assistant.  You bring unexpected angles,
+lateral thinking, and fresh framings to every problem.  You are comfortable
+with ambiguity and enjoy exploring the edges.
+
+You are warm and enthusiastic but not sycophantic.  You share genuine
+opinions.  You know when to stop generating and help the user land the idea.
+""",
+    "direct": """\
+# SOUL.md — Who You Are
+
+You are a no-nonsense assistant.  Short sentences.  Strong verbs.  You give
+the answer first, the reasoning second, and you stop when you're done.
+
+You do not hedge.  You do not soften.  When you are uncertain you say so
+plainly.  You treat the user as a capable adult.
+""",
+    "balanced": """\
+# SOUL.md — Who You Are
+
+You are a well-rounded assistant — analytical when precision matters, creative
+when exploration helps, direct when time is short.  You read the situation
+and match accordingly.
+
+You are reliable, curious, and honest.  You do not perform enthusiasm or
+false confidence.  You are here to be genuinely useful.
+""",
+}
+
+_DEFAULT_SOUL = _PERSONALITY_SOULS["balanced"]
+
+
+def _build_user_md(p: "UserPersonalization | None") -> str:
+    if p is None:
+        return "# USER.md — About You\n\n_(Fill in your details here.)_\n"
+
+    lines = ["# USER.md — About You", ""]
+
+    if p.name:
+        lines.append(f"- **Name:** {p.name}")
+    if p.role:
+        lines.append(f"- **Role:** {p.role}")
+    if p.company_website:
+        lines.append(f"- **Company / Website:** {p.company_website}")
+    if p.linkedin:
+        lines.append(f"- **LinkedIn:** {p.linkedin}")
+    if p.goals:
+        goals_str = ", ".join(p.goals) if isinstance(p.goals, list) else str(p.goals)
+        lines.append(f"- **Goals:** {goals_str}")
+    if p.custom_instructions:
+        lines += ["", "## Custom Instructions", "", p.custom_instructions]
+
+    lines += ["", "---", "", "_Update this file as you evolve what you need from your agent._", ""]
+    return "\n".join(lines)
+
+
+def _build_soul_md(p: "UserPersonalization | None") -> str:
+    if p is None or not p.personality:
+        return _DEFAULT_SOUL
+    return _PERSONALITY_SOULS.get(p.personality.lower(), _DEFAULT_SOUL)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+def _workspace_path(workspace_id: uuid.UUID) -> Path:
+    """Return the absolute path for a workspace directory."""
+    return Path(settings.workspace_base_dir) / str(workspace_id)
+
+
+def seed_workspace(
+    workspace_id: uuid.UUID,
+    personalization: "UserPersonalization | None" = None,
+) -> Path:
+    """Create the workspace directory tree and write seed files.
+
+    Idempotent — existing files are not overwritten, so re-running after a
+    partial seed is safe.  New directories are always created.
+
+    Returns the workspace root path.
+    """
+    root = _workspace_path(workspace_id)
+
+    # Create standard subdirectories.
+    for subdir in ("memory", "skills", "artifacts"):
+        (root / subdir).mkdir(parents=True, exist_ok=True)
+        gitkeep = root / subdir / ".gitkeep"
+        if not gitkeep.exists():
+            gitkeep.touch()
+
+    # Write seed files — skip if already present so edits aren't clobbered.
+    seed_files: dict[str, str] = {
+        "AGENTS.md": _AGENTS_MD,
+        "IDENTITY.md": _IDENTITY_MD,
+        "TOOLS.md": _TOOLS_MD,
+        "SOUL.md": _build_soul_md(personalization),
+        "USER.md": _build_user_md(personalization),
+    }
+    for filename, content in seed_files.items():
+        target = root / filename
+        if not target.exists():
+            target.write_text(content, encoding="utf-8")
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+async def get_default_workspace(
+    user_id: uuid.UUID,
+    session: AsyncSession,
+) -> "Workspace | None":
+    """Return the user's default workspace row, or None if it doesn't exist."""
+    from app.models import Workspace  # local import to avoid circular deps
+
+    result = await session.execute(
+        select(Workspace)
+        .where(Workspace.user_id == user_id, Workspace.is_default.is_(True))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_workspaces(
+    user_id: uuid.UUID,
+    session: AsyncSession,
+) -> list["Workspace"]:
+    """Return all workspaces owned by the user, default first."""
+    from app.models import Workspace
+
+    result = await session.execute(
+        select(Workspace)
+        .where(Workspace.user_id == user_id)
+        .order_by(Workspace.is_default.desc(), Workspace.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def create_workspace(
+    user_id: uuid.UUID,
+    session: AsyncSession,
+    name: str = "Main",
+    slug: str = "main",
+    is_default: bool = True,
+    personalization: "UserPersonalization | None" = None,
+) -> "Workspace":
+    """Create a new workspace row in the DB and seed its directory.
+
+    Does NOT commit — the caller is responsible for committing the session so
+    this can participate in larger transactions.
+    """
+    from app.models import Workspace
+
+    workspace_id = uuid.uuid4()
+    path = str(_workspace_path(workspace_id))
+
+    ws = Workspace(
+        id=workspace_id,
+        user_id=user_id,
+        name=name,
+        slug=slug,
+        path=path,
+        is_default=is_default,
+        created_at=datetime.now(UTC),
+    )
+    session.add(ws)
+
+    # Seed filesystem immediately so path is valid before commit.
+    seed_workspace(workspace_id, personalization)
+
+    return ws
+
+
+async def ensure_default_workspace(
+    user_id: uuid.UUID,
+    session: AsyncSession,
+    personalization: "UserPersonalization | None" = None,
+) -> "Workspace":
+    """Return the existing default workspace or create one.
+
+    Safe to call multiple times — only creates the workspace on the first
+    call.  Uses ``get_default_workspace`` as the idempotency guard.
+    """
+    existing = await get_default_workspace(user_id, session)
+    if existing is not None:
+        return existing
+    return await create_workspace(
+        user_id=user_id,
+        session=session,
+        name="Main",
+        slug="main",
+        is_default=True,
+        personalization=personalization,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -260,3 +260,34 @@ class ChatMessage(Base):
     assistant_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class Workspace(Base):
+    """An agent workspace — a named directory on the host filesystem containing
+    the standard OpenClaw-style file structure (AGENTS.md, SOUL.md, USER.md,
+    IDENTITY.md, memory/, skills/, artifacts/).
+
+    One user can own many workspaces.  The first workspace created for a user
+    is flagged ``is_default=True`` and seeded automatically at the end of the
+    onboarding flow using the user's ``UserPersonalization`` data.
+
+    The ``path`` column is the absolute path on the host.  Agents that need
+    filesystem access resolve the path from here rather than constructing it
+    ad-hoc from the user ID.
+    """
+
+    __tablename__ = "workspaces"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Human-readable label shown in the UI (e.g. "Main", "Work", "Personal").
+    name: Mapped[str] = mapped_column(String(255), nullable=False, default="Main")
+    # Filesystem-safe slug used only as a readable hint alongside the UUID path.
+    slug: Mapped[str] = mapped_column(String(255), nullable=False, default="main")
+    # Absolute path to the workspace root directory on the host.
+    path: Mapped[str] = mapped_column(String(4096), nullable=False)
+    # Exactly one workspace per user should be the default at any given time.
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from fastapi_users import schemas
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
 # --- User schemas (provided by fastapi-users) --------------------------------
 
@@ -316,3 +316,48 @@ class ChannelLinkCodeResponse(BaseModel):
     expires_at: datetime
     bot_username: str | None = None
     deep_link: str | None = None
+
+
+# --- Workspace schemas --------------------------------------------------------
+
+
+class WorkspaceRead(BaseModel):
+    """Workspace summary returned by list / detail endpoints."""
+
+    id: uuid.UUID
+    name: str
+    slug: str
+    path: str
+    is_default: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WorkspaceFileNode(BaseModel):
+    """A single node in a workspace file-tree response."""
+
+    name: str
+    path: str          # workspace-relative path, e.g. "memory/2026-05-06.md"
+    is_dir: bool
+    size: int | None = None  # None for directories
+
+
+class WorkspaceTreeResponse(BaseModel):
+    """Recursive file tree rooted at the workspace directory."""
+
+    workspace_id: uuid.UUID
+    nodes: list[WorkspaceFileNode]
+
+
+class WorkspaceFileContent(BaseModel):
+    """Contents of a single workspace file."""
+
+    path: str
+    content: str
+
+
+class WorkspaceFileWrite(BaseModel):
+    """Payload for writing a workspace file."""
+
+    content: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from app.api.models import get_models_router
 from app.api.oauth import get_oauth_router
 from app.api.personalization import get_personalization_router
 from app.api.projects import get_projects_router
+from app.api.workspace import get_workspace_router
 from app.api.stt import get_stt_router
 from app.cli.admin_seed import seed_admin_user
 from app.core.config import settings
@@ -116,6 +117,9 @@ def create_app() -> FastAPI:
     )
     fastapi_app.include_router(
         get_channels_router(),
+    )
+    fastapi_app.include_router(
+        get_workspace_router(),
     )
 
     return fastapi_app

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -1,0 +1,466 @@
+"""Tests for the workspace service and API.
+
+Covers:
+- seed_workspace: directory structure and file contents
+- ensure_default_workspace: idempotency and DB row creation
+- GET /api/v1/workspaces: list workspaces
+- GET /api/v1/workspaces/{id}/tree: file tree
+- GET /api/v1/workspaces/{id}/files/{path}: read file
+- PUT /api/v1/workspaces/{id}/files/{path}: write file
+- DELETE /api/v1/workspaces/{id}/files/{path}: delete file
+- Path traversal guard
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from types import SimpleNamespace
+
+from app.core.workspace import (
+    _build_soul_md,
+    _build_user_md,
+    _workspace_path,
+    create_workspace,
+    ensure_default_workspace,
+    get_default_workspace,
+    list_workspaces,
+    seed_workspace,
+)
+from app.models import Workspace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_personalization(**kwargs) -> SimpleNamespace:
+    """Build a lightweight UserPersonalization stub (not persisted).
+
+    Returns a SimpleNamespace so attribute access works the same as the ORM
+    model without needing a database session.
+    """
+    defaults = dict(
+        user_id=uuid.uuid4(),
+        name="Tavi",
+        role="Engineer",
+        company_website="https://example.com",
+        linkedin="https://linkedin.com/in/tavi",
+        goals=["Build great products", "Automate toil"],
+        personality="direct",
+        custom_instructions=None,
+        chatgpt_context=None,
+        connected_channels=None,
+        updated_at=None,
+    )
+    return SimpleNamespace(**{**defaults, **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# seed_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestSeedWorkspace:
+    def test_creates_standard_subdirectories(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "memory").is_dir()
+        assert (root / "skills").is_dir()
+        assert (root / "artifacts").is_dir()
+
+    def test_creates_gitkeep_in_each_subdir(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        for subdir in ("memory", "skills", "artifacts"):
+            assert (root / subdir / ".gitkeep").exists()
+
+    def test_writes_agents_md(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        agents = (root / "AGENTS.md").read_text()
+        assert "AGENTS.md" in agents
+        assert "Session Startup" in agents
+
+    def test_writes_identity_and_tools_md(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "IDENTITY.md").exists()
+        assert (root / "TOOLS.md").exists()
+
+    def test_does_not_overwrite_existing_files(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        # Manually write custom content.
+        custom = "# My custom AGENTS.md\n"
+        (root / "AGENTS.md").write_text(custom)
+
+        # Re-seed — existing file must survive.
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            seed_workspace(ws_id)
+
+        assert (root / "AGENTS.md").read_text() == custom
+
+    def test_populates_user_md_from_personalization(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        p = _make_personalization(name="Alice", role="PM")
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id, personalization=p)
+
+        user_md = (root / "USER.md").read_text()
+        assert "Alice" in user_md
+        assert "PM" in user_md
+
+    def test_uses_personality_for_soul_md(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        p = _make_personalization(personality="analytical")
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id, personalization=p)
+
+        soul = (root / "SOUL.md").read_text()
+        assert "analytical" in soul.lower()
+
+    def test_falls_back_to_balanced_soul_for_unknown_personality(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        p = _make_personalization(personality="goblin")
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id, personalization=p)
+
+        soul = (root / "SOUL.md").read_text()
+        # Balanced soul is the fallback.
+        assert "SOUL.md" in soul
+
+    def test_seed_without_personalization_writes_placeholder_user_md(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id, personalization=None)
+
+        user_md = (root / "USER.md").read_text()
+        assert "Fill in" in user_md
+
+
+# ---------------------------------------------------------------------------
+# Template builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUserMd:
+    def test_includes_name_role_company(self) -> None:
+        p = _make_personalization(name="Bob", role="CTO", company_website="https://acme.com")
+        md = _build_user_md(p)
+        assert "Bob" in md
+        assert "CTO" in md
+        assert "https://acme.com" in md
+
+    def test_includes_goals_list(self) -> None:
+        p = _make_personalization(goals=["Ship fast", "Sleep well"])
+        md = _build_user_md(p)
+        assert "Ship fast" in md
+        assert "Sleep well" in md
+
+    def test_includes_custom_instructions(self) -> None:
+        p = _make_personalization(custom_instructions="Always use British English.")
+        md = _build_user_md(p)
+        assert "British English" in md
+
+    def test_none_personalization_returns_placeholder(self) -> None:
+        md = _build_user_md(None)
+        assert "Fill in" in md
+
+
+class TestBuildSoulMd:
+    @pytest.mark.parametrize("personality", ["analytical", "creative", "direct", "balanced"])
+    def test_known_personalities_return_content(self, personality: str) -> None:
+        p = _make_personalization(personality=personality)
+        md = _build_soul_md(p)
+        assert len(md) > 50
+
+    def test_unknown_personality_returns_balanced(self) -> None:
+        p = _make_personalization(personality="wizard")
+        md = _build_soul_md(p)
+        # Balanced soul contains "well-rounded".
+        assert "well-rounded" in md
+
+    def test_none_personalization_returns_balanced(self) -> None:
+        md = _build_soul_md(None)
+        assert "well-rounded" in md
+
+
+# ---------------------------------------------------------------------------
+# DB service functions
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceService:
+    @pytest.mark.anyio
+    async def test_create_workspace_adds_db_row(
+        self, db_session: AsyncSession, test_user: object, tmp_path: Path
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        assert ws.id is not None
+        assert ws.user_id == test_user.id
+        assert ws.name == "Main"
+        assert ws.is_default is True
+
+    @pytest.mark.anyio
+    async def test_create_workspace_seeds_filesystem(
+        self, db_session: AsyncSession, test_user: object, tmp_path: Path
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        root = Path(ws.path)
+        assert (root / "AGENTS.md").exists()
+        assert (root / "memory").is_dir()
+
+    @pytest.mark.anyio
+    async def test_get_default_workspace_returns_none_when_absent(
+        self, db_session: AsyncSession, test_user: object
+    ) -> None:
+        result = await get_default_workspace(test_user.id, db_session)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_get_default_workspace_returns_existing(
+        self, db_session: AsyncSession, test_user: object, tmp_path: Path
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            created = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        fetched = await get_default_workspace(test_user.id, db_session)
+        assert fetched is not None
+        assert fetched.id == created.id
+
+    @pytest.mark.anyio
+    async def test_ensure_default_workspace_is_idempotent(
+        self, db_session: AsyncSession, test_user: object, tmp_path: Path
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws1 = await ensure_default_workspace(test_user.id, db_session)
+            await db_session.commit()
+            ws2 = await ensure_default_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        assert ws1.id == ws2.id
+
+    @pytest.mark.anyio
+    async def test_list_workspaces_empty_for_new_user(
+        self, db_session: AsyncSession, test_user: object
+    ) -> None:
+        workspaces = await list_workspaces(test_user.id, db_session)
+        assert workspaces == []
+
+    @pytest.mark.anyio
+    async def test_list_workspaces_returns_all(
+        self, db_session: AsyncSession, test_user: object, tmp_path: Path
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            await create_workspace(test_user.id, db_session, name="Main", slug="main")
+            await create_workspace(
+                test_user.id, db_session, name="Work", slug="work", is_default=False
+            )
+            await db_session.commit()
+
+        workspaces = await list_workspaces(test_user.id, db_session)
+        assert len(workspaces) == 2
+
+
+# ---------------------------------------------------------------------------
+# Workspace API
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceAPI:
+    @pytest.mark.anyio
+    async def test_list_workspaces_empty(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/workspaces")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.anyio
+    async def test_list_workspaces_returns_created(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get("/api/v1/workspaces")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Main"
+
+    @pytest.mark.anyio
+    async def test_tree_returns_seeded_files(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get(f"/api/v1/workspaces/{ws.id}/tree")
+        assert resp.status_code == 200
+        names = {node["name"] for node in resp.json()["nodes"]}
+        assert "AGENTS.md" in names
+        assert "USER.md" in names
+        assert "memory" in names
+
+    @pytest.mark.anyio
+    async def test_tree_returns_404_for_unknown_workspace(
+        self, client: AsyncClient
+    ) -> None:
+        resp = await client.get(f"/api/v1/workspaces/{uuid.uuid4()}/tree")
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_read_file_returns_content(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get(f"/api/v1/workspaces/{ws.id}/files/AGENTS.md")
+        assert resp.status_code == 200
+        assert "AGENTS.md" in resp.json()["content"]
+
+    @pytest.mark.anyio
+    async def test_read_file_404_for_missing(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get(f"/api/v1/workspaces/{ws.id}/files/DOES_NOT_EXIST.md")
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_write_then_read_file(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        content = "# My Note\n\nHello from the test.\n"
+        put_resp = await client.put(
+            f"/api/v1/workspaces/{ws.id}/files/memory/2026-05-06.md",
+            json={"content": content},
+        )
+        assert put_resp.status_code == 200
+
+        get_resp = await client.get(
+            f"/api/v1/workspaces/{ws.id}/files/memory/2026-05-06.md"
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["content"] == content
+
+    @pytest.mark.anyio
+    async def test_delete_file(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        # Write a file first.
+        await client.put(
+            f"/api/v1/workspaces/{ws.id}/files/artifacts/output.txt",
+            json={"content": "some output"},
+        )
+        del_resp = await client.delete(
+            f"/api/v1/workspaces/{ws.id}/files/artifacts/output.txt"
+        )
+        assert del_resp.status_code == 204
+
+        get_resp = await client.get(
+            f"/api/v1/workspaces/{ws.id}/files/artifacts/output.txt"
+        )
+        assert get_resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_path_traversal_is_rejected(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: object,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws.id}/files/../../../etc/passwd"
+        )
+        # Either 400 (traversal blocked) or 404 (path normalised to inside workspace).
+        assert resp.status_code in (400, 404)


### PR DESCRIPTION
## Summary

Introduces a proper workspace backend modelled on the real OpenClaw workspace pattern — where **a user owns many workspaces**, each being a named agent home directory on the filesystem.

### What was wrong with the old model

`get_user_workspace(user_id)` keyed the workspace by user ID: one user → one workspace, no name, no DB row, no structure. That is architecturally backwards — the workspace belongs to an agent context, and users have many of them (home, work, project-specific).

### What this adds

**`Workspace` ORM model** (`workspaces` table)
- `id`, `user_id` (FK → user CASCADE), `name` (e.g. "Main"), `slug`, `path` (absolute fs path), `is_default`, `created_at`
- One user → many workspaces

**OpenClaw file structure** seeded at onboarding:
```
{workspace_base_dir}/{workspace_id}/
├── AGENTS.md       # operating instructions
├── SOUL.md         # persona from personality preset
├── IDENTITY.md     # agent name placeholder
├── USER.md         # name, role, company, linkedin, goals from onboarding
├── TOOLS.md        # tool conventions
├── memory/
├── skills/
└── artifacts/
```

**Four personality presets** for `SOUL.md`: analytical / creative / direct / balanced.

**Seeding** triggered automatically on the first `PUT /api/v1/personalization` call. Idempotent. Non-fatal (workspace failure never breaks the personalization save).

**Workspace API** (`/api/v1/workspaces`)
- `GET /workspaces` — list workspaces
- `GET /workspaces/{id}/tree` — flat file-tree JSON
- `GET /workspaces/{id}/files/{path}` — read file
- `PUT /workspaces/{id}/files/{path}` — write/create file
- `DELETE /workspaces/{id}/files/{path}` — delete file

Path traversal is guarded (400 if resolved path escapes workspace root).

**35 tests** — all passing.

## Summary by Sourcery

Introduce a multi-workspace backend where each user can own multiple OpenClaw-style workspaces, each backed by a dedicated filesystem directory and ORM record, and expose them via a workspace API.

New Features:
- Add a Workspace ORM model and database migration to support multiple named workspaces per user with default selection.
- Seed each workspace with a standardized OpenClaw-style directory structure and markdown templates driven by the user’s personalization profile.
- Expose workspace management HTTP endpoints to list user workspaces, browse the workspace file tree, and read/write/delete files within a workspace from the UI.

Enhancements:
- Tie workspace seeding into the personalization onboarding flow so a default workspace is created automatically and idempotently on first profile save.

Tests:
- Add a comprehensive workspace test suite covering seeding, service helpers, API behavior, and path traversal protections.