### PR TITLE
fix(workspace): prevent duplicate default workspace rows

### DIFF
--- a/.beans/ai-nexus-pq4r--bug-duplicate-default-workspace-rows-on-personaliz.md
+++ b/.beans/ai-nexus-pq4r--bug-duplicate-default-workspace-rows-on-personaliz.md
@@ -1,11 +1,12 @@
 ---
 # ai-nexus-pq4r
 title: 'Bug: duplicate default Workspace rows on personalization save'
-status: todo
+status: in-review
 type: bug
 priority: high
 created_at: 2026-05-07T16:17:18Z
-updated_at: 2026-05-07T16:17:18Z
+updated_at: 2026-05-07T18:10:00Z
+pr: https://github.com/OctavianTocan/ai-nexus/pull/111
 ---
 
 ## Symptom

--- a/backend/alembic/versions/009_unique_default_workspace_per_user.py
+++ b/backend/alembic/versions/009_unique_default_workspace_per_user.py
@@ -1,0 +1,46 @@
+"""add partial unique index — one default workspace per user
+
+Revision ID: 009_unique_default_workspace_per_user
+Revises: 008_add_workspaces
+Create Date: 2026-05-07
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "009_unique_default_workspace_per_user"
+down_revision: Union[str, None] = "008_add_workspaces"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add a partial unique index so each user can have at most one default workspace.
+
+    Both SQLite (≥ 3.8.9) and Postgres support partial unique indexes with a
+    WHERE clause.  We use ``true`` (lowercase) which both engines accept as a
+    boolean literal, avoiding the ``IS TRUE`` syntax that was only added to
+    SQLite in 3.35 (2021-03-12).
+
+    If the database already has duplicate default-workspace rows for any user,
+    run the companion cleanup script (``scripts/dedupe_default_workspaces.py``)
+    *before* applying this migration.  On a fresh dev database the migration
+    is safe to apply directly.
+    """
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "uq_workspaces_one_default_per_user "
+            "ON workspaces (user_id) "
+            "WHERE is_default = true"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DROP INDEX IF EXISTS uq_workspaces_one_default_per_user")
+    )

--- a/backend/app/core/workspace.py
+++ b/backend/app/core/workspace.py
@@ -26,15 +26,19 @@ service is idempotent — calling it again on an existing workspace is a no-op.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from app.models import UserPersonalization, Workspace
@@ -321,17 +325,48 @@ async def ensure_default_workspace(
 ) -> "Workspace":
     """Return the existing default workspace or create one.
 
-    Safe to call multiple times — only creates the workspace on the first
-    call.  Uses ``get_default_workspace`` as the idempotency guard.
+    Safe to call multiple times — idempotent against both normal duplicate
+    calls and the React StrictMode double-effect pattern.
+
+    Strategy:
+    1. Fast-path: look up an existing default workspace and return it.
+    2. Slow-path: create one.  If two concurrent requests both pass step 1
+       before either has committed, the partial unique index
+       ``uq_workspaces_one_default_per_user`` makes the second INSERT raise
+       an ``IntegrityError``.  We catch that, roll back the failed nested
+       savepoint, and re-fetch — which now finds the row the first request
+       committed.
     """
     existing = await get_default_workspace(user_id, session)
     if existing is not None:
         return existing
-    return await create_workspace(
-        user_id=user_id,
-        session=session,
-        name="Main",
-        slug="main",
-        is_default=True,
-        personalization=personalization,
-    )
+
+    try:
+        # Use a savepoint so a constraint violation only rolls back this
+        # nested transaction, not the whole outer session.
+        async with session.begin_nested():
+            ws = await create_workspace(
+                user_id=user_id,
+                session=session,
+                name="Main",
+                slug="main",
+                is_default=True,
+                personalization=personalization,
+            )
+        return ws
+    except IntegrityError:
+        # Another concurrent request already inserted the default workspace.
+        # The savepoint was rolled back automatically; re-fetch the winner.
+        log.warning(
+            "ensure_default_workspace: IntegrityError for user %s — "
+            "concurrent insert detected, re-fetching existing row.",
+            user_id,
+        )
+        result = await get_default_workspace(user_id, session)
+        if result is None:
+            # Should never happen: the constraint fired but no row exists.
+            raise RuntimeError(
+                f"ensure_default_workspace: could not find default workspace "
+                f"for user {user_id} after IntegrityError"
+            ) from None
+        return result

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -311,6 +311,42 @@ class TestWorkspaceService:
         workspaces = await list_workspaces(test_user.id, db_session)
         assert len(workspaces) == 2
 
+    @pytest.mark.anyio
+    async def test_ensure_default_workspace_handles_integrity_error(
+        self, db_session: AsyncSession, test_user: User, tmp_path: Path
+    ) -> None:
+        """ensure_default_workspace must recover cleanly when a concurrent
+        request already committed the workspace (simulated via IntegrityError).
+
+        We mock ``create_workspace`` to raise ``IntegrityError`` after first
+        seeding the DB row directly, so the subsequent re-fetch in the except
+        branch has a real row to return.
+        """
+        from sqlalchemy.exc import IntegrityError as SAIntegrityError
+
+        # First, create the workspace directly so it already exists in the DB.
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            real_ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        # Now patch create_workspace to raise IntegrityError, simulating the
+        # race where two requests both passed the "no existing workspace" check
+        # before either committed.
+        with (
+            patch("app.core.workspace.settings") as mock_settings,
+            patch(
+                "app.core.workspace.create_workspace",
+                side_effect=SAIntegrityError("mock", {}, Exception()),
+            ),
+        ):
+            mock_settings.workspace_base_dir = str(tmp_path)
+            # ensure_default_workspace should catch the IntegrityError,
+            # re-fetch, and return the already-committed row.
+            recovered_ws = await ensure_default_workspace(test_user.id, db_session)
+
+        assert recovered_ws.id == real_ws.id
+
 
 # ---------------------------------------------------------------------------
 # Workspace API

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -312,6 +312,69 @@ class TestWorkspaceService:
         assert len(workspaces) == 2
 
     @pytest.mark.anyio
+    async def test_unique_index_blocks_duplicate_default_insert(
+        self, db_session: AsyncSession, test_user: User, tmp_path: Path
+    ) -> None:
+        """Regression test for ai-nexus-pq4r.
+
+        Applies the partial unique index from migration 009 directly to the
+        in-memory test DB and verifies that a second direct INSERT of a default
+        workspace raises IntegrityError — proving the constraint actually fires
+        before the application-level recovery path is even needed.
+        """
+        from sqlalchemy import text
+        from sqlalchemy.exc import IntegrityError as SAIntegrityError
+
+        # Manually apply migration 009's partial unique index to the test DB.
+        # (conftest uses Base.metadata.create_all, not Alembic, so this
+        # would not exist otherwise.)
+        await db_session.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "uq_workspaces_one_default_per_user "
+                "ON workspaces (user_id) "
+                "WHERE is_default = true"
+            )
+        )
+        await db_session.commit()
+
+        # Create the first default workspace — must succeed.
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws1 = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        # Attempt a second default workspace via a savepoint so the session
+        # stays alive after the expected constraint violation.
+        caught = False
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            try:
+                async with db_session.begin_nested():
+                    await create_workspace(test_user.id, db_session)
+            except SAIntegrityError:
+                caught = True
+
+        assert caught, "Expected IntegrityError from unique index — constraint is not applied"
+
+        # Only the first workspace must remain.
+        from sqlalchemy import func
+        from sqlalchemy import select as sa_select
+
+        from app.models import Workspace
+
+        count_result = await db_session.execute(
+            sa_select(func.count())
+            .select_from(Workspace)
+            .where(
+                Workspace.user_id == test_user.id,
+                Workspace.is_default.is_(True),
+            )
+        )
+        assert count_result.scalar_one() == 1
+        assert (await get_default_workspace(test_user.id, db_session)).id == ws1.id  # type: ignore[union-attr]
+
+    @pytest.mark.anyio
     async def test_ensure_default_workspace_handles_integrity_error(
         self, db_session: AsyncSession, test_user: User, tmp_path: Path
     ) -> None:

--- a/scripts/dedupe_default_workspaces.py
+++ b/scripts/dedupe_default_workspaces.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""One-shot script to remove duplicate default-workspace rows.
+
+Run this BEFORE applying the 009_unique_default_workspace_per_user Alembic
+migration on any database that already has rows (i.e. any deployed instance
+that has ever run the onboarding flow).
+
+On a brand-new database the migration is safe to apply without this script.
+
+Usage
+-----
+    python scripts/dedupe_default_workspaces.py [--dry-run] [--db-url URL]
+
+Options
+-------
+    --dry-run   Print what would be deleted without touching the database.
+    --db-url    SQLAlchemy database URL (defaults to $DATABASE_URL or the
+                app's configured DB URL).
+
+Strategy
+--------
+For each user that has more than one workspace with is_default=True:
+  - Keep the row with the latest ``created_at`` timestamp (most complete
+    seed, closest to the last onboarding submission).
+  - Delete all earlier duplicates.
+  - Optionally remove the orphaned workspace directories from the filesystem.
+
+Exit codes
+----------
+    0  — success (or dry-run with no errors)
+    1  — one or more users had un-resolvable duplicates (check logs)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Sync SQLAlchemy (this script runs outside uvicorn, no async required)
+# ---------------------------------------------------------------------------
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true", help="Show what would be deleted without changing anything.")
+    p.add_argument("--db-url", default="", help="SQLAlchemy DB URL. Falls back to DATABASE_URL env var.")
+    p.add_argument("--remove-dirs", action="store_true", help="Also delete orphaned workspace directories from disk.")
+    return p.parse_args()
+
+
+def get_db_url(args: argparse.Namespace) -> str:
+    url = args.db_url or os.environ.get("DATABASE_URL", "")
+    if not url:
+        # Try to load from app config as last resort.
+        try:
+            sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+            from app.core.config import settings  # type: ignore[import]
+            url = str(settings.database_url)
+        except Exception as exc:
+            print(f"ERROR: Could not determine database URL: {exc}", file=sys.stderr)
+            sys.exit(1)
+    return url
+
+
+def main() -> None:
+    args = parse_args()
+    db_url = get_db_url(args)
+
+    # Strip async driver prefix if present (asyncpg → psycopg2, aiosqlite → sqlite).
+    sync_url = db_url.replace("postgresql+asyncpg://", "postgresql://").replace(
+        "sqlite+aiosqlite:///", "sqlite:///"
+    )
+
+    engine = create_engine(sync_url, echo=False)
+
+    with engine.connect() as conn:
+        # Find all users with more than one default workspace.
+        dupes = conn.execute(
+            text(
+                """
+                SELECT user_id, COUNT(*) AS cnt
+                FROM workspaces
+                WHERE is_default = true
+                GROUP BY user_id
+                HAVING COUNT(*) > 1
+                """
+            )
+        ).fetchall()
+
+        if not dupes:
+            print("No duplicate default workspaces found. Nothing to do.")
+            return
+
+        print(f"Found {len(dupes)} user(s) with duplicate default workspaces.\n")
+        errors = 0
+
+        for row in dupes:
+            user_id = row[0]
+            count = row[1]
+
+            # Fetch all default workspaces for this user, newest first.
+            ws_rows = conn.execute(
+                text(
+                    """
+                    SELECT id, path, created_at
+                    FROM workspaces
+                    WHERE user_id = :uid AND is_default = true
+                    ORDER BY created_at DESC
+                    """
+                ),
+                {"uid": user_id},
+            ).fetchall()
+
+            keeper = ws_rows[0]
+            victims = ws_rows[1:]
+
+            print(
+                f"User {user_id}: {count} default workspaces "
+                f"→ keeping {keeper[0]} (created {keeper[2]})"
+            )
+            for v in victims:
+                print(f"  {'[DRY RUN] ' if args.dry_run else ''}DELETE id={v[0]}  path={v[1]}")
+
+                if not args.dry_run:
+                    try:
+                        conn.execute(
+                            text("DELETE FROM workspaces WHERE id = :id"),
+                            {"id": v[0]},
+                        )
+                        print(f"    ✓ deleted DB row {v[0]}")
+                    except Exception as exc:
+                        print(f"    ✗ ERROR deleting {v[0]}: {exc}", file=sys.stderr)
+                        errors += 1
+                        continue
+
+                if args.remove_dirs:
+                    victim_path = Path(v[1])
+                    if victim_path.exists():
+                        if args.dry_run:
+                            print(f"    [DRY RUN] would remove directory: {victim_path}")
+                        else:
+                            try:
+                                shutil.rmtree(victim_path)
+                                print(f"    ✓ removed directory {victim_path}")
+                            except Exception as exc:
+                                print(f"    ✗ ERROR removing {victim_path}: {exc}", file=sys.stderr)
+                                errors += 1
+                    else:
+                        print(f"    (directory already absent: {victim_path})")
+
+        if not args.dry_run:
+            conn.commit()
+            print("\nCommitted.")
+
+        if errors:
+            print(f"\n{errors} error(s) encountered. Check output above.", file=sys.stderr)
+            sys.exit(1)
+        else:
+            action = "Would delete" if args.dry_run else "Deleted"
+            total_victims = sum(row[1] - 1 for row in dupes)
+            print(f"\n{action} {total_victims} duplicate row(s) across {len(dupes)} user(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes ai-nexus-pq4r.

Two concurrent `PUT /api/v1/personalization` requests (React StrictMode double-effect, double-click, network retry) could both pass the `get_default_workspace` check before either committed, producing two `is_default=True` rows for the same user.

## What changed

**Migration 009** — partial unique index on `workspaces(user_id) WHERE is_default = true`. Works on SQLite and Postgres. The second concurrent INSERT now fails immediately with `IntegrityError`.

**`ensure_default_workspace`** — wraps the create branch in a `begin_nested()` savepoint so `IntegrityError` only rolls back the nested transaction, not the outer session. Catches the error, logs a warning, and re-fetches the row the winning request already committed.

**Test** — `test_ensure_default_workspace_handles_integrity_error` patches `create_workspace` to raise `IntegrityError` after a real row is seeded, then asserts the recovery path returns the existing row. All 36 workspace tests pass.

**Cleanup script** — `scripts/dedupe_default_workspaces.py` for one-shot deduplication of any existing dirty rows on deployed DBs. Run with `--dry-run` first, then apply migration 009.