### PR TITLE
fix(shimmer): cache motion.create() calls to stop CPU runaway during streaming

### DIFF
--- a/frontend/components/ai-elements/shimmer.tsx
+++ b/frontend/components/ai-elements/shimmer.tsx
@@ -7,8 +7,17 @@
 'use client';
 
 import { motion } from 'motion/react';
-import { type CSSProperties, type ElementType, type JSX, memo, useMemo } from 'react';
+import { type CSSProperties, type ElementType, memo, useMemo } from 'react';
 import { cn } from '@/lib/utils';
+
+// `motion.create()` accepts both intrinsic-tag strings (`'p'`, `'span'`)
+// and React component types, but the public typing uses
+// `keyof IntrinsicElements`. We cast at the seam (in `resolveMotionComponent`
+// below) and treat the result as a permissive component because the
+// shape we render is `<MotionComponent>` with the standard `className` /
+// `style` / framer props — Framer's typings can't represent that union.
+// biome-ignore lint/suspicious/noExplicitAny: Framer Motion 11 typings can't model the ElementType-or-component union
+type MotionWrappedComponent = React.ComponentType<any>;
 
 export type TextShimmerProps = {
 	children: string;
@@ -18,6 +27,43 @@ export type TextShimmerProps = {
 	spread?: number;
 };
 
+// Hoist the motion-wrapped element factory cache to module scope.
+//
+// Why: calling `motion.create(Component)` inside the render body builds
+// a brand-new motion-wrapped component on every render.  React sees a
+// different component identity each time, unmounts the previous Framer
+// Motion tree, and remounts a fresh one — which means animation state
+// resets and Framer's heavy mount work runs on every parent re-render.
+//
+// `<Shimmer>` is rendered while a chat reply is streaming.  The chat
+// container re-renders on every SSE delta (one per streamed byte/token),
+// so the previous version triggered a Framer remount cascade per byte
+// and pegged the renderer at multi-core CPU.  Caching by component
+// identity collapses that to one motion-wrap per element type.
+// String tags (`'p'`, `'span'`) keyed in a regular Map; React component
+// types (functions/classes) keyed in a WeakMap so re-rendered ad-hoc
+// components don't pin themselves alive in the cache forever.
+const motionTagCache = new Map<string, MotionWrappedComponent>();
+const motionComponentCache = new WeakMap<React.ComponentType<unknown>, MotionWrappedComponent>();
+
+function resolveMotionComponent(Component: ElementType): MotionWrappedComponent {
+	if (typeof Component === 'string') {
+		const cached = motionTagCache.get(Component);
+		if (cached) return cached;
+		// biome-ignore lint/suspicious/noExplicitAny: see top-of-file
+		const created = motion.create(Component as any) as MotionWrappedComponent;
+		motionTagCache.set(Component, created);
+		return created;
+	}
+	const componentKey = Component as React.ComponentType<unknown>;
+	const cached = motionComponentCache.get(componentKey);
+	if (cached) return cached;
+	// biome-ignore lint/suspicious/noExplicitAny: see top-of-file
+	const created = motion.create(Component as any) as MotionWrappedComponent;
+	motionComponentCache.set(componentKey, created);
+	return created;
+}
+
 const ShimmerComponent = ({
 	children,
 	as: Component = 'p',
@@ -25,7 +71,7 @@ const ShimmerComponent = ({
 	duration = 2,
 	spread = 2,
 }: TextShimmerProps) => {
-	const MotionComponent = motion.create(Component as keyof JSX.IntrinsicElements);
+	const MotionComponent = useMemo(() => resolveMotionComponent(Component), [Component]);
 
 	const dynamicSpread = useMemo(() => (children?.length ?? 0) * spread, [children, spread]);
 


### PR DESCRIPTION
Tavi reported the AI Nexus Electron build pegging ~696% CPU (~7 cores). Diagnosis below.

## Root cause

`components/ai-elements/shimmer.tsx` called `motion.create(Component)` inside the render body. While streaming a reply:

1. The chat container re-renders on every SSE delta (one per streamed byte/token).
2. `<Shimmer>` is mounted next to `<AgentSpinner>` while waiting for the response.
3. `motion.create(Component)` returns a **new component identity** every call.
4. React sees a different component type on every render and unmounts the previous Framer Motion subtree, then mounts a fresh one.
5. Animation state resets and Framer's mount work re-runs per byte.

This is a known Framer Motion anti-pattern; the docs say to call `motion.create` once per element type and reuse the result.

## Fix

Cache motion-wrapped components by element identity at module scope:
- `Map<string, MotionComponent>` for HTML tag strings (`'p'`, `'div'`)
- `WeakMap<ElementType, MotionComponent>` for arbitrary component refs

Per-render is now a single map hit + `useMemo` keyed on `as`, so streaming a long reply stops triggering the remount cascade. Comment in the file explains the reasoning so the next person doesn't re-introduce the bug.

## Out of scope (follow-ups, not in this PR)

A second contributor I noticed while investigating: `features/chat/ChatView.tsx` maps over `chatHistory` and renders `<AssistantMessage>` per row, but:
- `<AssistantMessage>` is not memo'd
- Callback props (`onCopy`, `onRegenerate`) are inline arrow functions

So every parent re-render passes new prop identities and the entire visible conversation re-parses through Streamdown on every streamed byte. Painful but a bigger refactor — separate PR for stable callback identities + memo on AssistantMessage.

The Shimmer fix alone should drop the steady-state CPU dramatically; the AssistantMessage refactor would close the rest of the gap.

## Verification

To smoke-test locally:
1. `just dev` + `just electron-dev`, or `just electron-dev-full`.
2. Open Activity Monitor / `htop`, sort by CPU.
3. Send a chat message with a long expected reply (e.g. "explain the agent loop in detail").
4. Watch the Electron renderer process during streaming.

Before this fix: renderer creeps to multi-core territory the longer the reply gets. After: should stay flat.

Co-Authored-By: Tavi <tocanoctavian@gmail.com>