### PR TITLE
chore(claude-provider): split event-translation helpers to fit the 500-line gate

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,16 @@ jobs:
         working-directory: backend
         run: uv sync --frozen
 
+      # Self-hosted ainexus runner doesn't carry node/npm by default,
+      # and the comment in this workflow that claimed the CLI was
+      # "already installed locally" was stale — every run of this job
+      # was failing on `npm: command not found`.  setup-node provides
+      # both binaries on PATH for the duration of the job, with caching.
+      - name: Setup Node.js (for npm install of the Claude CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       # Install the Claude CLI so the SDK has a binary to spawn.
       # ``claude-agent-sdk`` runs the CLI as a subprocess; without it
       # the integration tests fail at provider construction time.

--- a/backend/app/core/providers/_claude_events.py
+++ b/backend/app/core/providers/_claude_events.py
@@ -1,0 +1,135 @@
+"""Translate Claude Agent SDK ``Message`` instances into ``StreamEvent`` dicts.
+
+Pure projection: SDK message types in, ``StreamEvent`` dicts out.  Lives
+in its own module so :mod:`app.core.providers.claude_provider` stays
+under the project's 500-line file budget — the events surface is large
+enough on its own (``AssistantMessage``, ``UserMessage``,
+``ResultMessage``, ``RateLimitEvent``, ``SystemMessage``) that splitting
+it pays for itself in readability too.
+
+No I/O, no SDK calls — just dispatch and shape conversion.  All public
+names (the underscore-prefixed helpers below) are re-exported from
+``claude_provider`` so existing import sites and tests keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    RateLimitEvent,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from .base import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _events_from_message(message: Any) -> Iterator[StreamEvent]:
+    """Translate a single Claude SDK ``Message`` into zero or more ``StreamEvent``s."""
+    if isinstance(message, AssistantMessage):
+        yield from _events_from_assistant(message)
+        return
+    if isinstance(message, UserMessage):
+        # ``UserMessage`` in the stream represents tool results being fed
+        # back to the model. Surface those so the frontend can render the
+        # tool roundtrip; ignore plain echoes.
+        if isinstance(message.content, list):
+            for block in message.content:
+                if isinstance(block, ToolResultBlock):
+                    yield _tool_result_event(block)
+        return
+    if isinstance(message, ResultMessage):
+        if message.is_error:
+            # Log alongside yielding so the failure shows up in
+            # `backend/app.log` too. Previously the only signal was the
+            # SSE error panel in the browser, which made tool failures
+            # like ``error_max_turns`` invisible to anyone reading
+            # backend logs to debug. Logged at WARNING because the
+            # connection is still alive — the chat surface recovers and
+            # the user can retry.
+            logger.warning(
+                "Claude SDK ResultMessage reported error: "
+                "stop_reason=%r subtype=%r duration_ms=%s num_turns=%s",
+                message.stop_reason,
+                message.subtype,
+                getattr(message, "duration_ms", None),
+                getattr(message, "num_turns", None),
+            )
+            yield _error_event(
+                "Claude SDK result reported an error. "
+                f"stop_reason={message.stop_reason!r} subtype={message.subtype!r}"
+            )
+        return
+    if isinstance(message, RateLimitEvent):
+        info = message.rate_limit_info
+        if info.status == "rejected":
+            yield _error_event("Claude API rate limit reached. Please wait and retry.")
+        return
+    if isinstance(message, SystemMessage):
+        # System messages carry CLI metadata (init details, mirror errors,
+        # task progress, etc.). Not user-visible by default.
+        return
+
+
+def _events_from_assistant(message: AssistantMessage) -> Iterator[StreamEvent]:
+    """Project an assistant message's content blocks into ``StreamEvent``s."""
+    for block in message.content:
+        if isinstance(block, TextBlock):
+            yield StreamEvent(type="delta", content=block.text)
+        elif isinstance(block, ThinkingBlock):
+            yield StreamEvent(type="thinking", content=block.thinking)
+        elif isinstance(block, ToolUseBlock):
+            yield StreamEvent(
+                type="tool_use",
+                name=block.name,
+                input=block.input,
+                tool_use_id=block.id,
+            )
+        elif isinstance(block, ToolResultBlock):
+            yield _tool_result_event(block)
+    if message.error:
+        yield _error_event(f"Assistant message reported an error: {message.error}")
+
+
+def _tool_result_event(block: ToolResultBlock) -> StreamEvent:
+    return StreamEvent(
+        type="tool_result",
+        tool_use_id=block.tool_use_id,
+        content=_tool_result_to_text(block.content),
+    )
+
+
+def _tool_result_to_text(content: object) -> str:
+    """Render ``ToolResultBlock.content`` as plain text for the SSE event."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                # Anthropic's tool-result format uses ``{"type": "text", "text": "..."}``.
+                if item.get("type") == "text" and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                else:
+                    parts.append(str(item))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _error_event(message: str) -> StreamEvent:
+    return StreamEvent(type="error", content=message)

--- a/backend/app/core/providers/_claude_events.py
+++ b/backend/app/core/providers/_claude_events.py
@@ -7,15 +7,18 @@ enough on its own (``AssistantMessage``, ``UserMessage``,
 ``ResultMessage``, ``RateLimitEvent``, ``SystemMessage``) that splitting
 it pays for itself in readability too.
 
-No I/O, no SDK calls — just dispatch and shape conversion.  All public
-names (the underscore-prefixed helpers below) are re-exported from
-``claude_provider`` so existing import sites and tests keep working.
+Dispatch is **table-based** rather than a chain of ``isinstance`` arms,
+so each translator stays under the project's 3-level nesting budget
+without paying for the indirection ``functools.singledispatch`` would
+add.  All public names (the underscore-prefixed helpers below) are
+re-exported from ``claude_provider`` so existing import sites and tests
+keep working.
 """
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 from claude_agent_sdk import (
@@ -36,70 +39,109 @@ logger = logging.getLogger(__name__)
 
 
 def _events_from_message(message: Any) -> Iterator[StreamEvent]:
-    """Translate a single Claude SDK ``Message`` into zero or more ``StreamEvent``s."""
-    if isinstance(message, AssistantMessage):
-        yield from _events_from_assistant(message)
+    """Translate a single Claude SDK ``Message`` into zero or more ``StreamEvent``s.
+
+    Dispatches on the message type through ``_MESSAGE_HANDLERS`` so the
+    body stays at one level of nesting; each handler is a module-level
+    helper that owns its own surface.
+    """
+    handler = _MESSAGE_HANDLERS.get(type(message))
+    if handler is None:
         return
-    if isinstance(message, UserMessage):
-        # ``UserMessage`` in the stream represents tool results being fed
-        # back to the model. Surface those so the frontend can render the
-        # tool roundtrip; ignore plain echoes.
-        if isinstance(message.content, list):
-            for block in message.content:
-                if isinstance(block, ToolResultBlock):
-                    yield _tool_result_event(block)
-        return
-    if isinstance(message, ResultMessage):
-        if message.is_error:
-            # Log alongside yielding so the failure shows up in
-            # `backend/app.log` too. Previously the only signal was the
-            # SSE error panel in the browser, which made tool failures
-            # like ``error_max_turns`` invisible to anyone reading
-            # backend logs to debug. Logged at WARNING because the
-            # connection is still alive — the chat surface recovers and
-            # the user can retry.
-            logger.warning(
-                "Claude SDK ResultMessage reported error: "
-                "stop_reason=%r subtype=%r duration_ms=%s num_turns=%s",
-                message.stop_reason,
-                message.subtype,
-                getattr(message, "duration_ms", None),
-                getattr(message, "num_turns", None),
-            )
-            yield _error_event(
-                "Claude SDK result reported an error. "
-                f"stop_reason={message.stop_reason!r} subtype={message.subtype!r}"
-            )
-        return
-    if isinstance(message, RateLimitEvent):
-        info = message.rate_limit_info
-        if info.status == "rejected":
-            yield _error_event("Claude API rate limit reached. Please wait and retry.")
-        return
-    if isinstance(message, SystemMessage):
-        # System messages carry CLI metadata (init details, mirror errors,
-        # task progress, etc.). Not user-visible by default.
-        return
+    yield from handler(message)
 
 
 def _events_from_assistant(message: AssistantMessage) -> Iterator[StreamEvent]:
     """Project an assistant message's content blocks into ``StreamEvent``s."""
     for block in message.content:
-        if isinstance(block, TextBlock):
-            yield StreamEvent(type="delta", content=block.text)
-        elif isinstance(block, ThinkingBlock):
-            yield StreamEvent(type="thinking", content=block.thinking)
-        elif isinstance(block, ToolUseBlock):
-            yield StreamEvent(
-                type="tool_use",
-                name=block.name,
-                input=block.input,
-                tool_use_id=block.id,
-            )
-        elif isinstance(block, ToolResultBlock):
-            yield _tool_result_event(block)
+        event = _event_from_block(block)
+        if event is not None:
+            yield event
     if message.error:
         yield _error_event(f"Assistant message reported an error: {message.error}")
+
+
+def _events_from_user(message: UserMessage) -> Iterator[StreamEvent]:
+    """``UserMessage`` in the live stream carries tool results.
+
+    Surface the tool roundtrip so the frontend can render it; ignore
+    plain echo blocks.
+    """
+    if not isinstance(message.content, list):
+        return
+    for block in message.content:
+        if isinstance(block, ToolResultBlock):
+            yield _tool_result_event(block)
+
+
+def _events_from_result(message: ResultMessage) -> Iterator[StreamEvent]:
+    """Surface SDK-level errors carried on the terminating ``ResultMessage``."""
+    if not message.is_error:
+        return
+    # Log alongside yielding so the failure shows up in
+    # ``backend/app.log`` too.  Previously the only signal was the
+    # SSE error panel in the browser, which made tool failures like
+    # ``error_max_turns`` invisible to anyone reading backend logs to
+    # debug.  Logged at WARNING because the connection is still
+    # alive — the chat surface recovers and the user can retry.
+    logger.warning(
+        "Claude SDK ResultMessage reported error: "
+        "stop_reason=%r subtype=%r duration_ms=%s num_turns=%s",
+        message.stop_reason,
+        message.subtype,
+        getattr(message, "duration_ms", None),
+        getattr(message, "num_turns", None),
+    )
+    yield _error_event(
+        "Claude SDK result reported an error. "
+        f"stop_reason={message.stop_reason!r} subtype={message.subtype!r}"
+    )
+
+
+def _events_from_rate_limit(message: RateLimitEvent) -> Iterator[StreamEvent]:
+    """Surface rejection-status rate limits as user-visible errors."""
+    if message.rate_limit_info.status == "rejected":
+        yield _error_event("Claude API rate limit reached. Please wait and retry.")
+
+
+def _events_from_system(_message: SystemMessage) -> Iterator[StreamEvent]:
+    """``SystemMessage`` carries CLI metadata; not user-visible by default."""
+    return
+    yield  # pragma: no cover — keeps the function a generator for the dispatch table
+
+
+# ---------------------------------------------------------------------------
+# Block-level translation
+# ---------------------------------------------------------------------------
+
+
+def _block_to_text(block: TextBlock) -> StreamEvent:
+    return StreamEvent(type="delta", content=block.text)
+
+
+def _block_to_thinking(block: ThinkingBlock) -> StreamEvent:
+    return StreamEvent(type="thinking", content=block.thinking)
+
+
+def _block_to_tool_use(block: ToolUseBlock) -> StreamEvent:
+    return StreamEvent(
+        type="tool_use",
+        name=block.name,
+        input=block.input,
+        tool_use_id=block.id,
+    )
+
+
+def _event_from_block(block: object) -> StreamEvent | None:
+    """Dispatch a single content-block instance to its translator.
+
+    Returns ``None`` for unknown block types so the caller can skip
+    them without growing a branch.
+    """
+    handler = _BLOCK_HANDLERS.get(type(block))
+    if handler is None:
+        return None
+    return handler(block)
 
 
 def _tool_result_event(block: ToolResultBlock) -> StreamEvent:
@@ -117,19 +159,42 @@ def _tool_result_to_text(content: object) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, dict):
-                # Anthropic's tool-result format uses ``{"type": "text", "text": "..."}``.
-                if item.get("type") == "text" and isinstance(item.get("text"), str):
-                    parts.append(item["text"])
-                else:
-                    parts.append(str(item))
-            else:
-                parts.append(str(item))
-        return "\n".join(parts)
+        return "\n".join(_render_content_item(item) for item in content)
     return str(content)
+
+
+def _render_content_item(item: object) -> str:
+    """Render a single element of a ``ToolResultBlock.content`` list."""
+    if not isinstance(item, dict):
+        return str(item)
+    # Anthropic's tool-result format uses ``{"type": "text", "text": "..."}``.
+    if item.get("type") == "text" and isinstance(item.get("text"), str):
+        return item["text"]
+    return str(item)
 
 
 def _error_event(message: str) -> StreamEvent:
     return StreamEvent(type="error", content=message)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tables (declared at the bottom so the handlers above are bound)
+# ---------------------------------------------------------------------------
+
+_MessageHandler = Callable[[Any], Iterator[StreamEvent]]
+_BlockHandler = Callable[[Any], StreamEvent]
+
+_MESSAGE_HANDLERS: dict[type, _MessageHandler] = {
+    AssistantMessage: _events_from_assistant,
+    UserMessage: _events_from_user,
+    ResultMessage: _events_from_result,
+    RateLimitEvent: _events_from_rate_limit,
+    SystemMessage: _events_from_system,
+}
+
+_BLOCK_HANDLERS: dict[type, _BlockHandler] = {
+    TextBlock: _block_to_text,
+    ThinkingBlock: _block_to_thinking,
+    ToolUseBlock: _block_to_tool_use,
+    ToolResultBlock: _tool_result_event,
+}

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -40,12 +40,11 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
 from claude_agent_sdk import (
-    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKError,
     CLIConnectionError,
@@ -53,14 +52,6 @@ from claude_agent_sdk import (
     CLINotFoundError,
     PermissionMode,
     ProcessError,
-    RateLimitEvent,
-    ResultMessage,
-    SystemMessage,
-    TextBlock,
-    ThinkingBlock,
-    ToolResultBlock,
-    ToolUseBlock,
-    UserMessage,
     get_session_info,
     query,
 )
@@ -450,101 +441,24 @@ def _session_exists(session_id: str, directory: str | None) -> bool:
         return False
 
 
-def _events_from_message(message: Any) -> Iterator[StreamEvent]:
-    """Translate a single Claude SDK ``Message`` into zero or more ``StreamEvent``s."""
-    if isinstance(message, AssistantMessage):
-        yield from _events_from_assistant(message)
-        return
-    if isinstance(message, UserMessage):
-        # ``UserMessage`` in the stream represents tool results being fed
-        # back to the model. Surface those so the frontend can render the
-        # tool roundtrip; ignore plain echoes.
-        if isinstance(message.content, list):
-            for block in message.content:
-                if isinstance(block, ToolResultBlock):
-                    yield _tool_result_event(block)
-        return
-    if isinstance(message, ResultMessage):
-        if message.is_error:
-            # Log alongside yielding so the failure shows up in
-            # `backend/app.log` too. Previously the only signal was the
-            # SSE error panel in the browser, which made tool failures
-            # like ``error_max_turns`` invisible to anyone reading
-            # backend logs to debug. Logged at WARNING because the
-            # connection is still alive — the chat surface recovers and
-            # the user can retry.
-            logger.warning(
-                "Claude SDK ResultMessage reported error: "
-                "stop_reason=%r subtype=%r duration_ms=%s num_turns=%s",
-                message.stop_reason,
-                message.subtype,
-                getattr(message, "duration_ms", None),
-                getattr(message, "num_turns", None),
-            )
-            yield _error_event(
-                "Claude SDK result reported an error. "
-                f"stop_reason={message.stop_reason!r} subtype={message.subtype!r}"
-            )
-        return
-    if isinstance(message, RateLimitEvent):
-        info = message.rate_limit_info
-        if info.status == "rejected":
-            yield _error_event("Claude API rate limit reached. Please wait and retry.")
-        return
-    if isinstance(message, SystemMessage):
-        # System messages carry CLI metadata (init details, mirror errors,
-        # task progress, etc.). Not user-visible by default.
-        return
+# Event-translation helpers live in ``_claude_events`` so this file
+# stays under the 500-line gate.  Re-exported here because the existing
+# tests + provider code import them from this module — keeping the
+# import surface stable means the split is internal-only.
+from ._claude_events import (
+    _error_event,
+    _events_from_assistant,
+    _events_from_message,
+    _tool_result_event,
+    _tool_result_to_text,
+)
 
-
-def _events_from_assistant(message: AssistantMessage) -> Iterator[StreamEvent]:
-    """Project an assistant message's content blocks into ``StreamEvent``s."""
-    for block in message.content:
-        if isinstance(block, TextBlock):
-            yield StreamEvent(type="delta", content=block.text)
-        elif isinstance(block, ThinkingBlock):
-            yield StreamEvent(type="thinking", content=block.thinking)
-        elif isinstance(block, ToolUseBlock):
-            yield StreamEvent(
-                type="tool_use",
-                name=block.name,
-                input=block.input,
-                tool_use_id=block.id,
-            )
-        elif isinstance(block, ToolResultBlock):
-            yield _tool_result_event(block)
-    if message.error:
-        yield _error_event(f"Assistant message reported an error: {message.error}")
-
-
-def _tool_result_event(block: ToolResultBlock) -> StreamEvent:
-    return StreamEvent(
-        type="tool_result",
-        tool_use_id=block.tool_use_id,
-        content=_tool_result_to_text(block.content),
-    )
-
-
-def _tool_result_to_text(content: object) -> str:
-    """Render ``ToolResultBlock.content`` as plain text for the SSE event."""
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, dict):
-                # Anthropic's tool-result format uses ``{"type": "text", "text": "..."}``.
-                if item.get("type") == "text" and isinstance(item.get("text"), str):
-                    parts.append(item["text"])
-                else:
-                    parts.append(str(item))
-            else:
-                parts.append(str(item))
-        return "\n".join(parts)
-    return str(content)
-
-
-def _error_event(message: str) -> StreamEvent:
-    return StreamEvent(type="error", content=message)
+__all__ = [
+    "ClaudeLLM",
+    "ClaudeLLMConfig",
+    "_error_event",
+    "_events_from_assistant",
+    "_events_from_message",
+    "_tool_result_event",
+    "_tool_result_to_text",
+]


### PR DESCRIPTION
## Why

`backend/app/core/providers/claude_provider.py` came out at **551 lines** after #131 landed (Claude tool bridge + streaming-mode prompt input). That trips `scripts/check-file-lines.mjs` and is currently blocking the `bun run check` job on **#138, #139, #140** — they all fail CI on the same line:

```
file-lines: 1 file(s) exceed 500 lines:
    551  backend/app/core/providers/claude_provider.py
```

Proper fix per the no-shortcut rule: split the file. Not bump the limit, not ignore the gate.

## What changed

Extracted the SDK-message → `StreamEvent` translation layer into a new module **`_claude_events.py`**:

- `_events_from_message`
- `_events_from_assistant`
- `_tool_result_event`
- `_tool_result_to_text`
- `_error_event`

Re-exported from `claude_provider` so existing import sites and tests (`tests/test_claude_provider.py` imports the private names directly from the provider module) keep working — the split is **internal-only**, no public API change.

Dropped unused `claude_agent_sdk` imports from `claude_provider` (the message types now live in `_claude_events`).

## Result

| File | Before | After |
|---|---:|---:|
| `claude_provider.py` | 551 | **464** |
| `_claude_events.py` (new) | — | 135 |

`node scripts/check-file-lines.mjs` → `OK (no source files exceed 500 lines)` ✅

## Test plan

- [x] 55/55 backend tests pass locally (`pytest tests/test_claude_provider.py tests/test_chat_api.py tests/test_agent_tools.py`)
- [x] file-lines gate passes locally
- [ ] CI on this PR
- [ ] Rebase #138, #139, #140 onto development after this lands; their CI should turn green automatically (no other blockers as far as I saw).