### PR TITLE
feat(agent): wire Exa search to Gemini via agent loop

### DIFF
--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -26,6 +26,7 @@ from app.core.agent_loop import (
 )
 from app.core.agent_loop.types import TextContent, ToolCallContent
 from app.core.config import settings
+from app.core.tools.exa_search_agent import make_exa_search_tool
 from .base import StreamEvent
 
 logger = logging.getLogger(__name__)
@@ -258,10 +259,20 @@ class GeminiLLM:
                     )
                 )
 
+        # Start from the caller-supplied tools (e.g. workspace file tools
+        # built by ``make_workspace_tools`` — see PR #112) so we don't
+        # silently drop them, then append the Exa web-search tool when
+        # the API key is configured.  Exa is instantiated per-request so
+        # it's trivially mockable in tests by patching
+        # ``make_exa_search_tool`` before calling ``stream()``.
+        effective_tools: list[AgentTool] = list(tools or [])
+        if settings.exa_api_key:
+            effective_tools.append(make_exa_search_tool())
+
         context = AgentContext(
             system_prompt=system_prompt or _FALLBACK_SYSTEM_PROMPT,
             messages=prior,
-            tools=list(tools or []),
+            tools=effective_tools,
         )
         prompt = UserMessage(role="user", content=question)
         config = AgentLoopConfig(convert_to_llm=_identity_convert)

--- a/backend/app/core/tools/exa_search_agent.py
+++ b/backend/app/core/tools/exa_search_agent.py
@@ -1,0 +1,105 @@
+"""Agent-loop adapter for the Exa web-search tool.
+
+Exposes :func:`make_exa_search_tool` which returns an :class:`AgentTool`
+that the Gemini (and any future) provider can append to
+``AgentContext.tools``.  The actual network call lives in the shared core
+(:mod:`app.core.tools.exa_search`) — this module only handles the schema
+definition and the thin async wrapper the loop calls.
+
+Usage::
+
+    from app.core.tools.exa_search_agent import make_exa_search_tool
+
+    tools = [make_exa_search_tool()] if settings.exa_api_key else []
+    context = AgentContext(system_prompt=..., messages=..., tools=tools)
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.exa_search import (
+    MAX_NUM_RESULTS,
+    exa_search,
+    format_results_as_markdown,
+)
+
+_TOOL_NAME = "exa_search"
+
+_TOOL_DESCRIPTION = (
+    "Search the public web through Exa and return up to "
+    f"{MAX_NUM_RESULTS} ranked results with title, URL, publish date, "
+    "and short relevance highlights. Use this whenever the user asks "
+    "for fresh information, current events, citations, or anything "
+    "that requires going beyond your training data. Always cite the "
+    "result URLs when you use information from them."
+)
+
+# JSON Schema for the tool's parameters — the agent loop passes this to
+# the LLM so it knows how to call the tool.
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Natural-language search query. Exa uses neural search, so "
+                "longer, more descriptive queries typically yield better results "
+                "than short keyword strings."
+            ),
+        },
+        "num_results": {
+            "type": "integer",
+            "description": (
+                f"Number of results to return (1–{MAX_NUM_RESULTS}). "
+                "Default 5 keeps token usage low."
+            ),
+            "default": 5,
+            "minimum": 1,
+            "maximum": MAX_NUM_RESULTS,
+        },
+        "include_full_text": {
+            "type": "boolean",
+            "description": (
+                "When true, include the full page text alongside highlights. "
+                "Significantly increases token usage — prefer false unless "
+                "deep reading of the source is required."
+            ),
+            "default": False,
+        },
+    },
+    "required": ["query"],
+}
+
+
+def make_exa_search_tool() -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the Exa web-search core.
+
+    The tool is intentionally stateless — callers should create a fresh
+    instance per request if needed, though in practice reuse is fine.
+
+    Returns:
+        A configured :class:`AgentTool` ready to be appended to
+        ``AgentContext.tools``.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        """Call Exa and return formatted Markdown for the LLM."""
+        query = str(kwargs.get("query") or "")
+        num_results = int(kwargs.get("num_results") or 5)
+        include_full_text = bool(kwargs.get("include_full_text") or False)
+
+        result = await exa_search(
+            query,
+            num_results=num_results,
+            include_full_text=include_full_text,
+        )
+        return format_results_as_markdown(result)
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/tests/test_exa_search_agent.py
+++ b/backend/tests/test_exa_search_agent.py
@@ -1,0 +1,213 @@
+"""Tests for the agent-loop Exa web-search adapter.
+
+Coverage:
+* ``make_exa_search_tool`` returns a correctly shaped ``AgentTool``.
+* ``execute`` calls the exa_search core and formats results as Markdown.
+* ``execute`` surfaces API-key-not-configured error as a string (not an
+  exception) so the LLM can report gracefully.
+* Tool is omitted from the Gemini provider's context when EXA_API_KEY is
+  absent, and included when it is present.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.exa_search import ExaSearchResult
+from app.core.tools.exa_search_agent import make_exa_search_tool
+
+
+# ---------------------------------------------------------------------------
+# make_exa_search_tool — shape
+# ---------------------------------------------------------------------------
+
+
+class TestMakeExaSearchTool:
+    def test_returns_agent_tool(self) -> None:
+        tool = make_exa_search_tool()
+        assert isinstance(tool, AgentTool)
+
+    def test_name_is_exa_search(self) -> None:
+        tool = make_exa_search_tool()
+        assert tool.name == "exa_search"
+
+    def test_description_is_non_empty(self) -> None:
+        tool = make_exa_search_tool()
+        assert isinstance(tool.description, str)
+        assert len(tool.description) > 20
+
+    def test_parameters_schema_has_query(self) -> None:
+        tool = make_exa_search_tool()
+        props = tool.parameters.get("properties", {})
+        assert "query" in props
+
+    def test_query_is_required(self) -> None:
+        tool = make_exa_search_tool()
+        assert "query" in tool.parameters.get("required", [])
+
+    def test_execute_is_callable(self) -> None:
+        import asyncio
+
+        tool = make_exa_search_tool()
+        assert callable(tool.execute)
+
+
+# ---------------------------------------------------------------------------
+# execute — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestExaSearchToolExecute:
+    async def test_execute_calls_core_and_returns_markdown(self) -> None:
+        """execute() should delegate to exa_search and format the results."""
+        fake_result: ExaSearchResult = {
+            "query": "python async",
+            "results": [
+                {
+                    "title": "Real Python: asyncio",
+                    "url": "https://realpython.com/async-io-python/",
+                    "highlights": ["asyncio is the backbone of async Python"],
+                }
+            ],
+            "error": None,
+        }
+        tool = make_exa_search_tool()
+        with patch(
+            "app.core.tools.exa_search_agent.exa_search",
+            new=AsyncMock(return_value=fake_result),
+        ):
+            result = await tool.execute("dummy-id", query="python async")
+
+        assert isinstance(result, str)
+        assert "Real Python" in result
+        assert "realpython.com" in result
+
+    async def test_execute_propagates_error_as_string(self) -> None:
+        """When the API key is missing the result error surfaces as a string."""
+        error_result: ExaSearchResult = {
+            "query": "test",
+            "results": [],
+            "error": "Exa API key is not configured on the server.",
+        }
+        tool = make_exa_search_tool()
+        with patch(
+            "app.core.tools.exa_search_agent.exa_search",
+            new=AsyncMock(return_value=error_result),
+        ):
+            result = await tool.execute("dummy-id", query="test")
+
+        assert isinstance(result, str)
+        assert "not configured" in result.lower() or "failed" in result.lower()
+
+    async def test_execute_passes_num_results(self) -> None:
+        """num_results kwarg should be forwarded to the core function."""
+        mock_search = AsyncMock(
+            return_value={"query": "x", "results": [], "error": None}
+        )
+        tool = make_exa_search_tool()
+        with patch("app.core.tools.exa_search_agent.exa_search", new=mock_search):
+            await tool.execute("dummy-id", query="x", num_results=3)
+
+        mock_search.assert_called_once()
+        _, kwargs = mock_search.call_args
+        assert kwargs.get("num_results") == 3
+
+    async def test_execute_passes_include_full_text(self) -> None:
+        """include_full_text kwarg should be forwarded to the core function."""
+        mock_search = AsyncMock(
+            return_value={"query": "x", "results": [], "error": None}
+        )
+        tool = make_exa_search_tool()
+        with patch("app.core.tools.exa_search_agent.exa_search", new=mock_search):
+            await tool.execute("dummy-id", query="x", include_full_text=True)
+
+        _, kwargs = mock_search.call_args
+        assert kwargs.get("include_full_text") is True
+
+    async def test_execute_defaults_num_results_to_5(self) -> None:
+        """When num_results is not supplied it should default to 5."""
+        mock_search = AsyncMock(
+            return_value={"query": "x", "results": [], "error": None}
+        )
+        tool = make_exa_search_tool()
+        with patch("app.core.tools.exa_search_agent.exa_search", new=mock_search):
+            await tool.execute("dummy-id", query="x")
+
+        _, kwargs = mock_search.call_args
+        assert kwargs.get("num_results") == 5
+
+
+# ---------------------------------------------------------------------------
+# GeminiLLM wiring — tool is included/excluded based on EXA_API_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestGeminiExaToolWiring:
+    async def test_tool_included_when_api_key_set(self) -> None:
+        """When EXA_API_KEY is non-empty the tool must appear in AgentContext.tools."""
+        import uuid
+
+        from app.core.providers.gemini_provider import GeminiLLM
+
+        provider = GeminiLLM("gemini-2.5-flash-preview-05-20")
+
+        captured_tools: list | None = None
+
+        async def _fake_loop(new_messages, ctx, cfg, stream_fn):  # type: ignore[return]
+            nonlocal captured_tools
+            captured_tools = list(ctx.tools)
+            return
+            yield  # make this an async generator
+
+        with (
+            patch("app.core.config.settings.exa_api_key", "test-key"),
+            patch(
+                "app.core.providers.gemini_provider.agent_loop",
+                side_effect=_fake_loop,
+            ),
+        ):
+            async for _ in provider.stream(
+                "hello", uuid.uuid4(), uuid.uuid4(), history=[]
+            ):
+                pass
+
+        assert captured_tools is not None
+        names = [t.name for t in captured_tools]
+        assert "exa_search" in names
+
+    async def test_tool_excluded_when_api_key_absent(self) -> None:
+        """When EXA_API_KEY is empty/absent the tool must NOT appear."""
+        import uuid
+
+        from app.core.providers.gemini_provider import GeminiLLM
+
+        provider = GeminiLLM("gemini-2.5-flash-preview-05-20")
+
+        captured_tools: list | None = None
+
+        async def _fake_loop(new_messages, ctx, cfg, stream_fn):  # type: ignore[return]
+            nonlocal captured_tools
+            captured_tools = list(ctx.tools)
+            return
+            yield
+
+        with (
+            patch("app.core.config.settings.exa_api_key", ""),
+            patch(
+                "app.core.providers.gemini_provider.agent_loop",
+                side_effect=_fake_loop,
+            ),
+        ):
+            async for _ in provider.stream(
+                "hello", uuid.uuid4(), uuid.uuid4(), history=[]
+            ):
+                pass
+
+        assert captured_tools is not None
+        names = [t.name for t in captured_tools]
+        assert "exa_search" not in names


### PR DESCRIPTION
## Summary

Wires Exa web search into the Gemini provider as an `AgentTool` so the model can look things up in real-time. Closes the `# TODO: wire filesystem + MCP tools here` comment in `GeminiLLM.stream()`.

---

## How it works

The `AgentTool` pattern (`name / description / parameters JSON Schema / execute async fn`) was already defined in `app.core.agent_loop.types`. This PR adds one new adapter module and two small edits:

### `app/core/tools/exa_search_agent.py` (new)

- `make_exa_search_tool()` factory returns an `AgentTool` whose `execute()` delegates to the shared `exa_search()` core and formats results with `format_results_as_markdown()`
- Parameters: `query` (required), `num_results` (default 5, max 10), `include_full_text` (default false — highlights-only per Exa best practices)
- Errors surface as formatted strings so the LLM can apologise without crashing the turn

### `app/core/providers/gemini_provider.py`

- Append the Exa tool only when `settings.exa_api_key` is truthy — empty key = search disabled, no change in behaviour

---

## Enabling search

```bash
# backend/.env
EXA_API_KEY=your-key-here
```

Restart the backend — no migration needed.

---

## Tests

13 new tests in `tests/test_exa_search_agent.py`:
- Shape / schema invariants
- Execute happy path and error propagation
- `num_results` / `include_full_text` kwarg forwarding
- GeminiLLM wiring: tool present when key set, absent when key empty

All 13 pass.