### PR TITLE
feat(infra): Docker Compose + Postgres for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 .env.test.local
 .env.production.local
 !.env.example
+!.env.docker
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
@@ -97,6 +98,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.docker
 
 # repomix output files
 repomix-output.*

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,37 @@
+# Python artefacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments — the Dockerfile creates its own
+.venv/
+venv/
+env/
+
+# Test + coverage
+.pytest_cache/
+.coverage
+htmlcov/
+tests/
+
+# Editor / OS artefacts
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Local secrets — never bake into the image
+.env
+*.env.local
+
+# SQLite databases used in local dev
+*.db
+*.sqlite3
+app.log*

--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -1,0 +1,72 @@
+# AI Nexus backend — Docker Compose environment template
+#
+# Usage:
+#   cp backend/.env.docker backend/.env
+#   # Fill in your API keys below
+#   docker compose up --build
+#
+# The DATABASE_URL is overridden by docker-compose.yml to point at the
+# bundled PostgreSQL service — you do not need to edit it here.
+
+# ===========================================
+# DATABASE (overridden by docker-compose.yml)
+# ===========================================
+DATABASE_URL=postgresql://nexus:nexus_dev@postgres:5432/nexus
+
+# ===========================================
+# AUTH & SECURITY
+# ===========================================
+
+# JWT secret. Generate: openssl rand -hex 32
+AUTH_SECRET=change-me-generate-with-openssl-rand-hex-32
+
+# Fernet key for encrypting stored API keys.
+# Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+FERNET_KEY=change-me-generate-with-fernet
+
+# Optional invite code for new account registration. Leave empty for open signup.
+REGISTRATION_SECRET=
+
+# ===========================================
+# ENVIRONMENT
+# ===========================================
+ENV=dev
+COOKIE_SAMESITE=lax
+COOKIE_SECURE=false
+CORS_ORIGINS=["http://localhost:3001"]
+
+# ===========================================
+# LLM PROVIDERS
+# ===========================================
+
+# Google Gemini (required — powers the default model)
+# Get from: https://aistudio.google.com/apikey
+GOOGLE_API_KEY=your-google-api-key-here
+
+# Claude Agent SDK OAuth token (optional — needed only for claude-* models)
+# Generate with: claude setup-token
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Exa web search API key (optional — enables the search tool)
+# Get from: https://exa.ai
+EXA_API_KEY=
+
+# xAI API key (optional — enables voice/STT input)
+XAI_API_KEY=
+
+# ===========================================
+# CHANNELS: TELEGRAM
+# ===========================================
+# Leave empty to disable the Telegram channel.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_BOT_USERNAME=
+TELEGRAM_MODE=polling
+TELEGRAM_WEBHOOK_URL=
+TELEGRAM_WEBHOOK_SECRET=
+
+# ===========================================
+# DEV ADMIN LOGIN
+# ===========================================
+# Seeded admin account for the dev shortcut on the login page.
+ADMIN_EMAIL=admin@nexus-ai.dev
+ADMIN_PASSWORD=admin1234

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,11 @@
 # AI Nexus Backend Configuration
 # Copy this file to .env and fill in the values
+#
+# ► Docker Compose quick-start (PostgreSQL already bundled):
+#     cp backend/.env.docker backend/.env   # fill in API keys
+#     docker compose up --build
+#
+# ► Manual / Railway setup: fill DATABASE_URL below.
 
 # ===========================================
 # DATABASE

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,51 @@
+# AI Nexus backend — Docker image
+#
+# Multi-stage build:
+#   builder  — installs Python deps via uv into /app/.venv
+#   runtime  — copies only the venv + source; no build tools in prod layer
+
+# ---------------------------------------------------------------------------
+# Stage 1: dependency builder
+# ---------------------------------------------------------------------------
+FROM python:3.13-slim AS builder
+
+WORKDIR /app
+
+# Install uv (fast pip replacement used by the project).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy dependency manifests first so Docker can cache the install layer.
+COPY pyproject.toml uv.lock ./
+
+# Install all runtime deps into the project venv.
+# --no-dev keeps test libs out of the production image.
+RUN uv sync --frozen --no-dev
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime image
+# ---------------------------------------------------------------------------
+FROM python:3.13-slim AS runtime
+
+WORKDIR /app
+
+# Grab the populated venv from the builder stage.
+COPY --from=builder /app/.venv /app/.venv
+
+# Activate the venv by prepending it to PATH.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Copy application source.
+COPY . .
+
+# Create the default workspace directory so the volume mount has a
+# target to bind to even if the host path doesn't pre-exist.
+RUN mkdir -p /data/workspaces
+
+EXPOSE 8000
+
+# Run Alembic migrations then start the server.
+# `alembic upgrade head` is idempotent; if the DB is already current
+# it exits 0 immediately without making any changes.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,4 +48,8 @@ EXPOSE 8000
 # Run Alembic migrations then start the server.
 # `alembic upgrade head` is idempotent; if the DB is already current
 # it exits 0 immediately without making any changes.
+# In the docker-compose dev stack this CMD is overridden by the compose
+# command so --reload is active and the source volume mount is writable.
+# For production (Railway / plain Docker run) this CMD runs migrations
+# then starts uvicorn without reload.
 CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
       # Override the DATABASE_URL from .env so it points at the compose
       # postgres service regardless of what the user typed in .env.
       DATABASE_URL: "postgresql://nexus:nexus_dev@postgres:5432/nexus"
+      # watchfiles uses kernel inotify by default, which doesn't fire
+      # reliably for changes made on the host through a Docker bind mount.
+      # Force polling so uvicorn --reload actually reloads on every save.
+      WATCHFILES_FORCE_POLLING: "true"
     ports:
       - "8000:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+# AI Nexus — local development stack
+#
+# Starts PostgreSQL and the FastAPI backend together.  The frontend is
+# intentionally omitted from this Compose file — run it with `bun dev`
+# (or `npm run dev`) in a separate terminal so Next.js hot-reload keeps
+# working normally.
+#
+# Quick-start:
+#
+#   cp backend/.env.docker backend/.env   # fill in your API keys
+#   docker compose up --build
+#
+# The backend will be available at http://localhost:8000.
+# The postgres port is also exposed at localhost:5432 so you can
+# connect with any database client without extra config.
+#
+# Migrations run automatically on backend startup; no manual step needed.
+
+services:
+  # ---------------------------------------------------------------------------
+  # PostgreSQL 16
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nexus
+      POSTGRES_PASSWORD: nexus_dev
+      POSTGRES_DB: nexus
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nexus -d nexus"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # FastAPI backend
+  # ---------------------------------------------------------------------------
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ./backend/.env
+    environment:
+      # Override the DATABASE_URL from .env so it points at the compose
+      # postgres service regardless of what the user typed in .env.
+      DATABASE_URL: "postgresql://nexus:nexus_dev@postgres:5432/nexus"
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      # Mount the backend source so code changes are reflected without
+      # a full rebuild.  Alembic migrations and static assets still go
+      # through the image layer; only Python source is hot-mounted.
+      - ./backend/app:/app/app:ro
+      # Workspace data lives outside the container so it persists across
+      # restarts and is not wiped by `docker compose down`.
+      - workspace_data:/data/workspaces
+
+volumes:
+  postgres_data:
+  workspace_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Override the production CMD: run migrations (with retry) then start
+    # uvicorn with --reload so source-mount edits apply immediately.
+    command: >
+      sh -c '
+        until alembic upgrade head; do
+          echo "[docker-compose] alembic failed, retrying in 2s…" && sleep 2;
+        done &&
+        uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+      '
     volumes:
-      # Mount the backend source so code changes are reflected without
-      # a full rebuild.  Alembic migrations and static assets still go
-      # through the image layer; only Python source is hot-mounted.
-      - ./backend/app:/app/app:ro
+      # Mount the backend source for hot-reload: uvicorn --reload detects
+      # file changes inside the container and restarts the worker in-place.
+      # New files in the image layer (e.g. alembic versions) still require
+      # `docker compose build backend` + restart.
+      - ./backend/app:/app/app
       # Workspace data lives outside the container so it persists across
       # restarts and is not wiped by `docker compose down`.
       - workspace_data:/data/workspaces

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,89 @@
+# Running AI Nexus with Docker Compose
+
+The `docker-compose.yml` at the repo root spins up PostgreSQL 16 and the
+FastAPI backend together. The Next.js frontend is left out intentionally —
+you run it with the normal dev server so hot-reload keeps working.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (or Docker Engine + Compose plugin)
+- A Google Gemini API key — everything else is optional
+
+## Quick start
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/OctavianTocan/ai-nexus.git
+cd ai-nexus
+
+# 2. Copy the Docker environment template and fill in your API keys
+cp backend/.env.docker backend/.env
+$EDITOR backend/.env   # set GOOGLE_API_KEY at minimum
+
+# 3. Build and start the stack
+docker compose up --build
+```
+
+The backend will be live at **http://localhost:8000** and PostgreSQL will be
+exposed at **localhost:5432** (credentials: `nexus` / `nexus_dev`, database `nexus`).
+
+Database migrations run automatically on every backend start via
+`alembic upgrade head` — no manual step needed.
+
+## Frontend
+
+In a separate terminal:
+
+```bash
+cd ai-nexus
+bun install          # or npm install
+bun dev              # or npm run dev
+```
+
+The dev server starts at **http://localhost:3001** and points at the backend
+on port 8000 by default.
+
+## Useful commands
+
+```bash
+# View live backend logs
+docker compose logs -f backend
+
+# Open a psql shell against the local postgres
+docker compose exec postgres psql -U nexus -d nexus
+
+# Run Alembic migrations manually (useful after pulling new code)
+docker compose exec backend alembic upgrade head
+
+# Rebuild after changing Python dependencies
+docker compose build backend
+docker compose up -d
+
+# Stop everything and remove volumes (wipes the DB)
+docker compose down -v
+
+# Stop but keep the DB volume
+docker compose down
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_API_KEY` | ✅ | Powers the default Gemini model |
+| `AUTH_SECRET` | ✅ | JWT signing secret — generate with `openssl rand -hex 32` |
+| `FERNET_KEY` | ✅ | Encryption key for stored API keys |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Optional | Needed only for `claude-*` models |
+| `EXA_API_KEY` | Optional | Enables web search |
+| `XAI_API_KEY` | Optional | Enables voice / STT input |
+| `TELEGRAM_BOT_TOKEN` | Optional | Enables the Telegram channel |
+
+`DATABASE_URL` is **overridden** by `docker-compose.yml` to point at the
+bundled postgres service — you do not need to change it in `.env`.
+
+## Production / Railway
+
+For Railway or any other managed platform, set `DATABASE_URL` in your
+environment to the platform's connection string (Railway injects it
+automatically) and deploy the backend normally. The Docker setup is
+local-dev only.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -28,7 +28,13 @@ The backend will be live at **http://localhost:8000** and PostgreSQL will be
 exposed at **localhost:5432** (credentials: `nexus` / `nexus_dev`, database `nexus`).
 
 Database migrations run automatically on every backend start via
-`alembic upgrade head` — no manual step needed.
+`alembic upgrade head` (with a retry loop in case postgres isn't
+fully accepting connections right as the healthcheck passes) — no
+manual step needed.
+
+The dev stack starts uvicorn with `--reload` and mounts `./backend/app`
+into the container, so Python edits take effect on the next request
+without a rebuild.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary

Adds a `docker-compose.yml` that boots PostgreSQL 16 and the FastAPI backend together — no Railway account, no external DB needed to hack on the project locally.

---

## Quick start

```bash
cp backend/.env.docker backend/.env
# fill in GOOGLE_API_KEY, AUTH_SECRET, FERNET_KEY at minimum
docker compose up --build
```

Backend → http://localhost:8000  
Postgres → localhost:5432 (`nexus` / `nexus_dev` / `nexus`)  
Frontend → still `bun dev` in a separate terminal

---

## Files

| File | Purpose |
|------|---------|
| `docker-compose.yml` | Postgres 16 + backend; DATABASE_URL overridden at compose level |
| `backend/Dockerfile` | Multi-stage uv build; `alembic upgrade head && uvicorn` CMD |
| `backend/.env.docker` | Ready-to-copy env template for Docker dev |
| `backend/.dockerignore` | Excludes .venv, tests, secrets from build context |
| `backend/.env.example` | Added Docker quick-start comment at the top |
| `.gitignore` | Allowlisted `backend/.env.docker` next to `.env.example` |
| `docs/docker.md` | Full setup guide with commands, env-var table, Railway note |

## Design notes

- **Migrations are automatic**: `alembic upgrade head` runs inside the container CMD, so the first boot creates all tables and subsequent boots are a no-op.
- **Hot-reload for Python**: `./backend/app` is mounted read-only into the container so code edits reflect without a rebuild (uvicorn needs `--reload` to pick them up, or just restart the service).
- **Workspace persistence**: `workspace_data` named volume survives `docker compose down` (only destroyed with `down -v`).
- **Frontend excluded**: Next.js hot-reload is terrible inside Docker; leaving it out of Compose keeps that experience good.