### PR TITLE
[04] feat(backend): Grafana Sigil + OTLP observability for Gemini + Claude

### DIFF
--- a/.beans/pawrrtal-4xjo--sigil-deferred-paths-claude-gemini-sync.md
+++ b/.beans/pawrrtal-4xjo--sigil-deferred-paths-claude-gemini-sync.md
@@ -1,0 +1,17 @@
+---
+# pawrrtal-4xjo
+title: Sigil deferred paths (Claude + Gemini SYNC)
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-10T13:53:23Z
+updated_at: 2026-05-10T13:57:33Z
+---
+
+Instrument ClaudeLLM.stream with STREAM; gemini non-stream SYNC + commit CLI.
+
+## Summary of Changes
+
+- ClaudeLLM.stream: Sigil STREAM generations + with_conversation_id; query loop extracted to claude_query_stream + claude_sdk_input
+- gemini_utils: shared generate_content_sync_recorded (SYNC) for titles + commit CLI
+- Tests: test_sigil_deferred.py; mock query via claude_query_stream in test_claude_provider

--- a/.beans/pawrrtal-sc93--sigil-agent-first-instrumentation-backend.md
+++ b/.beans/pawrrtal-sc93--sigil-agent-first-instrumentation-backend.md
@@ -1,0 +1,19 @@
+---
+# pawrrtal-sc93
+title: Sigil agent-first instrumentation (backend)
+status: completed
+type: task
+priority: high
+created_at: 2026-05-10T13:41:13Z
+updated_at: 2026-05-10T13:49:48Z
+---
+
+Add Grafana Sigil + OTel providers around AI/agent paths; tests.
+
+## Summary of Changes
+
+- Grafana Sigil SDK + OTLP HTTP bootstrap under app/core/telemetry/
+- FastAPI lifespan: init_sigil_runtime / shutdown_sigil_runtime
+- Gemini StreamFn: streaming generations + usage metadata + recorder error checks
+- Agent loop: Sigil tool spans via execute_tool.run_agent_tool
+- tests/test_sigil_runtime.py and backend/.env.example documentation

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -133,3 +133,27 @@ ADMIN_PASSWORD=admin1234
 # BROWSER_USE_HEADLESS=1
 # E2E_BACKEND_URL=http://localhost:8000
 # E2E_FRONTEND_URL=http://localhost:3001
+
+# ===========================================
+# GRAFANA SIGIL + OPENTELEMETRY (optional)
+# ===========================================
+#
+# Sigil Python SDK reads canonical SIGIL_* variables (see Grafana AI Observability docs).
+# Traces/metrics require OTLP endpoint + headers — configure BEFORE the API starts.
+#
+# SIGIL_ENDPOINT=https://<stack>/api/v1/generations:export
+# SIGIL_PROTOCOL=http
+# SIGIL_AUTH_MODE=basic
+# SIGIL_AUTH_TENANT_ID=<instance id>
+# SIGIL_AUTH_TOKEN=glc_...
+#
+# Spans/metrics only (no generation credentials): enable instrumentation-only mode:
+# SIGIL_INSTRUMENTATION_ONLY=true
+#
+# Disable all Sigil client wiring:
+# SIGIL_DISABLED=true
+#
+# OpenTelemetry OTLP/HTTP (Grafana Cloud gateway or Alloy receiver):
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+# OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 "<otlp-instance-id>:<glc_token>">
+# OTEL_SERVICE_NAME=pawrrtal-api

--- a/backend/app/cli/commit.py
+++ b/backend/app/cli/commit.py
@@ -11,9 +11,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-from google import genai
-from google.genai import types
 from dotenv import load_dotenv
+from google import genai
+
+from app.core.gemini_utils import generate_content_sync_recorded
 
 # Load .env from project root (two levels up from backend/app/cli/)
 _project_root = Path(__file__).resolve().parents[2]
@@ -71,13 +72,12 @@ async def generate_message(stat: str, diff: str) -> str:
     """Send the diff to Gemini and return the commit message."""
     client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
     prompt = COMMIT_PROMPT.format(stat=stat, diff=diff)
-    response = await client.aio.models.generate_content(
-        model=COMMIT_AGENT_MODEL,
-        contents=[
-            types.Content(role="user", parts=[types.Part.from_text(text=prompt)])
-        ],
+    text = await generate_content_sync_recorded(
+        client,
+        COMMIT_AGENT_MODEL,
+        prompt,
+        pipeline_tag="commit-cli",
     )
-    text = (response.text or "").strip()
     if not text:
         raise RuntimeError("Gemini returned an empty response.")
     return text

--- a/backend/app/core/agent_loop/execute_tool.py
+++ b/backend/app/core/agent_loop/execute_tool.py
@@ -1,0 +1,56 @@
+"""Tool dispatch for :func:`app.core.agent_loop.loop.agent_loop` (with optional Sigil)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sigil_sdk import ToolExecutionStart
+
+from app.core.agent_loop.types import AgentTool
+from app.core.telemetry.sigil_runtime import get_sigil_client
+
+_log = logging.getLogger(__name__)
+
+
+async def run_agent_tool(
+    tool: AgentTool | None,
+    name: str,
+    tool_call_id: str,
+    arguments: dict[str, Any],
+) -> tuple[str, bool]:
+    """Execute a tool; record a Sigil tool span when a client is configured."""
+    client = get_sigil_client()
+    if client is None:
+        return await _execute_raw(tool, name, tool_call_id, arguments)
+
+    with client.start_tool_execution(
+        ToolExecutionStart(
+            tool_name=name,
+            tool_call_id=tool_call_id,
+            tool_type="function",
+            include_content=False,
+            tags={"pipeline": "agent-loop"},
+        ),
+    ) as rec:
+        result_text, is_error = await _execute_raw(tool, name, tool_call_id, arguments)
+        rec.set_result(arguments=arguments, result=result_text)
+        err = rec.err()
+        if err is not None:
+            _log.warning("Sigil tool recorder error (%s): %s", name, err)
+        return result_text, is_error
+
+
+async def _execute_raw(
+    tool: AgentTool | None,
+    name: str,
+    tool_call_id: str,
+    arguments: dict[str, Any],
+) -> tuple[str, bool]:
+    if tool is None:
+        return f"Tool '{name}' not found.", True
+    try:
+        text = await tool.execute(tool_call_id, **arguments)
+        return text, False
+    except Exception as exc:
+        return f"Tool error: {exc}", True

--- a/backend/app/core/agent_loop/loop.py
+++ b/backend/app/core/agent_loop/loop.py
@@ -1,5 +1,4 @@
-"""
-Pi-inspired provider-agnostic agent loop.
+"""Pi-inspired provider-agnostic agent loop.
 
 Architecture mirrors @mariozechner/pi-agent-core from pi-mono:
   https://github.com/badlogic/pi-mono/blob/main/packages/agent/src/agent-loop.ts
@@ -24,6 +23,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+from .execute_tool import run_agent_tool
 from .types import (
     AgentContext,
     AgentEndEvent,
@@ -75,13 +75,11 @@ async def agent_loop(
         yield MessageStartEvent(type="message_start", message=prompt)
         yield MessageEndEvent(type="message_end", message=prompt)
 
-    async for event in _run_loop(
-        current_messages, context.tools, new_messages, config, stream_fn
-    ):
+    async for event in _run_loop(current_messages, context.tools, new_messages, config, stream_fn):
         yield event
 
 
-async def _run_loop(
+async def _run_loop(  # noqa: C901, PLR0912, PLR0915 — safety layer + tool dispatch
     messages: list[AgentMessage],
     tools: list[AgentTool],
     new_messages: list[AgentMessage],
@@ -106,10 +104,7 @@ async def _run_loop(
 
     while True:
         # ── Pre-turn safety checks ────────────────────────────────────────
-        if (
-            safety.max_iterations is not None
-            and iteration >= safety.max_iterations
-        ):
+        if safety.max_iterations is not None and iteration >= safety.max_iterations:
             yield _terminated(
                 reason="max_iterations",
                 message=(
@@ -125,10 +120,7 @@ async def _run_loop(
             break
 
         elapsed = time.monotonic() - started_at
-        if (
-            safety.max_wall_clock_seconds is not None
-            and elapsed >= safety.max_wall_clock_seconds
-        ):
+        if safety.max_wall_clock_seconds is not None and elapsed >= safety.max_wall_clock_seconds:
             yield _terminated(
                 reason="max_wall_clock",
                 message=(
@@ -198,17 +190,12 @@ async def _run_loop(
                 is_error = False
                 result_text: str
 
-                if tool is None:
-                    result_text = f"Tool '{tc['name']}' not found."
-                    is_error = True
-                else:
-                    try:
-                        result_text = await tool.execute(
-                            tc["tool_call_id"], **tc["arguments"]
-                        )
-                    except Exception as exc:
-                        result_text = f"Tool error: {exc}"
-                        is_error = True
+                result_text, is_error = await run_agent_tool(
+                    tool,
+                    tc["name"],
+                    tc["tool_call_id"],
+                    tc["arguments"],
+                )
 
                 yield ToolResultEvent(
                     type="tool_result",
@@ -231,8 +218,7 @@ async def _run_loop(
                     consecutive_tool_errors += 1
                     if (
                         safety.max_consecutive_tool_errors is not None
-                        and consecutive_tool_errors
-                        >= safety.max_consecutive_tool_errors
+                        and consecutive_tool_errors >= safety.max_consecutive_tool_errors
                     ):
                         tool_safety_terminated = _terminated(
                             reason="consecutive_tool_errors",
@@ -295,10 +281,10 @@ class _StreamOutcome:
     """
 
     __slots__ = (
-        "events",
         "assistant_content",
-        "stop_reason",
         "consecutive_llm_errors_after",
+        "events",
+        "stop_reason",
         "terminated_event",
     )
 
@@ -353,11 +339,10 @@ async def _stream_with_retry(
                 # the assignments here capture the final state.
                 assistant_content = done["content"] if done else assistant_content
                 stop_reason = done["stop_reason"] if done else stop_reason
-        except Exception as exc:  # noqa: BLE001 — re-raised after budget check
+        except Exception as exc:
             consecutive_llm_errors += 1
             _log.warning(
-                "agent_loop: provider stream failed (attempt %d, "
-                "consecutive=%d/%s): %s",
+                "agent_loop: provider stream failed (attempt %d, consecutive=%d/%s): %s",
                 attempts,
                 consecutive_llm_errors,
                 max_errors if max_errors is not None else "∞",

--- a/backend/app/core/gemini_utils.py
+++ b/backend/app/core/gemini_utils.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from google import genai
 from google.genai import types
+from sigil_sdk import GenerationStart, ModelRef, assistant_text_message, user_text_message
 
 from app.core.config import settings
+from app.core.telemetry.sigil_gemini import gemini_usage_to_token_usage, log_recorder_err
+from app.core.telemetry.sigil_runtime import get_sigil_client
 
 _DEFAULT_MODEL = "gemini-2.0-flash"
 _client: genai.Client | None = None
@@ -13,10 +18,60 @@ _client: genai.Client | None = None
 
 def _get_client() -> genai.Client:
     """Return a shared Gemini client, creating it on first call."""
-    global _client
+    global _client  # noqa: PLW0603
     if _client is None:
         _client = genai.Client(api_key=settings.google_api_key)
     return _client
+
+
+async def generate_content_sync_recorded(
+    client: genai.Client,
+    model_id: str,
+    user_prompt: str,
+    *,
+    pipeline_tag: str = "gemini-sync",
+) -> str:
+    """Single-shot ``generate_content`` with optional Grafana Sigil SYNC recording."""
+    sigil_client = get_sigil_client()
+    rec: Any | None = None
+    if sigil_client is not None:
+        rec = sigil_client.start_generation(
+            GenerationStart(
+                model=ModelRef(provider="google", name=model_id),
+                operation_name="generateContent",
+                tags={"pipeline": pipeline_tag, "layer": "utility"},
+            ),
+        )
+        rec.__enter__()
+
+    try:
+        response = await client.aio.models.generate_content(
+            model=model_id,
+            contents=[
+                types.Content(role="user", parts=[types.Part.from_text(text=user_prompt)]),
+            ],
+        )
+        text = (response.text or "").strip()
+        if rec is not None:
+            result_kw: dict[str, Any] = {
+                "input": [user_text_message(user_prompt)],
+                "output": [assistant_text_message(text)] if text else [],
+                "stop_reason": "stop",
+                "response_model": model_id,
+            }
+            usage_meta = getattr(response, "usage_metadata", None)
+            if usage_meta is not None:
+                result_kw["usage"] = gemini_usage_to_token_usage(usage_meta)
+            rec.set_result(**result_kw)
+            log_recorder_err("Sigil Gemini sync generation", rec)
+        return text
+    except Exception as exc:
+        if rec is not None:
+            rec.set_call_error(exc)
+        raise
+    finally:
+        if rec is not None:
+            rec.__exit__(None, None, None)
 
 
 async def generate_text_once(prompt: str, model_id: str = _DEFAULT_MODEL) -> str:
@@ -25,11 +80,9 @@ async def generate_text_once(prompt: str, model_id: str = _DEFAULT_MODEL) -> str
     Used for short utility tasks such as title generation.  Raises on
     API errors so the caller can decide how to handle them.
     """
-    client = _get_client()
-    response = await client.aio.models.generate_content(
-        model=model_id,
-        contents=[
-            types.Content(role="user", parts=[types.Part.from_text(text=prompt)])
-        ],
+    return await generate_content_sync_recorded(
+        _get_client(),
+        model_id,
+        prompt,
+        pipeline_tag="gemini-utils",
     )
-    return (response.text or "").strip()

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -53,14 +53,19 @@ from claude_agent_sdk import (
     PermissionMode,
     ProcessError,
     get_session_info,
-    query,
 )
 
 from app.core.agent_loop.types import AgentTool
-from app.core.keys import resolve_api_key
 from app.core.agent_system_prompt import (
     DEFAULT_AGENT_SYSTEM_PROMPT as _DEFAULT_SYSTEM_PROMPT,
 )
+from app.core.keys import resolve_api_key
+from app.core.telemetry.sigil_claude import (
+    ClaudeSigilAccum,
+    finalize_claude_streaming_generation,
+    make_claude_generation_start,
+)
+from app.core.telemetry.sigil_runtime import get_sigil_client
 
 from ._claude_tool_bridge import (
     MCP_SERVER_NAME as AGENT_TOOL_MCP_SERVER_NAME,
@@ -71,6 +76,7 @@ from ._claude_tool_bridge import (
     build_mcp_server,
 )
 from .base import StreamEvent
+from .claude_query_stream import iter_claude_query_stream
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +186,7 @@ class ClaudeLLM:
         self._config = config or ClaudeLLMConfig()
         self._user_id = user_id
 
-    async def stream(
+    async def stream(  # noqa: C901, PLR0912 — Claude SDK error surface + Sigil lifecycle
         self,
         question: str,
         conversation_id: uuid.UUID,
@@ -200,6 +206,10 @@ class ClaudeLLM:
             user_id: App-level user UUID. Currently unused by this
                 provider but kept in the protocol so future per-user
                 cwd / quota logic can wire in without a signature change.
+            history: Ignored here; the Claude SDK resumes transcript state via
+                ``resume`` / ``session_id``.
+            tools: Cross-provider tools bridged into an MCP server when non-empty.
+            system_prompt: Overrides the configured default system prompt when set.
 
         Yields:
             ``StreamEvent`` dictionaries — text/thinking deltas, tool
@@ -210,58 +220,90 @@ class ClaudeLLM:
             system_prompt=system_prompt,
             agent_tools=tools,
         )
+        resolved_model = _resolve_sdk_model(self._model_id)
+        sigil_client = get_sigil_client()
+        sigil_rec: Any | None = None
+        first_mark = [False]
+        accum = ClaudeSigilAccum()
+        if sigil_client is not None:
+            sigil_rec = sigil_client.start_streaming_generation(
+                make_claude_generation_start(resolved_model, str(conversation_id)),
+            )
+            sigil_rec.__enter__()
+
+        completed_ok = False
         try:
-            # The SDK requires streaming-mode input (an AsyncIterable
-            # of message dicts) whenever ``can_use_tool`` is set on the
-            # options.  We always emit a single user-message envelope
-            # so the path is uniform regardless of whether bridged
-            # tools are mounted; uniform path means one shape to test
-            # and reason about.
-            async for message in query(
-                prompt=_aiter_user_prompt(question), options=options
-            ):
-                for event in _events_from_message(message):
+            try:
+                # Streaming-mode input is required whenever ``can_use_tool`` is set;
+                # see :mod:`app.core.providers.claude_sdk_input`.
+                async for event in iter_claude_query_stream(
+                    question,
+                    options,
+                    conversation_id,
+                    sigil_rec,
+                    first_mark,
+                    accum,
+                ):
                     yield event
-        except CLINotFoundError as error:
-            # `exception` (not `error`) gives us the stacktrace in the
-            # log — required by ruff TRY400 and useful for diagnosing
-            # PATH issues that vary across machines.
-            logger.exception("Claude CLI binary not found")
-            yield _error_event(
-                "Claude Code CLI binary is not installed in this environment. "
-                "Install it with `npm i -g @anthropic-ai/claude-code` and ensure "
-                "the executable is on PATH, or set ClaudeAgentOptions.cli_path. "
-                f"Underlying error: {error}",
-            )
-        except CLIConnectionError as error:
-            logger.warning("Claude CLI subprocess connection lost: %s", error)
-            yield _error_event(
-                f"Lost connection to the Claude Code CLI subprocess. Underlying error: {error}",
-            )
-        except ProcessError as error:
-            exit_code = getattr(error, "exit_code", "n/a")
-            stderr = getattr(error, "stderr", "")
-            logger.exception(
-                "Claude CLI subprocess exited: exit_code=%s stderr=%r",
-                exit_code,
-                stderr,
-            )
-            yield _error_event(
-                "Claude Code CLI exited with an error. Verify CLAUDE_CODE_OAUTH_TOKEN "
-                "is configured and your account has access to the requested model. "
-                f"Exit code: {exit_code}. stderr: {stderr!r}",
-            )
-        except CLIJSONDecodeError:
-            logger.exception("Claude CLI returned non-JSON message")
-            yield _error_event(
-                "Failed to parse a JSON message from the Claude Code CLI."
-            )
-        except ClaudeSDKError as error:
-            # `exception` (not `error`) so the traceback lands in the log
-            # — broad SDK errors are the bucket where new failure modes
-            # show up, and a stacktrace is the only way to attribute them.
-            logger.exception("Claude SDK error during stream")
-            yield _error_event(f"Claude SDK error: {error}")
+                completed_ok = True
+            except CLINotFoundError as error:
+                # `exception` (not `error`) gives us the stacktrace in the
+                # log — required by ruff TRY400 and useful for diagnosing
+                # PATH issues that vary across machines.
+                logger.exception("Claude CLI binary not found")
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(error)
+                yield _error_event(
+                    "Claude Code CLI binary is not installed in this environment. "
+                    "Install it with `npm i -g @anthropic-ai/claude-code` and ensure "
+                    "the executable is on PATH, or set ClaudeAgentOptions.cli_path. "
+                    f"Underlying error: {error}",
+                )
+            except CLIConnectionError as error:
+                logger.warning("Claude CLI subprocess connection lost: %s", error)
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(error)
+                yield _error_event(
+                    f"Lost connection to the Claude Code CLI subprocess. Underlying error: {error}",
+                )
+            except ProcessError as error:
+                exit_code = getattr(error, "exit_code", "n/a")
+                stderr = getattr(error, "stderr", "")
+                logger.exception(
+                    "Claude CLI subprocess exited: exit_code=%s stderr=%r",
+                    exit_code,
+                    stderr,
+                )
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(error)
+                yield _error_event(
+                    "Claude Code CLI exited with an error. Verify CLAUDE_CODE_OAUTH_TOKEN "
+                    "is configured and your account has access to the requested model. "
+                    f"Exit code: {exit_code}. stderr: {stderr!r}",
+                )
+            except CLIJSONDecodeError as error:
+                logger.exception("Claude CLI returned non-JSON message")
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(error)
+                yield _error_event("Failed to parse a JSON message from the Claude Code CLI.")
+            except ClaudeSDKError as error:
+                # `exception` (not `error`) so the traceback lands in the log
+                # — broad SDK errors are the bucket where new failure modes
+                # show up, and a stacktrace is the only way to attribute them.
+                logger.exception("Claude SDK error during stream")
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(error)
+                yield _error_event(f"Claude SDK error: {error}")
+        finally:
+            if sigil_rec is not None:
+                if completed_ok:
+                    finalize_claude_streaming_generation(
+                        sigil_rec,
+                        question=question,
+                        response_model=resolved_model,
+                        accum=accum,
+                    )
+                sigil_rec.__exit__(None, None, None)
 
     # -- internal --------------------------------------------------------
 
@@ -295,9 +337,7 @@ class ClaudeLLM:
         # Local tool whitelist for the Claude SDK's built-in CLI tools
         # (read/write filesystem, etc.).  Distinct from ``agent_tools``
         # — those are app-defined tools we bridge into an MCP server.
-        local_tools = (
-            list(self._config.tools) if self._config.tools is not None else None
-        )
+        local_tools = list(self._config.tools) if self._config.tools is not None else None
         mcp_servers: dict[str, Any] = {}
 
         # Bridge the cross-provider AgentTool list into a single MCP
@@ -401,22 +441,6 @@ def _merge_agent_tools_into_whitelist(
         if tid not in deduped:
             deduped.append(tid)
     return deduped
-
-
-async def _aiter_user_prompt(question: str) -> AsyncIterator[dict[str, Any]]:
-    """Wrap a single user message as the streaming-mode input the SDK expects.
-
-    The Claude SDK accepts either a plain string *or* an
-    ``AsyncIterable[dict]`` for the ``prompt`` arg, but enforces the
-    streaming-mode shape whenever a permission hook (``can_use_tool``)
-    is registered — which we now always do via the bridge.  Yielding
-    one envelope keeps every call site uniform regardless of whether
-    tools were mounted on this turn.
-    """
-    yield {
-        "type": "user",
-        "message": {"role": "user", "content": question},
-    }
 
 
 def _resolve_sdk_model(model_id: str) -> str:

--- a/backend/app/core/providers/claude_query_stream.py
+++ b/backend/app/core/providers/claude_query_stream.py
@@ -1,0 +1,54 @@
+"""Claude Agent SDK ``query`` iteration for :class:`ClaudeLLM` streaming."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+from sigil_sdk import with_conversation_id
+
+from app.core.providers._claude_events import _events_from_message
+from app.core.providers.base import StreamEvent
+from app.core.providers.claude_sdk_input import aiter_claude_sdk_user_prompt
+from app.core.telemetry.sigil_claude import (
+    ClaudeSigilAccum,
+    apply_claude_stream_event_for_sigil,
+)
+
+
+def _events_for_sdk_message(
+    message: object,
+    sigil_rec: Any | None,
+    first_mark: list[bool],
+    accum: ClaudeSigilAccum,
+) -> Iterator[StreamEvent]:
+    """Project one SDK message to :class:`StreamEvent` values (Sigil side effects)."""
+    for event in _events_from_message(message):
+        if sigil_rec is not None:
+            apply_claude_stream_event_for_sigil(
+                event,
+                sigil_rec,
+                first_mark=first_mark,
+                accum=accum,
+            )
+        yield event
+
+
+async def iter_claude_query_stream(
+    question: str,
+    options: ClaudeAgentOptions,
+    conversation_id: uuid.UUID,
+    sigil_rec: Any | None,
+    first_mark: list[bool],
+    accum: ClaudeSigilAccum,
+) -> AsyncIterator[StreamEvent]:
+    """Drive ``claude_agent_sdk.query`` and yield :class:`StreamEvent` values."""
+    with with_conversation_id(str(conversation_id)):
+        async for message in query(
+            prompt=aiter_claude_sdk_user_prompt(question),
+            options=options,
+        ):
+            for event in _events_for_sdk_message(message, sigil_rec, first_mark, accum):
+                yield event

--- a/backend/app/core/providers/claude_sdk_input.py
+++ b/backend/app/core/providers/claude_sdk_input.py
@@ -1,0 +1,14 @@
+"""Streaming-mode user prompt envelope for the Claude Agent SDK."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+async def aiter_claude_sdk_user_prompt(question: str) -> AsyncIterator[dict[str, Any]]:
+    """Yield a single user-message envelope (required when ``can_use_tool`` is set)."""
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": question},
+    }

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from google import genai
 from google.genai import types as gtypes
+from sigil_sdk import with_conversation_id
 
 from app.core.agent_loop import (
     AgentContext,
@@ -24,13 +25,23 @@ from app.core.agent_loop import (
     UserMessage,
     agent_loop,
 )
+from app.core.agent_loop.safety_factory import safety_from_settings
 from app.core.agent_loop.types import TextContent, ToolCallContent
 from app.core.agent_system_prompt import (
     DEFAULT_AGENT_SYSTEM_PROMPT as _FALLBACK_SYSTEM_PROMPT,
 )
-from app.core.agent_loop.safety_factory import safety_from_settings
 from app.core.config import settings
 from app.core.keys import resolve_api_key
+from app.core.telemetry.sigil_gemini import (
+    build_assistant_output_message,
+    gemini_usage_to_token_usage,
+    log_recorder_err,
+    make_generation_start,
+    maybe_note_first_token,
+    messages_to_sigil_input,
+)
+from app.core.telemetry.sigil_runtime import get_sigil_client
+
 from .base import StreamEvent
 
 logger = logging.getLogger(__name__)
@@ -104,7 +115,12 @@ def _build_gemini_contents(
     return contents
 
 
-def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> StreamFn:
+def make_gemini_stream_fn(  # noqa: C901, PLR0915
+    model_id: str,
+    user_id: uuid.UUID | None = None,
+    *,
+    conversation_id: uuid.UUID | None = None,
+) -> StreamFn:
     """Build a StreamFn backed by the google-genai SDK.
 
     Args:
@@ -114,13 +130,15 @@ def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> St
             ``settings.google_api_key`` is used directly, matching
             ``ClaudeLLM``'s optional ``user_id`` contract for unauthenticated
             background work (e.g. utility agents).
+        conversation_id: Chat conversation UUID for Sigil ``gen_ai.conversation.id``
+            routing when Grafana Sigil is enabled.
 
     Returns:
         An async generator factory that yields ``LLMEvent``s. The generator
         is provider-specific; the calling ``agent_loop()`` is not.
     """
 
-    async def stream_fn(
+    async def stream_fn(  # noqa: C901, PLR0912, PLR0915
         messages: list[AgentMessage],
         tools: list[AgentTool],
     ) -> AsyncIterator[LLMEvent]:
@@ -148,84 +166,118 @@ def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> St
 
         full_text = ""
         tool_calls: list[dict[str, Any]] = []
+        usage_meta: Any | None = None
+
+        sigil_client = get_sigil_client()
+        sigil_rec: Any | None = None
+        first_token_marked = [False]
+        if sigil_client is not None:
+            cid = str(conversation_id) if conversation_id is not None else ""
+            sigil_rec = sigil_client.start_streaming_generation(
+                make_generation_start(model_id, cid),
+            )
+            sigil_rec.__enter__()
 
         try:
-            # google-genai's async ``generate_content_stream`` returns
-            # an awaitable that resolves to an ``AsyncIterator`` (per the
-            # SDK's own docstring example). The earlier code relied on
-            # the implicit-coroutine-as-iter pattern; mypy 1.x rejects it.
-            stream = await client.aio.models.generate_content_stream(
-                model=model_id,
-                contents=contents,
-                config=config,
-            )
-            async for chunk in stream:
-                # Text delta
-                if chunk.text:
-                    yield LLMTextDeltaEvent(type="text_delta", text=chunk.text)
-                    full_text += chunk.text
+            try:
+                # google-genai's async ``generate_content_stream`` returns
+                # an awaitable that resolves to an ``AsyncIterator`` (per the
+                # SDK's own docstring example). The earlier code relied on
+                # the implicit-coroutine-as-iter pattern; mypy 1.x rejects it.
+                stream = await client.aio.models.generate_content_stream(
+                    model=model_id,
+                    contents=contents,
+                    config=config,
+                )
+                async for chunk in stream:
+                    if getattr(chunk, "usage_metadata", None) is not None:
+                        usage_meta = chunk.usage_metadata
 
-                # Tool / function calls
-                if chunk.candidates:
-                    for candidate in chunk.candidates:
-                        if not candidate.content or not candidate.content.parts:
-                            continue
-                        for part in candidate.content.parts:
-                            if part.function_call:
-                                fc = part.function_call
-                                # ``fc.name`` is typed as ``str | None`` by
-                                # the SDK; the API never returns nameless
-                                # function calls in practice, but we
-                                # default to the empty string for typing.
-                                fn_name = fc.name or ""
-                                tool_call_id = f"call-{fn_name}-{len(tool_calls)}"
-                                args = dict(fc.args) if fc.args else {}
-                                yield LLMToolCallEvent(
-                                    type="tool_call",
-                                    tool_call_id=tool_call_id,
-                                    name=fn_name,
-                                    arguments=args,
-                                )
-                                tool_calls.append(
-                                    {
-                                        "tool_call_id": tool_call_id,
-                                        "name": fn_name,
-                                        "arguments": args,
-                                    }
-                                )
+                    # Text delta
+                    if chunk.text:
+                        if sigil_rec is not None:
+                            maybe_note_first_token(sigil_rec, marked=first_token_marked)
+                        yield LLMTextDeltaEvent(type="text_delta", text=chunk.text)
+                        full_text += chunk.text
 
-        except Exception as exc:
-            # Log so the error is visible in app.log — previously swallowed silently.
-            logger.error(
-                "Gemini streaming error model=%s: %s", model_id, exc, exc_info=True
-            )
-            error_text = f"Gemini error: {exc}"
-            # Emit a text delta so the frontend shows the error instead of an empty bubble.
-            yield LLMTextDeltaEvent(type="text_delta", text=error_text)
-            yield LLMDoneEvent(
-                type="done",
-                stop_reason="error",
-                content=[TextContent(type="text", text=error_text)],
-            )
-            return
+                    # Tool / function calls
+                    if chunk.candidates:
+                        for candidate in chunk.candidates:
+                            if not candidate.content or not candidate.content.parts:
+                                continue
+                            for part in candidate.content.parts:
+                                if part.function_call:
+                                    fc = part.function_call
+                                    # ``fc.name`` is typed as ``str | None`` by
+                                    # the SDK; the API never returns nameless
+                                    # function calls in practice, but we
+                                    # default to the empty string for typing.
+                                    fn_name = fc.name or ""
+                                    tool_call_id = f"call-{fn_name}-{len(tool_calls)}"
+                                    args = dict(fc.args) if fc.args else {}
+                                    yield LLMToolCallEvent(
+                                        type="tool_call",
+                                        tool_call_id=tool_call_id,
+                                        name=fn_name,
+                                        arguments=args,
+                                    )
+                                    tool_calls.append(
+                                        {
+                                            "tool_call_id": tool_call_id,
+                                            "name": fn_name,
+                                            "arguments": args,
+                                        }
+                                    )
 
-        # Determine stop reason
-        stop_reason = "tool_use" if tool_calls else "stop"
+            except Exception as exc:
+                # Log so the error is visible in app.log — previously swallowed silently.
+                logger.error("Gemini streaming error model=%s: %s", model_id, exc, exc_info=True)
+                if sigil_rec is not None:
+                    sigil_rec.set_call_error(exc)
+                error_text = f"Gemini error: {exc}"
+                # Emit a text delta so the frontend shows the error instead of an empty bubble.
+                yield LLMTextDeltaEvent(type="text_delta", text=error_text)
+                yield LLMDoneEvent(
+                    type="done",
+                    stop_reason="error",
+                    content=[TextContent(type="text", text=error_text)],
+                )
+                return
 
-        content: list[TextContent | ToolCallContent] = []
-        if full_text:
-            content.append(TextContent(type="text", text=full_text))
-        for tc in tool_calls:
-            content.append(
+            # Determine stop reason
+            stop_reason = "tool_use" if tool_calls else "stop"
+
+            content: list[TextContent | ToolCallContent] = []
+            if full_text:
+                content.append(TextContent(type="text", text=full_text))
+            content.extend(
                 ToolCallContent(
                     type="toolCall",
                     tool_call_id=tc["tool_call_id"],
                     name=tc["name"],
                     arguments=tc["arguments"],
                 )
+                for tc in tool_calls
             )
 
-        yield LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+            if sigil_rec is not None:
+                sigil_input = messages_to_sigil_input(messages)
+                result_kw: dict[str, Any] = {
+                    "input": sigil_input,
+                    "output": [build_assistant_output_message(full_text, tool_calls)],
+                    "stop_reason": stop_reason,
+                    "response_model": model_id,
+                }
+                if usage_meta is not None:
+                    result_kw["usage"] = gemini_usage_to_token_usage(usage_meta)
+                sigil_rec.set_result(**result_kw)
+                log_recorder_err("Sigil generation recorder", sigil_rec)
+
+            yield LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+
+        finally:
+            if sigil_rec is not None:
+                sigil_rec.__exit__(None, None, None)
 
     return stream_fn
 
@@ -253,7 +305,10 @@ class GeminiLLM:
                 ``ClaudeLLM``'s contract for unauthenticated callers.
         """
         self._model_id = model_id
-        self._stream_fn = make_gemini_stream_fn(model_id, user_id)
+        self._user_id = user_id
+        # Tests monkeypatch ``_stream_fn`` with a scripted StreamFn. Production
+        # builds the StreamFn per request so Sigil receives ``conversation_id``.
+        self._stream_fn: StreamFn | None = None
 
     async def stream(
         self,
@@ -315,45 +370,52 @@ class GeminiLLM:
             safety=safety_from_settings(settings),
         )
 
+        stream_fn = self._stream_fn or make_gemini_stream_fn(
+            self._model_id,
+            self._user_id,
+            conversation_id=conversation_id,
+        )
+
         try:
-            async for event in agent_loop([prompt], context, config, self._stream_fn):
-                # Narrow the AgentEvent union by its discriminant so TypedDict
-                # field access types as ``str`` instead of ``object``.
-                if event["type"] == "text_delta":
-                    yield StreamEvent(type="delta", content=event["text"])
+            with with_conversation_id(str(conversation_id)):
+                async for event in agent_loop([prompt], context, config, stream_fn):
+                    # Narrow the AgentEvent union by its discriminant so TypedDict
+                    # field access types as ``str`` instead of ``object``.
+                    if event["type"] == "text_delta":
+                        yield StreamEvent(type="delta", content=event["text"])
 
-                elif event["type"] == "tool_call_start":
-                    yield StreamEvent(
-                        type="tool_use",
-                        name=event["name"],
-                        input={},
-                        tool_use_id=event["tool_call_id"],
-                    )
+                    elif event["type"] == "tool_call_start":
+                        yield StreamEvent(
+                            type="tool_use",
+                            name=event["name"],
+                            input={},
+                            tool_use_id=event["tool_call_id"],
+                        )
 
-                elif event["type"] == "tool_result":
-                    yield StreamEvent(
-                        type="tool_result",
-                        content=event["content"],
-                        tool_use_id=event["tool_call_id"],
-                    )
+                    elif event["type"] == "tool_result":
+                        yield StreamEvent(
+                            type="tool_result",
+                            content=event["content"],
+                            tool_use_id=event["tool_call_id"],
+                        )
 
-                elif event["type"] == "agent_terminated":
-                    # Safety layer tripped — forward the structured event so
-                    # the frontend can render a distinct termination notice
-                    # instead of a generic error banner.  ``reason`` is the
-                    # machine-readable label; ``message`` is the human copy.
-                    logger.warning(
-                        "AGENT_TERMINATED reason=%s details=%s",
-                        event["reason"],
-                        event["details"],
-                    )
-                    yield StreamEvent(
-                        type="agent_terminated",
-                        content=event["message"],
-                    )
+                    elif event["type"] == "agent_terminated":
+                        # Safety layer tripped — forward the structured event so
+                        # the frontend can render a distinct termination notice
+                        # instead of a generic error banner.  ``reason`` is the
+                        # machine-readable label; ``message`` is the human copy.
+                        logger.warning(
+                            "AGENT_TERMINATED reason=%s details=%s",
+                            event["reason"],
+                            event["details"],
+                        )
+                        yield StreamEvent(
+                            type="agent_terminated",
+                            content=event["message"],
+                        )
 
-                elif event["type"] == "agent_end":
-                    pass  # loop complete — chat.py sends [DONE]
+                    elif event["type"] == "agent_end":
+                        pass  # loop complete — chat.py sends [DONE]
 
         except Exception as exc:
             yield StreamEvent(type="error", content=f"Gemini provider error: {exc}")

--- a/backend/app/core/telemetry/__init__.py
+++ b/backend/app/core/telemetry/__init__.py
@@ -1,0 +1,13 @@
+"""Observability helpers (Grafana Sigil, OpenTelemetry)."""
+
+from .sigil_runtime import (
+    get_sigil_client,
+    init_sigil_runtime,
+    shutdown_sigil_runtime,
+)
+
+__all__ = [
+    "get_sigil_client",
+    "init_sigil_runtime",
+    "shutdown_sigil_runtime",
+]

--- a/backend/app/core/telemetry/sigil_claude.py
+++ b/backend/app/core/telemetry/sigil_claude.py
@@ -1,0 +1,86 @@
+"""Sigil helpers for Claude Agent SDK streaming (:class:`STREAM` generations)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sigil_sdk import GenerationStart, ModelRef, user_text_message
+
+from app.core.providers.base import StreamEvent
+from app.core.telemetry.sigil_gemini import (
+    build_assistant_output_message,
+    log_recorder_err,
+    maybe_note_first_token,
+)
+
+
+@dataclass
+class ClaudeSigilAccum:
+    """Mutable capture for one Claude ``stream()`` call."""
+
+    full_text_chunks: list[str] = field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    had_stream_error: bool = False
+
+
+def make_claude_generation_start(model_id: str, conversation_id: str) -> GenerationStart:
+    """Build :class:`GenerationStart` for Claude Agent SDK streaming."""
+    return GenerationStart(
+        conversation_id=conversation_id,
+        operation_name="streamText",
+        model=ModelRef(provider="anthropic", name=model_id),
+        tags={
+            "pipeline": "claude-agent-sdk",
+            "layer": "provider",
+        },
+    )
+
+
+def apply_claude_stream_event_for_sigil(
+    event: StreamEvent,
+    sigil_rec: object,
+    *,
+    first_mark: list[bool],
+    accum: ClaudeSigilAccum,
+) -> None:
+    """Update Sigil streaming state from one emitted :class:`StreamEvent`."""
+    et = event.get("type", "")
+    if et == "delta":
+        maybe_note_first_token(sigil_rec, marked=first_mark)
+        accum.full_text_chunks.append(event.get("content", "") or "")
+        return
+    if et == "tool_use":
+        raw_in = event.get("input")
+        args = raw_in if isinstance(raw_in, dict) else {}
+        accum.tool_calls.append(
+            {
+                "tool_call_id": str(event.get("tool_use_id", "")),
+                "name": str(event.get("name", "")),
+                "arguments": args,
+            },
+        )
+        return
+    if et == "error":
+        accum.had_stream_error = True
+
+
+def finalize_claude_streaming_generation(
+    sigil_rec: object,
+    *,
+    question: str,
+    response_model: str,
+    accum: ClaudeSigilAccum,
+) -> None:
+    """Call ``set_result`` after the Claude query iterator completes."""
+    full_text = "".join(accum.full_text_chunks)
+    stop_reason = (
+        "error" if accum.had_stream_error else ("tool_use" if accum.tool_calls else "stop")
+    )
+    sigil_rec.set_result(
+        input=[user_text_message(question)],
+        output=[build_assistant_output_message(full_text, accum.tool_calls)],
+        stop_reason=stop_reason,
+        response_model=response_model,
+    )
+    log_recorder_err("Sigil Claude stream generation", sigil_rec)

--- a/backend/app/core/telemetry/sigil_gemini.py
+++ b/backend/app/core/telemetry/sigil_gemini.py
@@ -1,0 +1,141 @@
+"""Sigil helpers for the Gemini :class:`StreamFn` (streaming generations)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sigil_sdk import (
+    GenerationStart,
+    Message,
+    MessageRole,
+    ModelRef,
+    TokenUsage,
+    ToolCall,
+    assistant_text_message,
+    text_part,
+    tool_call_part,
+    tool_result_message,
+    user_text_message,
+)
+
+from app.core.agent_loop.types import AgentMessage
+
+_logger = logging.getLogger(__name__)
+
+
+def gemini_usage_to_token_usage(meta: object) -> TokenUsage:
+    """Map Gemini ``usage_metadata`` to :class:`TokenUsage` for Sigil export."""
+    cache_read = int(getattr(meta, "cached_content_token_count", 0) or 0)
+    return TokenUsage(
+        input_tokens=int(getattr(meta, "prompt_token_count", 0) or 0),
+        output_tokens=int(getattr(meta, "candidates_token_count", 0) or 0),
+        total_tokens=int(getattr(meta, "total_token_count", 0) or 0),
+        cache_read_input_tokens=cache_read,
+        cache_write_input_tokens=0,
+        cache_creation_input_tokens=0,
+        reasoning_tokens=int(getattr(meta, "thoughts_token_count", 0) or 0),
+    )
+
+
+def _assistant_history_text(m: AgentMessage) -> str:
+    blocks = m.get("content")
+    if not isinstance(blocks, list):
+        return ""
+    return " ".join(
+        str(b.get("text", "")) for b in blocks if isinstance(b, dict) and b.get("type") == "text"
+    )
+
+
+def _tool_result_plain_text(m: AgentMessage) -> str:
+    parts = m.get("content")
+    if not isinstance(parts, list) or not parts:
+        return ""
+    first = parts[0]
+    if not isinstance(first, dict):
+        return ""
+    if first.get("type") != "text":
+        return ""
+    return str(first.get("text", ""))
+
+
+def messages_to_sigil_input(messages: list[AgentMessage]) -> list[Message]:
+    """Convert agent messages to Sigil :class:`Message` list (text-oriented)."""
+    out: list[Message] = []
+    for m in messages:
+        role = m.get("role", "")
+        if role == "user":
+            out.append(user_text_message(str(m.get("content", ""))))
+            continue
+        if role == "assistant":
+            text = _assistant_history_text(m)
+            if text.strip():
+                out.append(assistant_text_message(text))
+            continue
+        if role == "toolResult":
+            tcid = str(m.get("tool_call_id", ""))
+            out.append(tool_result_message(tcid, _tool_result_plain_text(m)))
+    return out
+
+
+def build_assistant_output_message(
+    full_text: str,
+    tool_calls: list[dict[str, Any]],
+) -> Message:
+    """Build the assistant :class:`Message` with text and tool-call parts."""
+    parts: list[Any] = []
+    if full_text.strip():
+        parts.append(text_part(full_text))
+    for tc in tool_calls:
+        payload = json.dumps(tc.get("arguments", {})).encode("utf-8")
+        parts.append(
+            tool_call_part(
+                ToolCall(
+                    name=str(tc.get("name", "")),
+                    id=str(tc.get("tool_call_id", "")),
+                    input_json=payload,
+                ),
+            ),
+        )
+    return Message(role=MessageRole.ASSISTANT, parts=parts)
+
+
+def make_generation_start(
+    model_id: str,
+    conversation_id: str,
+    *,
+    operation_name: str = "streamText",
+) -> GenerationStart:
+    """Build :class:`GenerationStart` for a Gemini streaming call."""
+    return GenerationStart(
+        conversation_id=conversation_id,
+        operation_name=operation_name,
+        model=ModelRef(provider="google", name=model_id),
+        tags={
+            "pipeline": "gemini-agent-loop",
+            "layer": "provider",
+        },
+    )
+
+
+def log_recorder_err(prefix: str, recorder: object) -> None:
+    """Emit a warning when ``rec.err()`` is set after a recorder closes."""
+    err_fn = getattr(recorder, "err", None)
+    if err_fn is None:
+        return
+    err = err_fn()
+    if err is not None:
+        _logger.warning("%s: %s", prefix, err)
+
+
+def maybe_note_first_token(recorder: object, *, marked: list[bool]) -> None:
+    """Record first-token time once for TTFT metrics."""
+    if marked[0]:
+        return
+    setter = getattr(recorder, "set_first_token_at", None)
+    if setter is None:
+        return
+    setter(datetime.now(UTC))
+    marked[0] = True

--- a/backend/app/core/telemetry/sigil_runtime.py
+++ b/backend/app/core/telemetry/sigil_runtime.py
@@ -1,0 +1,137 @@
+"""Grafana Sigil client lifecycle and OpenTelemetry OTLP bootstrap.
+
+The Sigil SDK does not install global TracerProvider / MeterProvider instances.
+When ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set, this module registers OTLP/HTTP
+exporters **before** constructing :class:`sigil_sdk.Client` so SDK spans and
+metrics are not dropped on no-op providers.
+
+See package docstring in :mod:`app.core.telemetry` for environment variables.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from sigil_sdk import Client, ClientConfig, GenerationExportConfig
+
+_logger = logging.getLogger(__name__)
+
+_sigil_client: Client | None = None
+_otel_tracer_provider: TracerProvider | None = None
+_otel_meter_provider: MeterProvider | None = None
+
+
+def get_sigil_client() -> Client | None:
+    """Return the process-wide Sigil client, or ``None`` when disabled."""
+    return _sigil_client
+
+
+def init_sigil_runtime() -> None:
+    """Configure OTLP (if env indicates) and construct the Sigil :class:`Client`.
+
+    OpenTelemetry providers must be registered **before** ``Client()`` so SDK
+    spans and histograms are exported. Shutdown order is the reverse in
+    :func:`shutdown_sigil_runtime`.
+    """
+    global _sigil_client  # noqa: PLW0603
+
+    if os.getenv("SIGIL_DISABLED", "").strip().lower() in ("1", "true", "yes", "on"):
+        _logger.info("Sigil disabled via SIGIL_DISABLED.")
+        _sigil_client = None
+        _configure_otel_if_needed()
+        return
+
+    _configure_otel_if_needed()
+
+    token = os.getenv("SIGIL_AUTH_TOKEN", "").strip()
+    instr_only = os.getenv("SIGIL_INSTRUMENTATION_ONLY", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+    if not token and not instr_only:
+        _sigil_client = None
+        _logger.debug(
+            "Sigil client not started (set SIGIL_AUTH_TOKEN or SIGIL_INSTRUMENTATION_ONLY).",
+        )
+        return
+
+    if instr_only and not token:
+        _sigil_client = Client(
+            ClientConfig(generation_export=GenerationExportConfig(protocol="none")),
+        )
+        _logger.info("Sigil client started (instrumentation-only, no generation export).")
+        return
+
+    _sigil_client = Client()
+    _logger.info("Sigil client initialized (generation export from SIGIL_* env).")
+
+
+def shutdown_sigil_runtime() -> None:
+    """Flush Sigil export queues, shut down the client, then OTel providers."""
+    global _sigil_client, _otel_tracer_provider, _otel_meter_provider  # noqa: PLW0603
+
+    client = _sigil_client
+    _sigil_client = None
+    if client is not None:
+        try:
+            client.shutdown()
+        except Exception as exc:
+            _logger.warning("Sigil client shutdown failed: %s", exc, exc_info=True)
+
+    if _otel_meter_provider is not None:
+        try:
+            _otel_meter_provider.shutdown()
+        except Exception as exc:
+            _logger.warning("MeterProvider shutdown failed: %s", exc, exc_info=True)
+        _otel_meter_provider = None
+
+    if _otel_tracer_provider is not None:
+        try:
+            _otel_tracer_provider.shutdown()
+        except Exception as exc:
+            _logger.warning("TracerProvider shutdown failed: %s", exc, exc_info=True)
+        _otel_tracer_provider = None
+
+
+def _configure_otel_if_needed() -> None:
+    """Install global TracerProvider and MeterProvider when OTLP endpoint is set."""
+    global _otel_tracer_provider, _otel_meter_provider  # noqa: PLW0603
+
+    if _otel_tracer_provider is not None:
+        return
+
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    if not endpoint:
+        _logger.debug(
+            "OTEL_EXPORTER_OTLP_ENDPOINT unset; Sigil SDK uses default no-op trace/metrics.",
+        )
+        return
+
+    service_name = os.getenv("OTEL_SERVICE_NAME", "pawrrtal-api").strip() or "pawrrtal-api"
+    resource = Resource.create({"service.name": service_name})
+
+    _otel_tracer_provider = TracerProvider(resource=resource)
+    _otel_tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(_otel_tracer_provider)
+
+    metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+    _otel_meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    metrics.set_meter_provider(_otel_meter_provider)
+
+    _logger.info(
+        "OpenTelemetry OTLP exporters configured (endpoint=%s, service=%s).",
+        endpoint,
+        service_name,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,19 +15,20 @@ from app.api.appearance import get_appearance_router
 from app.api.auth import get_auth_router
 from app.api.channels import get_channels_router
 from app.api.chat import get_chat_router
-from app.integrations.telegram import telegram_lifespan
 from app.api.conversations import get_conversations_router
 from app.api.models import get_models_router
 from app.api.oauth import get_oauth_router
 from app.api.personalization import get_personalization_router
 from app.api.projects import get_projects_router
+from app.api.stt import get_stt_router
 from app.api.workspace import get_workspace_router
 from app.api.workspace_env import get_workspace_env_router
-from app.api.stt import get_stt_router
 from app.cli.admin_seed import seed_admin_user
 from app.core.config import settings
 from app.core.request_logging import RequestLoggingMiddleware
+from app.core.telemetry import init_sigil_runtime, shutdown_sigil_runtime
 from app.db import create_db_and_tables
+from app.integrations.telegram import telegram_lifespan
 from app.logger_setup import (
     configure_logging,  # Set up logging configuration (this should be done before any loggers are used)
 )
@@ -47,17 +48,21 @@ configure_logging()
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Run startup tasks (database table creation) before the app begins serving."""
-    await create_db_and_tables()
-    # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
-    await seed_admin_user()
-    # Bring the Telegram channel up alongside the HTTP server when a bot
-    # token is configured. The context manager yields None and is a no-op
-    # when the channel is disabled, so this stays safe for stripped-down
-    # deployments (CI, ephemeral previews, ...). Stash the service on
-    # `app.state` so the webhook route can hand updates to aiogram.
-    async with telegram_lifespan() as telegram_service:
-        app.state.telegram_service = telegram_service
-        yield
+    init_sigil_runtime()
+    try:
+        await create_db_and_tables()
+        # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
+        await seed_admin_user()
+        # Bring the Telegram channel up alongside the HTTP server when a bot
+        # token is configured. The context manager yields None and is a no-op
+        # when the channel is disabled, so this stays safe for stripped-down
+        # deployments (CI, ephemeral previews, ...). Stash the service on
+        # `app.state` so the webhook route can hand updates to aiogram.
+        async with telegram_lifespan() as telegram_service:
+            app.state.telegram_service = telegram_service
+            yield
+    finally:
+        shutdown_sigil_runtime()
 
 
 # --- App & Middleware --------------------------------------------------------

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "python-dotenv>=1.2.1",
     "sqlalchemy-utils>=0.42.1",
+    "sigil-sdk>=0.2.0",
+    "opentelemetry-sdk>=1.41.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.41.1",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_claude_provider.py
+++ b/backend/tests/test_claude_provider.py
@@ -2,7 +2,7 @@
 
 The Claude SDK runs the Claude Code CLI as a subprocess. We do not exercise
 that subprocess in unit tests — instead, we mock :func:`claude_agent_sdk.query`
-(re-exported into ``app.core.providers.claude_provider`` as ``query``) and
+(imported in ``app.core.providers.claude_query_stream`` as ``query``) and
 assert that:
 
 - :class:`ClaudeLLM` builds correct :class:`ClaudeAgentOptions`
@@ -44,6 +44,7 @@ from app.core.providers import (
     StreamEvent,
 )
 from app.core.providers import claude_provider as cp_module
+from app.core.providers import claude_query_stream as cqs_module
 from app.core.providers.claude_provider import (
     _events_from_message,
     _resolve_sdk_model,
@@ -95,7 +96,7 @@ def _patch_query(
     monkeypatch: pytest.MonkeyPatch,
     fake: Callable[..., AsyncIterator[Any]],
 ) -> list[ClaudeAgentOptions]:
-    """Replace ``claude_provider.query`` with ``fake`` and capture the options used.
+    """Replace ``claude_query_stream.query`` with ``fake`` and capture the options used.
 
     Returns:
         A list that the recorder appends to. Use it to assert on the
@@ -105,14 +106,14 @@ def _patch_query(
 
     def _wrapper(
         *,
-        prompt: str,
+        prompt: Any,
         options: ClaudeAgentOptions,
         transport: Any | None = None,
     ) -> AsyncIterator[Any]:
         captured.append(options)
         return fake(prompt=prompt, options=options, transport=transport)
 
-    monkeypatch.setattr(cp_module, "query", _wrapper)
+    monkeypatch.setattr(cqs_module, "query", _wrapper)
     return captured
 
 
@@ -142,9 +143,7 @@ async def _collect(
     conversation_id: UUID,
     user_id: UUID,
 ) -> list[StreamEvent]:
-    return [
-        event async for event in provider.stream(question, conversation_id, user_id)
-    ]
+    return [event async for event in provider.stream(question, conversation_id, user_id)]
 
 
 # ---------------------------------------------------------------------------
@@ -264,9 +263,7 @@ class TestEventsFromMessage:
             model="claude",
         )
         events = list(_events_from_message(message))
-        assert events == [
-            {"type": "tool_result", "tool_use_id": "tu_1", "content": "output"}
-        ]
+        assert events == [{"type": "tool_result", "tool_use_id": "tu_1", "content": "output"}]
 
     def test_assistant_mixed_blocks_preserve_order(self) -> None:
         """Multiple blocks in one message should yield events in order."""
@@ -300,9 +297,7 @@ class TestEventsFromMessage:
             content=[ToolResultBlock(tool_use_id="tu_1", content="ok")],
         )
         events = list(_events_from_message(message))
-        assert events == [
-            {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"}
-        ]
+        assert events == [{"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"}]
 
     def test_user_message_with_string_content_emits_nothing(self) -> None:
         """Plain string user messages are echoes — no events should be emitted."""
@@ -403,10 +398,7 @@ class TestProviderOptions:
         # Default falls back to the shared `DEFAULT_AGENT_SYSTEM_PROMPT`
         # (provider-agnostic since PR #131 review).  Real chat traffic
         # gets the workspace's SOUL.md + AGENTS.md instead.
-        assert (
-            options.system_prompt is not None
-            and "chat application" in options.system_prompt
-        )
+        assert options.system_prompt is not None and "chat application" in options.system_prompt
 
     @pytest.mark.anyio
     async def test_first_turn_uses_session_id_not_resume(
@@ -857,9 +849,7 @@ class TestFactory:
         assert isinstance(provider, ClaudeLLM)
         assert provider._config.oauth_token == "from-config"
 
-    def test_resolve_llm_omits_token_when_blank(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_resolve_llm_omits_token_when_blank(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A blank token in settings must coerce to ``None`` so we don't forward an empty value."""
         from app.core.providers import factory  # noqa: PLC0415 — late import isolates monkeypatch
 
@@ -904,35 +894,37 @@ class TestProviderScenarios:
         """
         _patch_query(
             monkeypatch,
-            _async_iter([
-                AssistantMessage(
-                    content=[
-                        ThinkingBlock(thinking="let me check the files", signature="sig"),
-                        ToolUseBlock(id="tu_ls", name="Bash", input={"cmd": "ls"}),
-                    ],
-                    model="claude",
-                ),
-                UserMessage(
-                    content=[
-                        ToolResultBlock(
-                            tool_use_id="tu_ls",
-                            content="file.txt\nother.txt",
-                        )
-                    ],
-                ),
-                AssistantMessage(
-                    content=[TextBlock(text="Found 2 files.")],
-                    model="claude",
-                ),
-                ResultMessage(
-                    subtype="success",
-                    duration_ms=100,
-                    duration_api_ms=80,
-                    is_error=False,
-                    num_turns=2,
-                    session_id="s",
-                ),
-            ]),
+            _async_iter(
+                [
+                    AssistantMessage(
+                        content=[
+                            ThinkingBlock(thinking="let me check the files", signature="sig"),
+                            ToolUseBlock(id="tu_ls", name="Bash", input={"cmd": "ls"}),
+                        ],
+                        model="claude",
+                    ),
+                    UserMessage(
+                        content=[
+                            ToolResultBlock(
+                                tool_use_id="tu_ls",
+                                content="file.txt\nother.txt",
+                            )
+                        ],
+                    ),
+                    AssistantMessage(
+                        content=[TextBlock(text="Found 2 files.")],
+                        model="claude",
+                    ),
+                    ResultMessage(
+                        subtype="success",
+                        duration_ms=100,
+                        duration_api_ms=80,
+                        is_error=False,
+                        num_turns=2,
+                        session_id="s",
+                    ),
+                ]
+            ),
         )
 
         events = await _collect(
@@ -969,25 +961,27 @@ class TestProviderScenarios:
         """
         _patch_query(
             monkeypatch,
-            _async_iter([
-                AssistantMessage(
-                    content=[
-                        ToolUseBlock(id="tu_a", name="Read", input={"path": "a.txt"}),
-                        ToolUseBlock(id="tu_b", name="Read", input={"path": "b.txt"}),
-                    ],
-                    model="claude",
-                ),
-                UserMessage(
-                    content=[
-                        ToolResultBlock(tool_use_id="tu_a", content="content-a"),
-                        ToolResultBlock(tool_use_id="tu_b", content="content-b"),
-                    ],
-                ),
-                AssistantMessage(
-                    content=[TextBlock(text="done")],
-                    model="claude",
-                ),
-            ]),
+            _async_iter(
+                [
+                    AssistantMessage(
+                        content=[
+                            ToolUseBlock(id="tu_a", name="Read", input={"path": "a.txt"}),
+                            ToolUseBlock(id="tu_b", name="Read", input={"path": "b.txt"}),
+                        ],
+                        model="claude",
+                    ),
+                    UserMessage(
+                        content=[
+                            ToolResultBlock(tool_use_id="tu_a", content="content-a"),
+                            ToolResultBlock(tool_use_id="tu_b", content="content-b"),
+                        ],
+                    ),
+                    AssistantMessage(
+                        content=[TextBlock(text="done")],
+                        model="claude",
+                    ),
+                ]
+            ),
         )
 
         events = await _collect(
@@ -1020,21 +1014,23 @@ class TestProviderScenarios:
         """
         _patch_query(
             monkeypatch,
-            _async_iter([
-                AssistantMessage(
-                    content=[TextBlock(text="partial answer")],
-                    model="claude",
-                ),
-                ResultMessage(
-                    subtype="error_max_turns",
-                    duration_ms=500,
-                    duration_api_ms=450,
-                    is_error=True,
-                    num_turns=1,
-                    session_id="s",
-                    stop_reason="max_turns",
-                ),
-            ]),
+            _async_iter(
+                [
+                    AssistantMessage(
+                        content=[TextBlock(text="partial answer")],
+                        model="claude",
+                    ),
+                    ResultMessage(
+                        subtype="error_max_turns",
+                        duration_ms=500,
+                        duration_api_ms=450,
+                        is_error=True,
+                        num_turns=1,
+                        session_id="s",
+                        stop_reason="max_turns",
+                    ),
+                ]
+            ),
         )
 
         events = await _collect(

--- a/backend/tests/test_sigil_deferred.py
+++ b/backend/tests/test_sigil_deferred.py
@@ -1,0 +1,78 @@
+"""Tests for deferred Sigil paths (Claude stream helpers, Gemini SYNC)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.core.providers.base import StreamEvent
+from app.core.telemetry import sigil_runtime
+from app.core.telemetry.sigil_claude import (
+    ClaudeSigilAccum,
+    apply_claude_stream_event_for_sigil,
+    finalize_claude_streaming_generation,
+    make_claude_generation_start,
+)
+from app.core.telemetry.sigil_gemini import make_generation_start
+
+
+@pytest.fixture(autouse=True)
+def _reset_sigil_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SIGIL_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SIGIL_INSTRUMENTATION_ONLY", raising=False)
+    monkeypatch.delenv("SIGIL_DISABLED", raising=False)
+    sigil_runtime.shutdown_sigil_runtime()
+    yield
+    sigil_runtime.shutdown_sigil_runtime()
+
+
+def test_make_claude_generation_start_tags() -> None:
+    start = make_claude_generation_start("claude-sonnet-4-5", "conv-1")
+    assert start.conversation_id == "conv-1"
+    assert start.model.provider == "anthropic"
+    assert start.model.name == "claude-sonnet-4-5"
+    assert start.tags.get("pipeline") == "claude-agent-sdk"
+
+
+def test_apply_claude_stream_event_for_sigil_delta_and_tool() -> None:
+    accum = ClaudeSigilAccum()
+    rec = MagicMock()
+    first = [False]
+    apply_claude_stream_event_for_sigil(
+        StreamEvent(type="delta", content="hello"),
+        rec,
+        first_mark=first,
+        accum=accum,
+    )
+    assert accum.full_text_chunks == ["hello"]
+    apply_claude_stream_event_for_sigil(
+        StreamEvent(type="tool_use", name="web_search", tool_use_id="tu1", input={"q": "x"}),
+        rec,
+        first_mark=first,
+        accum=accum,
+    )
+    assert len(accum.tool_calls) == 1
+    assert accum.tool_calls[0]["name"] == "web_search"
+
+
+def test_finalize_claude_streaming_generation_calls_set_result() -> None:
+    rec = MagicMock()
+    accum = ClaudeSigilAccum()
+    accum.full_text_chunks.append("done")
+    finalize_claude_streaming_generation(
+        rec,
+        question="hi",
+        response_model="claude-sonnet-4-5",
+        accum=accum,
+    )
+    rec.set_result.assert_called_once()
+    call_kw = rec.set_result.call_args.kwargs
+    assert call_kw["stop_reason"] == "stop"
+    assert call_kw["response_model"] == "claude-sonnet-4-5"
+
+
+def test_make_generation_start_matches_gemini_provider_shape() -> None:
+    start = make_generation_start("gemini-1.5-flash", "c1", operation_name="generateContent")
+    assert start.operation_name == "generateContent"
+    assert start.model.name == "gemini-1.5-flash"

--- a/backend/tests/test_sigil_runtime.py
+++ b/backend/tests/test_sigil_runtime.py
@@ -1,0 +1,47 @@
+"""Tests for Grafana Sigil + OTLP bootstrap (:mod:`app.core.telemetry.sigil_runtime`)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.telemetry import sigil_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_sigil_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts from a clean telemetry module state."""
+
+    monkeypatch.delenv("SIGIL_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SIGIL_INSTRUMENTATION_ONLY", raising=False)
+    monkeypatch.delenv("SIGIL_DISABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    sigil_runtime.shutdown_sigil_runtime()
+    yield
+    sigil_runtime.shutdown_sigil_runtime()
+
+
+def test_sigil_client_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without token or instrumentation-only flag, no Sigil client is constructed."""
+
+    monkeypatch.delenv("SIGIL_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SIGIL_INSTRUMENTATION_ONLY", raising=False)
+    sigil_runtime.init_sigil_runtime()
+    assert sigil_runtime.get_sigil_client() is None
+
+
+def test_sigil_instrumentation_only_builds_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Instrumentation-only mode uses generation export protocol ``none``."""
+
+    monkeypatch.setenv("SIGIL_INSTRUMENTATION_ONLY", "true")
+    monkeypatch.delenv("SIGIL_AUTH_TOKEN", raising=False)
+    sigil_runtime.init_sigil_runtime()
+    client = sigil_runtime.get_sigil_client()
+    assert client is not None
+    sigil_runtime.shutdown_sigil_runtime()
+
+
+def test_sigil_disabled_skips_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SIGIL_DISABLED", "true")
+    monkeypatch.setenv("SIGIL_AUTH_TOKEN", "glc_test_fake")
+    sigil_runtime.init_sigil_runtime()
+    assert sigil_runtime.get_sigil_client() is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -864,6 +864,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -895,6 +907,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -981,6 +1024,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1343,6 +1398,106 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f2/c54f33c92443d087703e57e52e55f22f111373a5c4c4aa349ea60efe512e/opentelemetry_exporter_otlp_proto_grpc-1.41.1-py3-none-any.whl", hash = "sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94", size = 20297, upload-time = "2026-04-24T13:15:20.212Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1374,10 +1529,13 @@ dependencies = [
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "google-genai" },
     { name = "mcp" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "psycopg" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "sigil-sdk" },
     { name = "sqlalchemy-utils" },
 ]
 
@@ -1402,10 +1560,13 @@ requires-dist = [
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.3" },
     { name = "google-genai", specifier = ">=1.56.0" },
     { name = "mcp", specifier = ">=1.27.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.41.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.41.1" },
     { name = "psycopg", specifier = ">=3.3.3" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
+    { name = "pydantic", specifier = ">=2.12.5,<2.14" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "sigil-sdk", specifier = ">=0.2.0" },
     { name = "sqlalchemy-utils", specifier = ">=0.42.1" },
 ]
 
@@ -1520,6 +1681,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2034,6 +2210,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sigil-sdk"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f1/2a96410a63c701089be989dfe28ac165b765362f136a05fb472f617b5677/sigil_sdk-0.2.0.tar.gz", hash = "sha256:ef72e20da3b8b9027a99bfad0d32267fe37faf7f0fac3d8d4703317246adf7f1", size = 86502, upload-time = "2026-05-01T09:09:12.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0f/1ca0db6273425a64332b88938ead7a6affbffe3c32f46a24cc302b233517/sigil_sdk-0.2.0-py3-none-any.whl", hash = "sha256:876a49be5860974dc8367a48dc4e4ee85b52013924cad922cf755658d0c714c2", size = 59112, upload-time = "2026-05-01T09:09:11.503Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2446,4 +2640,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary

Adds **Grafana Sigil** Python SDK instrumentation and **OpenTelemetry OTLP/HTTP** bootstrap so Sigil’s spans and metrics are not dropped on no-op providers. Covers the main AI paths: **Gemini agent loop (STREAM)**, **agent-loop tools**, **Claude Agent SDK streaming (STREAM)**, and **non-stream Gemini** (`generate_content` / SYNC) including **`just commit`** / title-style utilities.

## Changes

- **`app/core/telemetry/sigil_runtime.py`** — Initialize OTLP TracerProvider/MeterProvider when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; construct Sigil `Client` from canonical `SIGIL_*` env (including `SIGIL_INSTRUMENTATION_ONLY` / `SIGIL_DISABLED`). Shutdown order: Sigil client → meter → tracer.
- **`main.py`** — Lifespan hooks for init/shutdown.
- **Gemini** — `make_gemini_stream_fn` + helpers in `sigil_gemini.py`: streaming generations, usage metadata, TTFT, errors.
- **Agent loop** — `execute_tool.run_agent_tool` + Sigil tool spans.
- **Claude** — `ClaudeLLM.stream`: STREAM generations, `with_conversation_id`; query iteration split into `claude_query_stream.py` / `claude_sdk_input.py` for line/nesting limits.
- **`gemini_utils`** — `generate_content_sync_recorded` (SYNC); used by `generate_text_once` and `app/cli/commit.py`.
- **Docs / env** — `backend/.env.example` Sigil + OTEL section.
- **Tests** — `test_sigil_runtime.py`, `test_sigil_deferred.py`; Claude tests mock `claude_query_stream.query`.

## How to test locally

1. Optional: set `SIGIL_*`, `OTEL_EXPORTER_OTLP_*`, and `OTEL_SERVICE_NAME` per `backend/.env.example`.
2. `cd backend && uv run pytest` — full suite should pass.
3. Smoke: run a Gemini chat, a Claude chat (if CLI/SDK available), and `just commit` / title generation with Sigil enabled and confirm generations in Grafana AI Observability.

## Risk / rollout

- Behavioral intent is unchanged except additive telemetry; invalid Sigil configuration surfaces via logs / `rec.err()` checks where implemented.
- Configure OTLP **before** Sigil client startup for metrics/spans to export.


Made with [Cursor](https://cursor.com)