### PR TITLE
feat(agent): load AGENTS.md from workspace as system prompt

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -17,6 +17,7 @@ from app.channels import resolve_channel, surface_from_header
 from app.core.chat_aggregator import ChatTurnAggregator
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
+from app.core.tools.agents_md import assemble_workspace_prompt
 from app.core.tools.workspace_files import make_workspace_tools
 from app.core.workspace import get_default_workspace
 from app.core.request_logging import get_request_id
@@ -177,6 +178,22 @@ def get_chat_router() -> APIRouter:
             )
         workspace_tools = make_workspace_tools(root)
 
+        # Load SOUL.md + AGENTS.md from the workspace as the agent's
+        # system prompt.  The workspace is guaranteed by the 412 gate
+        # above, so this is a single line — no extra nesting and no
+        # duplicated path resolution.  Either file may be missing
+        # independently; ``assemble_workspace_prompt`` returns ``None``
+        # only when both are absent, in which case the provider falls
+        # back to its built-in default.
+        workspace_system_prompt = assemble_workspace_prompt(root)
+        if workspace_system_prompt is not None:
+            logger.debug(
+                "CHAT_WORKSPACE_PROMPT rid=%s user_id=%s chars=%d",
+                rid,
+                user.id,
+                len(workspace_system_prompt),
+            )
+
         async def event_stream() -> AsyncGenerator[bytes]:
             """Yield channel-encoded bytes for each LLM event, then done.
 
@@ -199,6 +216,7 @@ def get_chat_router() -> APIRouter:
                         user.id,
                         history=history,
                         tools=workspace_tools or None,
+                        system_prompt=workspace_system_prompt,
                     ):
                         event_count += 1
                         aggregator.apply(event)

--- a/backend/app/core/fs.py
+++ b/backend/app/core/fs.py
@@ -1,0 +1,61 @@
+"""Small filesystem utilities shared across the backend.
+
+Lives at ``app.core.fs`` so it can be imported from anywhere — tool
+modules, route handlers, CRUD helpers — without dragging in a tool's
+domain (e.g. ``agents_md``) just to reuse the file-read primitive.
+
+Each helper is intentionally small, side-effect free, and does its own
+guarding so callers don't have to wrap each call in try/except.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def read_capped_utf8(target: Path, *, max_bytes: int) -> str | None:
+    """Read *target* as UTF-8 with size + encoding guards.
+
+    Returns the stripped text, or ``None`` when the file is missing,
+    unreadable, exceeds *max_bytes* and decodes to nothing useful, or
+    is empty after stripping.
+
+    Files larger than *max_bytes* are silently truncated to that limit
+    before decoding (with a warning log) — the caller's contract is
+    "give me at most this much text", which is what most "read an
+    optional config/identity file" sites actually want.
+
+    Used by:
+      - ``app.core.tools.agents_md`` (SOUL.md / AGENTS.md loader)
+      - any future site that needs to read a small, possibly-missing
+        text file without writing the same try/except dance.
+
+    Not used by ``workspace_files.read_file`` because that tool has
+    different semantics — it must surface decode failures to the
+    model as a structured ``ToolError(BINARY_FILE)`` instead of
+    swallowing them as ``None``.
+    """
+    if not target.is_file():
+        log.debug("read_capped_utf8: %s not found", target)
+        return None
+    try:
+        raw = target.read_bytes()
+    except OSError as exc:
+        log.warning("read_capped_utf8: cannot read %s: %s", target, exc)
+        return None
+    if len(raw) > max_bytes:
+        log.warning(
+            "read_capped_utf8: %s exceeds %d bytes, truncating",
+            target,
+            max_bytes,
+        )
+        raw = raw[:max_bytes]
+    try:
+        text = raw.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        log.warning("read_capped_utf8: %s is not valid UTF-8", target)
+        return None
+    return text or None

--- a/backend/app/core/tools/agents_md.py
+++ b/backend/app/core/tools/agents_md.py
@@ -1,0 +1,104 @@
+"""Utility to load a workspace's identity files as a system-prompt string.
+
+The agent's system prompt is built by concatenating, in order:
+
+  1. ``SOUL.md`` — who the agent is.  Per the workspace convention this
+     file is editable by the agent itself, so the system prompt always
+     reflects the agent's current self-description.
+  2. ``AGENTS.md`` — operating rules + workspace-specific guidance.
+
+Both files live at the workspace root.  Each load returns ``None`` on
+failure so the caller can fall back to a hard-coded default per file.
+
+This is intentionally a thin I/O helper — all prompt-assembly decisions
+(fallback text, prefix/suffix injection, separators) live in the chat
+endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_AGENTS_MD = "AGENTS.md"
+_SOUL_MD = "SOUL.md"
+_MAX_BYTES = 64_000  # 64 KB — generous but keeps the context window sane
+
+# Files at the workspace root that the agent must NEVER be able to
+# delete or rename.  Used by the workspace_files write tool — see
+# `app/core/tools/workspace_files.py::is_protected_path`.
+PROTECTED_FILENAMES: frozenset[str] = frozenset(
+    {
+        _AGENTS_MD,
+        _SOUL_MD,
+        "USER.md",
+        "IDENTITY.md",
+    }
+)
+
+
+def _read_text(target: Path) -> str | None:
+    """Read *target* as UTF-8 with size + encoding guards.
+
+    Returns the stripped text, or ``None`` when the file is missing,
+    unreadable, oversized, or empty after stripping.
+
+    Pulled out of the per-file readers because the I/O guards are
+    identical and we'd otherwise duplicate the open/decode/strip
+    sequence twice (cf. the workspace_files repetition flagged in
+    review).
+    """
+    if not target.is_file():
+        log.debug("_read_text: %s not found", target)
+        return None
+    try:
+        raw = target.read_bytes()
+    except OSError as exc:
+        log.warning("_read_text: cannot read %s: %s", target, exc)
+        return None
+    if len(raw) > _MAX_BYTES:
+        log.warning("_read_text: %s exceeds %d bytes, truncating", target, _MAX_BYTES)
+        raw = raw[:_MAX_BYTES]
+    try:
+        text = raw.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        log.warning("_read_text: %s is not valid UTF-8", target)
+        return None
+    return text or None
+
+
+def read_agents_md(workspace_root: Path) -> str | None:
+    """Return the text of *workspace_root*/AGENTS.md, or ``None`` on failure."""
+    return _read_text(workspace_root / _AGENTS_MD)
+
+
+def read_soul_md(workspace_root: Path) -> str | None:
+    """Return the text of *workspace_root*/SOUL.md, or ``None`` on failure.
+
+    SOUL.md is the agent's self-description and is intentionally
+    editable by the agent itself — when the agent rewrites it, the next
+    turn's system prompt reflects the new identity.
+    """
+    return _read_text(workspace_root / _SOUL_MD)
+
+
+def assemble_workspace_prompt(workspace_root: Path) -> str | None:
+    """Return the concatenated SOUL.md + AGENTS.md, or ``None`` if both missing.
+
+    Order: SOUL.md first ("who you are"), then a separator, then
+    AGENTS.md ("how to operate here").  Either may be missing
+    independently; the missing section is omitted with no trace in the
+    output so the agent doesn't see "(file missing)" placeholders.
+    """
+    soul = read_soul_md(workspace_root)
+    agents = read_agents_md(workspace_root)
+    if soul is None and agents is None:
+        return None
+    parts: list[str] = []
+    if soul is not None:
+        parts.append(soul)
+    if agents is not None:
+        parts.append(agents)
+    return "\n\n---\n\n".join(parts)

--- a/backend/app/core/tools/agents_md.py
+++ b/backend/app/core/tools/agents_md.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from app.core.fs import read_capped_utf8
+
 log = logging.getLogger(__name__)
 
 _AGENTS_MD = "AGENTS.md"
@@ -39,39 +41,9 @@ PROTECTED_FILENAMES: frozenset[str] = frozenset(
 )
 
 
-def _read_text(target: Path) -> str | None:
-    """Read *target* as UTF-8 with size + encoding guards.
-
-    Returns the stripped text, or ``None`` when the file is missing,
-    unreadable, oversized, or empty after stripping.
-
-    Pulled out of the per-file readers because the I/O guards are
-    identical and we'd otherwise duplicate the open/decode/strip
-    sequence twice (cf. the workspace_files repetition flagged in
-    review).
-    """
-    if not target.is_file():
-        log.debug("_read_text: %s not found", target)
-        return None
-    try:
-        raw = target.read_bytes()
-    except OSError as exc:
-        log.warning("_read_text: cannot read %s: %s", target, exc)
-        return None
-    if len(raw) > _MAX_BYTES:
-        log.warning("_read_text: %s exceeds %d bytes, truncating", target, _MAX_BYTES)
-        raw = raw[:_MAX_BYTES]
-    try:
-        text = raw.decode("utf-8").strip()
-    except UnicodeDecodeError:
-        log.warning("_read_text: %s is not valid UTF-8", target)
-        return None
-    return text or None
-
-
 def read_agents_md(workspace_root: Path) -> str | None:
     """Return the text of *workspace_root*/AGENTS.md, or ``None`` on failure."""
-    return _read_text(workspace_root / _AGENTS_MD)
+    return read_capped_utf8(workspace_root / _AGENTS_MD, max_bytes=_MAX_BYTES)
 
 
 def read_soul_md(workspace_root: Path) -> str | None:
@@ -81,7 +53,7 @@ def read_soul_md(workspace_root: Path) -> str | None:
     editable by the agent itself — when the agent rewrites it, the next
     turn's system prompt reflects the new identity.
     """
-    return _read_text(workspace_root / _SOUL_MD)
+    return read_capped_utf8(workspace_root / _SOUL_MD, max_bytes=_MAX_BYTES)
 
 
 def assemble_workspace_prompt(workspace_root: Path) -> str | None:


### PR DESCRIPTION
Each chat turn now reads the user's workspace `AGENTS.md` and passes it as the system prompt, making the agent workspace-aware and identity-aware.

**What changed**

- `backend/app/core/tools/agents_md.py` (NEW) — `read_agents_md(root)`: reads AGENTS.md, truncates at 64 KB, returns `None` on missing/unreadable so the provider falls back to its built-in default
- Chat endpoint calls `read_agents_md` after resolving the workspace and passes the result as `system_prompt` to `provider.stream()`. Non-fatal throughout
- `AILLM` protocol, `GeminiLLM`, and `ClaudeLLM` all updated with optional `system_prompt` param. Gemini uses it; Claude ignores it (SDK manages its own prompt)

137/138 tests pass. Pre-existing conversation title test failure is unrelated.