### PR TITLE
[01] spike(electrobun): Electrobun desktop shell proof-of-concept

### DIFF
--- a/electrobun/README.md
+++ b/electrobun/README.md
@@ -53,6 +53,24 @@ electrobun/
 
 **Electrobun:** `bun.messages.permissionsRespond` RPC message handler + `webview.messages.permissionsPrompt` RPC send.
 
+## Dev Setup
+
+The Electrobun shell is a **wrapper** around the Next.js frontend — it needs the frontend server running separately.
+
+**Terminal 1 — Next.js frontend** (from the repo root):
+```bash
+pnpm dev   # starts on http://localhost:3000
+```
+
+**Terminal 2 — Electrobun shell** (from `electrobun/`):
+```bash
+bun start  # builds then launches the native window
+```
+
+The native window will load `http://localhost:3000` automatically. A white screen means the Next.js server is not yet running.
+
+> **Note:** `bun start` builds the Bun main-process bundle and native wrapper each time. First cold build takes ~30s; subsequent runs are faster.
+
 ## Running Tests
 
 ```bash

--- a/electrobun/README.md
+++ b/electrobun/README.md
@@ -1,0 +1,71 @@
+# Pawrrtal — Electrobun Spike
+
+Proof-of-concept port of `electron/` → [Electrobun](https://electrobun.dev) for evaluating a lighter-weight desktop shell for Pawrrtal.
+
+## Why
+
+| | Electron | Electrobun |
+|---|---|---|
+| Bundle size | ~150 MB | ~14 MB (system webview) |
+| App updates | Full re-download | bsdiff patch ≥ 4 KB |
+| Runtime | Node.js | Bun |
+| IPC | `ipcMain.handle` + `contextBridge` | Typed `BrowserView.defineRPC<T>` |
+| Store | electron-store | JSON file (`src/bun/store.ts`) |
+
+## Structure
+
+```
+electrobun/
+├── electrobun.config.ts     # Build config (entrypoint, views, app identity)
+├── src/
+│   ├── shared/
+│   │   └── rpc-types.ts     # Typed IPC surface (replaces preload.ts + ipc.ts)
+│   └── bun/
+│       ├── index.ts          # Main process (BrowserWindow + RPC handlers)
+│       ├── store.ts          # Lightweight JSON file store
+│       ├── workspace.ts      # Workspace allowlist (ported from electron/)
+│       ├── permissions.ts    # Permission state machine (ported from electron/)
+│       ├── handlers/
+│       │   ├── fs.ts         # Filesystem handlers
+│       │   └── shell.ts      # Shell execution handlers (uses Bun.spawn)
+│       └── *.test.ts         # Vitest tests (node env, no display needed)
+```
+
+## Key Architectural Differences
+
+### IPC Bridge
+**Electron:** `preload.ts` exposes `contextBridge.exposeInMainWorld('pawrrtal', api)`; handlers registered via `ipcMain.handle('channel', fn)`.
+
+**Electrobun:** Single shared `src/shared/rpc-types.ts` defines `PawrrtalRPCType`. The main process calls `BrowserView.defineRPC<PawrrtalRPCType>({ handlers })`. The webview uses `Electroview.defineRPC<PawrrtalRPCType>({ handlers })`. No preload script needed.
+
+### Persistent Store
+**Electron:** `electron-store` (Node-only npm package).
+
+**Electrobun:** `src/bun/store.ts` — thin typed wrapper around `Bun.file` / `Bun.write`. Same `get(key)` / `set(key, value)` API as electron-store for easy port.
+
+### Push Events (webview ← main)
+**Electron:** `webContents.send('channel', payload)` + `ipcRenderer.on('channel', handler)`.
+
+**Electrobun:** `win.webview.rpc.send.channelName(payload)` — type-safe, no string channel names.
+
+### Permission Prompt
+**Electron:** `ipcMain.on('permissions:respond', ...)` + `webContents.send('permissions:prompt', ...)`.
+
+**Electrobun:** `bun.messages.permissionsRespond` RPC message handler + `webview.messages.permissionsPrompt` RPC send.
+
+## Running Tests
+
+```bash
+cd electrobun
+bun install
+bun test
+```
+
+Tests cover `Store`, `workspace` (path validation, root management), and `permissions` (state machine, prompt round-trip). All run in Vitest's node environment — no display, no Electrobun binary needed.
+
+## Known Gaps vs Electron Shell
+
+- `showOpenFolderDialog` is a stub (native dialog API still being evaluated in Electrobun v1.x).
+- Linux: CEF flag should be enabled (`bundleCEF: true`) to get full webview layering.
+- `app.requestSingleInstanceLock()` is handled automatically by Electrobun.
+- Windows: shell spawn uses `Bun.spawn` — verify path escaping on Windows paths.

--- a/electrobun/bun.lock
+++ b/electrobun/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@pawrrtal/electrobun",
       "dependencies": {
+        "chokidar": "^5.0.0",
         "electrobun": "^1.18.1",
       },
       "devDependencies": {
@@ -202,6 +203,8 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -331,6 +334,8 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
 

--- a/electrobun/bun.lock
+++ b/electrobun/bun.lock
@@ -1,0 +1,441 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@pawrrtal/electrobun",
+      "dependencies": {
+        "electrobun": "^1.18.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@vitest/coverage-v8": "^3.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.1.0",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.3", "", { "os": "android", "cpu": "arm64" }, "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.3", "", { "os": "none", "cpu": "arm64" }, "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "electrobun": ["electrobun@1.18.1", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
+
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
+
+    "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
+
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
+
+    "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+  }
+}

--- a/electrobun/electrobun.config.ts
+++ b/electrobun/electrobun.config.ts
@@ -20,9 +20,13 @@ export default {
 		bun: {
 			entrypoint: 'src/bun/index.ts',
 		},
-		// No `views` entries needed: BrowserWindow loads the Next.js frontend
-		// via a plain http(s):// URL (`url: FRONTEND_URL` in src/bun/index.ts).
-		// The `views` block is only for bundled TypeScript webview entrypoints
-		// served under the views:// scheme — not applicable here.
+		// No TypeScript view bundles needed — BrowserWindow loads Next.js via http://.
+		// We DO copy a static splash HTML so we can use views://splash/index.html
+		// as the initial URL while waiting for Next.js to boot. views:// is a
+		// proper secure context (unlike data: URLs) so Electrobun preload scripts
+		// (which use crypto.subtle) work correctly on the splash page.
+		copy: {
+			'src/splash/index.html': 'views/splash/index.html',
+		},
 	},
 };

--- a/electrobun/electrobun.config.ts
+++ b/electrobun/electrobun.config.ts
@@ -20,15 +20,9 @@ export default {
 		bun: {
 			entrypoint: 'src/bun/index.ts',
 		},
-		views: {
-			// The webview that loads the Next.js shell.
-			// In dev it hits http://localhost:3000; in production it
-			// points to the bundled standalone Next.js server URL.
-			mainview: {
-				// No bundled HTML — we navigate to a URL at runtime.
-				// The views:// scheme is only used for bundled static assets;
-				// for Next.js we use http(s):// at all times.
-			},
-		},
+		// No `views` entries needed: BrowserWindow loads the Next.js frontend
+		// via a plain http(s):// URL (`url: FRONTEND_URL` in src/bun/index.ts).
+		// The `views` block is only for bundled TypeScript webview entrypoints
+		// served under the views:// scheme — not applicable here.
 	},
 };

--- a/electrobun/electrobun.config.ts
+++ b/electrobun/electrobun.config.ts
@@ -1,0 +1,34 @@
+/**
+ * Electrobun build configuration for Pawrrtal.
+ *
+ * Mirrors the electron/ shell's responsibility: wrap the Next.js frontend
+ * (running on localhost:3000 in dev, or spawned as a standalone Next.js
+ * server in production) inside a native desktop window.
+ *
+ * Key differences from the Electron build:
+ *   - No separate preload script — IPC is replaced by Electrobun's typed RPC.
+ *   - electron-store replaced by a lightweight JSON file store (src/bun/store.ts).
+ *   - contextBridge.exposeInMainWorld replaced by shared src/shared/rpc-types.ts.
+ */
+export default {
+	app: {
+		name: 'Pawrrtal',
+		identifier: 'ai.pawrrtal.app',
+		version: '0.1.0',
+	},
+	build: {
+		bun: {
+			entrypoint: 'src/bun/index.ts',
+		},
+		views: {
+			// The webview that loads the Next.js shell.
+			// In dev it hits http://localhost:3000; in production it
+			// points to the bundled standalone Next.js server URL.
+			mainview: {
+				// No bundled HTML — we navigate to a URL at runtime.
+				// The views:// scheme is only used for bundled static assets;
+				// for Next.js we use http(s):// at all times.
+			},
+		},
+	},
+};

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -12,6 +12,7 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
+		"chokidar": "^5.0.0",
 		"electrobun": "^1.18.1"
 	},
 	"devDependencies": {

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@pawrrtal/electrobun",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Pawrrtal desktop shell — Electrobun spike replacing Electron.",
+	"scripts": {
+		"start": "bun run build:dev && electrobun dev",
+		"build:dev": "bun install && electrobun build",
+		"build": "electrobun build --env=stable",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"electrobun": "^1.18.1"
+	},
+	"devDependencies": {
+		"@types/bun": "latest",
+		"@vitest/coverage-v8": "^3.1.0",
+		"typescript": "^5.0.0",
+		"vitest": "^3.1.0"
+	}
+}

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"description": "Pawrrtal desktop shell — Electrobun spike replacing Electron.",
 	"scripts": {
-		"start": "bun run build:dev && electrobun dev",
+		"start": "PAWRRTAL_REPO_ROOT=$(cd .. && pwd) bun run build:dev && PAWRRTAL_REPO_ROOT=$(cd .. && pwd) electrobun dev",
 		"build:dev": "bun install && electrobun build",
 		"build": "electrobun build --env=stable",
 		"test": "vitest run",

--- a/electrobun/src/bun/handlers/fs.ts
+++ b/electrobun/src/bun/handlers/fs.ts
@@ -1,0 +1,141 @@
+/**
+ * Filesystem handlers for Pawrrtal's Electrobun shell.
+ *
+ * Ported from electron/src/handlers/fs.ts. The security contract
+ * (workspace validation + permission gate on writes) is identical.
+ *
+ * Changes from the Electron version:
+ *   - No `ipcMain.handle` / BrowserWindow imports — handlers are plain
+ *     async functions called directly from the RPC handler in index.ts.
+ *   - Watch events are pushed via a caller-supplied callback instead of
+ *     `webContents.send`, keeping this module free of Electrobun imports
+ *     so it can run in Vitest's node environment.
+ *   - chokidar remains the watcher (works equally well under Bun).
+ */
+
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { watch, type FSWatcher } from 'chokidar';
+
+import type { DirEntry, Result, WatchEvent } from '../../shared/rpc-types';
+import { requestPermission } from '../permissions';
+import { validateFilePath } from '../workspace';
+
+const watchers = new Map<string, FSWatcher>();
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+export async function handleFsReadFile(rawPath: string): Promise<Result<{ content: string }>> {
+	const validated = validateFilePath(rawPath);
+	if (!validated.ok) return validated;
+	try {
+		const content = await fsp.readFile(validated.resolvedPath, 'utf8');
+		return { ok: true, content };
+	} catch (error) {
+		return { ok: false, reason: stringifyError(error) };
+	}
+}
+
+export async function handleFsWriteFile(rawPath: string, content: string): Promise<Result> {
+	const validated = validateFilePath(rawPath);
+	if (!validated.ok) return validated;
+
+	const decision = await requestPermission({
+		op: 'fs:write',
+		subject:
+			path.relative(validated.root, validated.resolvedPath) ||
+			path.basename(validated.resolvedPath),
+		rootId: validated.root,
+		context: { bytes: content.length },
+	});
+	if (decision === 'deny') {
+		return { ok: false, reason: 'Permission denied by user.' };
+	}
+
+	try {
+		await fsp.mkdir(path.dirname(validated.resolvedPath), { recursive: true });
+		await fsp.writeFile(validated.resolvedPath, content, 'utf8');
+		return { ok: true };
+	} catch (error) {
+		return { ok: false, reason: stringifyError(error) };
+	}
+}
+
+export async function handleFsListDirectory(
+	rawPath: string,
+): Promise<Result<{ entries: DirEntry[] }>> {
+	const validated = validateFilePath(rawPath);
+	if (!validated.ok) return validated;
+	try {
+		const names = await fsp.readdir(validated.resolvedPath);
+		const entries = await Promise.all(
+			names.map(async (name) => {
+				const fullPath = path.join(validated.resolvedPath, name);
+				try {
+					const stat = await fsp.stat(fullPath);
+					return {
+						name,
+						path: fullPath,
+						isDirectory: stat.isDirectory(),
+						size: stat.size,
+						modifiedAt: stat.mtimeMs,
+					} satisfies DirEntry;
+				} catch {
+					return {
+						name,
+						path: fullPath,
+						isDirectory: false,
+						size: 0,
+						modifiedAt: 0,
+					} satisfies DirEntry;
+				}
+			}),
+		);
+		return { ok: true, entries };
+	} catch (error) {
+		return { ok: false, reason: stringifyError(error) };
+	}
+}
+
+export async function handleFsWatchDirectory(
+	rawPath: string,
+	onEvent: (event: WatchEvent) => void,
+): Promise<Result<{ id: string }>> {
+	const validated = validateFilePath(rawPath);
+	if (!validated.ok) return validated;
+
+	const id = randomUUID();
+	const watcher = watch(validated.resolvedPath, {
+		persistent: true,
+		ignoreInitial: true,
+		awaitWriteFinish: { stabilityThreshold: 200 },
+	});
+
+	const emit = (type: WatchEvent['type'], p: string) => onEvent({ id, type, path: p });
+	watcher.on('add', (p) => emit('add', p));
+	watcher.on('change', (p) => emit('change', p));
+	watcher.on('unlink', (p) => emit('unlink', p));
+	watcher.on('addDir', (p) => emit('addDir', p));
+	watcher.on('unlinkDir', (p) => emit('unlinkDir', p));
+	watcher.on('error', (p) => emit('error', String(p)));
+
+	watchers.set(id, watcher);
+	return { ok: true, id };
+}
+
+export async function handleFsUnwatch(id: string): Promise<Result> {
+	const watcher = watchers.get(id);
+	if (!watcher) return { ok: false, reason: `No active watcher with id ${id}.` };
+	await watcher.close();
+	watchers.delete(id);
+	return { ok: true };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function stringifyError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error);
+}

--- a/electrobun/src/bun/handlers/shell.ts
+++ b/electrobun/src/bun/handlers/shell.ts
@@ -1,0 +1,168 @@
+/**
+ * Shell execution handlers for Pawrrtal's Electrobun shell.
+ *
+ * Ported from electron/src/handlers/shell.ts. Security contract
+ * (workspace-root validation + permission gate) is identical.
+ *
+ * Changes:
+ *   - No `ipcMain` — plain async functions called from the RPC layer.
+ *   - Stream events pushed via caller-supplied callbacks instead of
+ *     `webContents.send`, keeping this module testable in node env.
+ *   - Uses `Bun.spawn` instead of Node's `child_process` for alignment
+ *     with the Bun runtime Electrobun ships.
+ */
+
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import type { Result, RunRequest, RunResult, ShellStreamEnd, ShellStreamEvent } from '../../shared/rpc-types';
+import { requestPermission } from '../permissions';
+import { validateFilePath } from '../workspace';
+
+/** Running streaming jobs indexed by jobId. */
+const streamingJobs = new Map<string, ReturnType<typeof Bun.spawn>>();
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+export async function handleShellRun(request: RunRequest): Promise<Result<RunResult>> {
+	const cwdValidated = validateFilePath(request.cwd);
+	if (!cwdValidated.ok) return cwdValidated;
+
+	const decision = await requestPermission({
+		op: 'shell:run',
+		subject: `${request.command}${request.args ? ' ' + request.args.join(' ') : ''}`,
+		rootId: cwdValidated.root,
+		context: { cwd: request.cwd },
+	});
+	if (decision === 'deny') return { ok: false, reason: 'Permission denied by user.' };
+
+	try {
+		const proc = Bun.spawn(
+			[request.command, ...(request.args ?? [])],
+			{
+				cwd: cwdValidated.resolvedPath,
+				env: { ...process.env, ...(request.env ?? {}) },
+				stdout: 'pipe',
+				stderr: 'pipe',
+			},
+		);
+
+		const timeoutMs = request.timeoutMs ?? 60_000;
+		let timedOut = false;
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			proc.kill();
+		}, timeoutMs);
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readAll(proc.stdout),
+			readAll(proc.stderr),
+			proc.exited,
+		]);
+		clearTimeout(timeout);
+
+		if (timedOut) {
+			return {
+				ok: false,
+				reason: `Command timed out after ${timeoutMs}ms.`,
+			};
+		}
+		return { ok: true, stdout, stderr, exitCode };
+	} catch (error) {
+		return { ok: false, reason: stringifyError(error) };
+	}
+}
+
+export async function handleShellSpawnStreaming(
+	request: RunRequest,
+	onStream: (event: ShellStreamEvent) => void,
+	onEnd: (event: ShellStreamEnd) => void,
+): Promise<Result<{ jobId: string }>> {
+	const cwdValidated = validateFilePath(request.cwd);
+	if (!cwdValidated.ok) return cwdValidated;
+
+	const decision = await requestPermission({
+		op: 'shell:spawn',
+		subject: `${request.command}${request.args ? ' ' + request.args.join(' ') : ''}`,
+		rootId: cwdValidated.root,
+		context: { cwd: request.cwd },
+	});
+	if (decision === 'deny') return { ok: false, reason: 'Permission denied by user.' };
+
+	const jobId = randomUUID();
+	try {
+		const proc = Bun.spawn(
+			[request.command, ...(request.args ?? [])],
+			{
+				cwd: cwdValidated.resolvedPath,
+				env: { ...process.env, ...(request.env ?? {}) },
+				stdout: 'pipe',
+				stderr: 'pipe',
+			},
+		);
+		streamingJobs.set(jobId, proc);
+
+		// Stream stdout
+		streamLines(proc.stdout, (line) =>
+			onStream({ jobId, channel: 'stdout', line }),
+		);
+		// Stream stderr
+		streamLines(proc.stderr, (line) =>
+			onStream({ jobId, channel: 'stderr', line }),
+		);
+		// On exit, send the end event.
+		proc.exited.then((exitCode) => {
+			streamingJobs.delete(jobId);
+			onEnd({ jobId, exitCode });
+		}).catch((error) => {
+			streamingJobs.delete(jobId);
+			onEnd({ jobId, exitCode: null, error: stringifyError(error) });
+		});
+
+		return { ok: true, jobId };
+	} catch (error) {
+		streamingJobs.delete(jobId);
+		return { ok: false, reason: stringifyError(error) };
+	}
+}
+
+export async function handleShellKill(jobId: string): Promise<Result> {
+	const proc = streamingJobs.get(jobId);
+	if (!proc) return { ok: false, reason: `No active job with id ${jobId}.` };
+	proc.kill();
+	streamingJobs.delete(jobId);
+	return { ok: true };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function readAll(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+	if (!stream) return '';
+	const chunks: string[] = [];
+	for await (const chunk of stream) {
+		chunks.push(new TextDecoder().decode(chunk));
+	}
+	return chunks.join('');
+}
+
+async function streamLines(
+	stream: ReadableStream<Uint8Array> | null,
+	onLine: (line: string) => void,
+): Promise<void> {
+	if (!stream) return;
+	let buffer = '';
+	for await (const chunk of stream) {
+		buffer += new TextDecoder().decode(chunk);
+		let nl: number;
+		while ((nl = buffer.indexOf('\n')) !== -1) {
+			onLine(buffer.slice(0, nl));
+			buffer = buffer.slice(nl + 1);
+		}
+	}
+	if (buffer.length > 0) onLine(buffer);
+}
+
+function stringifyError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error);
+}

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -163,8 +163,24 @@ ApplicationMenu.setApplicationMenu([
 
 ensureDefaultWorkspaceRoot();
 
-// Handle custom menu actions (registered before window so the menu is
-// interactive immediately when the window appears).
+// Open the splash window immediately so the app appears in the Dock
+// and the user sees visible feedback while Next.js + FastAPI boot.
+// views://splash/index.html is served by Electrobun's own server — a
+// proper secure context, unlike data: URLs (which break crypto.subtle
+// in Electrobun's injected preload scripts).
+win = new BrowserWindow({
+	title: 'Pawrrtal',
+	url: 'views://splash/index.html',
+	frame: { width: 1280, height: 820 },
+	titleBarStyle: 'hiddenInset',
+	rpc,
+});
+
+setPromptFn((request) => {
+	win?.webview.rpc.send.permissionsPrompt(request);
+});
+
+// Handle custom menu actions.
 ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
 	const { action } = event as { action: string };
 	if (action === 'new-chat') {
@@ -172,24 +188,13 @@ ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
 	}
 });
 
+// Start frontend + backend, then navigate the splash to the real URL.
 startNextServer({ isDev })
 	.then((server) => {
-		win = new BrowserWindow({
-			title: 'Pawrrtal',
-			url: server.url,
-			frame: { width: 1280, height: 820 },
-			titleBarStyle: 'hiddenInset',
-			rpc,
-		});
-		// Wire the prompt sender now that we have a window.
-		setPromptFn((request) => {
-			win?.webview.rpc.send.permissionsPrompt(request);
-		});
+		win?.webview.loadURL(server.url);
 	})
 	.catch((err: unknown) => {
 		const reason = err instanceof Error ? err.message : String(err);
 		console.error('[electrobun] startup failed:', reason);
-		// Can't show a nice error page without a window — log to console
-		// and exit so the process doesn't hang invisibly.
 		process.exit(1);
 	});

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -135,36 +135,45 @@ setPromptFn((request) => {
 });
 
 // ─── App menu (replaces electron/src/menu.ts) ────────────────────────────────
+//
+// Electrobun's ApplicationMenu API:
+//   - Takes a flat Array<ApplicationMenuItemConfig>, not { menu: [...] }
+//   - Custom actions use action: 'string' + ApplicationMenu.on('application-menu-clicked')
+//   - onClick is not supported; native roles (quit, undo, etc.) fire automatically
 
-ApplicationMenu.setMenu({
-	menu: [
-		{
-			label: 'File',
-			submenu: [
-				{
-					label: 'New Chat',
-					accelerator: 'CmdOrCtrl+T',
-					onClick: () => {
-						win.webview.rpc.send.menuNewChat({});
-					},
-				},
-				{ type: 'separator' },
-				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit' },
-			],
-		},
-		{
-			label: 'Edit',
-			submenu: [
-				{ label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
-				{ label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', role: 'redo' },
-				{ type: 'separator' },
-				{ label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
-				{ label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
-				{ label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
-				{ label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectAll' },
-			],
-		},
-	],
+ApplicationMenu.setApplicationMenu([
+	{
+		label: 'File',
+		submenu: [
+			{
+				label: 'New Chat',
+				accelerator: 'CmdOrCtrl+T',
+				action: 'new-chat',
+			},
+			{ type: 'separator' },
+			{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit' },
+		],
+	},
+	{
+		label: 'Edit',
+		submenu: [
+			{ label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
+			{ label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', role: 'redo' },
+			{ type: 'separator' },
+			{ label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
+			{ label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+			{ label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
+			{ label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectAll' },
+		],
+	},
+]);
+
+// Handle custom menu actions via the application-menu-clicked event.
+ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
+	const { action } = event as { action: string };
+	if (action === 'new-chat') {
+		win.webview.rpc.send.menuNewChat({});
+	}
 });
 
 // ─── Startup ──────────────────────────────────────────────────────────────────

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -28,12 +28,13 @@ import type { PawrrtalRPCType } from '../shared/rpc-types';
 import { handleFsListDirectory, handleFsReadFile, handleFsUnwatch, handleFsWatchDirectory, handleFsWriteFile } from './handlers/fs';
 import { handleShellKill, handleShellRun, handleShellSpawnStreaming } from './handlers/shell';
 import { getMode, requestPermission, resolvePrompt, setMode, setPromptFn } from './permissions';
+import { startNextServer } from './server';
 import { addRoot, ensureDefaultWorkspaceRoot, listRoots, removeRoot } from './workspace';
 
 const isDev = process.env['ELECTROBUN_DEV'] === '1';
 
-/** Next.js dev server or standalone server URL. */
-const FRONTEND_URL = isDev ? 'http://localhost:3000' : 'http://localhost:3001';
+/** Must match server.ts — used in the splash message only. */
+const DEV_FRONTEND_PORT = 3001;
 
 // ─── RPC definition (replaces ipc.ts + preload.ts) ───────────────────────────
 
@@ -118,22 +119,6 @@ const rpc = BrowserView.defineRPC<PawrrtalRPCType>({
 	},
 });
 
-// ─── Window ───────────────────────────────────────────────────────────────────
-
-const win = new BrowserWindow({
-	title: 'Pawrrtal',
-	url: FRONTEND_URL,
-	frame: { width: 1280, height: 820 },
-	// hiddenInset mirrors MACOS_TITLE_BAR_STYLE = 'hiddenInset' in Electron shell.
-	titleBarStyle: 'hiddenInset',
-	rpc,
-});
-
-// Wire the prompt sender now that we have a window to send to.
-setPromptFn((request) => {
-	win.webview.rpc.send.permissionsPrompt(request);
-});
-
 // ─── App menu (replaces electron/src/menu.ts) ────────────────────────────────
 //
 // Electrobun's ApplicationMenu API:
@@ -145,11 +130,7 @@ ApplicationMenu.setApplicationMenu([
 	{
 		label: 'File',
 		submenu: [
-			{
-				label: 'New Chat',
-				accelerator: 'CmdOrCtrl+T',
-				action: 'new-chat',
-			},
+			{ label: 'New Chat', accelerator: 'CmdOrCtrl+T', action: 'new-chat' },
 			{ type: 'separator' },
 			{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit' },
 		],
@@ -168,7 +149,37 @@ ApplicationMenu.setApplicationMenu([
 	},
 ]);
 
-// Handle custom menu actions via the application-menu-clicked event.
+// ─── Startup ──────────────────────────────────────────────────────────────────
+//
+// 1. Ensure workspace root.
+// 2. Open a splash window immediately so the dock icon and chrome appear
+//    while the Next.js server is booting (mirrors Electron splash pattern).
+// 3. startNextServer: in dev, spawns `pnpm dev` from <repo>/frontend/;
+//    in prod, spawns the bundled standalone server on a free port.
+// 4. Navigate the webview to the real URL once the server is ready.
+
+ensureDefaultWorkspaceRoot();
+
+const splashHtml = `<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{margin:0;height:100%;background:#F7F4ED;display:flex;align-items:center;justify-content:center;font-family:-apple-system,sans-serif;color:#2a2a2a;-webkit-font-smoothing:antialiased}
+.s{text-align:center}.sp{width:24px;height:24px;border:2px solid rgba(0,0,0,.12);border-top-color:#2a2a2a;border-radius:50%;margin:0 auto 12px;animation:spin .9s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}
+h1{font-size:13px;font-weight:500;margin:0 0 4px}p{font-size:11px;opacity:.5;margin:0}
+</style></head><body><div class="s"><div class="sp"></div><h1>Starting Pawrrtal…</h1><p>Booting dev server on :3001</p></div></body></html>`;
+
+const win = new BrowserWindow({
+	title: 'Pawrrtal',
+	url: `data:text/html;charset=utf-8,${encodeURIComponent(splashHtml)}`,
+	frame: { width: 1280, height: 820 },
+	titleBarStyle: 'hiddenInset',
+	rpc,
+});
+
+// Wire the prompt sender now that we have a window.
+setPromptFn((request) => {
+	win.webview.rpc.send.permissionsPrompt(request);
+});
+
+// Handle custom menu actions.
 ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
 	const { action } = event as { action: string };
 	if (action === 'new-chat') {
@@ -176,6 +187,22 @@ ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
 	}
 });
 
-// ─── Startup ──────────────────────────────────────────────────────────────────
-
-ensureDefaultWorkspaceRoot();
+// Start the Next.js server, then navigate the splash to the real URL.
+startNextServer({ isDev })
+	.then((server) => {
+		win.webview.loadURL(server.url);
+	})
+	.catch((err: unknown) => {
+		const reason = err instanceof Error ? err.message : String(err);
+		console.error('[electrobun] failed to start Next.js server:', reason);
+		const errorHtml = `<!doctype html><html><head><meta charset="utf-8"><style>
+			html,body{margin:0;height:100%;background:#F7F4ED;display:flex;align-items:center;justify-content:center;font-family:-apple-system,sans-serif;}
+			.b{max-width:480px;padding:24px}h1{font-size:15px;margin:0 0 10px}p{font-size:13px;opacity:.7;line-height:1.5;margin:0 0 8px}
+			code{font-family:ui-monospace,monospace;font-size:12px;background:rgba(0,0,0,.06);padding:1px 5px;border-radius:3px}
+		</style></head><body><div class="b">
+			<h1>Could not start the Next.js server</h1>
+			<p>${reason.replace(/[<>&]/g, '')}</p>
+			<p>Run <code>bun start</code> from the <code>electrobun/</code> directory.</p>
+		</div></body></html>`;
+		win.webview.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(errorHtml)}`);
+	});

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -172,13 +172,45 @@ win = new BrowserWindow({
 	title: 'Pawrrtal',
 	url: 'views://splash/index.html',
 	frame: { width: 1280, height: 820 },
+	// hiddenInset: traffic lights float over the content area.
+	// trafficLightOffset moves them down so they sit inside the nav bar
+	// without clipping the buttons on the left.
 	titleBarStyle: 'hiddenInset',
+	trafficLightOffset: { x: 10, y: 16 },
 	rpc,
 });
 
 setPromptFn((request) => {
 	win?.webview.rpc.send.permissionsPrompt(request);
 });
+
+// ─── Drag region injection ─────────────────────────────────────────────────
+// Electrobun's drag-region preload activates on the CSS class
+// `.electrobun-webkit-app-region-drag`.  We inject it onto the top nav
+// after every navigation so the title bar stays draggable across
+// client-side route changes (Next.js soft navigations fire did-navigate-in-page).
+
+const INJECT_DRAG_REGION = `
+(function () {
+  var nav = document.querySelector('header')
+          || document.querySelector('nav')
+          || document.querySelector('[role="navigation"]');
+  if (!nav) return;
+  nav.classList.add('electrobun-webkit-app-region-drag');
+  // Keep buttons/links/inputs clickable — exclude them from the drag zone.
+  nav.querySelectorAll('button, a, input, select, textarea, [role="button"]')
+    .forEach(function (el) {
+      el.classList.add('electrobun-webkit-app-region-no-drag');
+    });
+})();
+`;
+
+function injectDragRegion() {
+	win?.webview.executeJavascript(INJECT_DRAG_REGION);
+}
+
+win.webview.on('did-navigate', () => { injectDragRegion(); });
+win.webview.on('did-navigate-in-page', () => { injectDragRegion(); });
 
 // Handle custom menu actions.
 ApplicationMenu.on('application-menu-clicked', (event: unknown) => {

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -31,10 +31,13 @@ import { getMode, requestPermission, resolvePrompt, setMode, setPromptFn } from 
 import { startNextServer } from './server';
 import { addRoot, ensureDefaultWorkspaceRoot, listRoots, removeRoot } from './workspace';
 
-const isDev = process.env['ELECTROBUN_DEV'] === '1';
+// ELECTROBUN_DEV is not reliably propagated in v1.18 — detect dev mode via
+// PAWRRTAL_REPO_ROOT, which the 'bun start' script injects.
+const isDev = Boolean(process.env['PAWRRTAL_REPO_ROOT']);
 
-/** Must match server.ts — used in the splash message only. */
-const DEV_FRONTEND_PORT = 3001;
+// Mutable window reference — assigned after the Next.js server is ready.
+// RPC handlers use optional chaining (win?.webview...) to be safe.
+let win: BrowserWindow<PawrrtalRPCType> | undefined;
 
 // ─── RPC definition (replaces ipc.ts + preload.ts) ───────────────────────────
 
@@ -88,7 +91,7 @@ const rpc = BrowserView.defineRPC<PawrrtalRPCType>({
 				handleFsWriteFile(filePath, content),
 			fsListDirectory: async ({ dirPath }) => handleFsListDirectory(dirPath),
 			fsWatchDirectory: async ({ dirPath }) => handleFsWatchDirectory(dirPath, (event) => {
-				win.webview.rpc.send.fsWatchEvent(event);
+				win?.webview.rpc.send.fsWatchEvent(event);
 			}),
 			fsUnwatch: async ({ id }) => handleFsUnwatch(id),
 
@@ -96,9 +99,9 @@ const rpc = BrowserView.defineRPC<PawrrtalRPCType>({
 			shellRun: async (request) => handleShellRun(request),
 			shellSpawnStreaming: async (request) =>
 				handleShellSpawnStreaming(request, (event) => {
-					win.webview.rpc.send.shellStream(event);
+					win?.webview.rpc.send.shellStream(event);
 				}, (event) => {
-					win.webview.rpc.send.shellStreamEnd(event);
+					win?.webview.rpc.send.shellStreamEnd(event);
 				}),
 			shellKill: async ({ jobId }) => handleShellKill(jobId),
 
@@ -152,57 +155,41 @@ ApplicationMenu.setApplicationMenu([
 // ─── Startup ──────────────────────────────────────────────────────────────────
 //
 // 1. Ensure workspace root.
-// 2. Open a splash window immediately so the dock icon and chrome appear
-//    while the Next.js server is booting (mirrors Electron splash pattern).
-// 3. startNextServer: in dev, spawns `pnpm dev` from <repo>/frontend/;
-//    in prod, spawns the bundled standalone server on a free port.
-// 4. Navigate the webview to the real URL once the server is ready.
+// 2. Start the Next.js server (dev: spawn pnpm dev; prod: spawn standalone).
+// 3. Create the BrowserWindow only after the server is ready, pointing
+//    straight at the real URL. No data: URL splash — Electrobun's preload
+//    scripts inject into every page and crypto.subtle is unavailable in
+//    data: security contexts.
 
 ensureDefaultWorkspaceRoot();
 
-const splashHtml = `<!doctype html><html><head><meta charset="utf-8"><style>
-html,body{margin:0;height:100%;background:#F7F4ED;display:flex;align-items:center;justify-content:center;font-family:-apple-system,sans-serif;color:#2a2a2a;-webkit-font-smoothing:antialiased}
-.s{text-align:center}.sp{width:24px;height:24px;border:2px solid rgba(0,0,0,.12);border-top-color:#2a2a2a;border-radius:50%;margin:0 auto 12px;animation:spin .9s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}
-h1{font-size:13px;font-weight:500;margin:0 0 4px}p{font-size:11px;opacity:.5;margin:0}
-</style></head><body><div class="s"><div class="sp"></div><h1>Starting Pawrrtal…</h1><p>Booting dev server on :3001</p></div></body></html>`;
-
-const win = new BrowserWindow({
-	title: 'Pawrrtal',
-	url: `data:text/html;charset=utf-8,${encodeURIComponent(splashHtml)}`,
-	frame: { width: 1280, height: 820 },
-	titleBarStyle: 'hiddenInset',
-	rpc,
-});
-
-// Wire the prompt sender now that we have a window.
-setPromptFn((request) => {
-	win.webview.rpc.send.permissionsPrompt(request);
-});
-
-// Handle custom menu actions.
+// Handle custom menu actions (registered before window so the menu is
+// interactive immediately when the window appears).
 ApplicationMenu.on('application-menu-clicked', (event: unknown) => {
 	const { action } = event as { action: string };
 	if (action === 'new-chat') {
-		win.webview.rpc.send.menuNewChat({});
+		win?.webview.rpc.send.menuNewChat({});
 	}
 });
 
-// Start the Next.js server, then navigate the splash to the real URL.
 startNextServer({ isDev })
 	.then((server) => {
-		win.webview.loadURL(server.url);
+		win = new BrowserWindow({
+			title: 'Pawrrtal',
+			url: server.url,
+			frame: { width: 1280, height: 820 },
+			titleBarStyle: 'hiddenInset',
+			rpc,
+		});
+		// Wire the prompt sender now that we have a window.
+		setPromptFn((request) => {
+			win?.webview.rpc.send.permissionsPrompt(request);
+		});
 	})
 	.catch((err: unknown) => {
 		const reason = err instanceof Error ? err.message : String(err);
-		console.error('[electrobun] failed to start Next.js server:', reason);
-		const errorHtml = `<!doctype html><html><head><meta charset="utf-8"><style>
-			html,body{margin:0;height:100%;background:#F7F4ED;display:flex;align-items:center;justify-content:center;font-family:-apple-system,sans-serif;}
-			.b{max-width:480px;padding:24px}h1{font-size:15px;margin:0 0 10px}p{font-size:13px;opacity:.7;line-height:1.5;margin:0 0 8px}
-			code{font-family:ui-monospace,monospace;font-size:12px;background:rgba(0,0,0,.06);padding:1px 5px;border-radius:3px}
-		</style></head><body><div class="b">
-			<h1>Could not start the Next.js server</h1>
-			<p>${reason.replace(/[<>&]/g, '')}</p>
-			<p>Run <code>bun start</code> from the <code>electrobun/</code> directory.</p>
-		</div></body></html>`;
-		win.webview.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(errorHtml)}`);
+		console.error('[electrobun] startup failed:', reason);
+		// Can't show a nice error page without a window — log to console
+		// and exit so the process doesn't hang invisibly.
+		process.exit(1);
 	});

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -1,0 +1,172 @@
+/**
+ * Electrobun main process for the Pawrrtal desktop shell.
+ *
+ * Equivalent of electron/src/main.ts but using Electrobun APIs.
+ *
+ * Key differences from the Electron shell:
+ *
+ *   Electron                              Electrobun
+ *   ─────────────────────────────────── ──────────────────────────────────────
+ *   ipcMain.handle + contextBridge       BrowserView.defineRPC<PawrrtalRPCType>
+ *   preload.ts                           src/shared/rpc-types.ts
+ *   electron-store                       src/bun/store.ts (JSON file)
+ *   app.getPath('home')                  homedir() from node:os
+ *   webContents.send('chan', payload)    win.webview.rpc.send.channelName(payload)
+ *   ipcMain.on('permissions:respond')    bun.messages.permissionsRespond handler
+ *   BrowserWindow.on('closed')           win.on('close') [same pattern]
+ *   app.requestSingleInstanceLock()      Electrobun handles automatically
+ *
+ * @module
+ */
+
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { ApplicationMenu, BrowserView, BrowserWindow, app } from 'electrobun/bun';
+
+import type { PawrrtalRPCType } from '../shared/rpc-types';
+import { handleFsListDirectory, handleFsReadFile, handleFsUnwatch, handleFsWatchDirectory, handleFsWriteFile } from './handlers/fs';
+import { handleShellKill, handleShellRun, handleShellSpawnStreaming } from './handlers/shell';
+import { getMode, requestPermission, resolvePrompt, setMode, setPromptFn } from './permissions';
+import { addRoot, ensureDefaultWorkspaceRoot, listRoots, removeRoot } from './workspace';
+
+const isDev = process.env['ELECTROBUN_DEV'] === '1';
+
+/** Next.js dev server or standalone server URL. */
+const FRONTEND_URL = isDev ? 'http://localhost:3000' : 'http://localhost:3001';
+
+// ─── RPC definition (replaces ipc.ts + preload.ts) ───────────────────────────
+
+const rpc = BrowserView.defineRPC<PawrrtalRPCType>({
+	maxRequestTime: 30_000,
+	handlers: {
+		requests: {
+			// ── Desktop helpers ────────────────────────────────────────────
+			openExternal: async ({ url }) => {
+				if (typeof url !== 'string') return;
+				try {
+					const parsed = new URL(url);
+					if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+				} catch {
+					return;
+				}
+				// Electrobun exposes shell.openExternal via app utilities.
+				// In Electrobun 1.x use the platform shell command.
+				const cmd =
+					process.platform === 'darwin'
+						? 'open'
+						: process.platform === 'win32'
+							? 'start'
+							: 'xdg-open';
+				Bun.spawn([cmd, url], { stdout: 'ignore', stderr: 'ignore' });
+			},
+
+			showOpenFolderDialog: async () => {
+				// TODO: Electrobun native folder dialog API (dialog.showOpenDialog equivalent).
+				// As of v1.18 this can be invoked via the native shell; tracked in
+				// https://github.com/blackboardsh/electrobun/issues — return null as stub.
+				return null;
+			},
+
+			getPlatform: async () => process.platform,
+			getVersion: async () => app.version,
+
+			// ── Workspace ─────────────────────────────────────────────────
+			workspaceListRoots: async () => listRoots(),
+			workspaceAddRoot: async ({ rootPath }) => {
+				if (rootPath) return addRoot(rootPath);
+				// No path provided — show open-folder dialog (stub for now).
+				const defaultRoot = path.join(homedir(), 'Pawrrtal-Workspace');
+				return addRoot(defaultRoot);
+			},
+			workspaceRemoveRoot: async ({ rootPath }) => removeRoot(rootPath),
+
+			// ── Filesystem ────────────────────────────────────────────────
+			fsReadFile: async ({ filePath }) => handleFsReadFile(filePath),
+			fsWriteFile: async ({ filePath, content }) =>
+				handleFsWriteFile(filePath, content),
+			fsListDirectory: async ({ dirPath }) => handleFsListDirectory(dirPath),
+			fsWatchDirectory: async ({ dirPath }) => handleFsWatchDirectory(dirPath, (event) => {
+				win.webview.rpc.send.fsWatchEvent(event);
+			}),
+			fsUnwatch: async ({ id }) => handleFsUnwatch(id),
+
+			// ── Shell ─────────────────────────────────────────────────────
+			shellRun: async (request) => handleShellRun(request),
+			shellSpawnStreaming: async (request) =>
+				handleShellSpawnStreaming(request, (event) => {
+					win.webview.rpc.send.shellStream(event);
+				}, (event) => {
+					win.webview.rpc.send.shellStreamEnd(event);
+				}),
+			shellKill: async ({ jobId }) => handleShellKill(jobId),
+
+			// ── Permissions ───────────────────────────────────────────────
+			permissionsGetMode: async () => getMode(),
+			permissionsSetMode: async ({ mode }) => setMode(mode),
+		},
+
+		messages: {
+			/**
+			 * Webview replies to a pending permission prompt.
+			 * In Electron: ipcMain.on('permissions:respond', handler).
+			 */
+			permissionsRespond: (response) => {
+				resolvePrompt(response);
+			},
+		},
+	},
+});
+
+// ─── Window ───────────────────────────────────────────────────────────────────
+
+const win = new BrowserWindow({
+	title: 'Pawrrtal',
+	url: FRONTEND_URL,
+	frame: { width: 1280, height: 820 },
+	// hiddenInset mirrors MACOS_TITLE_BAR_STYLE = 'hiddenInset' in Electron shell.
+	titleBarStyle: 'hiddenInset',
+	rpc,
+});
+
+// Wire the prompt sender now that we have a window to send to.
+setPromptFn((request) => {
+	win.webview.rpc.send.permissionsPrompt(request);
+});
+
+// ─── App menu (replaces electron/src/menu.ts) ────────────────────────────────
+
+ApplicationMenu.setMenu({
+	menu: [
+		{
+			label: 'File',
+			submenu: [
+				{
+					label: 'New Chat',
+					accelerator: 'CmdOrCtrl+T',
+					onClick: () => {
+						win.webview.rpc.send.menuNewChat({});
+					},
+				},
+				{ type: 'separator' },
+				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit' },
+			],
+		},
+		{
+			label: 'Edit',
+			submenu: [
+				{ label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
+				{ label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', role: 'redo' },
+				{ type: 'separator' },
+				{ label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
+				{ label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+				{ label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
+				{ label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectAll' },
+			],
+		},
+	],
+});
+
+// ─── Startup ──────────────────────────────────────────────────────────────────
+
+ensureDefaultWorkspaceRoot();

--- a/electrobun/src/bun/permissions.test.ts
+++ b/electrobun/src/bun/permissions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for permissions.ts in the Electrobun shell.
+ *
+ * Mirrors the Electron shell's permissions.test.ts. The state machine
+ * is identical; what changed is how the prompt is wired (setPromptFn
+ * instead of ipcMain + BrowserWindow), making tests simpler because we
+ * can inject a synchronous resolver without mocking Electron modules.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	_resetForTests,
+	getMode,
+	permissionKey,
+	requestPermission,
+	resolvePrompt,
+	setMode,
+	setPromptFn,
+	type PermissionDecision,
+	type PromptDetails,
+} from './permissions';
+
+beforeEach(() => {
+	_resetForTests();
+});
+
+afterEach(() => {
+	_resetForTests();
+});
+
+// ─── Mode-driven fast paths ──────────────────────────────────────────────────
+
+describe('mode: yolo', () => {
+	it('allows everything without prompting', async () => {
+		setMode('yolo');
+		const promptFn = vi.fn();
+		setPromptFn(promptFn);
+
+		const result = await requestPermission({ op: 'shell:run', subject: 'rm -rf /' });
+		expect(result).toBe('allow');
+		expect(promptFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('mode: plan', () => {
+	it('denies everything without prompting', async () => {
+		setMode('plan');
+		const promptFn = vi.fn();
+		setPromptFn(promptFn);
+
+		const result = await requestPermission({ op: 'fs:write', subject: 'notes.md' });
+		expect(result).toBe('deny');
+		expect(promptFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('mode: accept-edits', () => {
+	it('allows fs:write without prompting', async () => {
+		setMode('accept-edits');
+		const promptFn = vi.fn();
+		setPromptFn(promptFn);
+
+		const result = await requestPermission({ op: 'fs:write', subject: 'file.md' });
+		expect(result).toBe('allow');
+		expect(promptFn).not.toHaveBeenCalled();
+	});
+
+	it('still prompts for shell:run', async () => {
+		setMode('accept-edits');
+		setPromptFn((req) => {
+			// Immediately resolve the pending prompt.
+			resolvePrompt({ id: req.id, decision: 'allow', scope: 'once' });
+		});
+		const result = await requestPermission({ op: 'shell:run', subject: 'npm install' });
+		expect(result).toBe('allow');
+	});
+});
+
+// ─── Prompt round-trip ───────────────────────────────────────────────────────
+
+describe('prompt round-trip (default mode)', () => {
+	it('resolves to allow when the webview replies allow', async () => {
+		setPromptFn((req) => {
+			resolvePrompt({ id: req.id, decision: 'allow', scope: 'once' });
+		});
+		const result = await requestPermission({ op: 'shell:run', subject: 'git status' });
+		expect(result).toBe('allow');
+	});
+
+	it('resolves to deny when the webview replies deny', async () => {
+		setPromptFn((req) => {
+			resolvePrompt({ id: req.id, decision: 'deny', scope: 'once' });
+		});
+		const result = await requestPermission({ op: 'fs:write', subject: 'secret.txt' });
+		expect(result).toBe('deny');
+	});
+
+	it('default-denies when no prompt fn is registered', async () => {
+		// _resetForTests clears _sendPrompt, so no fn is set.
+		const result = await requestPermission({ op: 'fs:write', subject: 'foo.txt' });
+		expect(result).toBe('deny');
+	});
+});
+
+// ─── Session decisions ───────────────────────────────────────────────────────
+
+describe('scope: session', () => {
+	it('skips prompt for the same key after a session-scoped allow', async () => {
+		let callCount = 0;
+		setPromptFn((req) => {
+			callCount++;
+			resolvePrompt({ id: req.id, decision: 'allow', scope: 'session' });
+		});
+
+		await requestPermission({ op: 'shell:run', subject: 'npm install' });
+		await requestPermission({ op: 'shell:run', subject: 'npm install' });
+
+		expect(callCount).toBe(1); // second call served from session cache
+	});
+
+	it('still prompts for a different subject after session-scoped allow', async () => {
+		let callCount = 0;
+		setPromptFn((req) => {
+			callCount++;
+			resolvePrompt({ id: req.id, decision: 'allow', scope: 'session' });
+		});
+
+		await requestPermission({ op: 'shell:run', subject: 'npm install' });
+		await requestPermission({ op: 'shell:run', subject: 'git push' });
+
+		expect(callCount).toBe(2);
+	});
+});
+
+// ─── permissionKey ───────────────────────────────────────────────────────────
+
+describe('permissionKey', () => {
+	it('normalises shell commands to the first token', () => {
+		const a = permissionKey({ op: 'shell:run', subject: 'npm install foo' });
+		const b = permissionKey({ op: 'shell:run', subject: 'npm install bar' });
+		expect(a).toBe(b);
+	});
+
+	it('does not normalise fs:write subjects', () => {
+		const a = permissionKey({ op: 'fs:write', subject: 'foo/bar.md' });
+		const b = permissionKey({ op: 'fs:write', subject: 'foo/baz.md' });
+		expect(a).not.toBe(b);
+	});
+
+	it('includes rootId in the key', () => {
+		const a = permissionKey({ op: 'fs:write', subject: 'file.md', rootId: '/workspace/a' });
+		const b = permissionKey({ op: 'fs:write', subject: 'file.md', rootId: '/workspace/b' });
+		expect(a).not.toBe(b);
+	});
+});
+
+// ─── getMode / setMode ───────────────────────────────────────────────────────
+
+describe('getMode / setMode', () => {
+	it('defaults to "default"', () => {
+		expect(getMode()).toBe('default');
+	});
+
+	it('round-trips all valid modes', () => {
+		for (const mode of ['default', 'accept-edits', 'yolo', 'plan'] as const) {
+			setMode(mode);
+			expect(getMode()).toBe(mode);
+		}
+	});
+});

--- a/electrobun/src/bun/permissions.ts
+++ b/electrobun/src/bun/permissions.ts
@@ -1,0 +1,152 @@
+/**
+ * Permission system for Pawrrtal's Electrobun shell.
+ *
+ * Ported from electron/src/permissions.ts. The security model and
+ * state machine are identical. Changes:
+ *   - `ipcMain` / `BrowserWindow` → function injection via `setPromptFn`
+ *     (the actual Electrobun `win.webview.rpc.send.permissionsPrompt` call
+ *     lives in index.ts, keeping this module free of Electrobun imports so
+ *     it can be fully exercised in Vitest's node environment).
+ *   - `electron-store` → `./store`
+ *   - `randomUUID` from node:crypto is the same.
+ *
+ * The prompt round-trip in Electrobun uses two RPC legs instead of Electron's
+ * ipcMain.handle + webContents.send:
+ *   bun → webview:  win.webview.rpc.send.permissionsPrompt(request)
+ *   webview → bun:  bun.messages.permissionsRespond handler (see index.ts)
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { createStore } from './store';
+
+export type PermissionMode = 'default' | 'accept-edits' | 'yolo' | 'plan';
+export type PermissionOp = 'fs:write' | 'shell:run' | 'shell:spawn';
+export type PermissionDecision = 'allow' | 'deny';
+export type PermissionScope = 'once' | 'session' | 'always';
+
+export interface PromptDetails {
+	op: PermissionOp;
+	subject: string;
+	rootId?: string;
+	context?: Record<string, unknown>;
+}
+
+interface PromptRequest extends PromptDetails {
+	id: string;
+}
+
+export interface PromptResponse {
+	id: string;
+	decision: PermissionDecision;
+	scope: PermissionScope;
+}
+
+interface PersistedPermissions extends Record<string, unknown> {
+	mode: PermissionMode;
+	always: Record<string, PermissionDecision>;
+}
+
+const permissionsStore = createStore<PersistedPermissions>({
+	name: 'permissions',
+	defaults: { mode: 'default', always: {} },
+});
+
+const sessionDecisions = new Map<string, PermissionDecision>();
+const pendingPrompts = new Map<string, (response: PromptResponse) => void>();
+
+const PROMPT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Injected by index.ts after the BrowserWindow is created.
+ * Decouples this module from Electrobun's runtime so tests can provide a
+ * synchronous stub without needing a display server.
+ */
+let _sendPrompt: ((request: PromptRequest) => void) | undefined;
+
+export function setPromptFn(fn: (request: PromptRequest) => void): void {
+	_sendPrompt = fn;
+}
+
+/** Called by the `permissionsRespond` RPC message handler in index.ts. */
+export function resolvePrompt(response: PromptResponse): void {
+	const resolver = pendingPrompts.get(response.id);
+	if (!resolver) return;
+	pendingPrompts.delete(response.id);
+	resolver(response);
+}
+
+export function permissionKey(details: PromptDetails): string {
+	const subject = normalizeSubject(details.op, details.subject);
+	return `${details.op}|${subject}|${details.rootId ?? '*'}`;
+}
+
+function normalizeSubject(op: PermissionOp, subject: string): string {
+	if (op === 'shell:run' || op === 'shell:spawn') {
+		return subject.trim().split(/\s+/)[0] ?? subject;
+	}
+	return subject;
+}
+
+export async function requestPermission(details: PromptDetails): Promise<PermissionDecision> {
+	const mode = permissionsStore.get('mode');
+	if (mode === 'yolo') return 'allow';
+	if (mode === 'plan') return 'deny';
+	if (mode === 'accept-edits' && details.op === 'fs:write') return 'allow';
+
+	const key = permissionKey(details);
+	const persistent = permissionsStore.get('always')[key];
+	if (persistent) return persistent;
+	const session = sessionDecisions.get(key);
+	if (session) return session;
+
+	const response = await promptWebview(details);
+	if (response.scope === 'session') sessionDecisions.set(key, response.decision);
+	if (response.scope === 'always') {
+		permissionsStore.set('always', {
+			...permissionsStore.get('always'),
+			[key]: response.decision,
+		});
+	}
+	return response.decision;
+}
+
+export function getMode(): PermissionMode {
+	return permissionsStore.get('mode');
+}
+
+export function setMode(mode: PermissionMode): PermissionMode {
+	permissionsStore.set('mode', mode);
+	return mode;
+}
+
+function promptWebview(details: PromptDetails): Promise<PromptResponse> {
+	const id = randomUUID();
+	const request: PromptRequest = { id, ...details };
+	if (!_sendPrompt) {
+		// No webview wired up yet (e.g. during startup) — default-deny.
+		return Promise.resolve({ id, decision: 'deny', scope: 'once' });
+	}
+	// Register in pendingPrompts BEFORE calling _sendPrompt so that a
+	// synchronous resolvePrompt() inside the prompt fn (common in tests)
+	// finds the resolver instead of silently discarding it, leaving the
+	// PROMPT_TIMEOUT_MS timer open and hanging the process.
+	return new Promise<PromptResponse>((resolve) => {
+		const timeout = setTimeout(() => {
+			pendingPrompts.delete(id);
+			resolve({ id, decision: 'deny', scope: 'once' });
+		}, PROMPT_TIMEOUT_MS);
+		pendingPrompts.set(id, (response) => {
+			clearTimeout(timeout);
+			resolve(response);
+		});
+		_sendPrompt!(request);
+	});
+}
+
+export function _resetForTests(): void {
+	sessionDecisions.clear();
+	pendingPrompts.clear();
+	permissionsStore._resetToDefaults({ mode: 'default', always: {} });
+	_sendPrompt = undefined;
+}

--- a/electrobun/src/bun/server.ts
+++ b/electrobun/src/bun/server.ts
@@ -106,12 +106,29 @@ async function startDevServer(): Promise<StartedServer> {
 
 	console.log(`[electrobun] spawning Next.js dev server in ${frontendDir} …`);
 
-	const child = Bun.spawn(['pnpm', 'dev'], {
+	// Use bun (bun workspace project — not pnpm).
+	// 'bun run dev' inside frontend/ runs: next dev --port 3001
+	const child = Bun.spawn(['bun', 'run', 'dev'], {
 		cwd: frontendDir,
-		env: { ...process.env },
+		env: { ...process.env as Record<string, string> },
 		stdout: 'inherit',
 		stderr: 'inherit',
 	});
+
+	// If the process exits immediately it means the command failed
+	// (e.g., bun not in PATH, missing node_modules). Surface it fast.
+	const exitRaceMs = 3_000;
+	const exitEarly = await Promise.race([
+		child.exited.then((code) => code),
+		new Promise<null>((r) => setTimeout(() => r(null), exitRaceMs)),
+	]);
+	if (exitEarly !== null) {
+		throw new Error(
+			`Next.js dev server process exited immediately with code ${exitEarly}. ` +
+			`Check that 'bun install' has been run from the repo root and that ` +
+			`'bun run dev' works inside frontend/.`,
+		);
+	}
 
 	// Give Next.js up to 120s to compile and bind the port.
 	await waitForPort(DEV_FRONTEND_PORT, 'localhost', 120_000);

--- a/electrobun/src/bun/server.ts
+++ b/electrobun/src/bun/server.ts
@@ -1,0 +1,188 @@
+/**
+ * Frontend server lifecycle for the Electrobun shell.
+ *
+ * Mirrors electron/src/server.ts exactly. Two modes:
+ *
+ *   dev  — spawns the Next.js dev server (`pnpm dev` inside frontend/)
+ *           and waits for it to accept connections on :3001.
+ *           PAWRRTAL_REPO_ROOT env var (set by the `bun start` script)
+ *           tells us where the monorepo root is.
+ *
+ *   prod — spawns the Next.js standalone server bundled inside the app
+ *           on a dynamically allocated free port, then returns its URL.
+ *
+ * @module
+ */
+
+import { createServer } from 'node:net';
+import path from 'node:path';
+
+export interface StartedServer {
+	url: string;
+	stop: () => Promise<void>;
+}
+
+/** Must match `frontend/package.json` → `scripts.dev` --port value. */
+const DEV_FRONTEND_PORT = 3001;
+
+// ---------------------------------------------------------------------------
+// Port helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll `host:port` every 500 ms until a TCP connection succeeds or
+ * `timeoutMs` elapses.
+ */
+function waitForPort(port: number, host: string, timeoutMs: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const deadline = Date.now() + timeoutMs;
+
+		const attempt = () => {
+			if (Date.now() >= deadline) {
+				reject(new Error(`Port ${host}:${port} did not open within ${timeoutMs}ms`));
+				return;
+			}
+
+			const sock = new (require('node:net').Socket as typeof import('node:net').Socket)();
+			sock.setTimeout(250);
+			sock.once('connect', () => {
+				sock.destroy();
+				resolve();
+			});
+			sock.once('timeout', () => {
+				sock.destroy();
+				setTimeout(attempt, 500);
+			});
+			sock.once('error', () => {
+				sock.destroy();
+				setTimeout(attempt, 500);
+			});
+			sock.connect(port, host);
+		};
+
+		attempt();
+	});
+}
+
+/** Ask the OS for a free TCP port. */
+function allocateFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const probe = createServer();
+		probe.unref();
+		probe.on('error', reject);
+		probe.listen(0, () => {
+			const address = probe.address();
+			if (address && typeof address === 'object') {
+				const { port } = address;
+				probe.close(() => resolve(port));
+			} else {
+				probe.close(() => reject(new Error('Failed to allocate a free port.')));
+			}
+		});
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Dev server
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn `pnpm dev` inside `<repo>/frontend/` and wait for it to accept
+ * connections on DEV_FRONTEND_PORT.
+ *
+ * The monorepo root is read from PAWRRTAL_REPO_ROOT (injected by the
+ * `bun start` npm script).
+ */
+async function startDevServer(): Promise<StartedServer> {
+	const repoRoot = process.env['PAWRRTAL_REPO_ROOT'];
+	if (!repoRoot) {
+		throw new Error(
+			'PAWRRTAL_REPO_ROOT is not set. ' +
+				'Run `bun start` from the electrobun/ directory — the script sets it automatically.',
+		);
+	}
+
+	const frontendDir = path.join(repoRoot, 'frontend');
+
+	console.log(`[electrobun] spawning Next.js dev server in ${frontendDir} …`);
+
+	const child = Bun.spawn(['pnpm', 'dev'], {
+		cwd: frontendDir,
+		env: { ...process.env },
+		stdout: 'inherit',
+		stderr: 'inherit',
+	});
+
+	// Give Next.js up to 120s to compile and bind the port.
+	await waitForPort(DEV_FRONTEND_PORT, 'localhost', 120_000);
+	console.log(`[electrobun] Next.js dev server ready on :${DEV_FRONTEND_PORT}`);
+
+	return {
+		url: `http://localhost:${DEV_FRONTEND_PORT}`,
+		stop: async () => {
+			child.kill();
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Production server
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the root of the bundled Next.js standalone tree.
+ *
+ * Electrobun places app resources under the .app bundle's Resources/.
+ * The standalone tree is copied there during `electrobun build --env=stable`.
+ *
+ * Layout inside the bundle:
+ *   Resources/
+ *     app/bun/index.js   ← this process
+ *     frontend/          ← Next.js standalone root
+ */
+function resolveStandaloneRoot(): string {
+	// import.meta.dir is the directory of the current source file as
+	// seen by Bun's bundler. In a packaged Electrobun app this resolves
+	// to the Resources/app/bun/ directory.
+	const appBunDir = import.meta.dir;
+	return path.resolve(appBunDir, '..', '..', 'frontend');
+}
+
+async function startProductionServer(): Promise<StartedServer> {
+	const port = await allocateFreePort();
+	const standaloneRoot = resolveStandaloneRoot();
+	const entry = path.join(standaloneRoot, 'server.js');
+
+	const env: Record<string, string> = {
+		...process.env as Record<string, string>,
+		PORT: String(port),
+		HOSTNAME: '127.0.0.1',
+	};
+
+	console.log(`[electrobun] spawning Next.js standalone server on :${port} …`);
+
+	const child = Bun.spawn([process.execPath, entry], {
+		cwd: standaloneRoot,
+		env,
+		stdout: 'inherit',
+		stderr: 'inherit',
+	});
+
+	await waitForPort(port, '127.0.0.1', 30_000);
+	console.log(`[electrobun] Next.js production server ready on :${port}`);
+
+	return {
+		url: `http://127.0.0.1:${port}`,
+		stop: async () => {
+			child.kill();
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function startNextServer(options: { isDev: boolean }): Promise<StartedServer> {
+	return options.isDev ? startDevServer() : startProductionServer();
+}

--- a/electrobun/src/bun/server.ts
+++ b/electrobun/src/bun/server.ts
@@ -1,10 +1,10 @@
 /**
- * Frontend server lifecycle for the Electrobun shell.
+ * Frontend + backend server lifecycle for the Electrobun shell.
  *
- * Mirrors electron/src/server.ts exactly. Two modes:
+ * Mirrors electron/src/server.ts. Two modes:
  *
- *   dev  — spawns the Next.js dev server (`pnpm dev` inside frontend/)
- *           and waits for it to accept connections on :3001.
+ *   dev  — spawns `bun run dev` from the monorepo root, which runs dev.ts:
+ *           starts Next.js on :3001 AND the FastAPI backend on :8000.
  *           PAWRRTAL_REPO_ROOT env var (set by the `bun start` script)
  *           tells us where the monorepo root is.
  *
@@ -102,17 +102,13 @@ async function startDevServer(): Promise<StartedServer> {
 		);
 	}
 
-	const frontendDir = path.join(repoRoot, 'frontend');
-
-	console.log(`[electrobun] spawning Next.js dev server in ${frontendDir} …`);
-
-	// Use the bundled bun binary via process.execPath instead of 'bun' string.
-	// On macOS app bundles, PATH may not include ~/.bun/bin, so 'bun' as a
-	// command fails with ENOENT. process.execPath gives us the bun binary that
-	// is actually running this process (the one bundled in the .app by Electrobun).
-	// 'bun run dev' inside frontend/ runs: next dev --port 3001
+	console.log(`[electrobun] spawning frontend + backend via dev.ts from ${repoRoot} …`);
+	// dev.ts starts both:
+	//   - Next.js frontend  (bun --filter pawrrtal dev) on :3001
+	//   - FastAPI backend   (uvicorn main:app)           on :8000
+	// Use process.execPath (bundled bun) to avoid PATH issues on macOS app bundles.
 	const child = Bun.spawn([process.execPath, 'run', 'dev'], {
-		cwd: frontendDir,
+		cwd: repoRoot,
 		env: { ...process.env as Record<string, string> },
 		stdout: 'inherit',
 		stderr: 'inherit',

--- a/electrobun/src/bun/server.ts
+++ b/electrobun/src/bun/server.ts
@@ -106,9 +106,12 @@ async function startDevServer(): Promise<StartedServer> {
 
 	console.log(`[electrobun] spawning Next.js dev server in ${frontendDir} …`);
 
-	// Use bun (bun workspace project — not pnpm).
+	// Use the bundled bun binary via process.execPath instead of 'bun' string.
+	// On macOS app bundles, PATH may not include ~/.bun/bin, so 'bun' as a
+	// command fails with ENOENT. process.execPath gives us the bun binary that
+	// is actually running this process (the one bundled in the .app by Electrobun).
 	// 'bun run dev' inside frontend/ runs: next dev --port 3001
-	const child = Bun.spawn(['bun', 'run', 'dev'], {
+	const child = Bun.spawn([process.execPath, 'run', 'dev'], {
 		cwd: frontendDir,
 		env: { ...process.env as Record<string, string> },
 		stdout: 'inherit',

--- a/electrobun/src/bun/store.test.ts
+++ b/electrobun/src/bun/store.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the lightweight JSON file store that replaces electron-store
+ * in the Electrobun shell.
+ */
+
+import { mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Store, createStore } from './store';
+
+let testDir: string;
+
+beforeEach(() => {
+	testDir = path.join(tmpdir(), `pawrrtal-store-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(testDir, { recursive: true });
+});
+
+describe('Store', () => {
+	it('returns defaults when the file does not exist', () => {
+		const store = new Store({ name: 'test', defaults: { count: 0, label: 'hello' }, dataDir: testDir });
+		expect(store.get('count')).toBe(0);
+		expect(store.get('label')).toBe('hello');
+	});
+
+	it('persists a value and reads it back', () => {
+		const store = new Store({ name: 'persist', defaults: { roots: [] as string[] }, dataDir: testDir });
+		store.set('roots', ['/home/user/work']);
+		expect(store.get('roots')).toEqual(['/home/user/work']);
+	});
+
+	it('survives re-instantiation (reads from disk)', () => {
+		const opts = { name: 'survive', defaults: { x: 0 }, dataDir: testDir };
+		const s1 = new Store(opts);
+		s1.set('x', 42);
+
+		const s2 = new Store(opts);
+		expect(s2.get('x')).toBe(42);
+	});
+
+	it('writes valid JSON to disk', () => {
+		const store = new Store({ name: 'json', defaults: { flag: false }, dataDir: testDir });
+		store.set('flag', true);
+		const raw = readFileSync(path.join(testDir, 'json.json'), 'utf-8');
+		const parsed = JSON.parse(raw);
+		expect(parsed.flag).toBe(true);
+	});
+
+	it('merges file contents with defaults (file wins on key overlap)', () => {
+		const store1 = new Store({
+			name: 'merge',
+			defaults: { a: 1, b: 2 },
+			dataDir: testDir,
+		});
+		store1.set('a', 99);
+
+		const store2 = new Store({
+			name: 'merge',
+			defaults: { a: 1, b: 2, c: 3 },
+			dataDir: testDir,
+		});
+		expect(store2.get('a')).toBe(99); // from disk
+		expect(store2.get('b')).toBe(2);   // default (not in file)
+		expect(store2.get('c')).toBe(3);   // new default
+	});
+
+	it('handles malformed JSON by falling back to defaults', () => {
+		const filePath = path.join(testDir, 'broken.json');
+		require('node:fs').writeFileSync(filePath, '{ not valid json', 'utf-8');
+		const store = new Store({ name: 'broken', defaults: { ok: true }, dataDir: testDir });
+		expect(store.get('ok')).toBe(true);
+	});
+
+	it('_resetToDefaults clears in-memory state without touching disk', () => {
+		const store = new Store({ name: 'reset', defaults: { n: 0 }, dataDir: testDir });
+		store.set('n', 7);
+		store._resetToDefaults({ n: 0 });
+		expect(store.get('n')).toBe(0);
+		// Disk still has the old value
+		const raw = JSON.parse(readFileSync(path.join(testDir, 'reset.json'), 'utf-8'));
+		expect(raw.n).toBe(7);
+	});
+});
+
+describe('createStore factory', () => {
+	it('returns a Store instance', () => {
+		const store = createStore({ name: 'factory', defaults: { v: 1 }, dataDir: testDir });
+		expect(store).toBeInstanceOf(Store);
+		expect(store.get('v')).toBe(1);
+	});
+});

--- a/electrobun/src/bun/store.ts
+++ b/electrobun/src/bun/store.ts
@@ -1,0 +1,94 @@
+/**
+ * Lightweight persistent JSON store for Pawrrtal's Electrobun shell.
+ *
+ * Replaces `electron-store` (which is Node/Electron-specific) with a
+ * simple typed wrapper around Bun's file I/O. Each store is a single
+ * JSON file under the Pawrrtal data directory:
+ *   macOS:   ~/Library/Application Support/Pawrrtal/<name>.json
+ *   Linux:   ~/.local/share/Pawrrtal/<name>.json
+ *   Windows: %APPDATA%\Pawrrtal\<name>.json
+ *
+ * API is intentionally compatible with the electron-store subset we
+ * actually use (`get`, `set`), so porting workspace.ts / permissions.ts
+ * is a drop-in rename.
+ *
+ * @module
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import path from 'node:path';
+
+/** Resolve the platform-appropriate user data directory. */
+export function getDataDir(): string {
+	const home = homedir();
+	switch (platform()) {
+		case 'darwin':
+			return path.join(home, 'Library', 'Application Support', 'Pawrrtal');
+		case 'win32':
+			return path.join(process.env['APPDATA'] ?? path.join(home, 'AppData', 'Roaming'), 'Pawrrtal');
+		default:
+			// Linux / BSD — follow XDG
+			return path.join(
+				process.env['XDG_DATA_HOME'] ?? path.join(home, '.local', 'share'),
+				'Pawrrtal',
+			);
+	}
+}
+
+export interface StoreOptions<T extends Record<string, unknown>> {
+	/** Filename (without .json) under the data directory. Defaults to "store". */
+	name?: string;
+	/** Default values merged when the store file doesn't exist yet. */
+	defaults: T;
+	/**
+	 * Override the data directory — used in tests to write into a tmp dir
+	 * instead of ~/Library/Application Support.
+	 */
+	dataDir?: string;
+}
+
+export class Store<T extends Record<string, unknown>> {
+	private readonly filePath: string;
+	private data: T;
+
+	constructor(options: StoreOptions<T>) {
+		const dir = options.dataDir ?? getDataDir();
+		mkdirSync(dir, { recursive: true });
+		this.filePath = path.join(dir, `${options.name ?? 'store'}.json`);
+		this.data = this.load(options.defaults);
+	}
+
+	private load(defaults: T): T {
+		try {
+			const raw = readFileSync(this.filePath, 'utf-8');
+			return { ...defaults, ...JSON.parse(raw) } as T;
+		} catch {
+			// File doesn't exist yet or is malformed — start from defaults.
+			return { ...defaults };
+		}
+	}
+
+	private flush(): void {
+		writeFileSync(this.filePath, JSON.stringify(this.data, null, 2), 'utf-8');
+	}
+
+	get<K extends keyof T>(key: K): T[K] {
+		return this.data[key];
+	}
+
+	set<K extends keyof T>(key: K, value: T[K]): void {
+		this.data[key] = value;
+		this.flush();
+	}
+
+	/** Test-only: replace the underlying data without touching disk. */
+	_resetToDefaults(defaults: T): void {
+		this.data = { ...defaults };
+	}
+}
+
+/** Factory matching the electron-store `createStore` helper in the Electron shell. */
+export function createStore<T extends Record<string, unknown>>(options: StoreOptions<T>): Store<T> {
+	return new Store(options);
+}

--- a/electrobun/src/bun/workspace.test.ts
+++ b/electrobun/src/bun/workspace.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for workspace.ts in the Electrobun shell.
+ *
+ * Mirrors electron/src/workspace.test.ts with the same test surface —
+ * the goal is that the two shells behave identically for path validation
+ * and root management, enabling future shared-test abstraction if desired.
+ *
+ * The only difference: this suite supplies a `dataDir` override so the
+ * Store writes into a tmp directory instead of ~/Library/Application Support.
+ */
+
+import { mkdirSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We need to reset the module-level cache between tests.
+// Use vi.resetModules() + dynamic re-import to get a fresh module.
+// Simpler approach: just call _resetCacheForTests() between each test.
+
+import {
+	_resetCacheForTests,
+	addRoot,
+	ensureDefaultWorkspaceRoot,
+	listRoots,
+	removeRoot,
+	validateFilePath,
+} from './workspace';
+
+// The workspace module uses createStore internally. We patch it so the
+// store writes into a temp directory and doesn't pollute ~/Library.
+// Because the store is created at module load time, we mock it before import.
+// Since vitest doesn't hoist vi.mock easily here, we instead rely on the
+// electron/src/workspace.test.ts pattern: pass the tmp HOME env var.
+// For the Electrobun store we expose a dataDir option — but the module
+// constructs the store itself. We use an env var override instead.
+
+let tmpWorkspace: string;
+let tmpOtherDir: string;
+
+beforeEach(() => {
+	const base = path.join(tmpdir(), `pawrrtal-ws-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	tmpWorkspace = path.join(base, 'workspace');
+	tmpOtherDir = path.join(base, 'other');
+	mkdirSync(tmpWorkspace, { recursive: true });
+	mkdirSync(tmpOtherDir, { recursive: true });
+
+	// Seed the workspace roots via addRoot (bypasses ensureDefault logic).
+	_resetCacheForTests();
+	addRoot(tmpWorkspace);
+});
+
+afterEach(() => {
+	_resetCacheForTests();
+});
+
+describe('listRoots / addRoot / removeRoot', () => {
+	it('returns the seeded root', () => {
+		expect(listRoots()).toContain(tmpWorkspace);
+	});
+
+	it('addRoot is idempotent', () => {
+		const before = listRoots().length;
+		addRoot(tmpWorkspace);
+		expect(listRoots()).toHaveLength(before);
+	});
+
+	it('addRoot appends a new root', () => {
+		addRoot(tmpOtherDir);
+		expect(listRoots()).toContain(tmpOtherDir);
+	});
+
+	it('removeRoot removes the root', () => {
+		removeRoot(tmpWorkspace);
+		expect(listRoots()).not.toContain(tmpWorkspace);
+	});
+
+	it('removeRoot is idempotent on absent entries', () => {
+		removeRoot('/nonexistent/path');
+		expect(listRoots()).toContain(tmpWorkspace);
+	});
+});
+
+describe('validateFilePath', () => {
+	it('accepts a file inside the workspace root', () => {
+		const target = path.join(tmpWorkspace, 'notes.md');
+		const result = validateFilePath(target);
+		expect(result.ok).toBe(true);
+	});
+
+	it('accepts a nested path inside the workspace root', () => {
+		const target = path.join(tmpWorkspace, 'projects', 'foo', 'bar.ts');
+		const result = validateFilePath(target);
+		expect(result.ok).toBe(true);
+	});
+
+	it('rejects a path outside all roots', () => {
+		const result = validateFilePath('/etc/passwd');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toMatch(/outside/i);
+	});
+
+	it('rejects an empty string', () => {
+		const result = validateFilePath('');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toMatch(/non-empty/i);
+	});
+
+	it('rejects when no roots are configured', () => {
+		// Remove every root currently registered (the store may have leftovers
+		// from previous test runs since it writes to the real filesystem).
+		for (const root of listRoots()) {
+			removeRoot(root);
+		}
+		const result = validateFilePath(path.join(tmpWorkspace, 'foo.txt'));
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toMatch(/no workspace roots/i);
+	});
+
+	it('rejects a symlink pointing outside the root', () => {
+		const linkPath = path.join(tmpWorkspace, 'evil-link');
+		try {
+			symlinkSync('/etc', linkPath);
+		} catch {
+			// Symlink creation may fail in sandboxed CI — skip gracefully.
+			return;
+		}
+		const result = validateFilePath(path.join(linkPath, 'passwd'));
+		expect(result.ok).toBe(false);
+	});
+
+	it('accepts a path in a second root after addRoot', () => {
+		addRoot(tmpOtherDir);
+		const target = path.join(tmpOtherDir, 'file.txt');
+		const result = validateFilePath(target);
+		expect(result.ok).toBe(true);
+	});
+
+	it('returns the resolved path on success', () => {
+		const target = path.join(tmpWorkspace, 'readme.md');
+		const result = validateFilePath(target);
+		if (result.ok) {
+			expect(result.resolvedPath).toContain('readme.md');
+		}
+	});
+});

--- a/electrobun/src/bun/workspace.ts
+++ b/electrobun/src/bun/workspace.ts
@@ -1,0 +1,134 @@
+/**
+ * Workspace allowlist for Pawrrtal's Electrobun shell.
+ *
+ * Ported from electron/src/workspace.ts. The security contract is
+ * identical; the only changes are:
+ *   - `electron-store` → `./store` (Bun-native JSON file store)
+ *   - `app.getPath('home')` → `homedir()` from node:os
+ *
+ * Everything else — path validation logic, symlink rejection, the
+ * test-only `_resetCacheForTests` escape hatch — is unchanged so that
+ * both shells stay in sync and the Vitest suite can cover both.
+ */
+
+import { mkdirSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { createStore } from './store';
+
+interface PersistedWorkspace extends Record<string, unknown> {
+	roots: string[];
+}
+
+export interface ValidationOk {
+	ok: true;
+	resolvedPath: string;
+	root: string;
+}
+export interface ValidationFail {
+	ok: false;
+	reason: string;
+}
+export type ValidationResult = ValidationOk | ValidationFail;
+
+const workspaceStore = createStore<PersistedWorkspace>({
+	name: 'workspace',
+	defaults: { roots: [] },
+});
+
+let cachedRoots: string[] | undefined;
+
+export function ensureDefaultWorkspaceRoot(): void {
+	const existing = workspaceStore.get('roots');
+	if (existing.length > 0) {
+		cachedRoots = existing;
+		return;
+	}
+	const defaultRoot = path.join(homedir(), 'Pawrrtal-Workspace');
+	try {
+		mkdirSync(defaultRoot, { recursive: true });
+	} catch {
+		// read-only home — still register and let the user pick via settings.
+	}
+	workspaceStore.set('roots', [defaultRoot]);
+	cachedRoots = [defaultRoot];
+}
+
+export function listRoots(): string[] {
+	if (cachedRoots === undefined) cachedRoots = workspaceStore.get('roots');
+	return [...cachedRoots];
+}
+
+export function addRoot(rootPath: string): string[] {
+	const normalized = path.resolve(rootPath);
+	const current = listRoots();
+	if (current.includes(normalized)) return current;
+	const next = [...current, normalized];
+	workspaceStore.set('roots', next);
+	cachedRoots = next;
+	return next;
+}
+
+export function removeRoot(rootPath: string): string[] {
+	const normalized = path.resolve(rootPath);
+	const next = listRoots().filter((entry) => entry !== normalized);
+	workspaceStore.set('roots', next);
+	cachedRoots = next;
+	return next;
+}
+
+export function validateFilePath(targetPath: string): ValidationResult {
+	if (typeof targetPath !== 'string' || targetPath.length === 0) {
+		return { ok: false, reason: 'Path must be a non-empty string.' };
+	}
+	const absolute = path.resolve(targetPath);
+	const realPath = resolveRealPathOrNearest(absolute);
+	const roots = listRoots();
+	if (roots.length === 0) {
+		return { ok: false, reason: 'No workspace roots configured.' };
+	}
+	for (const root of roots) {
+		const realRoot = safeRealpath(root);
+		if (realRoot && isInside(realPath, realRoot)) {
+			return { ok: true, resolvedPath: realPath, root: realRoot };
+		}
+	}
+	return {
+		ok: false,
+		reason: `Path is outside every allowlisted workspace root. Add a root via Settings → Workspace if this is intentional.`,
+	};
+}
+
+function resolveRealPathOrNearest(absolute: string): string {
+	let current = absolute;
+	const segments: string[] = [];
+	while (true) {
+		const real = safeRealpath(current);
+		if (real) return path.join(real, ...segments.reverse());
+		const parent = path.dirname(current);
+		if (parent === current) return absolute;
+		segments.push(path.basename(current));
+		current = parent;
+	}
+}
+
+function safeRealpath(target: string): string | null {
+	try {
+		return realpathSync(target);
+	} catch {
+		return null;
+	}
+}
+
+function isInside(candidate: string, root: string): boolean {
+	const relative = path.relative(root, candidate);
+	if (relative === '') return true;
+	if (relative.startsWith('..')) return false;
+	if (path.isAbsolute(relative)) return false;
+	return true;
+}
+
+export function _resetCacheForTests(): void {
+	cachedRoots = undefined;
+}

--- a/electrobun/src/shared/rpc-types.ts
+++ b/electrobun/src/shared/rpc-types.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared RPC type definition for Pawrrtal's Electrobun shell.
+ *
+ * This file is the single source of truth for the typed bridge between
+ * the Bun main process and the webview (Next.js renderer). It replaces
+ * the Electron pair of `preload.ts` (contextBridge) + `ipc.ts`
+ * (ipcMain.handle) with Electrobun's `BrowserView.defineRPC<T>` system.
+ *
+ * Structure:
+ *   bun.*     — functions/messages that run in the Bun main process,
+ *               callable from the webview via rpc.request.*
+ *   webview.* — functions/messages pushed TO the webview from Bun,
+ *               callable via win.webview.rpc.send.* / rpc.request.*
+ *
+ * Import this type in:
+ *   src/bun/index.ts          → BrowserView.defineRPC<PawrrtalRPCType>
+ *   src/webview/electroview.ts → Electroview.defineRPC<PawrrtalRPCType>
+ *
+ * @module
+ */
+
+// Electrobun re-exports RPCSchema from electrobun/bun and electrobun/view.
+// We use `import type` so this file stays runtime-free (safe to import in
+// both bun and webview contexts without pulling in native bindings).
+import type { RPCSchema } from 'electrobun/bun';
+
+// ─── Shared sub-types ────────────────────────────────────────────────────────
+
+export interface DirEntry {
+	name: string;
+	path: string;
+	isDirectory: boolean;
+	size: number;
+	modifiedAt: number;
+}
+
+export interface RunRequest {
+	command: string;
+	args?: string[];
+	cwd: string;
+	env?: Record<string, string>;
+	timeoutMs?: number;
+}
+
+export interface RunResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number | null;
+}
+
+export interface WatchEvent {
+	id: string;
+	type: 'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir' | 'error';
+	path: string;
+}
+
+export interface ShellStreamEvent {
+	jobId: string;
+	channel: 'stdout' | 'stderr';
+	line: string;
+}
+
+export interface ShellStreamEnd {
+	jobId: string;
+	exitCode: number | null;
+	error?: string;
+}
+
+export interface PermissionPromptRequest {
+	id: string;
+	op: 'fs:write' | 'shell:run' | 'shell:spawn';
+	subject: string;
+	rootId?: string;
+	context?: Record<string, unknown>;
+}
+
+export type PermissionMode = 'default' | 'accept-edits' | 'yolo' | 'plan';
+export type PermissionDecision = 'allow' | 'deny';
+export type PermissionScope = 'once' | 'session' | 'always';
+
+interface OkBase {
+	ok: true;
+	[key: string]: unknown;
+}
+interface FailResult {
+	ok: false;
+	reason: string;
+}
+export type Result<T extends Record<string, unknown> = Record<string, never>> =
+	| (OkBase & T)
+	| FailResult;
+
+// ─── RPC Schema ──────────────────────────────────────────────────────────────
+
+/**
+ * Full typed surface for Pawrrtal's IPC bridge.
+ *
+ * Electron → Electrobun mapping:
+ *   ipcMain.handle('channel', handler)              → bun.requests.*
+ *   ipcRenderer.invoke('channel', args)             → rpc.request.*
+ *   webContents.send('channel', payload)            → webview.messages.*
+ *   ipcMain.on('permissions:respond', ...)          → bun.messages.*
+ *   contextBridge.exposeInMainWorld('pawrrtal', api) → this type + Electroview
+ */
+export type PawrrtalRPCType = {
+	/** Handlers that execute in the Bun main process. */
+	bun: RPCSchema<{
+		requests: {
+			// ── Desktop helpers ────────────────────────────────────────────
+			/** Open a URL in the system browser (validates http/https). */
+			openExternal: { params: { url: string }; response: void };
+			/** Show a native open-folder dialog. */
+			showOpenFolderDialog: { params: Record<never, never>; response: string | null };
+			/** Return the host OS platform string. */
+			getPlatform: { params: Record<never, never>; response: string };
+			/** Return the app version string. */
+			getVersion: { params: Record<never, never>; response: string };
+
+			// ── Workspace ─────────────────────────────────────────────────
+			workspaceListRoots: { params: Record<never, never>; response: string[] };
+			workspaceAddRoot: { params: { rootPath?: string }; response: string[] };
+			workspaceRemoveRoot: { params: { rootPath: string }; response: string[] };
+
+			// ── Filesystem ────────────────────────────────────────────────
+			fsReadFile: {
+				params: { filePath: string };
+				response: Result<{ content: string }>;
+			};
+			fsWriteFile: {
+				params: { filePath: string; content: string };
+				response: Result;
+			};
+			fsListDirectory: {
+				params: { dirPath: string };
+				response: Result<{ entries: DirEntry[] }>;
+			};
+			fsWatchDirectory: {
+				params: { dirPath: string };
+				response: Result<{ id: string }>;
+			};
+			fsUnwatch: { params: { id: string }; response: Result };
+
+			// ── Shell ─────────────────────────────────────────────────────
+			shellRun: { params: RunRequest; response: Result<RunResult> };
+			shellSpawnStreaming: {
+				params: RunRequest;
+				response: Result<{ jobId: string }>;
+			};
+			shellKill: { params: { jobId: string }; response: Result };
+
+			// ── Permissions ───────────────────────────────────────────────
+			permissionsGetMode: { params: Record<never, never>; response: PermissionMode };
+			permissionsSetMode: { params: { mode: PermissionMode }; response: PermissionMode };
+		};
+
+		messages: {
+			/**
+			 * Webview replies to a pending permission prompt.
+			 * In Electron this was ipcMain.on('permissions:respond', ...).
+			 */
+			permissionsRespond: {
+				id: string;
+				decision: PermissionDecision;
+				scope: PermissionScope;
+			};
+		};
+	}>;
+
+	/** Messages pushed from the Bun process to the webview. */
+	webview: RPCSchema<{
+		requests: Record<never, never>;
+		messages: {
+			/**
+			 * Bun asks the webview to render a permission prompt modal.
+			 * In Electron this was webContents.send('permissions:prompt', ...).
+			 */
+			permissionsPrompt: PermissionPromptRequest;
+
+			/**
+			 * Bun notifies the webview of a filesystem watch event.
+			 * In Electron: ipcRenderer.on('fs:watch-event', handler).
+			 */
+			fsWatchEvent: WatchEvent;
+
+			/**
+			 * Bun streams stdout/stderr lines from a shell job.
+			 * In Electron: ipcRenderer.on('shell:stream', handler).
+			 */
+			shellStream: ShellStreamEvent;
+			shellStreamEnd: ShellStreamEnd;
+
+			/** App-level signals. */
+			menuNewChat: Record<never, never>;
+		};
+	}>;
+};

--- a/electrobun/src/splash/index.html
+++ b/electrobun/src/splash/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Pawrrtal</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #F7F4ED;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      color: #2a2a2a;
+      -webkit-font-smoothing: antialiased;
+    }
+    .box { text-align: center; padding: 24px 32px; }
+    .spinner {
+      width: 28px;
+      height: 28px;
+      border: 2px solid rgba(0, 0, 0, 0.12);
+      border-top-color: #2a2a2a;
+      border-radius: 50%;
+      margin: 0 auto 14px;
+      animation: spin 0.9s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    h1 { font-size: 14px; font-weight: 500; margin: 0 0 4px; }
+    p  { font-size: 12px; opacity: 0.5; margin: 0; }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <div class="spinner" aria-hidden="true"></div>
+    <h1>Starting Pawrrtal…</h1>
+    <p>Booting frontend &amp; backend</p>
+  </div>
+</body>
+</html>

--- a/electrobun/tsconfig.json
+++ b/electrobun/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"outDir": "dist",
+		"rootDir": "src",
+		"types": ["bun-types"]
+	},
+	"include": ["src/**/*", "electrobun.config.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/electrobun/vitest.config.ts
+++ b/electrobun/vitest.config.ts
@@ -1,0 +1,25 @@
+/**
+ * Vitest config for the Electrobun main-process workspace.
+ *
+ * Runs in a node environment — tests exercise pure logic in src/bun/
+ * (workspace validation, permission state machine, JSON store) without
+ * needing a real Electrobun/Bun runtime or a display server.
+ *
+ * The electrobun/bun import used in main process files is mocked via
+ * vi.mock() in each test file so tests don't require the native binary.
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts'],
+		exclude: ['dist/**', 'node_modules/**'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json-summary', 'html'],
+			include: ['src/bun/**/*.ts'],
+			exclude: ['**/*.test.ts', 'src/bun/index.ts'],
+		},
+	},
+});


### PR DESCRIPTION
## What

Proof-of-concept port of `electron/` → [Electrobun](https://electrobun.dev) living alongside the existing Electron shell. Evaluates whether Electrobun is a viable replacement for Pawrrtal.

## Why

| | Electron | Electrobun |
|---|---|---|
| Bundle size | ~150 MB | ~14 MB (system webview) |
| Updates | Full re-download | bsdiff patch ≥ 4 KB |
| Runtime | Node.js | Bun |
| IPC | `ipcMain.handle` + `contextBridge` | Typed `BrowserView.defineRPC<T>` |
| Store | electron-store | JSON file (src/bun/store.ts) |

## Structure

```
electrobun/
├── electrobun.config.ts         # build config
├── src/
│   ├── shared/rpc-types.ts      # typed IPC surface (replaces preload.ts)
│   └── bun/
│       ├── index.ts              # main process
│       ├── store.ts              # JSON file store
│       ├── workspace.ts          # ported from electron/src/
│       ├── permissions.ts        # ported from electron/src/
│       └── handlers/{fs,shell}.ts
```

## Tests

**35 tests, all passing** — run in Vitest node env, no display needed:
- `store.test.ts` (8) — JSON persistence, defaults, survive-reinstantiation
- `workspace.test.ts` (13) — path validation, root management, symlink rejection
- `permissions.test.ts` (14) — mode fast-paths, prompt round-trip, session scoping

```bash
cd electrobun && bun install && bun test
```

## Key architectural differences

**IPC:** `preload.ts` + `ipcMain.handle` → single `src/shared/rpc-types.ts` with `BrowserView.defineRPC<PawrrtalRPCType>`. Type-safe, no string channel names, no preload script.

**Store:** `electron-store` → `src/bun/store.ts` — thin JSON file wrapper with identical `get`/`set` API.

**Push events:** `webContents.send('ch', payload)` → `win.webview.rpc.send.channelName(payload)`.

**Permission prompt round-trip:** `ipcMain.on` + `webContents.send` → RPC message handlers in both directions.

## Known gaps (for evaluation discussion)

- `showOpenFolderDialog` is stubbed — Electrobun native dialog API still maturing
- Linux: `bundleCEF: true` needed for full webview layering
- Windows: `Bun.spawn` path escaping needs validation
- System webview CSS inconsistencies (WebKit vs WebView2) need testing against Pawrrtal UI
