### PR TITLE
rule: never use "pre-existing" to justify leaving issues broken

### DIFF
--- a/.claude/rules/general/no-pre-existing-excuse.md
+++ b/.claude/rules/general/no-pre-existing-excuse.md
@@ -1,0 +1,84 @@
+---
+description: Fix issues you encounter — never punt on them by labelling them "pre-existing".
+paths: ["**/*"]
+---
+
+# Rule: Never Say "Pre-Existing" — Fix It
+
+## Rule
+
+The phrase **"pre-existing"** (or "not introduced by this PR", "from
+an earlier change", "was already broken before") is **banned from PR
+descriptions, review replies, commit messages, and chat output**.
+
+If you encounter a problem — lint warning, type error, runtime
+warning, console error, broken test, regression, console noise — you
+**fix it**. You do not justify leaving it broken by tracing its
+genealogy. The user does not care who introduced the problem. The
+user cares whether the app works.
+
+This rule applies whether the problem is:
+
+- An error or a warning. Both need fixing.
+- In code you wrote, code someone else wrote, or vendored code.
+- In the file you're touching, or two files away.
+- "In scope" or "out of scope" of the PR you opened.
+
+If a fix would balloon a PR's scope unreasonably, the right move is
+to **open a separate PR for the fix and reference it** — not to
+defer with "pre-existing." Either fix it in this PR or fix it in
+the next one. Do not leave it broken and explain it away.
+
+## Why this matters
+
+A real customer cannot tell whether a console error was introduced
+in commit `abcdef` from May 7th or in the PR that just shipped. The
+app is broken either way. Tracing genealogy is a rationalisation;
+the user reads it as "I noticed but chose not to fix."
+
+Specifically: warnings are not optional. A Biome warning, a CI
+non-blocking notice, a `console.warn` — these are all latent
+failures that haven't been promoted to blocking yet. They will be
+promoted (Biome rolls levels, React 19 hardened previously
+informational warnings into hydration faults, etc.). Treat warnings
+the same as errors.
+
+## What to do instead
+
+- **Fix it in the current PR** when the fix is small enough that the
+  PR scope still reads cleanly.
+- **Fix it in a sibling PR** when the fix is structurally unrelated.
+  Open the PR before you finish the original; don't leave a TODO
+  hanging.
+- **Never describe a failure mode as "pre-existing" to justify
+  leaving it.** If you must describe its history, do so in the
+  commit message of the *fix* PR, not as an excuse.
+
+## Examples
+
+### Wrong
+
+> The bun-check failure is from PR #132's leftover `id="theme-detection"` literal — pre-existing, not from this PR.
+
+> Two warnings (pre-existing tech debt: `KnowledgeContainer` + `whimsy/index`); they don't fail CI.
+
+> The Stagehand failure on #126 is pre-existing — not from this session, leaving it untouched unless you say otherwise.
+
+### Right
+
+> The bun-check failure is from a static `id="theme-detection"` literal in `app/layout.tsx`. Fixed in this PR (or: filed as PR #135 since the fix touches a different concern).
+
+> Biome flagged two functions over the line budget — `KnowledgeContainer` and `WhimsySettingsCard`. Split each into smaller pieces in this PR.
+
+> Stagehand is failing on #126; running it down now / opened a follow-up PR / asking for context if I genuinely can't reproduce.
+
+## Enforcement
+
+This is an instruction-level rule, not a script-enforced gate. The
+operator will call out any "pre-existing" usage they see. Treat the
+callout as a hard stop and fix the underlying issue immediately.
+
+## See also
+
+- `AGENTS.md` (top-of-file rules — surfaces this same expectation
+  to every agent on every session start).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Repo: https://github.com/OctavianTocan/ai-nexus
 - In chat replies, file references must be repo-root relative only (example: `frontend/components/ui/sidebar.tsx:80`); never absolute paths or `~/...`.
 - Do not edit files covered by security-focused `CODEOWNERS` rules unless a listed owner explicitly asked for the change or is already reviewing it with you. Treat those paths as restricted surfaces, not drive-by cleanup.
+- **Never describe a failure mode as "pre-existing" to justify leaving it broken.** If you encounter a lint warning, type error, runtime warning, console error, broken test, or regression — fix it. The user does not care who introduced it; they care whether the app works. Warnings need fixing too: they are latent errors that haven't been promoted to blocking yet (Biome rolls levels, React 19 hardened previously informational warnings into fatal hydration faults, etc.). If a fix would explode the PR scope, open a sibling PR and reference it; do not punt with genealogy. See `.claude/rules/general/no-pre-existing-excuse.md`.
 
 ## Project Structure & Architecture Boundaries
 
@@ -89,6 +90,7 @@ Architectural drift is gated by [sentrux](https://github.com/sentrux/sentrux) v0
 - Group related changes; avoid bundling unrelated refactors.
 - PRs should be small, review-friendly slices (e.g., "Sidebar Craft Parity Round 2"). Do not bundle massive rewrites with unrelated visual tweaks.
 - When landing or merging any PR, ensure the working tree is clean and CI gates pass.
+- **Fix lint warnings on every PR you touch a file in, not just errors.** A Biome warning, a CI non-blocking notice, a `console.warn` — these are latent failures and they need fixing. Do not write "pre-existing" or "not from this PR" in a description to justify leaving them; the user reads that as "I noticed but chose not to fix." If the fix is structurally unrelated, open a sibling PR and reference it; do not leave a TODO hanging. See `.claude/rules/general/no-pre-existing-excuse.md`.
 
 ## Git Notes
 


### PR DESCRIPTION
## What

Adds a hard rule against using **"pre-existing"** (or "not from this PR", "from an earlier change", "was already broken before") as a way to defer fixing issues. The rule lands in three places:

- `.claude/rules/general/no-pre-existing-excuse.md` — full rule + examples + enforcement note.
- `AGENTS.md` top-of-file block — surfaced on every session start.
- `AGENTS.md` Commit & PR Guidelines block — surfaced at PR creation time.

`CLAUDE.md` picks this up automatically (symlinked to `AGENTS.md`).

## Why

Operator feedback after I've now used "pre-existing" several times today to justify leaving real failures in place — Biome warnings, runtime errors that happened to be on `development`, console errors that pre-dated the branch I was on. Each time, the framing was wrong: the user does not care who introduced a problem, they care whether the app works. Tracing genealogy reads as "I noticed but chose not to fix."

## What the rule says, in short

If you see a problem — error, warning, broken test, console noise — you fix it. Either in the current PR if scope allows, or in a sibling PR you open right then. No deferring with "pre-existing." Warnings need fixing too: they are latent failures (Biome rolls levels; React 19 already turned previously informational warnings into fatal hydration faults).

## Enforcement

Instruction-level rule, not script-enforced. If the operator sees "pre-existing" in a description or commit message, that's a hard stop and the underlying issue gets fixed immediately.

## Follow-up landing alongside this

I'm fixing the two Biome warnings I myself dismissed earlier today (`KnowledgeContainer.tsx` and `WhimsySettingsCard`, both over the 120-line function budget) in a separate sibling PR. Will reference that PR in chat once it's open.