### PR TITLE
fix(proxy): exclude public/ static assets from auth-redirect matcher

### DIFF
--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -40,7 +40,14 @@ export function proxy(request: NextRequest) {
 	return NextResponse.next();
 }
 
-/** Limits middleware to page navigations; skips API, static assets, and favicon. */
+/** Limits middleware to page navigations; skips API, framework static
+ * assets, favicon, and anything served from `frontend/public/` (matched
+ * heuristically by trailing file extension — e.g. `theme-detection.js`,
+ * `*.svg`, `*.png`).  Without the file-extension carve-out, every
+ * `public/` asset request from a cold (no-cookie) client — like the
+ * first visit to `/login` — gets redirected to `/login` itself,
+ * returning an HTML body that the browser then tries to parse as JS
+ * and chokes on ("SyntaxError: Unexpected token '<'"). */
 export const config = {
-	matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+	matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.+\\.[a-zA-Z0-9]+$).*)'],
 };


### PR DESCRIPTION
## What

Pre-existing bug in `frontend/proxy.ts`: every file served from `frontend/public/` (e.g. `theme-detection.js`, `bars-rotate-fade.svg`, `textures/*`) gets redirected to `/login` when the user has no `session_token` cookie. The browser then tries to parse the HTML body of the redirect target as JS and throws `SyntaxError: Unexpected token '<'`.

## How #133 caught this

PR #133's dev-mode console smoke flagged it on the very first run after the runtime issue was supposedly fixed:

```
[diag] 307 http://localhost:3001/theme-detection.js
[1] (pageerror) SyntaxError: Unexpected token '<'
```

Exactly the class of regression the gate is meant to flag — fine in production (warmed cookies), broken on cold visits.

## Cause

```ts
const protectedRoutes = ['/'];
const isProtectedRoute = (path) => protectedRoutes.some((route) => path.startsWith(route));
```

Every path begins with `/`, so `isProtectedRoute` returns true for everything. The existing matcher excludes `/api`, `/_next/static`, `/_next/image`, and `/favicon.ico`, but not arbitrary files in `public/`.

## Fix

Extend the matcher's negative-lookahead to also exclude paths ending in a file extension. One regex addition, no logic changes:

```diff
-matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
+matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.+\.[a-zA-Z0-9]+$).*)']
```

## Verification

Local matcher test:

| Path | Should match? | Result |
| :--- | :---: | :---: |
| `/login` | yes (page) | ✅ |
| `/` | yes (page) | ✅ |
| `/dashboard/page` | yes (page) | ✅ |
| `/conversations/abc-123` | yes (page) | ✅ |
| `/theme-detection.js` | no (public file) | ✅ |
| `/bars-rotate-fade.svg` | no (public file) | ✅ |
| `/textures/foo.png` | no (public file) | ✅ |
| `/api/auth` | no (api) | ✅ |
| `/_next/static/chunk.js` | no (framework) | ✅ |

`bun run check` clean. The gate in PR #133 will go green automatically once this lands.