### PR TITLE
fix(frontend): lazy-mount React Query Devtools to fix dev-startup "No QueryClient set"

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type * as React from 'react';
 import { Toaster } from 'sonner';
 import { getQueryClient } from './get-query-client';
+import { QueryDevtools } from './query-devtools';
 
 /**
  * App-root provider tree.
@@ -25,7 +25,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 	return (
 		<QueryClientProvider client={queryClient}>
-			<ReactQueryDevtools initialIsOpen={false} />
+			<QueryDevtools />
 			{children}
 			<Toaster
 				closeButton

--- a/frontend/app/query-devtools.tsx
+++ b/frontend/app/query-devtools.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ReactQueryDevtools as RQDevtools } from '@tanstack/react-query-devtools';
+import { useEffect, useState } from 'react';
+
+/**
+ * Client-only wrapper around `ReactQueryDevtools`.
+ *
+ * Why this file exists:
+ *
+ * In Next 16 + React 19 + Turbopack, rendering `<ReactQueryDevtools>` as a
+ * direct child of `<QueryClientProvider>` inside a `'use client'` boundary
+ * occasionally throws a fatal "No QueryClient set" runtime error during dev
+ * startup.  The crash blocks the entire tree from hydrating, so the rest of
+ * the app cannot be loaded until the dev server is restarted (and even then
+ * the error often returns).  The root cause is suspected to be a context
+ * identity mismatch when the devtools subscribe to the `QueryClient` while
+ * Turbopack is still wiring the module graph — devtools resolve their own
+ * copy of the query-core context before `<QueryClientProvider>` has installed
+ * the runtime instance.
+ *
+ * Mounting devtools only after the first client effect (post-hydration) and
+ * only in development sidesteps the race entirely: by the time `mounted` is
+ * true, `<QueryClientProvider>` has been committed and the devtools find the
+ * client they expect.  Production builds never render this component because
+ * `process.env.NODE_ENV` is statically replaced at build time, so the
+ * devtools bundle is dead-code-eliminated.
+ *
+ * Reported by the operator on 2026-05-08 against
+ * `frontend/app/providers.tsx:28` ("No QueryClient set").
+ */
+export function QueryDevtools() {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	if (!mounted || process.env.NODE_ENV !== 'development') {
+		return null;
+	}
+
+	return <RQDevtools initialIsOpen={false} />;
+}


### PR DESCRIPTION
Re-opens #138 (auto-closed when its branch was force-pushed during a rebase onto development).

## Symptom

On dev server startup (Next 16.2.4 + React 19 + Turbopack), the entire app crashes with:

```
Runtime Error: No QueryClient set, use QueryClientProvider to set one
  at Providers (app/providers.tsx:28:4)
```

Reported by Tavi 2026-05-08 — blocks the entire dev experience.

## Fix

New client component `frontend/app/query-devtools.tsx` that:
1. Mounts only after `useEffect` (post-hydration) — sidesteps the SSR/Turbopack context-identity race entirely.
2. Renders only when `process.env.NODE_ENV === "development"` — production bundles dead-code-eliminate the devtools.

Rebased on top of the file-length fix (#141) so `bun run check` clears.

## Test plan

- [x] CI: backend + frontend + integration suites
- [ ] Operator confirms `bun run dev` starts without the runtime error