### PR TITLE
fix(frontend): use next/script for theme-detection IIFE (React 19 compat)

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -88,12 +88,27 @@ export default function RootLayout({
 					href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400..700&family=Google+Sans:wght@400..700&display=swap"
 					rel="stylesheet"
 				/>
-				{/* System theme detection — blocking script before hydration to prevent FOUC.
-				    Body lives in `frontend/lib/theme-detection-script.ts` so the JSX surface
-				    here stays small. The `noDangerouslySetInnerHtml` rule is silenced for
-				    this file via biome.json's `frontend/app/layout.tsx` override (the
-				    body is a static string from a server-only module — no user input). */}
-				<script dangerouslySetInnerHTML={{ __html: THEME_DETECTION_SCRIPT }} />
+				{/* System theme detection — blocking inline script before hydration
+				    to prevent FOUC.  Body lives in `frontend/lib/theme-detection-script.ts`
+				    so the JSX surface here stays small.
+
+				    Why `next/script` rather than a bare `<script>` tag: under React 19
+				    the bare-tag form throws a runtime error "Encountered a script tag
+				    while rendering React component" during client render, which
+				    cascades and breaks hydration of the rest of the tree (notably
+				    the `QueryClientProvider` in `app/providers.tsx`).  `next/script`
+				    with `strategy="beforeInteractive"` renders the script directly
+				    into the SSR'd HTML and is skipped by React's reconciler on the
+				    client, so the warning never fires and downstream providers mount
+				    cleanly.  The `noDangerouslySetInnerHtml` Biome rule is silenced
+				    for this file via `biome.json`'s `frontend/app/layout.tsx`
+				    override — the body is a static string from a server-only module,
+				    no user input. */}
+				<Script
+					id="theme-detection"
+					strategy="beforeInteractive"
+					dangerouslySetInnerHTML={{ __html: THEME_DETECTION_SCRIPT }}
+				/>
 				{/* React Grab */}
 				{process.env.NODE_ENV === 'development' && (
 					<Script

--- a/frontend/lib/theme-detection-script.ts
+++ b/frontend/lib/theme-detection-script.ts
@@ -8,20 +8,22 @@
  * happen if the dark theme were only applied after hydration.
  *
  * Why this is a string constant rather than JSX:
- * - The Next.js 16 / React 19 console warning "Encountered a script tag while
- *   rendering React component" fires whenever `<script>` is rendered as JSX.
- *   The warning is informational — the script DOES execute in the SSR'd HTML —
- *   but moving the body to a server-only constant keeps the JSX surface clean
- *   and lets us suppress the warning at exactly one site.
- * - The body must be a single self-invoking function so it executes immediately
- *   and doesn't pollute the global namespace.
- * - Wrapped in try/catch because `matchMedia` can throw on unusual user agents;
- *   theme detection failing should never break the app.
+ * - The body must be a single self-invoking function so it executes
+ *   immediately and doesn't pollute the global namespace.
+ * - Wrapped in try/catch because `matchMedia` can throw on unusual user
+ *   agents; theme detection failing should never break the app.
+ *
+ * IMPORTANT: do NOT embed this string with a bare `<script
+ * dangerouslySetInnerHTML={...} />` JSX tag.  React 19 throws a runtime
+ * error "Encountered a script tag while rendering React component" on
+ * the client side, which cascades and breaks hydration of the rest of
+ * the tree.  Use `next/script` with `strategy="beforeInteractive"`
+ * instead — see `frontend/app/layout.tsx`.
  */
 
 /**
  * Inline IIFE that mirrors the system color-scheme preference onto
- * `document.documentElement.classList`. Safe to embed via
- * `dangerouslySetInnerHTML` in the root layout's `<head>`.
+ * `document.documentElement.classList`. Embedded via Next.js's
+ * `<Script strategy="beforeInteractive">` in the root layout's `<head>`.
  */
 export const THEME_DETECTION_SCRIPT = `(function(){try{var d=document.documentElement;var m=window.matchMedia('(prefers-color-scheme:dark)');if(m.matches){d.classList.add('dark')}m.addEventListener('change',function(e){e.matches?d.classList.add('dark'):d.classList.remove('dark')})}catch(e){}})()`;


### PR DESCRIPTION
## What

Replace the bare `<script dangerouslySetInnerHTML={...} />` in `app/layout.tsx` with `next/script` carrying the same payload but `strategy="beforeInteractive"`.

## Why

Two errors fire within five seconds of `next dev` boot on the current `development` branch:

```
Encountered a script tag while rendering React component.
Scripts inside React components are never executed when rendering on the client.
  at script (<anonymous>:null:null)
  at RootLayout (app/layout.tsx:96:5)

Uncaught Error: No QueryClient set, use QueryClientProvider to set one
  at Providers (app/providers.tsx:28:4)
  at RootLayout (app/layout.tsx:107:5)
```

Same root cause, two symptoms. React 19 throws a runtime error when it sees a bare `<script>` tag during client render — the reconciler bails, the rest of the layout tree never finishes mounting, and the `QueryClientProvider` in `Providers` never wraps `ReactQueryDevtools`, which then can't find a client.

This warning has been there since `abcdc52` (May 7, 2026). It was originally documented as "informational"; it's not — React 19 tightened the rules and now it's fatal to hydration.

## How

`next/script` was already imported in this file (used below for React Grab). One JSX element swap:

```tsx
<Script
  id="theme-detection"
  strategy="beforeInteractive"
  dangerouslySetInnerHTML={{ __html: THEME_DETECTION_SCRIPT }}
/>
```

Next.js renders the body directly into the SSR'd `<head>`; React's reconciler skips the element on the client; the warning never fires; the rest of the tree (including `QueryClientProvider`) hydrates cleanly.

Also updated `frontend/lib/theme-detection-script.ts` so the docstring no longer claims the warning is informational and points readers at the `<Script>` pattern instead.

## Why our gates didn't catch this

| Gate | Why it missed |
| :--- | :--- |
| `tsc --noEmit` | JSX is well-typed. |
| Biome | Lint, not runtime. |
| Vitest | jsdom; nobody renders `<RootLayout>`. |
| Stagehand E2E | Hits Vercel preview (production React). React production downgrades these warnings to no-ops. |
| Vercel preview | Build succeeds; runtime console errors don't fail the build. |
| Manual | Nobody booted `next dev`. |

The honest gap: **no gate boots the dev server and asserts a clean console.** I'm filing a follow-up to add a Stagehand path that runs against `next dev` (or a Playwright smoke against the dev URL) so React-19-strict console errors fail CI. That's the durable fix for this class of bug.

## Verification

I couldn't boot `next dev` locally (sandbox lacks `bun`; repo uses `workspace:*` which `npm` rejects). The change is mechanical — same payload, same `dangerouslySetInnerHTML`, just wrapped in the Next.js-blessed `<Script>` component that's already used elsewhere in this same file. Please pull this branch and confirm both errors are gone within the first 5 seconds of `bun dev` on your machine before merging.