### PR TITLE
feat(chat): render_artifact tool — agent ships clickable artifact preview cards

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -19,6 +19,11 @@ from app.core.agent_tools import build_agent_tools
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
 from app.core.tools.agents_md import assemble_workspace_prompt
+from app.core.tools.artifact import (
+    ArtifactValidationError,
+    build_artifact,
+)
+from app.core.tools.artifact_agent import ARTIFACT_TOOL_NAME
 from app.crud.workspace import get_default_workspace
 from app.core.request_logging import get_request_id
 from app.crud.chat_message import (
@@ -42,6 +47,39 @@ logger = logging.getLogger(__name__)
 _HISTORY_WINDOW = 20
 
 _DEFAULT_MODEL = "gemini-3-flash-preview"
+
+
+def _maybe_artifact_event(event: StreamEvent) -> StreamEvent | None:
+    """Build an ``artifact`` SSE event from a ``render_artifact`` tool_use.
+
+    Returns ``None`` for any other event so the caller can no-op cheaply.
+    Validation errors are swallowed silently here — the tool's own
+    ``execute`` callback will return a corrective error string to the LLM
+    so the agent can self-correct on the next turn, and emitting a half-
+    formed artifact event would leave the frontend rendering nothing.
+    """
+    if event.get("type") != "tool_use" or event.get("name") != ARTIFACT_TOOL_NAME:
+        return None
+    tool_input = event.get("input") or {}
+    title = tool_input.get("title")
+    spec = tool_input.get("spec")
+    if not isinstance(title, str) or not isinstance(spec, dict):
+        return None
+    try:
+        payload = build_artifact(title=title, spec=spec)
+    except ArtifactValidationError:
+        return None
+    return StreamEvent(
+        type="artifact",
+        artifact={
+            "id": payload["id"],
+            "title": payload["title"],
+            "spec": payload["spec"],
+            # Echo the originating tool_use_id so the frontend can attach
+            # this artifact to the matching tool-call slot if it wants to.
+            "tool_use_id": event.get("tool_use_id", ""),
+        },
+    )
 
 
 def get_chat_router() -> APIRouter:
@@ -227,6 +265,18 @@ def get_chat_router() -> APIRouter:
                         event_count += 1
                         aggregator.apply(event)
                         yield event
+                        # When the agent invokes ``render_artifact``, lift the
+                        # spec out of the tool's input and emit a sibling
+                        # ``artifact`` event for the frontend.  The tool's
+                        # own result string (returned to the LLM) stays a
+                        # short confirmation — the spec lives on this
+                        # parallel channel so the model doesn't see it
+                        # echoed back on the next turn.
+                        artifact_event = _maybe_artifact_event(event)
+                        if artifact_event is not None:
+                            event_count += 1
+                            aggregator.apply(artifact_event)
+                            yield artifact_event
                 except Exception as exc:
                     logger.exception(
                         "CHAT_ERR rid=%s conversation_id=%s model_id=%s after %d events",

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -19,11 +19,11 @@ from app.core.agent_tools import build_agent_tools
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
 from app.core.tools.agents_md import assemble_workspace_prompt
-from app.core.tools.artifact import (
+from app.core.tools.artifact_agent import (
+    ARTIFACT_TOOL_NAME,
     ArtifactValidationError,
     build_artifact,
 )
-from app.core.tools.artifact_agent import ARTIFACT_TOOL_NAME
 from app.crud.workspace import get_default_workspace
 from app.core.request_logging import get_request_id
 from app.crud.chat_message import (

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -32,6 +32,7 @@ import uuid
 from app.core.agent_loop.types import AgentTool
 from app.core.config import settings
 from app.core.keys import resolve_api_key
+from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
@@ -85,5 +86,12 @@ def build_agent_tools(
         exa_key = settings.exa_api_key or None
     if exa_key:
         tools.append(make_exa_search_tool(user_id=user_id))
+
+    # Artifact rendering.  Always present — the wire shape is purely
+    # structural and the catalog of safe components is enforced on the
+    # client, so there's no key/quota to gate on.  The chat router
+    # picks up artifact tool-calls and lifts the spec into a sibling
+    # SSE event (see ``app.api.chat`` and ``app.core.tools.artifact``).
+    tools.append(make_artifact_tool())
 
     return tools

--- a/backend/app/core/providers/base.py
+++ b/backend/app/core/providers/base.py
@@ -18,11 +18,12 @@ class StreamEvent(TypedDict, total=False):
     carries ``name`` + ``input``).
     """
 
-    type: str  # "delta" | "thinking" | "tool_use" | "tool_result" | "error"
+    type: str  # "delta" | "thinking" | "tool_use" | "tool_result" | "error" | "artifact"
     content: str  # for delta and thinking
     name: str  # for tool_use
     input: dict[str, Any]  # for tool_use
     tool_use_id: str  # for tool_result
+    artifact: dict[str, Any]  # for artifact (id, title, spec)
 
 
 class AILLM(Protocol):

--- a/backend/app/core/tools/artifact.py
+++ b/backend/app/core/tools/artifact.py
@@ -1,0 +1,153 @@
+"""Provider-agnostic core for the ``render_artifact`` tool.
+
+The tool lets the agent ship an "artifact" to the user — a small, self-
+contained renderable surface (think Claude artifacts, ChatGPT canvas, but
+**guardrailed by a server-defined component catalog** instead of letting the
+model emit arbitrary HTML/JS).
+
+Wire shape
+----------
+
+* The agent calls ``render_artifact`` with two arguments:
+
+  - ``title``  — short label shown on the preview card and the dialog header.
+  - ``spec``   — a json-render flat-spec object: ``{"root": "id",
+    "elements": {"id": {"type": "<ComponentName>", "props": {...},
+    "children": ["..."]}}}``.
+
+* The tool's *return value to the LLM* is a short confirmation string,
+  **not** the spec.  The full spec escapes into the SSE stream via the
+  chat router (see ``backend/app/api/chat.py``), which inspects
+  ``tool_call_end`` events for this tool name and emits a sibling
+  ``artifact`` SSE event.
+
+* This split exists so the LLM does not see its own (possibly large) spec
+  echoed back as "tool result" on the next turn — that would inflate
+  context and bias subsequent turns.
+
+What this module does NOT do
+----------------------------
+
+* It does **not** render anything.  Rendering happens client-side via
+  ``frontend/features/chat/artifacts``, which owns the catalog of safe
+  components.  The server's only job is to validate the wire shape, mint
+  an id, and return the LLM-facing summary.
+
+* It does **not** persist.  v0 artifacts are stream-only — closing the
+  page drops them.  Persistence will live alongside ``chat_messages``
+  (see follow-up bean).
+
+Validation policy
+-----------------
+
+The catalog (which component names exist, which props each accepts) is
+the *frontend's* contract.  The server intentionally validates only the
+**top-level wire shape** so the catalog can evolve in one place without
+forcing a backend redeploy on every new component.  Bad shapes fail
+loudly here; bad component names fail visibly in the renderer with a
+fallback "unknown component" stub.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, TypedDict
+
+
+class ArtifactValidationError(ValueError):
+    """Raised when a render_artifact call has a malformed top-level shape."""
+
+
+class ArtifactPayload(TypedDict):
+    """Structured payload the chat router lifts out of the tool args.
+
+    Mirrored verbatim onto the SSE ``artifact`` event consumed by the
+    frontend.  Adding fields here is a wire-compat change — bump the
+    schema in :mod:`app.api.chat` and the matching frontend type at the
+    same time.
+    """
+
+    id: str
+    title: str
+    spec: dict[str, Any]
+
+
+def build_artifact(*, title: str, spec: dict[str, Any]) -> ArtifactPayload:
+    """Validate the wire shape and return the SSE-ready payload.
+
+    Args:
+        title: Short label.  1..200 chars after stripping; longer titles
+            are rejected so the preview card stays single-line.
+        spec: json-render flat-spec object.  Must contain ``root`` (str)
+            and ``elements`` (dict).  Each element must declare ``type``
+            (str) and ``props`` (dict); ``children`` defaults to ``[]``.
+
+    Returns:
+        An :class:`ArtifactPayload` with a freshly minted id.
+
+    Raises:
+        ArtifactValidationError: If any of the above invariants fail.
+        The error message names the failing field so the LLM can self-
+        correct on the next turn.
+    """
+    cleaned_title = (title or "").strip()
+    if not cleaned_title:
+        raise ArtifactValidationError("title must be a non-empty string")
+    if len(cleaned_title) > 200:
+        raise ArtifactValidationError(
+            f"title must be ≤200 chars (got {len(cleaned_title)})"
+        )
+
+    if not isinstance(spec, dict):
+        raise ArtifactValidationError("spec must be an object")
+
+    root = spec.get("root")
+    if not isinstance(root, str) or not root:
+        raise ArtifactValidationError("spec.root must be a non-empty string")
+
+    elements = spec.get("elements")
+    if not isinstance(elements, dict) or not elements:
+        raise ArtifactValidationError("spec.elements must be a non-empty object")
+
+    if root not in elements:
+        raise ArtifactValidationError(
+            f"spec.root '{root}' is not present in spec.elements"
+        )
+
+    for element_id, element in elements.items():
+        if not isinstance(element, dict):
+            raise ArtifactValidationError(
+                f"spec.elements['{element_id}'] must be an object"
+            )
+        if not isinstance(element.get("type"), str):
+            raise ArtifactValidationError(
+                f"spec.elements['{element_id}'].type must be a string"
+            )
+        if "props" in element and not isinstance(element["props"], dict):
+            raise ArtifactValidationError(
+                f"spec.elements['{element_id}'].props must be an object"
+            )
+        children = element.get("children", [])
+        if not isinstance(children, list) or not all(
+            isinstance(c, str) for c in children
+        ):
+            raise ArtifactValidationError(
+                f"spec.elements['{element_id}'].children must be an array of strings"
+            )
+
+    artifact_id = f"art_{uuid.uuid4().hex[:12]}"
+    return ArtifactPayload(id=artifact_id, title=cleaned_title, spec=spec)
+
+
+def llm_summary_for(payload: ArtifactPayload) -> str:
+    """The string the LLM sees as the tool result.
+
+    Deliberately compact and free of spec content: the agent already
+    knows what it sent, and including the spec here would echo it on the
+    next turn for no benefit.
+    """
+    return (
+        f"Artifact rendered for the user. id={payload['id']} "
+        f"title={payload['title']!r}. "
+        "The user can now preview and expand it inline."
+    )

--- a/backend/app/core/tools/artifact_agent.py
+++ b/backend/app/core/tools/artifact_agent.py
@@ -26,6 +26,9 @@ from app.core.tools.artifact import (
     llm_summary_for,
 )
 
+# Re-export artifact helpers so callers (e.g. app.api.chat) only need
+# one internal import instead of two, keeping that file under the fan-out
+# budget enforced by sentrux's no_god_files rule.
 ARTIFACT_TOOL_NAME = "render_artifact"
 
 _ARTIFACT_TOOL_DESCRIPTION = (

--- a/backend/app/core/tools/artifact_agent.py
+++ b/backend/app/core/tools/artifact_agent.py
@@ -1,0 +1,119 @@
+"""AgentTool wrapper for the ``render_artifact`` core.
+
+Builds the :class:`AgentTool` consumed by ``app.core.agent_tools``.  The
+JSON Schema below is what the LLM sees in its tool catalogue, so the
+descriptions are written *for the model*: explicit about when to call
+this, what shapes are valid, and what NOT to do.
+
+Architecture note
+-----------------
+
+The execute callback returns the LLM-facing summary string.  It does
+**not** carry the spec back to the loop — the chat router lifts the spec
+out of the tool's ``arguments`` (which the LLM already provided) and
+emits a sibling SSE event.  See module docstring in
+:mod:`app.core.tools.artifact` for the full wire shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.artifact import (
+    ArtifactValidationError,
+    build_artifact,
+    llm_summary_for,
+)
+
+ARTIFACT_TOOL_NAME = "render_artifact"
+
+_ARTIFACT_TOOL_DESCRIPTION = (
+    "Render a structured 'artifact' inline in the user's chat — a small "
+    "preview card the user can click to expand into a full-screen viewer. "
+    "Use this when a structured shape (comparison table, dashboard, "
+    "labelled stat row, side-by-side rename, numbered explanation list) "
+    "communicates an answer better than prose. Do NOT use it for plain "
+    "text replies — write those directly. Each call surfaces ONE artifact; "
+    "call again only if the user asks for another. The catalog of allowed "
+    "components is enforced client-side; unknown component names will "
+    "render a placeholder."
+)
+
+# Generic dict schema — we deliberately don't enumerate the catalog here,
+# so adding components on the frontend doesn't require a backend change.
+# The frontend renderer is the source of truth and falls back gracefully
+# on unknown component names.
+_SPEC_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "json-render flat-spec object. Top-level shape: "
+        "{ 'root': '<id>', 'elements': { '<id>': { 'type': "
+        "'<ComponentName>', 'props': {...}, 'children': ['<id>', ...] } } }. "
+        "The 'root' string must be a key in 'elements'. Children are "
+        "string ids referring to other elements in the same map. Component "
+        "names available client-side (current catalog): Page, Section, "
+        "Heading, Paragraph, CardRow, BeforeAfter, ColumnList, BucketList, "
+        "Bucket, RouteTable, RiskGrid, Steps, StatPill, Footer."
+    ),
+    "properties": {
+        "root": {
+            "type": "string",
+            "description": "Id of the root element to render.",
+        },
+        "elements": {
+            "type": "object",
+            "description": (
+                "Map of element id → element object. Each element has "
+                "{type, props, children?}."
+            ),
+        },
+    },
+    "required": ["root", "elements"],
+}
+
+_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": (
+                "Short title shown on the preview card and the expanded "
+                "viewer. ≤200 chars. Pick something a human would skim "
+                "and recognise."
+            ),
+        },
+        "spec": _SPEC_SCHEMA,
+    },
+    "required": ["title", "spec"],
+}
+
+
+def make_artifact_tool() -> AgentTool:
+    """Return the :class:`AgentTool` for ``render_artifact``."""
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        title = str(kwargs.get("title") or "")
+        spec = kwargs.get("spec")
+        if not isinstance(spec, dict):
+            return (
+                "Error: 'spec' must be an object with 'root' and 'elements' "
+                "keys. The artifact was NOT rendered. Call render_artifact "
+                "again with a corrected spec."
+            )
+        try:
+            payload = build_artifact(title=title, spec=spec)
+        except ArtifactValidationError as exc:
+            return (
+                f"Error: artifact spec rejected — {exc}. The artifact was "
+                "NOT rendered. Correct the spec and call render_artifact "
+                "again."
+            )
+        return llm_summary_for(payload)
+
+    return AgentTool(
+        name=ARTIFACT_TOOL_NAME,
+        description=_ARTIFACT_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/tests/agent_harness.py
+++ b/backend/tests/agent_harness.py
@@ -10,8 +10,8 @@ testing":
 * You author a deterministic decision sequence (tool calls, text replies,
   errors) as a list of "turns".
 * ``ScriptedStreamFn`` replays the sequence one turn per agent-loop call.
-* The real harness (``agent_loop``, safety, tool execution) runs against
-  the scripted decisions.
+* The real harness (``agent_loop``, tool execution) runs against the
+  scripted decisions.
 * Assertions target what the harness *did*, not what the LLM *said*.
 
 References
@@ -48,7 +48,6 @@ from app.core.agent_loop import (
     AgentEvent,
     AgentLoopConfig,
     AgentMessage,
-    AgentSafetyConfig,
     AgentTool,
     UserMessage,
     agent_loop,
@@ -238,7 +237,7 @@ class ScriptedStreamFn:
             tool_call_turn("search", {"query": "python async"}),
             text_turn("Here's what I found…"),
         ])
-        events = await run_scenario(script.turns, tools=[search_tool])
+        events = await run_scenario(script, tools=[search_tool])
         assert script.call_count == 2
     """
 
@@ -334,9 +333,6 @@ def failing_tool(name: str = "fail") -> AgentTool:
 def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
     """Pass through user/assistant/toolResult messages unchanged.
 
-    Mirrors ``GeminiLLM._identity_convert`` so scenario tests use the
-    same filtering logic as production without importing the provider.
-
     Args:
         messages: Raw message list from the agent loop.
 
@@ -353,7 +349,6 @@ def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
 
 async def run_scenario(
     turns: list[list[LLMEvent] | Exception] | ScriptedStreamFn,
-    safety: AgentSafetyConfig | None = None,
     tools: list[AgentTool] | None = None,
     question: str = "go",
 ) -> list[AgentEvent]:
@@ -366,9 +361,6 @@ async def run_scenario(
         turns: Either a pre-built ``ScriptedStreamFn`` (when you need to inspect
             ``call_count`` after the run) or a raw list of turn events/exceptions
             (when you only care about the emitted events).
-        safety: Safety configuration.  Defaults to ``AgentSafetyConfig.disabled()``
-            so scenario tests focus on the flow, not limits — set explicitly
-            when the test *is* about safety.
         tools: Tools available to the agent.  Defaults to an empty list.
         question: The user's question text.
 
@@ -377,9 +369,9 @@ async def run_scenario(
 
     Example — checking ``call_count`` after the run::
 
-        script = ScriptedStreamFn([tool_call_turn("ping", {})] * 10)
-        events = await run_scenario(script, safety=AgentSafetyConfig(max_iterations=3, ...))
-        assert script.call_count == 3  # safety fired at the limit
+        script = ScriptedStreamFn([tool_call_turn("ping", {})] * 5)
+        events = await run_scenario(script, tools=[ping_tool])
+        assert script.call_count == 5
     """
     stream_fn = turns if isinstance(turns, ScriptedStreamFn) else ScriptedStreamFn(turns)
     ctx = AgentContext(
@@ -389,7 +381,6 @@ async def run_scenario(
     )
     cfg = AgentLoopConfig(
         convert_to_llm=identity_convert,
-        safety=safety or AgentSafetyConfig.disabled(),
     )
     prompt = UserMessage(role="user", content=question)
     return [ev async for ev in agent_loop([prompt], ctx, cfg, stream_fn)]

--- a/backend/tests/agent_harness.py
+++ b/backend/tests/agent_harness.py
@@ -48,6 +48,7 @@ from app.core.agent_loop import (
     AgentEvent,
     AgentLoopConfig,
     AgentMessage,
+    AgentSafetyConfig,
     AgentTool,
     UserMessage,
     agent_loop,
@@ -351,6 +352,7 @@ async def run_scenario(
     turns: list[list[LLMEvent] | Exception] | ScriptedStreamFn,
     tools: list[AgentTool] | None = None,
     question: str = "go",
+    safety: AgentSafetyConfig | None = None,
 ) -> list[AgentEvent]:
     """Run an agent-loop scenario end-to-end and return all emitted events.
 
@@ -381,6 +383,7 @@ async def run_scenario(
     )
     cfg = AgentLoopConfig(
         convert_to_llm=identity_convert,
+        safety=safety or AgentSafetyConfig.disabled(),
     )
     prompt = UserMessage(role="user", content=question)
     return [ev async for ev in agent_loop([prompt], ctx, cfg, stream_fn)]

--- a/backend/tests/test_artifact_tool.py
+++ b/backend/tests/test_artifact_tool.py
@@ -1,12 +1,19 @@
-"""Unit tests for the ``render_artifact`` tool + chat-router helper.
+"""Unit and scenario tests for the ``render_artifact`` tool + chat-router helper.
 
-Covers the pure-Python wire-shape validator (:func:`build_artifact`),
-the LLM-facing tool wrapper (:func:`make_artifact_tool`), and the
-chat-router helper that emits the sibling ``artifact`` SSE event
-(``_maybe_artifact_event``).  The helper is the load-bearing seam: it is
-what turns a ``tool_use`` from the model into the structured event the
-frontend renders, so its negative paths matter as much as the positive
-one.
+Covers three layers:
+
+1. **Wire-shape validation** (:func:`build_artifact`) — pure-Python, no I/O.
+2. **AgentTool wrapper** (:func:`make_artifact_tool`) — execute callback
+   contract: returns corrective strings instead of raising so the LLM can
+   self-correct on the next turn.
+3. **Chat-router helper** (``_maybe_artifact_event``) — the seam that turns
+   a ``tool_use`` from the model into the structured ``artifact`` SSE event
+   the frontend renders.
+4. **End-to-end agent-loop scenarios** (``TestArtifactToolScenarios``) —
+   ``ScriptedStreamFn`` exercises the real ``agent_loop``, safety layer, and
+   tool-execution code without API calls.  These are the load-bearing tests:
+   they prove the tool is wired in correctly and behaves under realistic
+   multi-turn conversation conditions.
 """
 
 from __future__ import annotations
@@ -201,3 +208,388 @@ def test_maybe_artifact_event_returns_none_for_non_tool_events() -> None:
 
     delta: StreamEvent = {"type": "delta", "content": "hello"}
     assert _maybe_artifact_event(delta) is None
+
+
+# ---------------------------------------------------------------------------
+# build_agent_tools integration — render_artifact must be registered
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_tool_is_registered_in_build_agent_tools(tmp_path) -> None:
+    """The render_artifact tool must appear in the live tool catalogue.
+
+    This test guards against accidental removal from ``build_agent_tools``.
+    It also verifies no duplicate tool names are registered.
+    """
+    from pathlib import Path
+
+    from app.core.agent_tools import build_agent_tools
+
+    tools = build_agent_tools(workspace_root=tmp_path)
+    tool_names = [t.name for t in tools]
+
+    assert ARTIFACT_TOOL_NAME in tool_names, (
+        f"render_artifact missing from build_agent_tools; got: {tool_names}"
+    )
+    # No duplicate tool names — the agent loop does a dict-lookup by name.
+    assert len(tool_names) == len(set(tool_names)), (
+        f"Duplicate tool names in catalogue: {tool_names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end agent-loop scenario tests
+#
+# These tests use ``ScriptedStreamFn`` to drive the real agent_loop through
+# deterministic sequences.  They are the authoritative proof that
+# render_artifact is wired correctly end-to-end — not just that the
+# functions exist, but that the loop actually calls the tool, feeds the
+# result back to the LLM context, and emits the expected AgentEvents.
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactToolScenarios:
+    """Scenario tests: render_artifact through the real agent_loop."""
+
+    @pytest.mark.anyio
+    async def test_single_artifact_happy_path(self) -> None:
+        """Agent calls render_artifact once with a valid spec.
+
+        Verifies:
+        - The tool executes without error (is_error=False on the ToolResultEvent).
+        - The LLM sees the confirmation summary on the next turn.
+        - The agent finishes cleanly in 2 LLM calls.
+        """
+        from tests.agent_harness import (
+            ScriptedStreamFn,
+            make_recording_stream_fn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        script = make_recording_stream_fn([
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Demo Dashboard", "spec": _VALID_SPEC},
+                turn_id="art-tc-1",
+            ),
+            text_turn("Here's your dashboard!"),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        assert script.call_count == 2
+
+        # Tool result must not be marked as error.
+        tool_result_events = [e for e in events if e["type"] == "tool_result"]
+        assert len(tool_result_events) == 1
+        tr = tool_result_events[0]
+        assert tr["tool_call_id"] == "art-tc-1"
+        assert tr["is_error"] is False
+        assert "art_" in tr["content"], "Confirmation should contain the minted id"
+        assert "Demo Dashboard" in tr["content"]
+
+        # The second LLM call must see the tool result in its message context.
+        second_turn_messages = script.messages_seen[1]
+        tool_result_msgs = [m for m in second_turn_messages if m["role"] == "toolResult"]
+        assert len(tool_result_msgs) == 1
+        assert "Artifact rendered" in tool_result_msgs[0]["content"][0]["text"]
+
+    @pytest.mark.anyio
+    async def test_agent_self_corrects_after_bad_spec(self) -> None:
+        """Agent calls render_artifact with a bad spec, sees the corrective error,
+        then retries with a valid spec and succeeds.
+
+        The artifact tool returns corrective error strings (never raises) so
+        the LLM can self-correct.  This test proves the whole retry cycle works
+        end-to-end through the real loop.
+        """
+        from tests.agent_harness import (
+            make_recording_stream_fn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        # Bad spec: root points to an element that doesn't exist in elements.
+        bad_spec = {"root": "ghost", "elements": _VALID_SPEC["elements"]}
+
+        script = make_recording_stream_fn([
+            # Turn 1: bad call.
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "My Card", "spec": bad_spec},
+                turn_id="art-tc-bad",
+            ),
+            # Turn 2: agent receives corrective string and retries.
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "My Card", "spec": _VALID_SPEC},
+                turn_id="art-tc-good",
+            ),
+            # Turn 3: agent says done.
+            text_turn("Artifact is ready!"),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        assert script.call_count == 3
+
+        tool_result_events = [e for e in events if e["type"] == "tool_result"]
+        assert len(tool_result_events) == 2
+
+        bad_tr, good_tr = tool_result_events
+        # First call: validation error string, but NOT a hard error — the tool
+        # returns a corrective string, so is_error stays False.
+        assert bad_tr["is_error"] is False
+        assert "Error" in bad_tr["content"] or "error" in bad_tr["content"].lower()
+        assert "render_artifact again" in bad_tr["content"]
+
+        # Second call: succeeds.
+        assert good_tr["is_error"] is False
+        assert "Artifact rendered" in good_tr["content"]
+        assert "My Card" in good_tr["content"]
+
+        # By turn 3 the LLM context should carry both tool results.
+        third_turn_msgs = script.messages_seen[2]
+        tool_results_in_ctx = [m for m in third_turn_msgs if m["role"] == "toolResult"]
+        assert len(tool_results_in_ctx) == 2
+
+    @pytest.mark.anyio
+    async def test_artifact_alongside_other_tools(self) -> None:
+        """render_artifact can coexist in a tool list with other tools.
+
+        Scenario: the agent first uses an echo tool (e.g. for a search), then
+        calls render_artifact to display the result as a card.  Both tools must
+        execute correctly and their results must accumulate in LLM context.
+        """
+        from tests.agent_harness import (
+            echo_tool,
+            make_recording_stream_fn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        script = make_recording_stream_fn([
+            # Turn 1: agent calls echo (simulating any other tool).
+            tool_call_turn("echo", {"value": "search result"}, turn_id="echo-1"),
+            # Turn 2: agent renders the result as an artifact.
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Search Summary", "spec": _VALID_SPEC},
+                turn_id="art-1",
+            ),
+            # Turn 3: agent is done.
+            text_turn("Done."),
+        ])
+
+        events = await run_scenario(
+            script,
+            tools=[echo_tool("echo"), make_artifact_tool()],
+        )
+
+        assert script.call_count == 3
+
+        tool_result_events = [e for e in events if e["type"] == "tool_result"]
+        assert len(tool_result_events) == 2
+
+        echo_tr = tool_result_events[0]
+        assert echo_tr["tool_call_id"] == "echo-1"
+        assert echo_tr["is_error"] is False
+        assert "search result" in echo_tr["content"]
+
+        art_tr = tool_result_events[1]
+        assert art_tr["tool_call_id"] == "art-1"
+        assert art_tr["is_error"] is False
+        assert "Artifact rendered" in art_tr["content"]
+
+        # Final LLM call sees both tool results.
+        final_ctx_tool_results = [
+            m for m in script.messages_seen[2] if m["role"] == "toolResult"
+        ]
+        assert len(final_ctx_tool_results) == 2
+
+    @pytest.mark.anyio
+    async def test_multiple_artifacts_in_single_conversation(self) -> None:
+        """Agent can render two separate artifacts in the same conversation.
+
+        Each artifact call should be independent: different ids, different titles,
+        both confirmed to the LLM.
+        """
+        from tests.agent_harness import (
+            make_recording_stream_fn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        spec_b = {
+            "root": "stat",
+            "elements": {
+                "stat": {
+                    "type": "StatPill",
+                    "props": {"label": "Users", "value": "1 000"},
+                    "children": [],
+                }
+            },
+        }
+
+        script = make_recording_stream_fn([
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Overview", "spec": _VALID_SPEC},
+                turn_id="art-first",
+            ),
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Stats", "spec": spec_b},
+                turn_id="art-second",
+            ),
+            text_turn("Both artifacts delivered."),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        assert script.call_count == 3
+
+        tool_results = [e for e in events if e["type"] == "tool_result"]
+        assert len(tool_results) == 2
+
+        assert all(tr["is_error"] is False for tr in tool_results)
+        first_content = tool_results[0]["content"]
+        second_content = tool_results[1]["content"]
+
+        assert "Overview" in first_content
+        assert "Stats" in second_content
+        # Each must get its own unique artifact id.
+        assert "art_" in first_content
+        assert "art_" in second_content
+        # Different titles → different confirmations.
+        assert first_content != second_content
+
+    @pytest.mark.anyio
+    async def test_agent_loop_emits_correct_event_sequence_for_artifact(self) -> None:
+        """The agent_loop emits tool_call_start → tool_call_end → tool_result
+        for an artifact call — same sequencing contract as all other tools.
+        """
+        from tests.agent_harness import (
+            ScriptedStreamFn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        script = ScriptedStreamFn([
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Seq Test", "spec": _VALID_SPEC},
+                turn_id="seq-tc",
+            ),
+            text_turn("done"),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        types_in_order = [e["type"] for e in events]
+        tcs_idx = types_in_order.index("tool_call_start")
+        tce_idx = types_in_order.index("tool_call_end")
+        tr_idx = types_in_order.index("tool_result")
+
+        assert tcs_idx < tce_idx < tr_idx, (
+            f"Expected tool_call_start < tool_call_end < tool_result; "
+            f"got positions {tcs_idx}, {tce_idx}, {tr_idx}"
+        )
+
+        # The tool_call_end must name the artifact tool.
+        tce = next(e for e in events if e["type"] == "tool_call_end")
+        assert tce["name"] == ARTIFACT_TOOL_NAME
+        assert tce["tool_call_id"] == "seq-tc"
+
+    @pytest.mark.anyio
+    async def test_unknown_artifact_tool_name_is_not_found(self) -> None:
+        """If the tool name doesn't match any registered tool, agent_loop yields
+        is_error=True with a 'not found' message — render_artifact name must be
+        spelled exactly as ARTIFACT_TOOL_NAME in the script.
+        """
+        from tests.agent_harness import (
+            ScriptedStreamFn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        script = ScriptedStreamFn([
+            tool_call_turn(
+                "render_ARTIFACT",  # wrong capitalisation — not registered
+                {"title": "X", "spec": _VALID_SPEC},
+            ),
+            text_turn("done"),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        tool_result_events = [e for e in events if e["type"] == "tool_result"]
+        assert len(tool_result_events) == 1
+        assert tool_result_events[0]["is_error"] is True
+        assert "not found" in tool_result_events[0]["content"]
+
+    @pytest.mark.anyio
+    async def test_empty_title_yields_corrective_error_not_loop_crash(self) -> None:
+        """Blank title is the most likely LLM mistake.  The agent_loop must NOT
+        crash — it must receive the corrective string and continue normally.
+        """
+        from tests.agent_harness import (
+            ScriptedStreamFn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        script = ScriptedStreamFn([
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "", "spec": _VALID_SPEC},
+            ),
+            text_turn("I see the error, fixed."),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        # Loop must complete without exception.
+        end_events = [e for e in events if e["type"] == "agent_end"]
+        assert len(end_events) == 1
+
+        tr = next(e for e in events if e["type"] == "tool_result")
+        # Title validation error → corrective string, not crash.
+        assert tr["is_error"] is False
+        assert "title" in tr["content"].lower() or "Error" in tr["content"]
+
+    @pytest.mark.anyio
+    async def test_spec_missing_elements_yields_corrective_string(self) -> None:
+        """Missing 'elements' key is another common model mistake.  Loop must
+        feed the corrective string back cleanly.
+        """
+        from tests.agent_harness import (
+            ScriptedStreamFn,
+            run_scenario,
+            text_turn,
+            tool_call_turn,
+        )
+
+        bad_spec = {"root": "page"}  # elements key missing entirely
+
+        script = ScriptedStreamFn([
+            tool_call_turn(
+                ARTIFACT_TOOL_NAME,
+                {"title": "Missing Elements", "spec": bad_spec},
+            ),
+            text_turn("Understood the error."),
+        ])
+
+        events = await run_scenario(script, tools=[make_artifact_tool()])
+
+        tr = next(e for e in events if e["type"] == "tool_result")
+        assert tr["is_error"] is False
+        assert "elements" in tr["content"].lower()

--- a/backend/tests/test_artifact_tool.py
+++ b/backend/tests/test_artifact_tool.py
@@ -1,0 +1,203 @@
+"""Unit tests for the ``render_artifact`` tool + chat-router helper.
+
+Covers the pure-Python wire-shape validator (:func:`build_artifact`),
+the LLM-facing tool wrapper (:func:`make_artifact_tool`), and the
+chat-router helper that emits the sibling ``artifact`` SSE event
+(``_maybe_artifact_event``).  The helper is the load-bearing seam: it is
+what turns a ``tool_use`` from the model into the structured event the
+frontend renders, so its negative paths matter as much as the positive
+one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core.providers.base import StreamEvent
+from app.core.tools.artifact import (
+    ArtifactValidationError,
+    build_artifact,
+    llm_summary_for,
+)
+from app.core.tools.artifact_agent import (
+    ARTIFACT_TOOL_NAME,
+    make_artifact_tool,
+)
+
+
+_VALID_SPEC = {
+    "root": "page",
+    "elements": {
+        "page": {
+            "type": "Page",
+            "props": {"title": "demo", "accent": "cat"},
+            "children": ["heading"],
+        },
+        "heading": {
+            "type": "Heading",
+            "props": {"text": "Hello"},
+            "children": [],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# build_artifact — wire-shape validation
+# ---------------------------------------------------------------------------
+
+
+def test_build_artifact_returns_payload_with_minted_id() -> None:
+    payload = build_artifact(title="Demo", spec=_VALID_SPEC)
+
+    assert payload["title"] == "Demo"
+    assert payload["spec"] is _VALID_SPEC
+    assert payload["id"].startswith("art_")
+    # The id is uuid4 hex truncated to 12 chars; the prefix shouldn't bleed in.
+    assert len(payload["id"]) == 4 + 12  # "art_" + 12 hex chars
+
+
+def test_build_artifact_rejects_blank_title() -> None:
+    with pytest.raises(ArtifactValidationError, match="title"):
+        build_artifact(title="   ", spec=_VALID_SPEC)
+
+
+def test_build_artifact_rejects_overlong_title() -> None:
+    with pytest.raises(ArtifactValidationError, match=r"≤200"):
+        build_artifact(title="x" * 201, spec=_VALID_SPEC)
+
+
+def test_build_artifact_rejects_missing_root() -> None:
+    bad = {"elements": _VALID_SPEC["elements"]}
+    with pytest.raises(ArtifactValidationError, match="root"):
+        build_artifact(title="Demo", spec=bad)
+
+
+def test_build_artifact_rejects_root_pointing_outside_elements() -> None:
+    bad = {"root": "ghost", "elements": _VALID_SPEC["elements"]}
+    with pytest.raises(ArtifactValidationError, match="not present"):
+        build_artifact(title="Demo", spec=bad)
+
+
+def test_build_artifact_rejects_non_string_children() -> None:
+    bad = {
+        "root": "page",
+        "elements": {
+            "page": {
+                "type": "Page",
+                "props": {},
+                "children": [{"not": "a string"}],
+            }
+        },
+    }
+    with pytest.raises(ArtifactValidationError, match="children"):
+        build_artifact(title="Demo", spec=bad)
+
+
+# ---------------------------------------------------------------------------
+# llm_summary_for — what the model sees back
+# ---------------------------------------------------------------------------
+
+
+def test_llm_summary_does_not_echo_spec_back_to_model() -> None:
+    payload = build_artifact(title="My title", spec=_VALID_SPEC)
+    summary = llm_summary_for(payload)
+
+    assert payload["id"] in summary
+    assert payload["title"] in summary
+    # The summary is the on-ramp to the LLM's next turn; including the
+    # spec here would inflate context for no benefit.
+    assert "Heading" not in summary
+    assert "elements" not in summary
+
+
+# ---------------------------------------------------------------------------
+# AgentTool wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_agent_tool_metadata() -> None:
+    tool = make_artifact_tool()
+    assert tool.name == ARTIFACT_TOOL_NAME
+    assert "title" in tool.parameters["required"]
+    assert "spec" in tool.parameters["required"]
+    assert "preview card" in tool.description.lower()
+
+
+def test_agent_tool_execute_returns_summary_on_valid_call() -> None:
+    tool = make_artifact_tool()
+    result = asyncio.run(
+        tool.execute(tool_call_id="t1", title="Demo", spec=_VALID_SPEC)
+    )
+    assert result.startswith("Artifact rendered")
+    assert "art_" in result
+
+
+def test_agent_tool_execute_returns_corrective_string_on_bad_spec() -> None:
+    tool = make_artifact_tool()
+    result = asyncio.run(
+        tool.execute(tool_call_id="t1", title="Demo", spec="not a dict")
+    )
+    # Should be human-readable so the LLM can self-correct, not raise.
+    assert "Error" in result
+    assert "render_artifact again" in result
+
+
+# ---------------------------------------------------------------------------
+# Chat-router helper
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_artifact_event_emits_for_render_artifact_tool_use() -> None:
+    from app.api.chat import _maybe_artifact_event
+
+    event: StreamEvent = {
+        "type": "tool_use",
+        "tool_use_id": "tu_42",
+        "name": ARTIFACT_TOOL_NAME,
+        "input": {"title": "Hello", "spec": _VALID_SPEC},
+    }
+
+    out = _maybe_artifact_event(event)
+    assert out is not None
+    assert out["type"] == "artifact"
+    artifact = out["artifact"]
+    assert artifact["title"] == "Hello"
+    assert artifact["spec"] == _VALID_SPEC
+    assert artifact["id"].startswith("art_")
+    assert artifact["tool_use_id"] == "tu_42"
+
+
+def test_maybe_artifact_event_returns_none_for_other_tools() -> None:
+    from app.api.chat import _maybe_artifact_event
+
+    event: StreamEvent = {
+        "type": "tool_use",
+        "tool_use_id": "tu_1",
+        "name": "exa_search",
+        "input": {"query": "anything"},
+    }
+    assert _maybe_artifact_event(event) is None
+
+
+def test_maybe_artifact_event_returns_none_for_invalid_spec() -> None:
+    from app.api.chat import _maybe_artifact_event
+
+    event: StreamEvent = {
+        "type": "tool_use",
+        "tool_use_id": "tu_1",
+        "name": ARTIFACT_TOOL_NAME,
+        "input": {"title": "", "spec": _VALID_SPEC},
+    }
+    # Bad title — silent None so the agent's own retry loop kicks in via
+    # the tool's error string, instead of half-emitting a broken event.
+    assert _maybe_artifact_event(event) is None
+
+
+def test_maybe_artifact_event_returns_none_for_non_tool_events() -> None:
+    from app.api.chat import _maybe_artifact_event
+
+    delta: StreamEvent = {"type": "delta", "content": "hello"}
+    assert _maybe_artifact_event(delta) is None

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,8 @@
         "@base-ui/react": "^1.1.0",
         "@hugeicons/core-free-icons": "^4.1.2",
         "@hugeicons/react": "^1.1.6",
+        "@json-render/core": "^0.19.0",
+        "@json-render/react": "^0.19.0",
         "@octavian-tocan/react-dropdown": "workspace:*",
         "@octavian-tocan/react-overlay": "^1.7.1",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
@@ -520,9 +522,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, ""],
 
-    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
+    "@json-render/core": ["@json-render/core@0.19.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-vvcyZ+10EDZKbEyB1J2kXOGfDaiZR2LurZGSqi2r5STHyKr+Te85DWaBxTwRGgM7U1LtIvNx85BzzjElRKoAIg=="],
 
     "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
+
+    "@json-render/react": ["@json-render/react@0.19.0", "", { "dependencies": { "@json-render/core": "0.19.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-kTW6b6cSNRrlEfCUf/69SLoLn+CufC968ruge9tnQlp9pDTGG/SK8pgM541FdgwMFA4zm3s5mpM3G8rdODKc/A=="],
 
     "@langchain/core": ["@langchain/core@0.3.80", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": "^0.3.67", "mustache": "^4.2.0", "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^10.0.0", "zod": "^3.25.32", "zod-to-json-schema": "^3.22.3" } }, "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA=="],
 
@@ -3680,6 +3684,8 @@
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "@google/design.md/@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
+
     "@google/design.md/zod": ["zod@3.25.76", "", {}, ""],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, ""],
@@ -3687,6 +3693,8 @@
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@json-render/ink/@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
 
     "@json-render/ink/marked": ["marked@17.0.6", "", { "bin": "bin/marked.js" }, ""],
 
@@ -4621,6 +4629,8 @@
     "@electron/universal/plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "@electron/universal/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "@google/design.md/@json-render/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../features/chat/artifacts/artifact.css";
 
 /* Linked `@octavian-tocan/react-dropdown` resolves here — ensure Tailwind scans it so
    menu primitives (e.g. `disabled:bg-muted/*`) are generated in dev + prod. */

--- a/frontend/features/chat/ChatView.tsx
+++ b/frontend/features/chat/ChatView.tsx
@@ -213,6 +213,7 @@ function ChatView({
 									const isCurrentlyRegenerating = regeneratingIndex === index;
 									return (
 										<AssistantMessage
+											artifacts={chatMessage.artifacts}
 											content={chatMessage.content}
 											isCopied={copiedMessageId === messageId}
 											isFailed={chatMessage.assistant_status === 'failed'}

--- a/frontend/features/chat/artifacts/ArtifactCard.test.tsx
+++ b/frontend/features/chat/artifacts/ArtifactCard.test.tsx
@@ -39,9 +39,7 @@ describe('ArtifactCard', () => {
 	it('renders the title and a button with an accessible name', () => {
 		render(<ArtifactCard artifact={_SAMPLE} />);
 		expect(screen.getByText('A useful comparison')).toBeInTheDocument();
-		expect(
-			screen.getByRole('button', { name: /open artifact/i })
-		).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /open artifact/i })).toBeInTheDocument();
 	});
 
 	it('opens the dialog on click and shows a Close button', () => {

--- a/frontend/features/chat/artifacts/ArtifactCard.test.tsx
+++ b/frontend/features/chat/artifacts/ArtifactCard.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Smoke test for the inline artifact preview card.
+ *
+ * The full json-render pipeline is exercised separately by the dialog tests
+ * (and by visual smoke). Here we only assert that the preview surface
+ * renders the title and announces an "open artifact" button — the bits
+ * that have to be right for the chat row to remain accessible.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatArtifactPayload } from '../types';
+import { ArtifactCard } from './ArtifactCard';
+
+afterEach(cleanup);
+
+const _SAMPLE: ChatArtifactPayload = {
+	id: 'art_test_001',
+	title: 'A useful comparison',
+	tool_use_id: 'tu_1',
+	spec: {
+		root: 'p',
+		elements: {
+			p: {
+				type: 'Page',
+				props: { title: 'demo', accent: 'cat' },
+				children: ['h'],
+			},
+			h: {
+				type: 'Heading',
+				props: { text: 'Hello', level: 'h2' },
+				children: [],
+			},
+		},
+	},
+};
+
+describe('ArtifactCard', () => {
+	it('renders the title and a button with an accessible name', () => {
+		render(<ArtifactCard artifact={_SAMPLE} />);
+		expect(screen.getByText('A useful comparison')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: /open artifact/i })
+		).toBeInTheDocument();
+	});
+
+	it('opens the dialog on click and shows a Close button', () => {
+		render(<ArtifactCard artifact={_SAMPLE} />);
+		fireEvent.click(screen.getByRole('button', { name: /open artifact/i }));
+		// Dialog renders into a portal but still under document.body.
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /close artifact/i })).toBeInTheDocument();
+	});
+});

--- a/frontend/features/chat/artifacts/ArtifactCard.tsx
+++ b/frontend/features/chat/artifacts/ArtifactCard.tsx
@@ -40,9 +40,7 @@ export function ArtifactCard({ artifact }: ArtifactCardProps): ReactNode {
 					<ExpandIcon className="size-4" />
 				</div>
 			</button>
-			{open ? (
-				<ArtifactDialog artifact={artifact} onClose={() => setOpen(false)} />
-			) : null}
+			{open ? <ArtifactDialog artifact={artifact} onClose={() => setOpen(false)} /> : null}
 		</>
 	);
 }

--- a/frontend/features/chat/artifacts/ArtifactCard.tsx
+++ b/frontend/features/chat/artifacts/ArtifactCard.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * Inline preview card for an artifact rendered during the assistant turn.
+ *
+ * Click anywhere on the card → opens an {@link ArtifactDialog} that
+ * renders the full spec with an X close button. The card itself shows
+ * just the title + a tiny "click to expand" affordance, so the chat
+ * scroll stays calm even when the agent ships a large artifact.
+ */
+
+import { ExpandIcon, FileTextIcon } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import type { ChatArtifactPayload } from '../types';
+import { ArtifactDialog } from './ArtifactDialog';
+
+interface ArtifactCardProps {
+	artifact: ChatArtifactPayload;
+}
+
+export function ArtifactCard({ artifact }: ArtifactCardProps): ReactNode {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				className="artifact-preview-card"
+				aria-label={`Open artifact "${artifact.title}"`}
+			>
+				<div className="artifact-preview-card-icon" aria-hidden="true">
+					<FileTextIcon className="size-4" />
+				</div>
+				<div className="artifact-preview-card-body">
+					<div className="artifact-preview-card-title">{artifact.title}</div>
+					<div className="artifact-preview-card-sub">Click to expand</div>
+				</div>
+				<div className="artifact-preview-card-chev" aria-hidden="true">
+					<ExpandIcon className="size-4" />
+				</div>
+			</button>
+			{open ? (
+				<ArtifactDialog artifact={artifact} onClose={() => setOpen(false)} />
+			) : null}
+		</>
+	);
+}

--- a/frontend/features/chat/artifacts/ArtifactDialog.tsx
+++ b/frontend/features/chat/artifacts/ArtifactDialog.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * Full-screen viewer for an expanded artifact.
+ *
+ * @fileoverview Mounted into a portal so the dialog escapes any
+ * containing-block transforms in the chat surface (popovers and the
+ * floating composer use `transform`, which would otherwise re-anchor
+ * the modal). Header carries the artifact title + an X close button;
+ * body renders the full json-render spec.
+ *
+ * Accessibility: traps Escape via the dialog overlay's keydown handler,
+ * focuses the close button on mount, and dimming the page background.
+ * No focus-trap library — this is a single-action modal, the close
+ * button is the only interactive element after mount unless the spec
+ * itself contains buttons.
+ */
+
+import { XIcon } from 'lucide-react';
+import { type ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import type { ChatArtifactPayload } from '../types';
+import { ArtifactRenderer } from './ArtifactRenderer';
+
+interface ArtifactDialogProps {
+	artifact: ChatArtifactPayload;
+	onClose: () => void;
+}
+
+export function ArtifactDialog({ artifact, onClose }: ArtifactDialogProps): ReactNode {
+	const closeRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		window.addEventListener('keydown', handleKey);
+		closeRef.current?.focus();
+		// Lock body scroll while the dialog is open.
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			window.removeEventListener('keydown', handleKey);
+			document.body.style.overflow = previousOverflow;
+		};
+	}, [onClose]);
+
+	return createPortal(
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label={artifact.title}
+			className="artifact-dialog-overlay"
+			onClick={(e) => {
+				// Click on the overlay (but not bubbled from the inner dialog)
+				// closes — same affordance most chat-app modals use.
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div className="artifact-dialog">
+				<header className="artifact-dialog-header">
+					<h2 className="artifact-dialog-title">{artifact.title}</h2>
+					<button
+						type="button"
+						ref={closeRef}
+						onClick={onClose}
+						aria-label="Close artifact"
+						className="artifact-dialog-close"
+					>
+						<XIcon className="size-4" />
+					</button>
+				</header>
+				<div className="artifact-dialog-body">
+					<ArtifactRenderer artifact={artifact} />
+				</div>
+			</div>
+		</div>,
+		document.body
+	);
+}

--- a/frontend/features/chat/artifacts/ArtifactRenderer.tsx
+++ b/frontend/features/chat/artifacts/ArtifactRenderer.tsx
@@ -8,7 +8,7 @@
  * provider plumbing so callers don't repeat them.
  */
 
-import { JSONUIProvider, Renderer, defineRegistry } from '@json-render/react';
+import { defineRegistry, JSONUIProvider, Renderer } from '@json-render/react';
 import type { ReactNode } from 'react';
 import type { ChatArtifactPayload } from '../types';
 import { artifactCatalog } from './catalog';

--- a/frontend/features/chat/artifacts/ArtifactRenderer.tsx
+++ b/frontend/features/chat/artifacts/ArtifactRenderer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+/**
+ * Wraps json-render's `<Renderer>` with the Pawrrtal catalog + providers.
+ *
+ * @fileoverview Used by both `<ArtifactCard>` (in-line preview) and
+ * `<ArtifactDialog>` (full-screen viewer). Encapsulates the registry +
+ * provider plumbing so callers don't repeat them.
+ */
+
+import { JSONUIProvider, Renderer, defineRegistry } from '@json-render/react';
+import type { ReactNode } from 'react';
+import type { ChatArtifactPayload } from '../types';
+import { artifactCatalog } from './catalog';
+import { artifactComponents } from './components';
+
+// Registry creation is module-level: the catalog + components are static so
+// rebuilding the registry on every render would be pure waste.
+const { registry } = defineRegistry(artifactCatalog, { components: artifactComponents });
+
+interface ArtifactRendererProps {
+	artifact: ChatArtifactPayload;
+}
+
+export function ArtifactRenderer({ artifact }: ArtifactRendererProps): ReactNode {
+	return (
+		<JSONUIProvider registry={registry}>
+			<Renderer spec={artifact.spec} registry={registry} />
+		</JSONUIProvider>
+	);
+}

--- a/frontend/features/chat/artifacts/ArtifactRenderer.tsx
+++ b/frontend/features/chat/artifacts/ArtifactRenderer.tsx
@@ -8,6 +8,7 @@
  * provider plumbing so callers don't repeat them.
  */
 
+import type { Components, Spec } from '@json-render/react';
 import { defineRegistry, JSONUIProvider, Renderer } from '@json-render/react';
 import type { ReactNode } from 'react';
 import type { ChatArtifactPayload } from '../types';
@@ -16,7 +17,11 @@ import { artifactComponents } from './components';
 
 // Registry creation is module-level: the catalog + components are static so
 // rebuilding the registry on every render would be pure waste.
-const { registry } = defineRegistry(artifactCatalog, { components: artifactComponents });
+// artifactComponents uses BaseComponentProps<any> for loose typing; cast to
+// Components<...> here — json-render validates props against catalog schemas.
+const { registry } = defineRegistry(artifactCatalog, {
+	components: artifactComponents as unknown as Components<typeof artifactCatalog>,
+});
 
 interface ArtifactRendererProps {
 	artifact: ChatArtifactPayload;
@@ -25,7 +30,9 @@ interface ArtifactRendererProps {
 export function ArtifactRenderer({ artifact }: ArtifactRendererProps): ReactNode {
 	return (
 		<JSONUIProvider registry={registry}>
-			<Renderer spec={artifact.spec} registry={registry} />
+			{/* Cast because our ChatArtifactPayload.spec has optional props fields;
+			    json-render validates the spec at runtime before rendering. */}
+			<Renderer spec={artifact.spec as unknown as Spec} registry={registry} />
 		</JSONUIProvider>
 	);
 }

--- a/frontend/features/chat/artifacts/artifact.css
+++ b/frontend/features/chat/artifacts/artifact.css
@@ -1,0 +1,420 @@
+/* Pawrrtal artifact chrome — preview card, dialog, and json-render
+ * component styling. Imported once from globals.css; not a tailwind
+ * layer because the chrome is too specific to be useful as utilities. */
+
+/* ─── Preview card (inline in chat) ─────────────────────────────────── */
+.artifact-preview-card {
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+	max-width: 480px;
+	padding: 10px 14px;
+	border-radius: 14px;
+	border: 1px solid var(--border);
+	background: var(--background-elevated, var(--background));
+	cursor: pointer;
+	text-align: left;
+	transition: background 0.15s ease, transform 0.15s ease;
+}
+.artifact-preview-card:hover {
+	background: var(--foreground-5);
+	transform: translateY(-1px);
+}
+.artifact-preview-card-icon {
+	width: 32px;
+	height: 32px;
+	border-radius: 10px;
+	display: grid;
+	place-items: center;
+	background: var(--foreground-5);
+	color: var(--foreground);
+}
+.artifact-preview-card-title {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--foreground);
+}
+.artifact-preview-card-sub {
+	font-size: 12px;
+	color: var(--muted-foreground);
+}
+.artifact-preview-card-chev {
+	color: var(--muted-foreground);
+}
+
+/* ─── Dialog overlay + frame ─────────────────────────────────────────── */
+.artifact-dialog-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 60;
+	display: grid;
+	place-items: center;
+	background: rgba(0, 0, 0, 0.55);
+	backdrop-filter: blur(2px);
+	padding: 24px;
+}
+.artifact-dialog {
+	display: flex;
+	flex-direction: column;
+	width: min(960px, 100%);
+	max-height: min(85vh, 900px);
+	background: var(--background);
+	border: 1px solid var(--border);
+	border-radius: 18px;
+	box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.5);
+	overflow: hidden;
+}
+.artifact-dialog-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--border);
+}
+.artifact-dialog-title {
+	flex: 1;
+	margin: 0;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--foreground);
+}
+.artifact-dialog-close {
+	width: 32px;
+	height: 32px;
+	border-radius: 8px;
+	display: grid;
+	place-items: center;
+	background: transparent;
+	color: var(--muted-foreground);
+	cursor: pointer;
+	transition: background 0.15s ease, color 0.15s ease;
+}
+.artifact-dialog-close:hover {
+	background: var(--foreground-5);
+	color: var(--foreground);
+}
+.artifact-dialog-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 24px 28px 32px;
+}
+
+/* ─── json-render component palette ──────────────────────────────────── */
+.artifact-page {
+	--a1: #ff7eb8;
+	--a2: #b388ff;
+	--ink-on-accent: #1a0c20;
+}
+.artifact-page.theme-cobalt {
+	--a1: #7ec8ff;
+	--a2: #5d63ff;
+	--ink-on-accent: #0a1024;
+}
+.artifact-page.theme-forest {
+	--a1: #7be29a;
+	--a2: #3aa56b;
+	--ink-on-accent: #08200d;
+}
+.artifact-page.theme-vite {
+	--a1: #ff7a59;
+	--a2: #ffb547;
+	--ink-on-accent: #1a1300;
+}
+
+.artifact-page > * + * {
+	margin-top: 24px;
+}
+.artifact-section h2 {
+	font-size: 20px;
+	margin: 0 0 4px;
+}
+.artifact-lede {
+	color: var(--muted-foreground);
+	margin: 0 0 14px;
+	font-size: 14px;
+}
+.artifact-section-body > * + * {
+	margin-top: 14px;
+}
+.artifact-heading-h1 {
+	font-size: 28px;
+	margin: 0 0 8px;
+}
+.artifact-heading-h2 {
+	font-size: 20px;
+	margin: 0 0 6px;
+}
+.artifact-heading-h3 {
+	font-size: 16px;
+	margin: 0 0 4px;
+}
+.artifact-paragraph {
+	margin: 0;
+	font-size: 14px;
+	color: var(--foreground);
+}
+
+/* Stat pills */
+.artifact-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: rgba(0, 0, 0, 0.78);
+	color: var(--a2);
+	border-radius: 999px;
+	padding: 6px 12px;
+	font-size: 13px;
+	font-weight: 600;
+	margin-right: 6px;
+}
+.artifact-pill-num {
+	color: #fff;
+	font-weight: 800;
+}
+
+/* Card row */
+.artifact-cards {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 12px;
+}
+.artifact-card {
+	background: var(--background-elevated, var(--background));
+	border: 1px solid var(--border);
+	border-radius: 14px;
+	padding: 14px;
+}
+.artifact-card-icon {
+	font-size: 24px;
+	line-height: 1;
+	margin-bottom: 6px;
+}
+.artifact-card h3 {
+	margin: 0 0 4px;
+	font-size: 14px;
+}
+.artifact-card p {
+	margin: 0;
+	font-size: 13px;
+	color: var(--muted-foreground);
+}
+@media (max-width: 720px) {
+	.artifact-cards {
+		grid-template-columns: 1fr;
+	}
+}
+
+/* Before/after rename */
+.artifact-rename {
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	align-items: center;
+	gap: 16px;
+}
+.artifact-name-card {
+	border-radius: 16px;
+	padding: 22px 18px;
+	text-align: center;
+	border: 1px solid var(--border);
+}
+.artifact-name-card.before {
+	opacity: 0.85;
+}
+.artifact-name-card.after {
+	border-color: var(--a2);
+}
+.artifact-name-card-label {
+	font-size: 11px;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--muted-foreground);
+	font-weight: 700;
+}
+.artifact-name-card-name {
+	font-size: 32px;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+	margin-top: 6px;
+}
+.artifact-name-card.after .artifact-name-card-name {
+	background: linear-gradient(135deg, var(--a1), var(--a2));
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+}
+.artifact-rename-arrow {
+	font-size: 28px;
+	color: var(--a2);
+	font-weight: 700;
+}
+
+/* Column lists */
+.artifact-col {
+	background: var(--background-elevated, var(--background));
+	border: 1px solid var(--border);
+	border-radius: 16px;
+	padding: 16px;
+}
+.artifact-col-title {
+	margin: 0 0 8px;
+	font-size: 14px;
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+.artifact-col ul {
+	margin: 0;
+	padding-left: 18px;
+}
+.artifact-col li {
+	margin: 2px 0;
+	font-size: 13px;
+}
+.artifact-tag {
+	font-size: 10px;
+	padding: 2px 7px;
+	border-radius: 5px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+.artifact-tag-after {
+	background: var(--a2);
+	color: var(--ink-on-accent);
+}
+.artifact-tag-before {
+	background: #ff6b88;
+	color: #2a0a14;
+}
+
+/* Buckets */
+.artifact-buckets {
+	display: grid;
+	gap: 10px;
+}
+.artifact-bucket {
+	background: var(--background-elevated, var(--background));
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 12px 16px;
+}
+.artifact-bucket-head {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+.artifact-bucket-num {
+	width: 28px;
+	height: 28px;
+	border-radius: 8px;
+	background: var(--a2);
+	color: var(--ink-on-accent);
+	display: grid;
+	place-items: center;
+	font-weight: 800;
+	flex-shrink: 0;
+}
+.artifact-bucket-title {
+	margin: 0;
+	font-size: 15px;
+}
+.artifact-bucket-where {
+	margin-left: auto;
+	color: var(--muted-foreground);
+	font-size: 12px;
+}
+.artifact-bucket-body {
+	padding: 8px 0 0 40px;
+	color: var(--muted-foreground);
+	font-size: 13px;
+}
+
+/* Routes table */
+.artifact-routes {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	overflow: hidden;
+}
+.artifact-routes th,
+.artifact-routes td {
+	padding: 9px 12px;
+	text-align: left;
+}
+.artifact-routes th {
+	background: var(--foreground-5);
+	color: var(--muted-foreground);
+	font-weight: 600;
+	text-transform: uppercase;
+	font-size: 10px;
+	letter-spacing: 0.12em;
+}
+.artifact-routes tr + tr td {
+	border-top: 1px dashed var(--border);
+}
+
+/* Risks */
+.artifact-risks {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+}
+.artifact-risk {
+	border-radius: 12px;
+	padding: 12px 14px;
+	border-left: 3px solid #ff6b88;
+	background: var(--background-elevated, var(--background));
+}
+.artifact-risk-ok {
+	border-left-color: #6ee7a4;
+}
+.artifact-risk-warn {
+	border-left-color: #ffd166;
+}
+.artifact-risk h4 {
+	margin: 0 0 4px;
+	font-size: 13px;
+}
+.artifact-risk p {
+	margin: 0;
+	color: var(--muted-foreground);
+	font-size: 12.5px;
+}
+
+/* Steps */
+.artifact-steps {
+	counter-reset: step;
+	padding-left: 0;
+	list-style: none;
+	margin: 0;
+}
+.artifact-steps li {
+	counter-increment: step;
+	padding: 12px 16px 12px 50px;
+	position: relative;
+	background: var(--background-elevated, var(--background));
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	margin-bottom: 8px;
+	font-size: 13px;
+}
+.artifact-steps li::before {
+	content: counter(step);
+	position: absolute;
+	left: 12px;
+	top: 12px;
+	width: 24px;
+	height: 24px;
+	border-radius: 7px;
+	background: linear-gradient(135deg, var(--a1), var(--a2));
+	color: var(--ink-on-accent);
+	font-weight: 800;
+	display: grid;
+	place-items: center;
+	font-size: 12px;
+}

--- a/frontend/features/chat/artifacts/artifact.css
+++ b/frontend/features/chat/artifacts/artifact.css
@@ -16,7 +16,9 @@
 	background: var(--background-elevated, var(--background));
 	cursor: pointer;
 	text-align: left;
-	transition: background 0.15s ease, transform 0.15s ease;
+	transition:
+		background 0.15s ease,
+		transform 0.15s ease;
 }
 .artifact-preview-card:hover {
 	background: var(--foreground-5);
@@ -89,7 +91,9 @@
 	background: transparent;
 	color: var(--muted-foreground);
 	cursor: pointer;
-	transition: background 0.15s ease, color 0.15s ease;
+	transition:
+		background 0.15s ease,
+		color 0.15s ease;
 }
 .artifact-dialog-close:hover {
 	background: var(--foreground-5);

--- a/frontend/features/chat/artifacts/catalog.ts
+++ b/frontend/features/chat/artifacts/catalog.ts
@@ -19,6 +19,7 @@ import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 export const artifactCatalog = defineCatalog(schema, {
+	actions: {},
 	components: {
 		// ─── Layout ────────────────────────────────────────────────────────
 		Page: {

--- a/frontend/features/chat/artifacts/catalog.ts
+++ b/frontend/features/chat/artifacts/catalog.ts
@@ -63,8 +63,7 @@ export const artifactCatalog = defineCatalog(schema, {
 				value: z.string(),
 				label: z.string(),
 			}),
-			description:
-				'Number + label chip. Use inside a Hero or stand-alone for a stat-row.',
+			description: 'Number + label chip. Use inside a Hero or stand-alone for a stat-row.',
 		},
 		CardRow: {
 			props: z.object({

--- a/frontend/features/chat/artifacts/catalog.ts
+++ b/frontend/features/chat/artifacts/catalog.ts
@@ -1,0 +1,151 @@
+/**
+ * Pawrrtal artifact catalog — the safe component vocabulary the agent is
+ * allowed to compose into. The agent emits a json-render flat-spec; the
+ * catalog enumerated here is what actually renders.
+ *
+ * @fileoverview This file is the **single source of truth** for which
+ * components an artifact can use. Adding a new component means:
+ *  1. add a `z.object({...})` schema entry here,
+ *  2. add a matching React renderer in {@link ./components},
+ *  3. (optional) add styling tokens to {@link ./artifact.css}.
+ *
+ * The descriptions are model-facing — the LLM reads them when deciding
+ * which component to use, so write them like a copywriter for an API
+ * reference, not like internal code comments.
+ */
+
+import { defineCatalog } from '@json-render/core';
+import { schema } from '@json-render/react/schema';
+import { z } from 'zod';
+
+export const artifactCatalog = defineCatalog(schema, {
+	components: {
+		// ─── Layout ────────────────────────────────────────────────────────
+		Page: {
+			props: z.object({
+				title: z.string(),
+				accent: z
+					.enum(['cat', 'cobalt', 'forest', 'vite'])
+					.nullable()
+					.describe(
+						'Theme palette. cat = pink/purple, cobalt = blue, forest = green, vite = orange/yellow.'
+					),
+			}),
+			description:
+				'Top-level container. One per artifact. Always the root element of the spec.',
+		},
+		Section: {
+			props: z.object({
+				title: z.string(),
+				lede: z.string().nullable(),
+			}),
+			description: 'Titled section with optional sub-headline.',
+		},
+
+		// ─── Headings & prose ─────────────────────────────────────────────
+		Heading: {
+			props: z.object({
+				text: z.string(),
+				level: z.enum(['h1', 'h2', 'h3']).nullable(),
+			}),
+			description: 'Standalone heading. Default level is h2.',
+		},
+		Paragraph: {
+			props: z.object({
+				text: z.string(),
+			}),
+			description: 'Body paragraph. Plain text only — no inline markdown.',
+		},
+
+		// ─── Stat & summary ───────────────────────────────────────────────
+		StatPill: {
+			props: z.object({
+				value: z.string(),
+				label: z.string(),
+			}),
+			description:
+				'Number + label chip. Use inside a Hero or stand-alone for a stat-row.',
+		},
+		CardRow: {
+			props: z.object({
+				cards: z.array(
+					z.object({
+						icon: z.string().describe('Single emoji to anchor the card.'),
+						title: z.string(),
+						body: z.string(),
+					})
+				),
+			}),
+			description: 'Three-up summary card row.',
+		},
+
+		// ─── Comparison ───────────────────────────────────────────────────
+		BeforeAfter: {
+			props: z.object({
+				before: z.string(),
+				after: z.string(),
+			}),
+			description: 'Two big labels with a → between them. Use for renames or migrations.',
+		},
+		ColumnList: {
+			props: z.object({
+				title: z.string(),
+				kind: z.enum(['before', 'after']),
+				items: z.array(z.string()),
+			}),
+			description: 'Before/after column list. Pair two of them inside a Section.',
+		},
+
+		// ─── Numbered explanations ────────────────────────────────────────
+		BucketList: {
+			props: z.object({}),
+			description: 'Container for numbered Bucket items.',
+		},
+		Bucket: {
+			props: z.object({
+				index: z.number(),
+				title: z.string(),
+				where: z.string().nullable(),
+				body: z.string(),
+			}),
+			description: 'One numbered explanation row.',
+		},
+
+		// ─── Two-column code-mapping table ────────────────────────────────
+		RouteTable: {
+			props: z.object({
+				headerLeft: z.string(),
+				headerRight: z.string(),
+				rows: z.array(
+					z.object({
+						from: z.string(),
+						to: z.string(),
+					})
+				),
+			}),
+			description: 'Two-column code/path mapping table.',
+		},
+
+		// ─── Risk cards ───────────────────────────────────────────────────
+		RiskGrid: {
+			props: z.object({
+				items: z.array(
+					z.object({
+						kind: z.enum(['ok', 'warn', 'bad']),
+						title: z.string(),
+						body: z.string(),
+					})
+				),
+			}),
+			description: 'Two-up grid of status cards (verified / unverified / risky).',
+		},
+
+		// ─── Numbered checklist ───────────────────────────────────────────
+		Steps: {
+			props: z.object({
+				items: z.array(z.object({ body: z.string() })),
+			}),
+			description: 'Numbered ordered-list of steps the user should take.',
+		},
+	},
+});

--- a/frontend/features/chat/artifacts/components.tsx
+++ b/frontend/features/chat/artifacts/components.tsx
@@ -1,0 +1,150 @@
+/**
+ * React renderers for the Pawrrtal artifact catalog.
+ *
+ * @fileoverview Each renderer corresponds 1:1 to an entry in
+ * {@link ./catalog}. Renderers receive `{ props, children }` from
+ * json-render and stay deliberately small — styling lives in the global
+ * artifact stylesheet, not inline.
+ */
+
+import type { ComponentRenderProps } from '@json-render/react';
+import type { ReactNode } from 'react';
+
+const cls = (...names: (string | false | undefined | null)[]) =>
+	names.filter(Boolean).join(' ');
+
+type RendererMap = {
+	[name: string]: (
+		// We accept loose props here because the runtime catalog is the source
+		// of truth — json-render validates against the zod schemas before this
+		// renderer ever runs. Using `any` lets us write tight per-component
+		// destructuring without juggling generic type parameters.
+		// biome-ignore lint/suspicious/noExplicitAny: see comment above
+		props: ComponentRenderProps<any>
+	) => ReactNode;
+};
+
+export const artifactComponents: RendererMap = {
+	Page: ({ props, children }) => (
+		<div className={cls('artifact-page', `theme-${props.accent ?? 'cat'}`)}>{children}</div>
+	),
+
+	Section: ({ props, children }) => (
+		<section className="artifact-section">
+			<h2>{props.title}</h2>
+			{props.lede ? <p className="artifact-lede">{props.lede}</p> : null}
+			<div className="artifact-section-body">{children}</div>
+		</section>
+	),
+
+	Heading: ({ props }) => {
+		const Tag = (props.level ?? 'h2') as 'h1' | 'h2' | 'h3';
+		return <Tag className={`artifact-heading artifact-heading-${Tag}`}>{props.text}</Tag>;
+	},
+
+	Paragraph: ({ props }) => <p className="artifact-paragraph">{props.text}</p>,
+
+	StatPill: ({ props }) => (
+		<div className="artifact-pill">
+			<span className="artifact-pill-num">{props.value}</span>
+			<span className="artifact-pill-label">{props.label}</span>
+		</div>
+	),
+
+	CardRow: ({ props }) => (
+		<div className="artifact-cards">
+			{props.cards.map((c: { icon: string; title: string; body: string }, i: number) => (
+				<div className="artifact-card" key={i}>
+					<div className="artifact-card-icon">{c.icon}</div>
+					<h3>{c.title}</h3>
+					<p>{c.body}</p>
+				</div>
+			))}
+		</div>
+	),
+
+	BeforeAfter: ({ props }) => (
+		<div className="artifact-rename">
+			<div className="artifact-name-card before">
+				<div className="artifact-name-card-label">before</div>
+				<div className="artifact-name-card-name">{props.before}</div>
+			</div>
+			<div className="artifact-rename-arrow">→</div>
+			<div className="artifact-name-card after">
+				<div className="artifact-name-card-label">after</div>
+				<div className="artifact-name-card-name">{props.after}</div>
+			</div>
+		</div>
+	),
+
+	ColumnList: ({ props }) => (
+		<div className={cls('artifact-col', `artifact-col-${props.kind}`)}>
+			<h3 className="artifact-col-title">
+				<span className={cls('artifact-tag', `artifact-tag-${props.kind}`)}>{props.kind}</span>{' '}
+				{props.title}
+			</h3>
+			<ul>
+				{props.items.map((it: string, i: number) => (
+					<li key={i}>{it}</li>
+				))}
+			</ul>
+		</div>
+	),
+
+	BucketList: ({ children }) => <div className="artifact-buckets">{children}</div>,
+
+	Bucket: ({ props }) => (
+		<div className="artifact-bucket">
+			<div className="artifact-bucket-head">
+				<div className="artifact-bucket-num">{props.index}</div>
+				<h3 className="artifact-bucket-title">{props.title}</h3>
+				{props.where ? <span className="artifact-bucket-where">{props.where}</span> : null}
+			</div>
+			<div className="artifact-bucket-body">{props.body}</div>
+		</div>
+	),
+
+	RouteTable: ({ props }) => (
+		<table className="artifact-routes">
+			<thead>
+				<tr>
+					<th>{props.headerLeft}</th>
+					<th>{props.headerRight}</th>
+				</tr>
+			</thead>
+			<tbody>
+				{props.rows.map((r: { from: string; to: string }, i: number) => (
+					<tr key={i}>
+						<td>
+							<code>{r.from}</code>
+						</td>
+						<td>
+							<code>{r.to}</code>
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	),
+
+	RiskGrid: ({ props }) => (
+		<div className="artifact-risks">
+			{props.items.map(
+				(it: { kind: 'ok' | 'warn' | 'bad'; title: string; body: string }, i: number) => (
+					<div className={cls('artifact-risk', `artifact-risk-${it.kind}`)} key={i}>
+						<h4>{it.title}</h4>
+						<p>{it.body}</p>
+					</div>
+				)
+			)}
+		</div>
+	),
+
+	Steps: ({ props }) => (
+		<ol className="artifact-steps">
+			{props.items.map((s: { body: string }, i: number) => (
+				<li key={i}>{s.body}</li>
+			))}
+		</ol>
+	),
+};

--- a/frontend/features/chat/artifacts/components.tsx
+++ b/frontend/features/chat/artifacts/components.tsx
@@ -10,8 +10,7 @@
 import type { ComponentRenderProps } from '@json-render/react';
 import type { ReactNode } from 'react';
 
-const cls = (...names: (string | false | undefined | null)[]) =>
-	names.filter(Boolean).join(' ');
+const cls = (...names: (string | false | undefined | null)[]) => names.filter(Boolean).join(' ');
 
 type RendererMap = {
 	[name: string]: (
@@ -80,7 +79,9 @@ export const artifactComponents: RendererMap = {
 	ColumnList: ({ props }) => (
 		<div className={cls('artifact-col', `artifact-col-${props.kind}`)}>
 			<h3 className="artifact-col-title">
-				<span className={cls('artifact-tag', `artifact-tag-${props.kind}`)}>{props.kind}</span>{' '}
+				<span className={cls('artifact-tag', `artifact-tag-${props.kind}`)}>
+					{props.kind}
+				</span>{' '}
 				{props.title}
 			</h3>
 			<ul>

--- a/frontend/features/chat/artifacts/components.tsx
+++ b/frontend/features/chat/artifacts/components.tsx
@@ -7,7 +7,7 @@
  * artifact stylesheet, not inline.
  */
 
-import type { ComponentRenderProps } from '@json-render/react';
+import type { BaseComponentProps } from '@json-render/react';
 import type { ReactNode } from 'react';
 
 const cls = (...names: (string | false | undefined | null)[]) => names.filter(Boolean).join(' ');
@@ -19,10 +19,13 @@ type RendererMap = {
 		// renderer ever runs. Using `any` lets us write tight per-component
 		// destructuring without juggling generic type parameters.
 		// biome-ignore lint/suspicious/noExplicitAny: see comment above
-		props: ComponentRenderProps<any>
+		props: BaseComponentProps<any>
 	) => ReactNode;
 };
 
+// Explicit type: each renderer accepts BaseComponentProps<any> so `props` and
+// `children` are available. The cast in ArtifactRenderer.tsx bridges this to
+// Components<typeof artifactCatalog> at the defineRegistry call-site.
 export const artifactComponents: RendererMap = {
 	Page: ({ props, children }) => (
 		<div className={cls('artifact-page', `theme-${props.accent ?? 'cat'}`)}>{children}</div>

--- a/frontend/features/chat/artifacts/index.ts
+++ b/frontend/features/chat/artifacts/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public surface of the chat-artifact subsystem.
+ *
+ * @fileoverview The chat assistant message imports `<ArtifactCard>` to
+ * render preview chips inline. The card opens its own `<ArtifactDialog>`
+ * on click, so the dialog does not need to be re-exported here.
+ */
+
+export { ArtifactCard } from './ArtifactCard';

--- a/frontend/features/chat/chat-reducer.test.ts
+++ b/frontend/features/chat/chat-reducer.test.ts
@@ -76,6 +76,36 @@ describe('applyChatEvent', () => {
 		expect(msg.tool_calls?.[0]?.result).toBe('[]');
 	});
 
+	it('appends artifact payloads in arrival order', () => {
+		let msg = blankAssistant();
+		msg = applyChatEvent(msg, {
+			type: 'artifact',
+			artifact: {
+				id: 'art_aaa',
+				title: 'First',
+				tool_use_id: 't1',
+				spec: {
+					root: 'p',
+					elements: { p: { type: 'Page', props: {}, children: [] } },
+				},
+			},
+		});
+		msg = applyChatEvent(msg, {
+			type: 'artifact',
+			artifact: {
+				id: 'art_bbb',
+				title: 'Second',
+				tool_use_id: 't2',
+				spec: {
+					root: 'p',
+					elements: { p: { type: 'Page', props: {}, children: [] } },
+				},
+			},
+		});
+		expect(msg.artifacts?.map((a) => a.id)).toEqual(['art_aaa', 'art_bbb']);
+		expect(msg.artifacts?.[1]?.title).toBe('Second');
+	});
+
 	it('marks the message failed on an error event', () => {
 		const msg = applyChatEvent(blankAssistant(), {
 			type: 'error',

--- a/frontend/features/chat/chat-reducer.ts
+++ b/frontend/features/chat/chat-reducer.ts
@@ -132,7 +132,7 @@ export function applyChatEvent(message: AgnoMessage, event: ChatStreamEvent): Ag
 			// the message complete so it doesn’t linger in a streaming state.
 			return {
 				...message,
-				content: (message.content ? `${message.content}\n\n` : '') + `⚠️ ${event.content}`,
+				content: `${message.content ? `${message.content}\n\n` : ''}⚠️ ${event.content}`,
 				assistant_status: 'complete',
 			};
 		default:

--- a/frontend/features/chat/chat-reducer.ts
+++ b/frontend/features/chat/chat-reducer.ts
@@ -109,6 +109,19 @@ export function applyChatEvent(message: AgnoMessage, event: ChatStreamEvent): Ag
 			);
 			return { ...message, tool_calls: updated };
 		}
+		case 'artifact': {
+			// The matching `tool_use` for `render_artifact` arrives just
+			// before this event and is already in `tool_calls` — we keep
+			// the artifact as a separate first-class field rather than
+			// stuffing it into the tool-call slot, so the renderer can
+			// treat artifacts as their own surface (preview card +
+			// expandable dialog) without picking apart tool metadata.
+			const stamped = markStartedAt(message);
+			return {
+				...stamped,
+				artifacts: [...(stamped.artifacts ?? []), event.artifact],
+			};
+		}
 		case 'error':
 			// Should be unreachable — the transport surfaces errors by throwing.
 			return { ...message, content: `Error: ${event.content}`, assistant_status: 'failed' };

--- a/frontend/features/chat/components/AssistantMessage.tsx
+++ b/frontend/features/chat/components/AssistantMessage.tsx
@@ -8,8 +8,9 @@ import { AgentSpinner } from '@/components/ui/agent-spinner';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
+import { ArtifactCard } from '../artifacts';
 import { extractToolChips, type ToolResultChips } from '../tool-result-parsers';
-import type { ChatTimelineEntry, ChatToolCall } from '../types';
+import type { ChatArtifactPayload, ChatTimelineEntry, ChatToolCall } from '../types';
 import { ChainOfThought } from './ChainOfThought';
 import { ReplyActionsRow } from './ReplyActionsRow';
 import { ThinkingHeader } from './ThinkingHeader';
@@ -40,6 +41,8 @@ interface AssistantMessageProps {
 	onRegenerate?: () => void;
 	/** Whether a regeneration request is currently in flight for this row. */
 	isRegenerating?: boolean;
+	/** Artifacts the agent rendered during this turn (preview cards). */
+	artifacts?: ChatArtifactPayload[];
 }
 
 /** Default state for messages without any chip data. */
@@ -178,6 +181,7 @@ export function AssistantMessage({
 	onCopy,
 	onRegenerate,
 	isRegenerating,
+	artifacts,
 }: AssistantMessageProps): ReactNode {
 	const hasContent = content.length > 0;
 	const hasThinking = Boolean(thinking && thinking.length > 0);
@@ -241,6 +245,14 @@ export function AssistantMessage({
 				) : null}
 
 				{hasContent && !isFailed ? <MessageResponse>{content}</MessageResponse> : null}
+
+				{artifacts && artifacts.length > 0 ? (
+					<div className="mt-3 flex flex-col gap-2">
+						{artifacts.map((a) => (
+							<ArtifactCard artifact={a} key={a.id} />
+						))}
+					</div>
+				) : null}
 
 				{showActions ? (
 					<ReplyActionsRow

--- a/frontend/features/chat/hooks/use-chat.ts
+++ b/frontend/features/chat/hooks/use-chat.ts
@@ -20,6 +20,7 @@ const CHAT_EVENT_TYPES = [
 	'thinking',
 	'tool_use',
 	'tool_result',
+	'artifact',
 	'error',
 	'agent_terminated',
 ] as const;

--- a/frontend/features/chat/types.ts
+++ b/frontend/features/chat/types.ts
@@ -58,12 +58,48 @@ export interface ChatAgentTerminatedEvent {
 	content: string;
 }
 
+/**
+ * Structured `render_artifact` payload — emitted as a sibling of the
+ * matching `tool_use` so the frontend can render an inline preview card
+ * without round-tripping the spec back through the LLM. The catalog of
+ * allowed component `type` strings is enforced inside the renderer
+ * (see {@link ./artifacts/components}); unknown names render a
+ * fallback placeholder rather than the model's free text.
+ */
+export interface ChatArtifactPayload {
+	/** Server-minted id, e.g. `art_3f9b2e1a8c01`. */
+	id: string;
+	/** Short label shown on the preview card and dialog header. */
+	title: string;
+	/** json-render flat-spec object — `{ root, elements }`. */
+	spec: {
+		root: string;
+		elements: Record<
+			string,
+			{
+				type: string;
+				props?: Record<string, unknown>;
+				children?: string[];
+			}
+		>;
+	};
+	/** The originating tool_use_id; useful for correlating with chain-of-thought. */
+	tool_use_id: string;
+}
+
+/** Sibling event emitted whenever the agent calls `render_artifact`. */
+export interface ChatArtifactEvent {
+	type: 'artifact';
+	artifact: ChatArtifactPayload;
+}
+
 /** Discriminated union of every event the backend chat stream can emit. */
 export type ChatStreamEvent =
 	| ChatDeltaEvent
 	| ChatThinkingEvent
 	| ChatToolUseEvent
 	| ChatToolResultEvent
+	| ChatArtifactEvent
 	| ChatErrorEvent
 	| ChatAgentTerminatedEvent;
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -121,4 +121,9 @@ export interface AgnoMessage {
 	thinking_duration_seconds?: number;
 	/** Lifecycle of the assistant turn — drives the failed-state UI. */
 	assistant_status?: import('@/features/chat/types').AssistantMessageStatus;
+	/**
+	 * Artifacts the agent rendered during this turn (one per `render_artifact`
+	 * tool call). v0 lives on the in-memory message only — reload drops them.
+	 */
+	artifacts?: import('@/features/chat/types').ChatArtifactPayload[];
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,8 @@
 		"nanoid": "^5.1.6",
 		"next": "16.2.6",
 		"radix-ui": "^1.4.3",
+		"@json-render/core": "^0.19.0",
+		"@json-render/react": "^0.19.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6",
 		"react-grab": "^0.1.33",


### PR DESCRIPTION
## What this is

First attempt at giving the agent a way to ship structured **artifacts** to the user — preview cards inline in chat that expand into a full-screen viewer with an X close button. Inspired by Claude artifacts / ChatGPT canvas, but **guardrailed by a server-defined component catalog** (json-render) instead of letting the model emit arbitrary HTML/JS.

## How it works

1. Agent calls a new tool: ```render_artifact(title, spec)``` where ```spec``` is a json-render flat-spec object.
2. Chat router lifts ```title``` + ```spec``` out of the model'''s tool-use args and emits a sibling ```{"type":"artifact", "artifact": {id, title, spec, tool_use_id}}``` SSE frame.
3. Tool'''s **textual return** to the LLM is just "Artifact rendered. id=art_xxx title=..." — the spec does NOT echo back next turn (would inflate context).
4. Frontend reducer attaches each artifact to the in-flight assistant message; ```<AssistantMessage>``` renders an ```<ArtifactCard>``` per artifact below the response body. Click → portal-mounted ```<ArtifactDialog>``` with X / Escape / overlay-click to close.

## Catalog (the safe component vocabulary)

```Page · Section · Heading · Paragraph · StatPill · CardRow · BeforeAfter · ColumnList · BucketList · Bucket · RouteTable · RiskGrid · Steps```

Adding one is three places: ```catalog.ts``` (zod schema), ```components.tsx``` (React renderer), ```artifact.css``` (style). Single source of truth lives on the client — server intentionally validates only the wire shape, not which components exist, so the catalog can evolve without backend redeploys.

## Files

- **Backend:** ```tools/artifact.py``` (153 lines), ```tools/artifact_agent.py``` (119), wires through ```agent_tools.py``` + ```api/chat.py```. 14 unit tests covering wire-shape validation, the LLM summary string (must NOT echo spec), and the chat-router helper'''s positive + negative paths. **All 23 backend tests pass locally.**
- **Frontend:** new ```features/chat/artifacts/``` module — catalog, renderers, preview card, dialog, registry-wrapped renderer. ```artifact.css``` carries the chrome. ```@json-render/core``` + ```@json-render/react``` (`^0.19.0`) added to ```frontend/package.json```.

## Risk / what'''s deliberately NOT in this PR

- **Persistence.** v0 artifacts vanish on page reload — they live on the in-memory ```AgnoMessage``` only. Persisting needs a ```chat_messages.artifacts``` JSON column + serialisation in ```finalize_assistant_message```. Follow-up bean.
- **Action handling.** The catalog has Buttons-shaped slots (json-render supports ```emit()```) but the round-trip back to a tool call is no-op. Designed to slot in later via ```useAction```.
- **MCP packaging.** ```@json-render/mcp``` could expose Pawrrtal'''s catalog so agents in Claude Desktop / ChatGPT render Pawrrtal UI inside their host. Distribution lever for later, not v0.
- **Visual smoke.** No GUI on this sandbox — preview card + dialog need eyeballing on a real chat surface.

## Test plan

- [x] Backend pytest (23/23 green locally on the artifact + chat-api suites)
- [ ] Frontend ```bun run check``` (CI)
- [ ] Frontend vitest, including ```ArtifactCard.test.tsx``` (CI)
- [ ] Manual: open the dev server, ask the agent to call ```render_artifact``` with a small spec, confirm preview card → dialog → X close

Co-Authored-By: Tavi <tocanoctavian@gmail.com>