### PR TITLE
feat(knowledge): wire My Files to real workspace API

### DIFF
--- a/frontend/features/knowledge/KnowledgeContainer.tsx
+++ b/frontend/features/knowledge/KnowledgeContainer.tsx
@@ -5,18 +5,34 @@
  *
  * Owns:
  *  - URL state parsing (`?view=` and `?path=`).
- *  - Mock data lookup (file tree + memory cards).
+ *  - Live workspace data via {@link useWorkspaceTree} and
+ *    {@link useWorkspaceFile} (real API, not mock).
  *  - Translation of UI events (select view, open child, close file, etc.) into
  *    `router.replace` calls so the URL stays the source of truth.
  *
  * Renders the pure {@link KnowledgeView} with everything pre-resolved.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * Data flow
+ * ──────────────────────────────────────────────────────────────────────────
+ * 1. `useWorkspaceTree()` fetches workspace list → picks default workspace →
+ *    fetches its flat file-tree → converts to recursive `FileTreeNode`.
+ * 2. URL `?path=` is parsed into segments.  `findNodeByPath` walks the
+ *    in-memory tree to resolve the current folder and open-file node.
+ * 3. When a `.md` file is open, `useWorkspaceFile()` fetches its text content
+ *    lazily (keyed by workspace + path so results are cached across navigations).
+ * 4. Loading / error states are surfaced through dedicated empty-state
+ *    wrappers so the rest of the view is unaffected.
  */
 
+import { AlertCircleIcon, LoaderIcon } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useCallback, useMemo } from 'react';
 import { DEFAULT_KNOWLEDGE_VIEW, KNOWLEDGE_QUERY_KEYS, KNOWLEDGE_VIEWS } from './constants';
+import { useWorkspaceFile } from './hooks/use-workspace-file';
+import { useWorkspaceTree } from './hooks/use-workspace-tree';
 import { KnowledgeView, type KnowledgeViewProps } from './KnowledgeView';
-import { KNOWLEDGE_FILE_TREE, KNOWLEDGE_MEMORY_CARDS } from './mock-data';
+import { KNOWLEDGE_MEMORY_CARDS } from './mock-data';
 import {
 	buildBreadcrumbs,
 	findNodeByPath,
@@ -24,7 +40,11 @@ import {
 	joinKnowledgePath,
 	parseKnowledgePath,
 } from './path-utils';
-import type { KnowledgeViewId } from './types';
+import type { FileTreeNode, KnowledgeViewId } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 /**
  * Type guard for `?view=` values. Anything unrecognised falls back to the
@@ -51,6 +71,46 @@ function buildQuery(view: KnowledgeViewId, path: string): string {
 }
 
 /**
+ * Empty root used as a fallback while the real workspace tree is loading.
+ * Prevents downstream components from receiving `null` while we wait.
+ */
+const EMPTY_FILE_TREE: FileTreeNode = {
+	kind: 'folder',
+	name: 'My Files',
+	updatedLabel: '',
+	children: [],
+};
+
+// ---------------------------------------------------------------------------
+// Inline loading / error states
+// ---------------------------------------------------------------------------
+
+/** Spinner shown while the workspace tree loads. */
+function TreeLoadingState(): ReactNode {
+	return (
+		<div className="flex h-full items-center justify-center text-muted-foreground">
+			<LoaderIcon className="size-4 animate-spin" aria-hidden="true" />
+			<span className="ml-2 text-[13px]">Loading workspace…</span>
+		</div>
+	);
+}
+
+/** Error banner shown when the workspace tree fetch fails. */
+function TreeErrorState({ message }: { message: string }): ReactNode {
+	return (
+		<div className="flex h-full flex-col items-center justify-center gap-2 px-8 text-center text-muted-foreground">
+			<AlertCircleIcon className="size-5 text-destructive" aria-hidden="true" />
+			<p className="text-[13px] font-medium text-foreground">Couldn't load your workspace</p>
+			<p className="max-w-[340px] text-[12px]">{message}</p>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Container
+// ---------------------------------------------------------------------------
+
+/**
  * Container component. Reads the URL, resolves it to render-ready data,
  * and forwards everything to the pure View. Always rendered as a client
  * component because it needs `useSearchParams`.
@@ -58,6 +118,8 @@ function buildQuery(view: KnowledgeViewId, path: string): string {
 export function KnowledgeContainer(): ReactNode {
 	const router = useRouter();
 	const searchParams = useSearchParams();
+
+	// ── URL state ─────────────────────────────────────────────────────────────
 
 	const rawView = searchParams.get(KNOWLEDGE_QUERY_KEYS.view);
 	const activeView: KnowledgeViewId = isKnowledgeViewId(rawView)
@@ -67,27 +129,57 @@ export function KnowledgeContainer(): ReactNode {
 	const rawPath = searchParams.get(KNOWLEDGE_QUERY_KEYS.path);
 	const segments = useMemo(() => parseKnowledgePath(rawPath), [rawPath]);
 
+	// ── Remote data ───────────────────────────────────────────────────────────
+
+	const {
+		workspaceId,
+		fileTree,
+		isLoading: treeLoading,
+		isError: treeError,
+		error,
+	} = useWorkspaceTree();
+
+	// The resolved tree — falls back to the empty root while loading so all
+	// downstream `useMemo` hooks can still run without null checks.
+	const resolvedTree = fileTree ?? EMPTY_FILE_TREE;
+
+	// When the URL points at a .md file, derive the workspace-relative path
+	// we need to fetch its content (matches the backend `path` field exactly).
+	const openFilePath = useMemo(
+		() => (isFilePath(segments) ? joinKnowledgePath(segments) : null),
+		[segments]
+	);
+
+	const { content: fileContent, isLoading: fileLoading } = useWorkspaceFile(
+		workspaceId,
+		openFilePath
+	);
+
+	// ── Tree navigation ───────────────────────────────────────────────────────
+
 	const folderSegments = useMemo(
 		() => (isFilePath(segments) ? segments.slice(0, -1) : segments),
 		[segments]
 	);
 
 	const currentNode = useMemo(
-		() => findNodeByPath(KNOWLEDGE_FILE_TREE, folderSegments),
-		[folderSegments]
+		() => findNodeByPath(resolvedTree, folderSegments),
+		[resolvedTree, folderSegments]
 	);
 
 	const openFileNode = useMemo(() => {
 		if (!isFilePath(segments)) return null;
-		const node = findNodeByPath(KNOWLEDGE_FILE_TREE, segments);
+		const node = findNodeByPath(resolvedTree, segments);
 		if (node && node.kind === 'file') return node;
 		return null;
-	}, [segments]);
+	}, [resolvedTree, segments]);
 
 	const crumbs = useMemo(
-		() => buildBreadcrumbs(KNOWLEDGE_FILE_TREE.name, folderSegments),
-		[folderSegments]
+		() => buildBreadcrumbs(resolvedTree.name, folderSegments),
+		[resolvedTree.name, folderSegments]
 	);
+
+	// ── Navigation handlers ───────────────────────────────────────────────────
 
 	/**
 	 * Pushes a new URL preserving whichever path segment is appropriate for
@@ -136,9 +228,8 @@ export function KnowledgeContainer(): ReactNode {
 	}, [folderSegments, navigate]);
 
 	const handleNew = useCallback<KnowledgeViewProps['onNew']>(() => {
-		// Mock — real implementation will open a "create file/folder" modal
-		// scoped to the current folder. For now we navigate to the root of My
-		// Files so something visibly changes.
+		// TODO: open a "create file/folder" modal scoped to the current folder.
+		// For now navigate to the root of My Files so something visibly changes.
 		navigate(KNOWLEDGE_VIEWS.myFiles, '');
 	}, [navigate]);
 
@@ -148,9 +239,62 @@ export function KnowledgeContainer(): ReactNode {
 		navigate(KNOWLEDGE_VIEWS.brainAccess, '');
 	}, [navigate]);
 
-	const openFile = openFileNode
-		? { name: openFileNode.name, markdown: openFileNode.markdown }
-		: null;
+	// ── Render ────────────────────────────────────────────────────────────────
+
+	// Surface tree loading / error inline so the sub-sidebar stays visible
+	// (the user can still switch to Memory / Brain Access while files load).
+	if (treeLoading && activeView === KNOWLEDGE_VIEWS.myFiles) {
+		return (
+			<KnowledgeView
+				activeView={activeView}
+				onSelectView={handleSelectView}
+				currentNode={null}
+				crumbs={crumbs}
+				onNavigateBreadcrumb={handleNavigateBreadcrumb}
+				onOpenChild={handleOpenChild}
+				openFile={null}
+				onCloseFile={handleCloseFile}
+				memoryCards={KNOWLEDGE_MEMORY_CARDS}
+				onNew={handleNew}
+				onShareFromEmptyState={handleShareFromEmptyState}
+				contentOverride={<TreeLoadingState />}
+			/>
+		);
+	}
+
+	if (treeError && activeView === KNOWLEDGE_VIEWS.myFiles) {
+		return (
+			<KnowledgeView
+				activeView={activeView}
+				onSelectView={handleSelectView}
+				currentNode={null}
+				crumbs={crumbs}
+				onNavigateBreadcrumb={handleNavigateBreadcrumb}
+				onOpenChild={handleOpenChild}
+				openFile={null}
+				onCloseFile={handleCloseFile}
+				memoryCards={KNOWLEDGE_MEMORY_CARDS}
+				onNew={handleNew}
+				onShareFromEmptyState={handleShareFromEmptyState}
+				contentOverride={
+					<TreeErrorState
+						message={error?.message ?? 'Unknown error — check the backend.'}
+					/>
+				}
+			/>
+		);
+	}
+
+	// Build the `openFile` prop. Content is fetched lazily — while it loads we
+	// pass an empty string so the DocumentViewer chrome is visible immediately
+	// and the body area fills in once the fetch resolves.
+	const openFile =
+		openFileNode !== null
+			? {
+					name: openFileNode.name,
+					markdown: fileLoading ? '' : (fileContent ?? ''),
+				}
+			: null;
 
 	return (
 		<KnowledgeView

--- a/frontend/features/knowledge/KnowledgeView.tsx
+++ b/frontend/features/knowledge/KnowledgeView.tsx
@@ -79,6 +79,13 @@ export interface KnowledgeViewProps {
 	onNew: () => void;
 	/** Fired by the empty-state CTA on Shared views. */
 	onShareFromEmptyState: () => void;
+
+	/**
+	 * When set, this node is rendered _instead of_ the normal `KnowledgeContent`
+	 * router. Used by the container to show loading spinners or error banners
+	 * while still keeping the sub-sidebar interactive.
+	 */
+	contentOverride?: ReactNode;
 }
 
 /**
@@ -253,7 +260,7 @@ export function KnowledgeView(props: KnowledgeViewProps): ReactNode {
 				className={`${PANEL_SURFACE_CLASSNAME} flex-1 min-w-0`}
 				style={PANEL_SURFACE_STYLE}
 			>
-				<KnowledgeContent {...props} />
+				{props.contentOverride ?? <KnowledgeContent {...props} />}
 			</section>
 		</div>
 	);

--- a/frontend/features/knowledge/hooks/use-workspace-file.ts
+++ b/frontend/features/knowledge/hooks/use-workspace-file.ts
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * React Query hook for lazily fetching a single workspace file's text content.
+ *
+ * Enabled only when both `workspaceId` and `filePath` are non-null — callers
+ * pass `null` for either argument to suspend fetching (e.g. when no file is
+ * currently open in the document viewer).
+ *
+ * The content is cached by `(workspaceId, filePath)` so switching between
+ * previously-opened files does not re-fetch.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthedFetch } from '@/hooks/use-authed-fetch';
+import { API_ENDPOINTS } from '@/lib/api';
+import type { WorkspaceFileApiResponse } from '../types';
+
+export interface WorkspaceFileResult {
+	/**
+	 * File content as a UTF-8 string, or `null` while loading / on error.
+	 * Consumers should render a loading state when `isLoading` is true and
+	 * `content` is null.
+	 */
+	content: string | null;
+	/** True while the file fetch is in-flight. */
+	isLoading: boolean;
+	/** True if the fetch failed (file not found, permission error, etc.). */
+	isError: boolean;
+}
+
+/**
+ * Hook: fetch one workspace file's text content.
+ *
+ * @param workspaceId - UUID of the workspace that owns the file.
+ * @param filePath    - Workspace-relative POSIX path, e.g. `memory/note.md`.
+ *                      Pass `null` when no file is open.
+ */
+export function useWorkspaceFile(
+	workspaceId: string | null,
+	filePath: string | null
+): WorkspaceFileResult {
+	const authedFetch = useAuthedFetch();
+
+	// Both IDs must be present; otherwise the hook is idle.
+	const enabled = !!workspaceId && !!filePath;
+
+	const query = useQuery<WorkspaceFileApiResponse>({
+		queryKey: ['workspace-file', workspaceId ?? '', filePath ?? ''],
+		queryFn: async () => {
+			// `enabled` above guarantees both are non-null when this runs.
+			const wsId = workspaceId ?? '';
+			const fp = filePath ?? '';
+			const res = await authedFetch(API_ENDPOINTS.workspaces.file(wsId, fp));
+			return res.json() as Promise<WorkspaceFileApiResponse>;
+		},
+		enabled,
+		// Cache file content for 60 seconds — aggressive enough to stay fresh
+		// while the user edits, conservative enough to avoid staleness.
+		staleTime: 60 * 1000,
+	});
+
+	return {
+		content: query.data?.content ?? null,
+		isLoading: enabled && query.isLoading,
+		isError: query.isError,
+	};
+}

--- a/frontend/features/knowledge/hooks/use-workspace-tree.ts
+++ b/frontend/features/knowledge/hooks/use-workspace-tree.ts
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * React Query hook that fetches the current user's default workspace and
+ * converts its flat file-tree API response into the recursive
+ * {@link FileTreeNode} structure consumed by the Knowledge UI.
+ *
+ * Two dependent fetches happen in sequence:
+ *   1. `GET /api/v1/workspaces`       → pick the default (or first) workspace.
+ *   2. `GET /api/v1/workspaces/:id/tree` → flat node list → recursive tree.
+ *
+ * The hook is designed to be called once inside `KnowledgeContainer` and its
+ * results passed down as props; no context or global state is needed.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthedFetch } from '@/hooks/use-authed-fetch';
+import { API_ENDPOINTS } from '@/lib/api';
+import { flatNodesToTree } from '../path-utils';
+import type { FileTreeNode, WorkspaceRead, WorkspaceTreeApiResponse } from '../types';
+
+export interface WorkspaceTreeResult {
+	/** UUID of the active workspace, or `null` while loading. */
+	workspaceId: string | null;
+	/**
+	 * Recursive file tree rooted at "My Files".  `null` until both fetches
+	 * complete; components should handle this with a loading skeleton or by
+	 * rendering an empty root.
+	 */
+	fileTree: FileTreeNode | null;
+	/** True while either network request is in-flight. */
+	isLoading: boolean;
+	/** True if either request failed. */
+	isError: boolean;
+	/** The first error encountered (workspace list or tree), if any. */
+	error: Error | null;
+}
+
+/**
+ * Hook: fetch the default workspace and its file tree.
+ *
+ * React Query caches both responses so navigating back to the Knowledge
+ * route does not re-fetch unless the cache has gone stale.
+ */
+export function useWorkspaceTree(): WorkspaceTreeResult {
+	const authedFetch = useAuthedFetch();
+
+	// ── Step 1: workspace list ────────────────────────────────────────────────
+
+	const workspacesQuery = useQuery<WorkspaceRead[]>({
+		queryKey: ['workspaces'],
+		queryFn: async () => {
+			const res = await authedFetch(API_ENDPOINTS.workspaces.list);
+			return res.json() as Promise<WorkspaceRead[]>;
+		},
+		// Keep the list fresh for 5 minutes — it's unlikely to change mid-session.
+		staleTime: 5 * 60 * 1000,
+	});
+
+	// Prefer is_default; fall back to the first workspace in the list.
+	const defaultWorkspace: WorkspaceRead | null =
+		workspacesQuery.data?.find((w) => w.is_default) ?? workspacesQuery.data?.[0] ?? null;
+
+	// ── Step 2: file tree (dependent on step 1) ───────────────────────────────
+
+	const treeQuery = useQuery<WorkspaceTreeApiResponse>({
+		queryKey: ['workspace-tree', defaultWorkspace?.id ?? ''],
+		queryFn: async () => {
+			// `enabled` above ensures defaultWorkspace is non-null when this runs.
+			const wsId = defaultWorkspace?.id ?? '';
+			const res = await authedFetch(API_ENDPOINTS.workspaces.tree(wsId));
+			return res.json() as Promise<WorkspaceTreeApiResponse>;
+		},
+		// Only run once we have a workspace ID.
+		enabled: !!defaultWorkspace?.id,
+		staleTime: 30 * 1000,
+	});
+
+	// ── Derived state ─────────────────────────────────────────────────────────
+
+	const fileTree: FileTreeNode | null = treeQuery.data
+		? flatNodesToTree(treeQuery.data.nodes)
+		: null;
+
+	const isLoading =
+		workspacesQuery.isLoading ||
+		// Tree is "loading" only while we actually have a workspace ID to fetch.
+		(!!defaultWorkspace && treeQuery.isLoading);
+
+	const isError = workspacesQuery.isError || treeQuery.isError;
+
+	const error: Error | null =
+		(workspacesQuery.error as Error | null) ?? (treeQuery.error as Error | null) ?? null;
+
+	return {
+		workspaceId: defaultWorkspace?.id ?? null,
+		fileTree,
+		isLoading,
+		isError,
+		error,
+	};
+}

--- a/frontend/features/knowledge/path-utils.ts
+++ b/frontend/features/knowledge/path-utils.ts
@@ -8,7 +8,7 @@
  */
 
 import { KNOWLEDGE_FILE_EXTENSION, KNOWLEDGE_PATH_SEPARATOR } from './constants';
-import type { FileTreeNode } from './types';
+import type { FileTreeNode, WorkspaceApiNode } from './types';
 
 /**
  * Splits a `?path=` value into trimmed, non-empty segments.
@@ -76,6 +76,69 @@ export interface KnowledgeBreadcrumb {
 	path: string;
 	/** True for the trailing crumb — usually styled differently and not focusable. */
 	isCurrent: boolean;
+}
+
+/**
+ * Converts the flat `WorkspaceApiNode[]` list returned by
+ * `GET /api/v1/workspaces/:id/tree` into the recursive {@link FileTreeNode}
+ * tree the Knowledge UI consumes.
+ *
+ * The backend emits nodes in depth-first order with directories before their
+ * children, so we can build the tree in a single linear pass using a
+ * `Map<path, FolderNode>` as an accumulator.
+ *
+ * @param nodes    - Flat list of workspace file-tree nodes from the API.
+ * @param rootName - Display label for the implicit root (default: `"My Files"`).
+ */
+export function flatNodesToTree(
+	nodes: readonly WorkspaceApiNode[],
+	rootName = 'My Files'
+): FileTreeNode {
+	type FolderNode = FileTreeNode & { kind: 'folder' };
+
+	const root: FolderNode = {
+		kind: 'folder',
+		name: rootName,
+		updatedLabel: '',
+		children: [],
+	};
+
+	// Map from workspace-relative path to the corresponding in-memory folder node.
+	// The empty-string key is the implicit root.
+	const folderMap = new Map<string, FolderNode>();
+	folderMap.set('', root);
+
+	for (const node of nodes) {
+		// Determine the parent folder's path
+		const lastSlash = node.path.lastIndexOf('/');
+		const parentPath = lastSlash === -1 ? '' : node.path.slice(0, lastSlash);
+		const parent = folderMap.get(parentPath);
+
+		// Skip orphaned nodes (shouldn’t happen with a well-formed API response).
+		if (!parent) continue;
+
+		if (node.is_dir) {
+			const folder: FolderNode = {
+				kind: 'folder',
+				name: node.name,
+				updatedLabel: '',
+				children: [],
+			};
+			parent.children.push(folder);
+			folderMap.set(node.path, folder);
+		} else {
+			// File content is not embedded — it’s fetched lazily by
+			// `useWorkspaceFile` when the user opens the document.
+			parent.children.push({
+				kind: 'file',
+				name: node.name,
+				updatedLabel: '',
+				markdown: '',
+			});
+		}
+	}
+
+	return root;
 }
 
 /**

--- a/frontend/features/knowledge/types.ts
+++ b/frontend/features/knowledge/types.ts
@@ -54,6 +54,51 @@ export type MemoryCardTone = 'info' | 'success' | 'accent' | 'destructive' | 'fo
  * Real implementations will swap `count` for a live observation count and
  * route the click to a dedicated detail page.
  */
+// ---------------------------------------------------------------------------
+// Workspace API shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Workspace summary returned by `GET /api/v1/workspaces`.
+ * Mirrors the backend `WorkspaceRead` Pydantic schema.
+ */
+export interface WorkspaceRead {
+	id: string;
+	name: string;
+	slug: string;
+	is_default: boolean;
+	created_at: string;
+}
+
+/**
+ * One entry in the flat node list from `GET /api/v1/workspaces/:id/tree`.
+ * Mirrors `WorkspaceFileNode` on the backend.
+ */
+export interface WorkspaceApiNode {
+	name: string;
+	/** Workspace-relative POSIX path, e.g. `memory/note.md`. */
+	path: string;
+	is_dir: boolean;
+	/** Byte size; `null` for directories. */
+	size: number | null;
+}
+
+/** Response envelope from `GET /api/v1/workspaces/:id/tree`. */
+export interface WorkspaceTreeApiResponse {
+	workspace_id: string;
+	nodes: WorkspaceApiNode[];
+}
+
+/** Response from `GET /api/v1/workspaces/:id/files/:path`. */
+export interface WorkspaceFileApiResponse {
+	path: string;
+	content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Memory card shapes
+// ---------------------------------------------------------------------------
+
 export interface MemoryCardData {
 	/** Stable identifier — used as the React key and any future routing slug. */
 	id: string;

--- a/frontend/hooks/use-authed-query.ts
+++ b/frontend/hooks/use-authed-query.ts
@@ -1,14 +1,32 @@
 import { type QueryKey, useQuery } from '@tanstack/react-query';
 import { useAuthedFetch } from './use-authed-fetch';
 
+export interface UseAuthedQueryOptions {
+	/**
+	 * When `false` the query is skipped entirely.  Mirrors the React Query
+	 * `enabled` flag — useful for dependent queries where the URL is not yet
+	 * known.
+	 *
+	 * @default true
+	 */
+	enabled?: boolean;
+	/** Stale time in milliseconds passed through to React Query. */
+	staleTime?: number;
+}
+
 /**
  * `useQuery` bound to {@link useAuthedFetch}: JSON GET with cookie auth and shared 401 handling.
  *
  * @typeParam T - Parsed JSON type of the response body.
  * @param queryKey - React Query cache key (include all values that should invalidate the fetch).
  * @param endpoint - API path appended to the configured backend origin (see `lib/api.ts`).
+ * @param options  - Optional React Query overrides (`enabled`, `staleTime`).
  */
-export function useAuthedQuery<T>(queryKey: QueryKey, endpoint: string) {
+export function useAuthedQuery<T>(
+	queryKey: QueryKey,
+	endpoint: string,
+	options?: UseAuthedQueryOptions
+) {
 	const authedFetch = useAuthedFetch();
 	return useQuery<T>({
 		queryKey,
@@ -16,5 +34,7 @@ export function useAuthedQuery<T>(queryKey: QueryKey, endpoint: string) {
 			const response = await authedFetch(endpoint);
 			return response.json();
 		},
+		enabled: options?.enabled,
+		staleTime: options?.staleTime,
 	});
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -149,6 +149,34 @@ export const API_ENDPOINTS = {
 		 */
 		delete: (id: string) => `/api/v1/projects/${id}`,
 	},
+	/** Workspace file-system API (backs the Knowledge → My Files surface). */
+	workspaces: {
+		/** List all workspaces owned by the current user. */
+		list: '/api/v1/workspaces',
+		/**
+		 * Flat file-tree for a workspace.
+		 * @param id - Workspace UUID
+		 */
+		tree: (id: string) => `/api/v1/workspaces/${id}/tree`,
+		/**
+		 * Read a single file from a workspace.
+		 * @param id   - Workspace UUID
+		 * @param path - Workspace-relative POSIX path (e.g. `memory/note.md`)
+		 */
+		file: (id: string, path: string) => `/api/v1/workspaces/${id}/files/${path}`,
+		/**
+		 * Write (create or replace) a file inside a workspace.
+		 * @param id   - Workspace UUID
+		 * @param path - Workspace-relative POSIX path
+		 */
+		writeFile: (id: string, path: string) => `/api/v1/workspaces/${id}/files/${path}`,
+		/**
+		 * Delete a file from a workspace.
+		 * @param id   - Workspace UUID
+		 * @param path - Workspace-relative POSIX path
+		 */
+		deleteFile: (id: string, path: string) => `/api/v1/workspaces/${id}/files/${path}`,
+	},
 	/** Third-party messaging channels (Telegram today; more later). */
 	channels: {
 		/** List every channel binding owned by the authenticated user. */


### PR DESCRIPTION
## Summary

Replaces all mock-data usage in the Knowledge → My Files sub-view with live calls to the workspace backend endpoints from #106.

## What changed

### New files
- `frontend/features/knowledge/hooks/use-workspace-tree.ts` — two dependent React Query calls: list workspaces → pick default → fetch flat file-tree → convert to recursive `FileTreeNode`
- `frontend/features/knowledge/hooks/use-workspace-file.ts` — lazy fetch for a single file text content; enabled only when a `.md` file is open in the viewer

### Modified files
- `frontend/lib/api.ts` — add `workspaces` endpoint constants
- `frontend/hooks/use-authed-query.ts` — add optional `enabled` and `staleTime` params
- `frontend/features/knowledge/types.ts` — add API response shapes
- `frontend/features/knowledge/path-utils.ts` — add `flatNodesToTree()`: converts the backend depth-first flat node list to the recursive `FileTreeNode` in a single linear pass
- `frontend/features/knowledge/KnowledgeView.tsx` — add optional `contentOverride` prop for loading/error states
- `frontend/features/knowledge/KnowledgeContainer.tsx` — replace `KNOWLEDGE_FILE_TREE` with `useWorkspaceTree()`; replace embedded markdown with `useWorkspaceFile()`; surface loading spinner and error banner

## What is still mock
- **Memory cards** — `KNOWLEDGE_MEMORY_CARDS` stays as mock; real memory is a separate feature
- **File row actions** (rename, share, delete) — still `console.info` placeholders; API endpoints exist but mutation UI not wired yet

## How to test
1. Complete onboarding (or `PUT /api/v1/personalization`) to seed a workspace
2. `/knowledge` → My Files should show real workspace files (`AGENTS.md`, `SOUL.md`, `memory/`, `skills/` etc.)
3. Click a `.md` file — DocumentViewer fetches and renders its content
4. Click into a folder — breadcrumbs and contents update correctly
5. `/knowledge?view=memory` — memory cards still mock (expected)

## Summary by Sourcery

Wire the Knowledge "My Files" view to the real workspace backend, replacing mock file-tree and content with data from workspace APIs while preserving memory cards as mock.

New Features:
- Add workspace API endpoint definitions for listing workspaces, reading trees, and file CRUD operations.
- Introduce React Query hooks to fetch the default workspace tree and lazily load individual file contents for the Knowledge view.
- Allow KnowledgeView to render custom loading or error content while keeping navigation usable.

Enhancements:
- Convert backend workspace tree responses into the recursive FileTreeNode structure used by the UI.
- Extend the authenticated query hook to support React Query's enabled and staleTime options for dependent queries.
- Surface inline loading and error states in the Knowledge container instead of blocking the entire view.