### PR TITLE
feat(knowledge): file editing in the document viewer (rebased)

### DIFF
--- a/frontend/features/knowledge/KnowledgeContainer.tsx
+++ b/frontend/features/knowledge/KnowledgeContainer.tsx
@@ -30,8 +30,9 @@
  */
 
 import { AlertCircleIcon, LoaderIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useCallback } from 'react';
 import { KNOWLEDGE_VIEWS } from './constants';
+import { useWriteWorkspaceFile } from './hooks/use-write-workspace-file';
 import { KnowledgeView } from './KnowledgeView';
 import { KNOWLEDGE_MEMORY_CARDS } from './mock-data';
 import { useKnowledgeNavigation } from './use-knowledge-navigation';
@@ -72,9 +73,36 @@ function TreeErrorState({ message }: { message: string }): ReactNode {
  * component because the underlying hooks need `useSearchParams`.
  */
 export function KnowledgeContainer(): ReactNode {
-	const { activeView, folderSegments, currentNode, crumbs, openFile, tree } =
-		useKnowledgeUrlState();
+	const {
+		activeView,
+		folderSegments,
+		currentNode,
+		crumbs,
+		openFile,
+		tree,
+		workspaceId,
+		openFilePath,
+	} = useKnowledgeUrlState();
 	const handlers = useKnowledgeNavigation(folderSegments);
+
+	// File-write mutation. The hook is always called (Rules of Hooks); when
+	// `workspaceId` is null the mutation rejects, which is surfaced as an
+	// inline banner inside the DocumentViewer.
+	const writeFile = useWriteWorkspaceFile(workspaceId);
+
+	// Save handler: only constructed when there's an open file path so the
+	// `Edit` button stays hidden on folder views (the viewer hides it when
+	// `onSave` is undefined).
+	const handleSaveFile = useCallback(
+		async (newContent: string) => {
+			if (!openFilePath) {
+				throw new Error('No file is open — cannot save.');
+			}
+			await writeFile.mutateAsync({ filePath: openFilePath, content: newContent });
+		},
+		[openFilePath, writeFile]
+	);
+	const onSaveFile = openFilePath ? handleSaveFile : undefined;
 
 	// Surface tree loading / error inline so the sub-sidebar stays
 	// visible (the user can still switch to Memory / Brain Access while
@@ -117,6 +145,7 @@ export function KnowledgeContainer(): ReactNode {
 			currentNode={currentNode}
 			crumbs={crumbs}
 			openFile={openFile}
+			onSaveFile={onSaveFile}
 			memoryCards={KNOWLEDGE_MEMORY_CARDS}
 			{...handlers}
 		/>

--- a/frontend/features/knowledge/KnowledgeView.tsx
+++ b/frontend/features/knowledge/KnowledgeView.tsx
@@ -71,6 +71,13 @@ export interface KnowledgeViewProps {
 	openFile: { name: string; markdown: string } | null;
 	/** Closes the currently-open file (drops the trailing `.md` segment). */
 	onCloseFile: () => void;
+	/**
+	 * Called when the user saves an edit in the document viewer. The
+	 * container is responsible for the network call and should return a
+	 * promise that rejects on failure so the viewer can show an error banner.
+	 * If omitted the Edit button is hidden.
+	 */
+	onSaveFile?: (newContent: string) => Promise<void>;
 
 	/** Memory cards for the `memory` view. */
 	memoryCards: readonly MemoryCardData[];
@@ -137,9 +144,11 @@ function KnowledgeContent(props: KnowledgeViewProps): ReactNode {
 					<div className="flex min-h-0 min-w-0 flex-1 flex-col">
 						{openFile ? (
 							<DocumentViewer
+								key={openFile.name}
 								filename={openFile.name}
 								markdown={openFile.markdown}
 								onClose={onCloseFile}
+								onSave={props.onSaveFile}
 							/>
 						) : (
 							<EmptyState

--- a/frontend/features/knowledge/components/DocumentViewer.tsx
+++ b/frontend/features/knowledge/components/DocumentViewer.tsx
@@ -32,7 +32,7 @@ import {
 	UserPlusIcon,
 	XIcon,
 } from 'lucide-react';
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 
 interface DocumentViewerProps {
@@ -66,36 +66,87 @@ export function DocumentViewer({
 	const [editContent, setEditContent] = useState('');
 	const [isSaving, setIsSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
+	// Markdown the user *started* editing from.  Set on Edit-button click
+	// so we can detect when the file is overwritten externally (e.g. the
+	// agent rewriting the same path) while a draft is in flight.  See the
+	// effect below + the stale-warning banner.  Stays a ref because the
+	// value is read inside callbacks that don't need to re-render when
+	// it changes — only the boolean below drives the UI.
+	const baselineMarkdownRef = useRef<string | null>(null);
+	// Latest editContent mirrored into a ref so handleSave can read the
+	// current value without listing it in its dep list (which would
+	// rebuild the callback on every keystroke for no benefit — the
+	// only consumer is the Save button).
+	const editContentRef = useRef('');
+	const [showStaleWarning, setShowStaleWarning] = useState(false);
 
-	// Seed the draft with the current markdown when the user enters edit mode.
-	// Moving this into the event handler (rather than a useEffect) means the
-	// captured value is always fresh and we don't need a ref to guard against
-	// mid-edit overwrites.  Cross-file resets are handled by the `key` prop
-	// applied to this component in KnowledgeView.
+	// Keep the ref in lock-step with the latest editContent so handleSave
+	// always sends what's currently in the textarea.
+	useEffect(() => {
+		editContentRef.current = editContent;
+	}, [editContent]);
+
+	// While the user is editing, watch for the upstream `markdown` prop
+	// changing under us — that means another writer (most often the
+	// agent) overwrote the same file on disk and the cached query has
+	// refetched.  We don't auto-clobber the user's draft; we surface a
+	// banner so they decide between "reload from server" and
+	// "overwrite anyway".
+	useEffect(() => {
+		if (!isEditing) return;
+		if (baselineMarkdownRef.current === null) return;
+		if (markdown !== baselineMarkdownRef.current) {
+			setShowStaleWarning(true);
+		}
+	}, [markdown, isEditing]);
+
+	// Seed the draft with the current markdown when the user enters edit
+	// mode.  Moving the seed into the click handler (rather than a
+	// `useEffect`) means the captured value is always the most recent
+	// markdown the user actually saw on screen.  Cross-file resets are
+	// handled by the `key` prop applied to this component in
+	// `KnowledgeView`.
 	const handleEdit = useCallback(() => {
 		setEditContent(markdown);
+		baselineMarkdownRef.current = markdown;
 		setSaveError(null);
+		setShowStaleWarning(false);
 		setIsEditing(true);
 	}, [markdown]);
 
 	const handleCancel = useCallback(() => {
 		setIsEditing(false);
 		setSaveError(null);
+		setShowStaleWarning(false);
+		baselineMarkdownRef.current = null;
 	}, []);
 
+	// Discard the draft and reload from the latest server markdown.
+	// Used by the stale-warning banner; keeps the user inside edit mode
+	// so they don't lose context if they want to keep tweaking.
+	const handleReload = useCallback(() => {
+		setEditContent(markdown);
+		baselineMarkdownRef.current = markdown;
+		setShowStaleWarning(false);
+	}, [markdown]);
+
+	// Reads the latest editContent from the ref so the dep list stays
+	// at `[onSave]` only — keystrokes don't rebuild the callback.
 	const handleSave = useCallback(async () => {
 		if (!onSave) return;
 		setIsSaving(true);
 		setSaveError(null);
 		try {
-			await onSave(editContent);
+			await onSave(editContentRef.current);
 			setIsEditing(false);
+			setShowStaleWarning(false);
+			baselineMarkdownRef.current = null;
 		} catch (err) {
 			setSaveError(err instanceof Error ? err.message : 'Save failed — please try again.');
 		} finally {
 			setIsSaving(false);
 		}
-	}, [onSave, editContent]);
+	}, [onSave]);
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
@@ -205,6 +256,37 @@ export function DocumentViewer({
 				<div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
 					<span className="mt-0.5 shrink-0">⚠</span>
 					<span>{saveError}</span>
+				</div>
+			)}
+
+			{/* Stale-on-save warning: the upstream `markdown` prop changed
+			   under us while the user was editing (typically the agent
+			   overwriting the same file). Surface a banner so the user
+			   chooses between reloading the server copy or keeping their
+			   draft and overwriting on Save. */}
+			{showStaleWarning && (
+				<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-700 dark:text-amber-300">
+					<span className="shrink-0">⚠</span>
+					<span className="flex-1">
+						This file changed externally while you were editing. Saving
+						now will overwrite the newer version.
+					</span>
+					<button
+						type="button"
+						onClick={handleReload}
+						disabled={isSaving}
+						className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-amber-500/40 bg-transparent px-2 text-[11px] font-medium text-amber-700 transition-colors duration-150 ease-out hover:bg-amber-500/10 disabled:pointer-events-none disabled:opacity-50 dark:text-amber-300"
+					>
+						Reload from server
+					</button>
+					<button
+						type="button"
+						onClick={() => setShowStaleWarning(false)}
+						disabled={isSaving}
+						className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md bg-amber-600 px-2 text-[11px] font-medium text-white transition-colors duration-150 ease-out hover:bg-amber-700 disabled:pointer-events-none disabled:opacity-50"
+					>
+						Keep my draft
+					</button>
 				</div>
 			)}
 

--- a/frontend/features/knowledge/components/DocumentViewer.tsx
+++ b/frontend/features/knowledge/components/DocumentViewer.tsx
@@ -3,15 +3,17 @@
 /**
  * Document viewer rendered when the user opens a `.md` file from My Files.
  *
- * Self-contained card chrome: small filename label on the top-left, a
- * "Publish" pill chip with a chevron (single grouped affordance) plus a
- * close button on the top-right. The document body is the same prose
- * renderer the chat surface uses, centered in a comfortable column.
+ * Two modes:
+ *  - **Read mode** (default): the same prose renderer (Streamdown) the chat
+ *    surface uses, with a toolbar offering "Edit", "Publish", and "Close".
+ *  - **Edit mode**: a plain textarea constrained to the same max-width column
+ *    as the prose view, with "Save" / "Cancel" buttons. On "Save" the
+ *    component calls the `onSave` callback; if saving fails it shows an
+ *    inline error banner below the toolbar.
  *
- * The chrome here intentionally avoids a horizontal divider line — the
- * design reference (image 33, image 35) draws the boundary with whitespace
- * + the column's left border. Adding a hard rule made the panel feel
- * busier than the reference.
+ * The component manages its own `editContent` draft state so the caller's
+ * `markdown` prop stays the source-of-truth for the saved content and we
+ * never mutate it directly.
  */
 
 import {
@@ -23,94 +25,222 @@ import {
 	ChevronDownIcon,
 	CopyIcon,
 	DownloadIcon,
+	Loader2Icon,
+	PencilIcon,
+	SaveIcon,
 	SendIcon,
 	UserPlusIcon,
 	XIcon,
 } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import { Streamdown } from 'streamdown';
 
 interface DocumentViewerProps {
 	/** Filename label shown at the top-left of the viewer chrome. */
 	filename: string;
-	/** Markdown source rendered inside the body. */
+	/** Markdown source rendered inside the body (read-mode) or pre-filled in
+	 *  the textarea (edit-mode entry). */
 	markdown: string;
 	/** Fired when the user clicks the close button. */
 	onClose: () => void;
+	/**
+	 * Called when the user clicks "Save" in edit mode with the new content.
+	 * The parent is responsible for the network call; while it's in-flight the
+	 * Save button shows a spinner and both Save and Cancel are disabled.
+	 * On error the parent should reject the promise so we can display a banner.
+	 */
+	onSave?: (newContent: string) => Promise<void>;
 }
 
 /**
- * Pure presentation. The container decides what the close button does —
- * typically: drop the trailing `.md` segment from the URL path so the
- * file list column survives the close.
+ * Pure presentation. The container decides what Close does, and provides the
+ * `onSave` handler that calls the write API.
  */
-export function DocumentViewer({ filename, markdown, onClose }: DocumentViewerProps): ReactNode {
+export function DocumentViewer({
+	filename,
+	markdown,
+	onClose,
+	onSave,
+}: DocumentViewerProps): ReactNode {
+	const [isEditing, setIsEditing] = useState(false);
+	const [editContent, setEditContent] = useState('');
+	const [isSaving, setIsSaving] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
+
+	// Seed the draft with the current markdown when the user enters edit mode.
+	// Moving this into the event handler (rather than a useEffect) means the
+	// captured value is always fresh and we don't need a ref to guard against
+	// mid-edit overwrites.  Cross-file resets are handled by the `key` prop
+	// applied to this component in KnowledgeView.
+	const handleEdit = useCallback(() => {
+		setEditContent(markdown);
+		setSaveError(null);
+		setIsEditing(true);
+	}, [markdown]);
+
+	const handleCancel = useCallback(() => {
+		setIsEditing(false);
+		setSaveError(null);
+	}, []);
+
+	const handleSave = useCallback(async () => {
+		if (!onSave) return;
+		setIsSaving(true);
+		setSaveError(null);
+		try {
+			await onSave(editContent);
+			setIsEditing(false);
+		} catch (err) {
+			setSaveError(err instanceof Error ? err.message : 'Save failed — please try again.');
+		} finally {
+			setIsSaving(false);
+		}
+	}, [onSave, editContent]);
+
 	return (
 		<div className="flex h-full min-h-0 flex-col">
+			{/* ── Toolbar ─────────────────────────────────────────────────────── */}
 			<header className="flex shrink-0 items-center gap-2 px-4 py-2">
 				<span className="flex-1 truncate text-[12px] text-muted-foreground">
 					{filename}
+					{isEditing && (
+						<span className="ml-1.5 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+							editing
+						</span>
+					)}
 				</span>
 
-				<DropdownPanelMenu
-					asChild
-					usePortal
-					align="end"
-					contentClassName="popover-styled p-1 min-w-44"
-					trigger={
+				{isEditing ? (
+					/* ── Edit-mode actions ──────────────────────────────────────── */
+					<div className="flex items-center gap-1.5">
 						<button
 							type="button"
-							className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-foreground-5 pr-1.5 pl-3 text-[12px] font-medium text-foreground transition-colors duration-150 ease-out hover:bg-foreground-10"
+							onClick={handleCancel}
+							disabled={isSaving}
+							className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
 						>
-							<SendIcon aria-hidden="true" className="size-3.5" />
-							Publish
-							<ChevronDownIcon aria-hidden="true" className="size-3.5" />
+							Cancel
 						</button>
-					}
-				>
-					<DropdownMenuItem>
-						<CopyIcon className="size-3.5" />
-						Copy
-					</DropdownMenuItem>
-					<DropdownMenuItem>
-						<DownloadIcon className="size-3.5" />
-						Download
-					</DropdownMenuItem>
-					<DropdownMenuItem>
-						<DownloadIcon className="size-3.5" />
-						Download as PDF
-					</DropdownMenuItem>
-					<DropdownMenuSeparator />
-					<DropdownMenuItem>
-						<SendIcon className="size-3.5" />
-						Publish
-					</DropdownMenuItem>
-					<DropdownMenuItem>
-						<UserPlusIcon className="size-3.5" />
-						Invite
-					</DropdownMenuItem>
-				</DropdownPanelMenu>
+						<button
+							type="button"
+							onClick={handleSave}
+							disabled={isSaving || !onSave}
+							className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md bg-foreground px-2.5 text-[12px] font-medium text-background transition-colors duration-150 ease-out hover:bg-foreground/90 disabled:pointer-events-none disabled:opacity-50"
+						>
+							{isSaving ? (
+								<Loader2Icon aria-hidden="true" className="size-3.5 animate-spin" />
+							) : (
+								<SaveIcon aria-hidden="true" className="size-3.5" />
+							)}
+							{isSaving ? 'Saving…' : 'Save'}
+						</button>
+					</div>
+				) : (
+					/* ── Read-mode actions ──────────────────────────────────────── */
+					<div className="flex items-center gap-1.5">
+						{onSave && (
+							<button
+								type="button"
+								onClick={handleEdit}
+								className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground"
+							>
+								<PencilIcon aria-hidden="true" className="size-3.5" />
+								Edit
+							</button>
+						)}
 
-				<button
-					type="button"
-					onClick={onClose}
-					aria-label="Close document"
-					className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-foreground-5 hover:text-foreground"
-				>
-					<XIcon aria-hidden="true" className="size-4" />
-				</button>
+						<DropdownPanelMenu
+							asChild
+							usePortal
+							align="end"
+							contentClassName="popover-styled p-1 min-w-44"
+							trigger={
+								<button
+									type="button"
+									className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-foreground-5 pr-1.5 pl-3 text-[12px] font-medium text-foreground transition-colors duration-150 ease-out hover:bg-foreground-10"
+								>
+									<SendIcon aria-hidden="true" className="size-3.5" />
+									Publish
+									<ChevronDownIcon aria-hidden="true" className="size-3.5" />
+								</button>
+							}
+						>
+							<DropdownMenuItem>
+								<CopyIcon className="size-3.5" />
+								Copy
+							</DropdownMenuItem>
+							<DropdownMenuItem>
+								<DownloadIcon className="size-3.5" />
+								Download
+							</DropdownMenuItem>
+							<DropdownMenuItem>
+								<DownloadIcon className="size-3.5" />
+								Download as PDF
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem>
+								<SendIcon className="size-3.5" />
+								Publish
+							</DropdownMenuItem>
+							<DropdownMenuItem>
+								<UserPlusIcon className="size-3.5" />
+								Invite
+							</DropdownMenuItem>
+						</DropdownPanelMenu>
+
+						<button
+							type="button"
+							onClick={onClose}
+							aria-label="Close document"
+							className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-foreground-5 hover:text-foreground"
+						>
+							<XIcon aria-hidden="true" className="size-4" />
+						</button>
+					</div>
+				)}
 			</header>
 
-			{/*
-			 * Document body uses the project's prose plugin (configured globally
-			 * in tailwind.config). `min-h-0` lets the flex child shrink so the
-			 * scroll container is the inner div, not the page.
-			 */}
-			<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
-				<article className="prose prose-sm mx-auto max-w-[680px] text-foreground">
-					<Streamdown>{markdown}</Streamdown>
-				</article>
-			</div>
+			{/* ── Save error banner ────────────────────────────────────────────── */}
+			{saveError && (
+				<div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
+					<span className="mt-0.5 shrink-0">⚠</span>
+					<span>{saveError}</span>
+				</div>
+			)}
+
+			{/* ── Document body ────────────────────────────────────────────────── */}
+			{isEditing ? (
+				/*
+				 * Edit mode: a monospace textarea. We deliberately use a plain
+				 * <textarea> rather than a rich editor — Markdown source editing
+				 * is already familiar, keeps the bundle small, and avoids the
+				 * cursor-sync complexity of a preview-alongside-edit layout.
+				 */
+				<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
+					<div className="mx-auto max-w-[680px]">
+						<textarea
+							value={editContent}
+							onChange={(e) => setEditContent(e.target.value)}
+							disabled={isSaving}
+							spellCheck={false}
+							className="w-full resize-none rounded-md border border-border bg-background px-4 py-3 font-mono text-[13px] leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 disabled:opacity-60"
+							// CSS min-height avoids recalculating rows on every keystroke.
+							style={{ minHeight: '480px' }}
+						/>
+					</div>
+				</div>
+			) : (
+				/*
+				 * Read mode: the same prose renderer the chat surface uses.
+				 * `min-h-0` lets the flex child shrink so the scroll container is
+				 * the inner div, not the page.
+				 */
+				<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
+					<article className="prose prose-sm mx-auto max-w-[680px] text-foreground">
+						<Streamdown>{markdown}</Streamdown>
+					</article>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/frontend/features/knowledge/components/DocumentViewer.tsx
+++ b/frontend/features/knowledge/components/DocumentViewer.tsx
@@ -14,6 +14,10 @@
  * The component manages its own `editContent` draft state so the caller's
  * `markdown` prop stays the source-of-truth for the saved content and we
  * never mutate it directly.
+ *
+ * The toolbar action rows, body, and banners are split into module-level
+ * subcomponents so the main `DocumentViewer` body fits inside Biome's
+ * 120-lines-per-function gate.
  */
 
 import {
@@ -34,6 +38,222 @@ import {
 } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Subcomponents
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Edit-mode action bar: Cancel + Save. */
+function EditActionsRow({
+	canSave,
+	isSaving,
+	onCancel,
+	onSave,
+}: {
+	canSave: boolean;
+	isSaving: boolean;
+	onCancel: () => void;
+	onSave: () => void;
+}): ReactNode {
+	return (
+		<div className="flex items-center gap-1.5">
+			<button
+				type="button"
+				onClick={onCancel}
+				disabled={isSaving}
+				className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				onClick={onSave}
+				disabled={isSaving || !canSave}
+				className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md bg-foreground px-2.5 text-[12px] font-medium text-background transition-colors duration-150 ease-out hover:bg-foreground/90 disabled:pointer-events-none disabled:opacity-50"
+			>
+				{isSaving ? (
+					<Loader2Icon aria-hidden="true" className="size-3.5 animate-spin" />
+				) : (
+					<SaveIcon aria-hidden="true" className="size-3.5" />
+				)}
+				{isSaving ? 'Saving…' : 'Save'}
+			</button>
+		</div>
+	);
+}
+
+/** Read-mode action bar: optional Edit, Publish dropdown, Close. */
+function ReadActionsRow({
+	canEdit,
+	onClose,
+	onEdit,
+}: {
+	canEdit: boolean;
+	onClose: () => void;
+	onEdit: () => void;
+}): ReactNode {
+	return (
+		<div className="flex items-center gap-1.5">
+			{canEdit && (
+				<button
+					type="button"
+					onClick={onEdit}
+					className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground"
+				>
+					<PencilIcon aria-hidden="true" className="size-3.5" />
+					Edit
+				</button>
+			)}
+
+			<DropdownPanelMenu
+				asChild
+				usePortal
+				align="end"
+				contentClassName="popover-styled p-1 min-w-44"
+				trigger={
+					<button
+						type="button"
+						className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-foreground-5 pr-1.5 pl-3 text-[12px] font-medium text-foreground transition-colors duration-150 ease-out hover:bg-foreground-10"
+					>
+						<SendIcon aria-hidden="true" className="size-3.5" />
+						Publish
+						<ChevronDownIcon aria-hidden="true" className="size-3.5" />
+					</button>
+				}
+			>
+				<DropdownMenuItem>
+					<CopyIcon className="size-3.5" />
+					Copy
+				</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DownloadIcon className="size-3.5" />
+					Download
+				</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DownloadIcon className="size-3.5" />
+					Download as PDF
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem>
+					<SendIcon className="size-3.5" />
+					Publish
+				</DropdownMenuItem>
+				<DropdownMenuItem>
+					<UserPlusIcon className="size-3.5" />
+					Invite
+				</DropdownMenuItem>
+			</DropdownPanelMenu>
+
+			<button
+				type="button"
+				onClick={onClose}
+				aria-label="Close document"
+				className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-foreground-5 hover:text-foreground"
+			>
+				<XIcon aria-hidden="true" className="size-4" />
+			</button>
+		</div>
+	);
+}
+
+/** Save-failed inline banner. */
+function SaveErrorBanner({ message }: { message: string }): ReactNode {
+	return (
+		<div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
+			<span className="mt-0.5 shrink-0">⚠</span>
+			<span>{message}</span>
+		</div>
+	);
+}
+
+/** "File changed externally" warning shown if the upstream markdown drifts mid-edit. */
+function StaleWarningBanner({
+	disabled,
+	onDismiss,
+	onReload,
+}: {
+	disabled: boolean;
+	onDismiss: () => void;
+	onReload: () => void;
+}): ReactNode {
+	return (
+		<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-700 dark:text-amber-300">
+			<span className="shrink-0">⚠</span>
+			<span className="flex-1">
+				This file changed externally while you were editing. Saving now will overwrite the newer version.
+			</span>
+			<button
+				type="button"
+				onClick={onReload}
+				disabled={disabled}
+				className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-amber-500/40 bg-transparent px-2 text-[11px] font-medium text-amber-700 transition-colors duration-150 ease-out hover:bg-amber-500/10 disabled:pointer-events-none disabled:opacity-50 dark:text-amber-300"
+			>
+				Reload from server
+			</button>
+			<button
+				type="button"
+				onClick={onDismiss}
+				disabled={disabled}
+				className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md bg-amber-600 px-2 text-[11px] font-medium text-white transition-colors duration-150 ease-out hover:bg-amber-700 disabled:pointer-events-none disabled:opacity-50"
+			>
+				Keep my draft
+			</button>
+		</div>
+	);
+}
+
+/**
+ * Body switch: edit-mode textarea OR read-mode prose renderer.
+ *
+ * Edit mode uses a plain `<textarea>` rather than a rich editor — Markdown
+ * source editing is already familiar, keeps the bundle small, and avoids
+ * the cursor-sync complexity of a preview-alongside-edit layout.
+ *
+ * Read mode uses the same Streamdown prose renderer the chat surface uses;
+ * `min-h-0` lets the flex child shrink so the scroll container is the
+ * inner div, not the page.
+ */
+function DocumentBody({
+	editContent,
+	isEditing,
+	isSaving,
+	markdown,
+	onChangeContent,
+}: {
+	editContent: string;
+	isEditing: boolean;
+	isSaving: boolean;
+	markdown: string;
+	onChangeContent: (value: string) => void;
+}): ReactNode {
+	if (isEditing) {
+		return (
+			<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
+				<div className="mx-auto max-w-[680px]">
+					<textarea
+						value={editContent}
+						onChange={(e) => onChangeContent(e.target.value)}
+						disabled={isSaving}
+						spellCheck={false}
+						className="w-full resize-none rounded-md border border-border bg-background px-4 py-3 font-mono text-[13px] leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 disabled:opacity-60"
+						style={{ minHeight: '480px' }}
+					/>
+				</div>
+			</div>
+		);
+	}
+	return (
+		<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
+			<article className="prose prose-sm mx-auto max-w-[680px] text-foreground">
+				<Streamdown>{markdown}</Streamdown>
+			</article>
+		</div>
+	);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Main component
+// ───────────────────────────────────────────────────────────────────────────
 
 interface DocumentViewerProps {
 	/** Filename label shown at the top-left of the viewer chrome. */
@@ -66,46 +286,27 @@ export function DocumentViewer({
 	const [editContent, setEditContent] = useState('');
 	const [isSaving, setIsSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
-	// Markdown the user *started* editing from.  Set on Edit-button click
-	// so we can detect when the file is overwritten externally (e.g. the
-	// agent rewriting the same path) while a draft is in flight.  See the
-	// effect below + the stale-warning banner.  Stays a ref because the
-	// value is read inside callbacks that don't need to re-render when
-	// it changes — only the boolean below drives the UI.
-	const baselineMarkdownRef = useRef<string | null>(null);
-	// Latest editContent mirrored into a ref so handleSave can read the
-	// current value without listing it in its dep list (which would
-	// rebuild the callback on every keystroke for no benefit — the
-	// only consumer is the Save button).
-	const editContentRef = useRef('');
 	const [showStaleWarning, setShowStaleWarning] = useState(false);
+	// Markdown the user *started* editing from. Set on Edit-button click so
+	// we can detect when the file is overwritten externally (typically the
+	// agent rewriting the same path) while a draft is in flight.
+	const baselineMarkdownRef = useRef<string | null>(null);
+	// Latest editContent mirrored into a ref so handleSave can read it
+	// without listing it in its dep list (which would rebuild the callback
+	// on every keystroke for no benefit — the only consumer is one button).
+	const editContentRef = useRef('');
 
-	// Keep the ref in lock-step with the latest editContent so handleSave
-	// always sends what's currently in the textarea.
 	useEffect(() => {
 		editContentRef.current = editContent;
 	}, [editContent]);
 
-	// While the user is editing, watch for the upstream `markdown` prop
-	// changing under us — that means another writer (most often the
-	// agent) overwrote the same file on disk and the cached query has
-	// refetched.  We don't auto-clobber the user's draft; we surface a
-	// banner so they decide between "reload from server" and
-	// "overwrite anyway".
+	// Watch for the upstream markdown drifting from the baseline mid-edit.
+	// We do not auto-clobber the draft; the banner lets the user choose.
 	useEffect(() => {
-		if (!isEditing) return;
-		if (baselineMarkdownRef.current === null) return;
-		if (markdown !== baselineMarkdownRef.current) {
-			setShowStaleWarning(true);
-		}
+		if (!isEditing || baselineMarkdownRef.current === null) return;
+		if (markdown !== baselineMarkdownRef.current) setShowStaleWarning(true);
 	}, [markdown, isEditing]);
 
-	// Seed the draft with the current markdown when the user enters edit
-	// mode.  Moving the seed into the click handler (rather than a
-	// `useEffect`) means the captured value is always the most recent
-	// markdown the user actually saw on screen.  Cross-file resets are
-	// handled by the `key` prop applied to this component in
-	// `KnowledgeView`.
 	const handleEdit = useCallback(() => {
 		setEditContent(markdown);
 		baselineMarkdownRef.current = markdown;
@@ -121,17 +322,12 @@ export function DocumentViewer({
 		baselineMarkdownRef.current = null;
 	}, []);
 
-	// Discard the draft and reload from the latest server markdown.
-	// Used by the stale-warning banner; keeps the user inside edit mode
-	// so they don't lose context if they want to keep tweaking.
 	const handleReload = useCallback(() => {
 		setEditContent(markdown);
 		baselineMarkdownRef.current = markdown;
 		setShowStaleWarning(false);
 	}, [markdown]);
 
-	// Reads the latest editContent from the ref so the dep list stays
-	// at `[onSave]` only — keystrokes don't rebuild the callback.
 	const handleSave = useCallback(async () => {
 		if (!onSave) return;
 		setIsSaving(true);
@@ -150,7 +346,6 @@ export function DocumentViewer({
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			{/* ── Toolbar ─────────────────────────────────────────────────────── */}
 			<header className="flex shrink-0 items-center gap-2 px-4 py-2">
 				<span className="flex-1 truncate text-[12px] text-muted-foreground">
 					{filename}
@@ -160,169 +355,36 @@ export function DocumentViewer({
 						</span>
 					)}
 				</span>
-
 				{isEditing ? (
-					/* ── Edit-mode actions ──────────────────────────────────────── */
-					<div className="flex items-center gap-1.5">
-						<button
-							type="button"
-							onClick={handleCancel}
-							disabled={isSaving}
-							className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-						>
-							Cancel
-						</button>
-						<button
-							type="button"
-							onClick={handleSave}
-							disabled={isSaving || !onSave}
-							className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md bg-foreground px-2.5 text-[12px] font-medium text-background transition-colors duration-150 ease-out hover:bg-foreground/90 disabled:pointer-events-none disabled:opacity-50"
-						>
-							{isSaving ? (
-								<Loader2Icon aria-hidden="true" className="size-3.5 animate-spin" />
-							) : (
-								<SaveIcon aria-hidden="true" className="size-3.5" />
-							)}
-							{isSaving ? 'Saving…' : 'Save'}
-						</button>
-					</div>
+					<EditActionsRow
+						canSave={Boolean(onSave)}
+						isSaving={isSaving}
+						onCancel={handleCancel}
+						onSave={handleSave}
+					/>
 				) : (
-					/* ── Read-mode actions ──────────────────────────────────────── */
-					<div className="flex items-center gap-1.5">
-						{onSave && (
-							<button
-								type="button"
-								onClick={handleEdit}
-								className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-foreground-5 hover:text-foreground"
-							>
-								<PencilIcon aria-hidden="true" className="size-3.5" />
-								Edit
-							</button>
-						)}
-
-						<DropdownPanelMenu
-							asChild
-							usePortal
-							align="end"
-							contentClassName="popover-styled p-1 min-w-44"
-							trigger={
-								<button
-									type="button"
-									className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-foreground-5 pr-1.5 pl-3 text-[12px] font-medium text-foreground transition-colors duration-150 ease-out hover:bg-foreground-10"
-								>
-									<SendIcon aria-hidden="true" className="size-3.5" />
-									Publish
-									<ChevronDownIcon aria-hidden="true" className="size-3.5" />
-								</button>
-							}
-						>
-							<DropdownMenuItem>
-								<CopyIcon className="size-3.5" />
-								Copy
-							</DropdownMenuItem>
-							<DropdownMenuItem>
-								<DownloadIcon className="size-3.5" />
-								Download
-							</DropdownMenuItem>
-							<DropdownMenuItem>
-								<DownloadIcon className="size-3.5" />
-								Download as PDF
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem>
-								<SendIcon className="size-3.5" />
-								Publish
-							</DropdownMenuItem>
-							<DropdownMenuItem>
-								<UserPlusIcon className="size-3.5" />
-								Invite
-							</DropdownMenuItem>
-						</DropdownPanelMenu>
-
-						<button
-							type="button"
-							onClick={onClose}
-							aria-label="Close document"
-							className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-foreground-5 hover:text-foreground"
-						>
-							<XIcon aria-hidden="true" className="size-4" />
-						</button>
-					</div>
+					<ReadActionsRow
+						canEdit={Boolean(onSave)}
+						onClose={onClose}
+						onEdit={handleEdit}
+					/>
 				)}
 			</header>
-
-			{/* ── Save error banner ────────────────────────────────────────────── */}
-			{saveError && (
-				<div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
-					<span className="mt-0.5 shrink-0">⚠</span>
-					<span>{saveError}</span>
-				</div>
-			)}
-
-			{/* Stale-on-save warning: the upstream `markdown` prop changed
-			   under us while the user was editing (typically the agent
-			   overwriting the same file). Surface a banner so the user
-			   chooses between reloading the server copy or keeping their
-			   draft and overwriting on Save. */}
+			{saveError && <SaveErrorBanner message={saveError} />}
 			{showStaleWarning && (
-				<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-700 dark:text-amber-300">
-					<span className="shrink-0">⚠</span>
-					<span className="flex-1">
-						This file changed externally while you were editing. Saving
-						now will overwrite the newer version.
-					</span>
-					<button
-						type="button"
-						onClick={handleReload}
-						disabled={isSaving}
-						className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-amber-500/40 bg-transparent px-2 text-[11px] font-medium text-amber-700 transition-colors duration-150 ease-out hover:bg-amber-500/10 disabled:pointer-events-none disabled:opacity-50 dark:text-amber-300"
-					>
-						Reload from server
-					</button>
-					<button
-						type="button"
-						onClick={() => setShowStaleWarning(false)}
-						disabled={isSaving}
-						className="inline-flex h-6 cursor-pointer items-center gap-1 rounded-md bg-amber-600 px-2 text-[11px] font-medium text-white transition-colors duration-150 ease-out hover:bg-amber-700 disabled:pointer-events-none disabled:opacity-50"
-					>
-						Keep my draft
-					</button>
-				</div>
+				<StaleWarningBanner
+					disabled={isSaving}
+					onDismiss={() => setShowStaleWarning(false)}
+					onReload={handleReload}
+				/>
 			)}
-
-			{/* ── Document body ────────────────────────────────────────────────── */}
-			{isEditing ? (
-				/*
-				 * Edit mode: a monospace textarea. We deliberately use a plain
-				 * <textarea> rather than a rich editor — Markdown source editing
-				 * is already familiar, keeps the bundle small, and avoids the
-				 * cursor-sync complexity of a preview-alongside-edit layout.
-				 */
-				<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
-					<div className="mx-auto max-w-[680px]">
-						<textarea
-							value={editContent}
-							onChange={(e) => setEditContent(e.target.value)}
-							disabled={isSaving}
-							spellCheck={false}
-							className="w-full resize-none rounded-md border border-border bg-background px-4 py-3 font-mono text-[13px] leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 disabled:opacity-60"
-							// CSS min-height avoids recalculating rows on every keystroke.
-							style={{ minHeight: '480px' }}
-						/>
-					</div>
-				</div>
-			) : (
-				/*
-				 * Read mode: the same prose renderer the chat surface uses.
-				 * `min-h-0` lets the flex child shrink so the scroll container is
-				 * the inner div, not the page.
-				 */
-				<div className="min-h-0 flex-1 overflow-y-auto px-8 pb-10">
-					<article className="prose prose-sm mx-auto max-w-[680px] text-foreground">
-						<Streamdown>{markdown}</Streamdown>
-					</article>
-				</div>
-			)}
+			<DocumentBody
+				editContent={editContent}
+				isEditing={isEditing}
+				isSaving={isSaving}
+				markdown={markdown}
+				onChangeContent={setEditContent}
+			/>
 		</div>
 	);
 }

--- a/frontend/features/knowledge/components/DocumentViewer.tsx
+++ b/frontend/features/knowledge/components/DocumentViewer.tsx
@@ -180,7 +180,8 @@ function StaleWarningBanner({
 		<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-700 dark:text-amber-300">
 			<span className="shrink-0">⚠</span>
 			<span className="flex-1">
-				This file changed externally while you were editing. Saving now will overwrite the newer version.
+				This file changed externally while you were editing. Saving now will overwrite the
+				newer version.
 			</span>
 			<button
 				type="button"

--- a/frontend/features/knowledge/hooks/use-write-workspace-file.ts
+++ b/frontend/features/knowledge/hooks/use-write-workspace-file.ts
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * React Query mutation hook for writing (creating or replacing) a single
+ * workspace file.
+ *
+ * On success the hook automatically invalidates the `workspace-file` query
+ * for the saved path so the DocumentViewer's cached content stays in sync
+ * with what we just wrote.
+ *
+ * Usage:
+ * ```ts
+ * const { mutate, isPending } = useWriteWorkspaceFile(workspaceId);
+ * mutate({ filePath: 'notes/readme.md', content: newMarkdown });
+ * ```
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthedFetch } from '@/hooks/use-authed-fetch';
+import { API_ENDPOINTS } from '@/lib/api';
+import type { WorkspaceFileApiResponse } from '../types';
+
+interface WriteFileArgs {
+	/** Workspace-relative POSIX path, e.g. `memory/note.md`. */
+	filePath: string;
+	/** Full UTF-8 text content to write. */
+	content: string;
+}
+
+/**
+ * Hook: write a workspace file via PUT and refresh the cached read query.
+ *
+ * @param workspaceId - UUID of the workspace that owns the file.  Pass
+ *   `null` to obtain a hook that always returns an error on mutation
+ *   (safe to call before the workspace loads).
+ */
+export function useWriteWorkspaceFile(workspaceId: string | null) {
+	const authedFetch = useAuthedFetch();
+	const queryClient = useQueryClient();
+
+	return useMutation<WorkspaceFileApiResponse, Error, WriteFileArgs>({
+		mutationFn: async ({ filePath, content }) => {
+			if (!workspaceId) {
+				throw new Error('No workspace selected — cannot save file.');
+			}
+			const res = await authedFetch(
+				API_ENDPOINTS.workspaces.writeFile(workspaceId, filePath),
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ content }),
+				}
+			);
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				throw new Error(
+					(body as { detail?: string }).detail ??
+						`HTTP ${res.status}: Failed to save file`
+				);
+			}
+			return res.json() as Promise<WorkspaceFileApiResponse>;
+		},
+
+		onSuccess: (_data, { filePath }) => {
+			// Invalidate the matching read query so any subsequent open of this
+			// file re-fetches the latest content from the server.
+			queryClient.invalidateQueries({
+				queryKey: ['workspace-file', workspaceId ?? '', filePath],
+			});
+		},
+	});
+}

--- a/frontend/features/knowledge/use-knowledge-url-state.ts
+++ b/frontend/features/knowledge/use-knowledge-url-state.ts
@@ -54,6 +54,10 @@ export interface KnowledgeUrlState {
 	crumbs: ReturnType<typeof buildBreadcrumbs>;
 	openFile: { name: string; markdown: string } | null;
 	tree: { isLoading: boolean; isError: boolean; error: Error | null };
+	/** Workspace UUID for the active workspace; `null` while it's loading. */
+	workspaceId: string | null;
+	/** Workspace-relative path of the currently-open file, or `null`. */
+	openFilePath: string | null;
 }
 
 /**
@@ -151,5 +155,7 @@ export function useKnowledgeUrlState(): KnowledgeUrlState {
 		crumbs,
 		openFile,
 		tree: { isLoading: treeLoading, isError: treeError, error },
+		workspaceId,
+		openFilePath,
 	};
 }


### PR DESCRIPTION
Replaces #117. Re-applies the file-editing workflow on top of the post-#137 KnowledgeContainer split (the original branch was stuck on a 12-commit rebase including a stale `chore(ci): unblock CI` commit that conflicted with the `useKnowledgeUrlState` / `useKnowledgeNavigation` extraction).

Dropped from #117 during the rebase:
- `dfc3274 chore(ci): unblock CI across all PRs` — superseded by the current CI setup.
- `dea9a1f / 6f6e66c fix(stagehand)` — superseded by Stagehand fixes already on `development`.
- `4a2c605 fix(vitest)` — already addressed by current vitest config.
- The component / hook tests from `bf28bf1` and `f4463b8` are intentionally deferred to a follow-up so this PR stays focused on the feature; they need to be re-targeted at the new `useKnowledgeUrlState` shape.

## What is here
- `DocumentViewer` gains read/edit modes (monospace textarea, save spinner, inline error banner, amber `editing` badge).
- New `useWriteWorkspaceFile` hook: `PUT /api/v1/workspaces/:id/files/:path`, invalidates the read query on success.
- `useKnowledgeUrlState` now also returns `workspaceId` and `openFilePath` so the container can build the save callback without re-deriving them.
- `KnowledgeContainer` wires the mutation into `handleSaveFile` and threads `onSaveFile` through `KnowledgeView` → `DocumentViewer`.
- `DocumentViewer` is keyed by `openFile.name` so cross-file draft resets fall out of normal mount/unmount semantics — no `useRef` draft guard needed.

## Closes
Closes #117.