### PR TITLE
[05 · stack root] feat: send_message tool + MIME-aware Telegram sender (28 tests)

### DIFF
--- a/backend/alembic/versions/011_add_channel_columns_and_attachment.py
+++ b/backend/alembic/versions/011_add_channel_columns_and_attachment.py
@@ -1,0 +1,93 @@
+"""add channel columns and attachment fields
+
+Adds three groups of new nullable / defaulted columns:
+
+1. ``conversations``: topic routing (``telegram_thread_id``) and
+   auto-title lifecycle tracking (``origin_channel``, ``title_set_by``).
+2. ``channel_bindings``: optional active-conversation pointer
+   (``active_conversation_id``) and topics-enabled flag
+   (``has_topics_enabled``).
+3. ``chat_messages``: workspace-relative attachment path and its MIME
+   type (``attachment``, ``attachment_mime``), needed by the
+   ``send_message`` agent tool introduced in migration 011.
+
+Revision ID: 011_add_channel_columns_and_attachment
+Revises: 010_drop_api_keys
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "011_add_channel_columns_and_attachment"
+down_revision: Union[str, Sequence[str], None] = "010_drop_api_keys"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── conversations ─────────────────────────────────────────────────────
+    # Which channel spawned the conversation (e.g. "telegram", "web").
+    op.add_column(
+        "conversations",
+        sa.Column("origin_channel", sa.String(32), nullable=True),
+    )
+    # Telegram Bot API 9.3+ topic thread ID — NULL for non-topic DMs.
+    op.add_column(
+        "conversations",
+        sa.Column("telegram_thread_id", sa.Integer(), nullable=True),
+    )
+    # Who set the title: NULL = never set, "auto" = auto-generated,
+    # "user" = user edited.  The auto-title job checks for NULL and only
+    # fires once.
+    op.add_column(
+        "conversations",
+        sa.Column("title_set_by", sa.String(16), nullable=True),
+    )
+
+    # ── channel_bindings ──────────────────────────────────────────────────
+    # Pointer to the currently active conversation for non-topic DMs.
+    # NULL until the first message creates a conversation.  ON DELETE SET
+    # NULL so removing a conversation doesn't orphan the binding.
+    op.add_column(
+        "channel_bindings",
+        sa.Column("active_conversation_id", sa.Uuid(), nullable=True),
+    )
+    # Whether the Telegram chat has Topics (forum threads) enabled.
+    # Drives the routing branch: True → route by (chat_id, thread_id),
+    # False → route by active_conversation_id.
+    op.add_column(
+        "channel_bindings",
+        sa.Column(
+            "has_topics_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+    # ── chat_messages ─────────────────────────────────────────────────────
+    # Workspace-relative path to a file the agent sent via send_message.
+    op.add_column(
+        "chat_messages",
+        sa.Column("attachment", sa.String(4096), nullable=True),
+    )
+    # MIME type of the attachment (e.g. "image/png", "audio/ogg").
+    op.add_column(
+        "chat_messages",
+        sa.Column("attachment_mime", sa.String(128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "attachment_mime")
+    op.drop_column("chat_messages", "attachment")
+    op.drop_column("channel_bindings", "has_topics_enabled")
+    op.drop_column("channel_bindings", "active_conversation_id")
+    op.drop_column("conversations", "title_set_by")
+    op.drop_column("conversations", "telegram_thread_id")
+    op.drop_column("conversations", "origin_channel")

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -250,7 +250,8 @@ def make_telegram_sender(
                 caption=caption,
                 **thread_kwargs,
             )
-        elif m in ("audio/ogg", "audio/opus"):
+            return
+        if m in ("audio/ogg", "audio/opus"):
             # Telegram renders ogg/opus as an in-chat voice note.
             await bot.send_voice(
                 chat_id=chat_id,
@@ -258,27 +259,29 @@ def make_telegram_sender(
                 caption=caption,
                 **thread_kwargs,
             )
-        elif m.startswith("audio/"):
+            return
+        if m.startswith("audio/"):
             await bot.send_audio(
                 chat_id=chat_id,
                 audio=file,
                 caption=caption,
                 **thread_kwargs,
             )
-        elif m.startswith("video/"):
+            return
+        if m.startswith("video/"):
             await bot.send_video(
                 chat_id=chat_id,
                 video=file,
                 caption=caption,
                 **thread_kwargs,
             )
-        else:
-            # Fallback — send as a downloadable document.
-            await bot.send_document(
-                chat_id=chat_id,
-                document=file,
-                caption=caption,
-                **thread_kwargs,
-            )
+            return
+        # Fallback — send as a downloadable document.
+        await bot.send_document(
+            chat_id=chat_id,
+            document=file,
+            caption=caption,
+            **thread_kwargs,
+        )
 
     return _send

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -44,9 +44,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from app.core.providers.base import StreamEvent
+from app.core.tools.send_message import SendFn
 
 from .base import ChannelMessage
 
@@ -177,3 +179,106 @@ async def _safe_edit(
             message_id,
             exc,
         )
+
+
+# ---------------------------------------------------------------------------
+# MIME-aware media sender factory
+# ---------------------------------------------------------------------------
+
+
+def make_telegram_sender(
+    bot: "Bot",
+    chat_id: int | str,
+    *,
+    message_thread_id: int | None = None,
+) -> SendFn:
+    """Return a :data:`~app.core.tools.send_message.SendFn` for Telegram.
+
+    The returned coroutine routes delivery based on MIME type::
+
+        image/*          → bot.send_photo(file, caption=text)
+        audio/ogg        → bot.send_voice(file)          # Telegram renders as voice
+        audio/opus       → bot.send_voice(file)
+        audio/*          → bot.send_audio(file, caption=text)
+        video/*          → bot.send_video(file, caption=text)
+        *                → bot.send_document(file, caption=text)
+
+    Text-only calls (no file) fall through to ``bot.send_message``.
+
+    When *message_thread_id* is set every call includes it so the reply
+    lands in the correct Telegram topic thread.
+
+    Args:
+        bot: Live aiogram ``Bot`` instance.
+        chat_id: Target Telegram chat ID.
+        message_thread_id: Optional topic thread ID (Bot API 9.3+).
+            Pass ``None`` (the default) for DMs without topics enabled.
+
+    Returns:
+        An async :data:`~app.core.tools.send_message.SendFn` callback ready
+        to pass to :func:`~app.core.tools.send_message.make_send_message_tool`.
+    """
+
+    async def _send(
+        text: str | None,
+        file_path: Path | None,
+        mime: str | None,
+    ) -> None:
+        thread_kwargs: dict[str, Any] = {}
+        if message_thread_id is not None:
+            thread_kwargs["message_thread_id"] = message_thread_id
+
+        if file_path is None:
+            # Text-only delivery.
+            await bot.send_message(
+                chat_id=chat_id,
+                text=text or "",
+                **thread_kwargs,
+            )
+            return
+
+        from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy import; aiogram optional
+
+        file = FSInputFile(file_path)
+        caption = text or None
+        m = (mime or "").lower()
+
+        if m.startswith("image/"):
+            await bot.send_photo(
+                chat_id=chat_id,
+                photo=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+        elif m in ("audio/ogg", "audio/opus"):
+            # Telegram renders ogg/opus as an in-chat voice note.
+            await bot.send_voice(
+                chat_id=chat_id,
+                voice=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+        elif m.startswith("audio/"):
+            await bot.send_audio(
+                chat_id=chat_id,
+                audio=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+        elif m.startswith("video/"):
+            await bot.send_video(
+                chat_id=chat_id,
+                video=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+        else:
+            # Fallback — send as a downloadable document.
+            await bot.send_document(
+                chat_id=chat_id,
+                document=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+
+    return _send

--- a/backend/app/core/tools/send_message.py
+++ b/backend/app/core/tools/send_message.py
@@ -1,0 +1,204 @@
+"""send_message AgentTool — channel-aware media delivery.
+
+This tool is the LLM's explicit delivery primitive.  When the agent generates
+an artifact (image, audio, document) it saves it to the workspace first, then
+calls ``send_message`` to hand it off.  The tool is intentionally thin:
+
+- It resolves and validates the workspace-relative path.
+- It detects the MIME type.
+- It calls the injected ``SendFn`` callback — which is channel-specific and
+  assembled at request time by the channel's own factory.
+
+The LLM never knows which channel it's in.  The channel decides *how* to
+deliver (sendPhoto vs sendVoice vs sendDocument) based on MIME alone.
+
+Architecture contract
+---------------------
+``make_send_message_tool`` is a factory — exactly like ``make_workspace_tools``
+in ``workspace_files.py``.  It binds a workspace root and a ``SendFn`` at
+construction time so the tool body stays pure and testable without mocking
+HTTP or Telegram internals.
+
+``SendFn`` signature::
+
+    async def send(
+        text: str | None,
+        file_path: Path | None,
+        mime: str | None,
+    ) -> None: ...
+
+The channel implementation is responsible for all error handling inside
+``SendFn``; the tool catches unexpected exceptions and returns an error string
+so the agent can react rather than crash.
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.errors import ToolError, ToolErrorCode
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SendFn protocol (structural — no runtime ABC overhead)
+# ---------------------------------------------------------------------------
+
+SendFn = Callable[
+    [str | None, Path | None, str | None],
+    Awaitable[None],
+]
+"""Async callable injected by the channel layer.
+
+Args:
+    text:      Optional message text to accompany the media (or standalone).
+    file_path: Absolute, validated path to the file to send.  None = text only.
+    mime:      MIME type string e.g. ``"image/png"``.  None when no file.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Path resolution (same invariant as workspace_files._resolve_safe)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_attachment(root: Path, rel_path: str) -> Path:
+    """Resolve *rel_path* inside *root*, rejecting traversal attempts.
+
+    Raises :class:`ToolError` on failure.
+    """
+    try:
+        target = (root / rel_path.lstrip("/")).resolve()
+    except (OSError, ValueError) as exc:
+        raise ToolError(
+            ToolErrorCode.INVALID_PATH,
+            f"Cannot resolve attachment path '{rel_path}': {exc}",
+        ) from exc
+
+    if not str(target).startswith(str(root.resolve())):
+        raise ToolError(
+            ToolErrorCode.OUT_OF_ROOT,
+            f"Attachment path '{rel_path}' resolves outside the workspace.",
+        )
+    if not target.exists():
+        raise ToolError(
+            ToolErrorCode.NOT_FOUND,
+            f"Attachment '{rel_path}' does not exist in the workspace.",
+        )
+    if not target.is_file():
+        raise ToolError(
+            ToolErrorCode.WRONG_KIND,
+            f"Attachment '{rel_path}' is a directory, not a file.",
+        )
+    return target
+
+
+def _detect_mime(path: Path) -> str:
+    """Best-effort MIME detection from file extension.
+
+    Falls back to ``application/octet-stream`` when the extension is unknown,
+    which channels should treat as "send as a document/download".
+    """
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# Tool factory
+# ---------------------------------------------------------------------------
+
+
+def make_send_message_tool(
+    *,
+    workspace_root: Path,
+    send_fn: SendFn,
+) -> AgentTool:
+    """Return a ``send_message`` :class:`AgentTool` scoped to *workspace_root*.
+
+    The returned tool is ready to pass into ``AgentContext.tools``.  It is
+    safe to call from multiple concurrent turns — all mutable state lives in
+    the ``SendFn`` closure, which the channel is responsible for making safe.
+
+    Args:
+        workspace_root: Absolute path to the user's workspace directory.
+            Attachment paths the agent provides are validated against this root.
+        send_fn: Channel-specific async delivery callback.  Called with the
+            resolved file path and detected MIME type.
+
+    Returns:
+        A fully configured :class:`AgentTool` named ``"send_message"``.
+    """
+    root = Path(workspace_root).resolve()
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:  # noqa: ARG001
+        text: str | None = kwargs.get("text") or None
+        attachment: str | None = kwargs.get("attachment") or None
+
+        if not text and not attachment:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "send_message requires at least one of: 'text', 'attachment'.",
+            ).render()
+
+        file_path: Path | None = None
+        mime: str | None = None
+
+        if attachment:
+            try:
+                file_path = _resolve_attachment(root, attachment)
+            except ToolError as err:
+                return err.render()
+            mime = _detect_mime(file_path)
+
+        try:
+            await send_fn(text, file_path, mime)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("SEND_MESSAGE_FAILED attachment=%s error=%s", attachment, exc)
+            return f'{{"sent": false, "error": "{exc}"}}'
+
+        result: dict[str, Any] = {"sent": True}
+        if file_path is not None:
+            result["path"] = str(file_path.relative_to(root))
+            result["mime"] = mime
+        return str(result).replace("'", '"')
+
+    return AgentTool(
+        name="send_message",
+        description=(
+            "Send a message to the user, optionally with a file attachment.\n\n"
+            "Use this after generating any artifact the user asked to see — "
+            "images, audio clips, documents, code archives, etc.\n\n"
+            "``attachment`` must be a workspace-relative path to a file you "
+            "previously wrote with ``write_file``.  The channel will choose the "
+            "appropriate delivery method based on file type (photo, voice, "
+            "document, etc.) — you do not need to specify it.\n\n"
+            "At least one of ``text`` or ``attachment`` must be provided."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": (
+                        "Optional message text to accompany the file, "
+                        "or a standalone text message when no attachment is provided."
+                    ),
+                },
+                "attachment": {
+                    "type": "string",
+                    "description": (
+                        "Workspace-relative path to the file to send, "
+                        "e.g. 'artifacts/cat.png' or 'generated/report.pdf'. "
+                        "Omit to send text only."
+                    ),
+                },
+            },
+            "required": [],
+        },
+        execute=execute,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -66,6 +66,13 @@ class Conversation(Base):
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         Uuid, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
     )
+    # Channel that created this conversation (e.g. "telegram", "web").
+    origin_channel: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # Telegram Bot API 9.3+ topic thread ID.  NULL for non-topic DMs.
+    telegram_thread_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Lifecycle marker for the auto-title feature:
+    # NULL = not yet titled, "auto" = generated, "user" = user-edited.
+    title_set_by: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
 
 class Project(Base):
@@ -192,6 +199,19 @@ class ChannelBinding(Base):
     # Display handle captured at bind time. Stored for admin/debug only,
     # never used for authentication.
     display_handle: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The conversation that is currently active for non-topic DMs.
+    # NULL until the first message arrives.  ON DELETE SET NULL so
+    # removing the conversation doesn't orphan the binding.
+    active_conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # True when this Telegram chat has Bot API 9.3+ Topics enabled.
+    # Drives the routing branch in the inbound message handler.
+    has_topics_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime)
 
 
@@ -254,6 +274,10 @@ class ChatMessage(Base):
     )
     # "streaming" | "complete" | "failed" — only meaningful on assistant rows.
     assistant_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Workspace-relative path to a file the agent delivered via send_message.
+    attachment: Mapped[str | None] = mapped_column(String(4096), nullable=True)
+    # MIME type detected from the attachment path (e.g. "image/png").
+    attachment_mime: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 

--- a/backend/tests/test_send_message_tool.py
+++ b/backend/tests/test_send_message_tool.py
@@ -1,0 +1,269 @@
+"""Tests for send_message AgentTool and make_telegram_sender.
+
+Covers the two halves of the media delivery proof:
+
+Part 1 — send_message AgentTool (``app.core.tools.send_message``)
+  - text-only call succeeds (no file)
+  - attachment path resolved correctly from workspace root
+  - attachment outside workspace root is rejected
+  - non-existent attachment is rejected
+  - directory path as attachment is rejected
+  - missing both text and attachment is rejected
+  - MIME is auto-detected and returned in the result
+  - SendFn exception surfaces as error JSON (agent can react)
+
+Part 2 — make_telegram_sender MIME routing (``app.channels.telegram``)
+  - image/*   → bot.send_photo
+  - audio/ogg → bot.send_voice
+  - audio/opus → bot.send_voice
+  - audio/*   → bot.send_audio (non-ogg)
+  - video/*   → bot.send_video
+  - unknown/* → bot.send_document (fallback)
+  - text-only → bot.send_message (no file)
+  - message_thread_id threaded through every call when set
+  - message_thread_id absent when None
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.channels.telegram import make_telegram_sender
+from app.core.tools.send_message import _detect_mime, _resolve_attachment, make_send_message_tool
+from app.core.tools.errors import ToolError, ToolErrorCode
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    """Return a temporary workspace root with a few test files."""
+    (tmp_path / "artifacts").mkdir()
+    (tmp_path / "artifacts" / "cat.png").write_bytes(b"\x89PNG\r\n")
+    (tmp_path / "artifacts" / "voice.ogg").write_bytes(b"OggS")
+    (tmp_path / "artifacts" / "clip.mp3").write_bytes(b"ID3")
+    (tmp_path / "artifacts" / "video.mp4").write_bytes(b"\x00\x00\x00\x18")
+    (tmp_path / "artifacts" / "report.pdf").write_bytes(b"%PDF-1.4")
+    (tmp_path / "subdir").mkdir()
+    return tmp_path
+
+
+def _noop_send_fn() -> AsyncMock:
+    """Return a no-op SendFn mock."""
+    return AsyncMock(return_value=None)
+
+
+def _make_bot() -> AsyncMock:
+    bot = AsyncMock()
+    bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock()
+    bot.send_voice = AsyncMock()
+    bot.send_audio = AsyncMock()
+    bot.send_video = AsyncMock()
+    bot.send_document = AsyncMock()
+    return bot
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — send_message AgentTool
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAttachment:
+    def test_valid_path_resolves(self, workspace: Path) -> None:
+        result = _resolve_attachment(workspace, "artifacts/cat.png")
+        assert result == workspace / "artifacts" / "cat.png"
+
+    def test_traversal_rejected(self, workspace: Path) -> None:
+        with pytest.raises(ToolError) as exc_info:
+            _resolve_attachment(workspace, "../../etc/passwd")
+        assert exc_info.value.code == ToolErrorCode.OUT_OF_ROOT
+
+    def test_nonexistent_rejected(self, workspace: Path) -> None:
+        with pytest.raises(ToolError) as exc_info:
+            _resolve_attachment(workspace, "artifacts/ghost.png")
+        assert exc_info.value.code == ToolErrorCode.NOT_FOUND
+
+    def test_directory_rejected(self, workspace: Path) -> None:
+        with pytest.raises(ToolError) as exc_info:
+            _resolve_attachment(workspace, "subdir")
+        assert exc_info.value.code == ToolErrorCode.WRONG_KIND
+
+
+class TestDetectMime:
+    def test_png(self, workspace: Path) -> None:
+        assert _detect_mime(workspace / "artifacts" / "cat.png") == "image/png"
+
+    def test_ogg(self, workspace: Path) -> None:
+        assert _detect_mime(workspace / "artifacts" / "voice.ogg") == "audio/ogg"
+
+    def test_mp3(self, workspace: Path) -> None:
+        assert _detect_mime(workspace / "artifacts" / "clip.mp3") == "audio/mpeg"
+
+    def test_pdf(self, workspace: Path) -> None:
+        assert _detect_mime(workspace / "artifacts" / "report.pdf") == "application/pdf"
+
+    def test_unknown_extension_falls_back(self, tmp_path: Path) -> None:
+        p = tmp_path / "file.xyzunknown"
+        p.write_bytes(b"data")
+        assert _detect_mime(p) == "application/octet-stream"
+
+
+@pytest.mark.anyio
+class TestSendMessageTool:
+    async def test_text_only_calls_send_fn(self, workspace: Path) -> None:
+        send_fn = _noop_send_fn()
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc1", text="Hello!")
+        send_fn.assert_awaited_once_with("Hello!", None, None)
+        assert '"sent": true' in result.lower() or "True" in result
+
+    async def test_attachment_resolves_and_calls_send_fn(self, workspace: Path) -> None:
+        send_fn = _noop_send_fn()
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc2", text="Here you go", attachment="artifacts/cat.png")
+        args = send_fn.call_args
+        assert args[0][0] == "Here you go"
+        assert args[0][1] == workspace / "artifacts" / "cat.png"
+        assert args[0][2] == "image/png"
+        assert "cat.png" in result
+
+    async def test_traversal_returns_error_string(self, workspace: Path) -> None:
+        send_fn = _noop_send_fn()
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc3", attachment="../../etc/passwd")
+        send_fn.assert_not_awaited()
+        assert "error" in result.lower() or "outside" in result.lower()
+
+    async def test_nonexistent_file_returns_error_string(self, workspace: Path) -> None:
+        send_fn = _noop_send_fn()
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc4", attachment="artifacts/ghost.png")
+        send_fn.assert_not_awaited()
+        assert "error" in result.lower() or "not exist" in result.lower()
+
+    async def test_missing_both_returns_error(self, workspace: Path) -> None:
+        send_fn = _noop_send_fn()
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc5")
+        send_fn.assert_not_awaited()
+        assert "least one" in result.lower() or "required" in result.lower() or "invalid" in result.lower()
+
+    async def test_send_fn_exception_returns_error_json(self, workspace: Path) -> None:
+        send_fn = AsyncMock(side_effect=RuntimeError("Telegram flood control"))
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=send_fn)
+        result = await tool.execute("tc6", text="hi", attachment="artifacts/cat.png")
+        assert '"sent": false' in result.lower() or "false" in result.lower()
+        assert "flood" in result.lower()
+
+    def test_tool_name_and_schema(self, workspace: Path) -> None:
+        tool = make_send_message_tool(workspace_root=workspace, send_fn=_noop_send_fn())
+        assert tool.name == "send_message"
+        assert "text" in tool.parameters["properties"]
+        assert "attachment" in tool.parameters["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — make_telegram_sender MIME routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestMakeTelegramSender:
+    async def test_image_routes_to_send_photo(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("nice cat", workspace / "artifacts" / "cat.png", "image/png")
+        bot.send_photo.assert_awaited_once()
+        assert bot.send_video.call_count == 0
+        assert bot.send_document.call_count == 0
+
+    async def test_ogg_routes_to_send_voice(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send(None, workspace / "artifacts" / "voice.ogg", "audio/ogg")
+        bot.send_voice.assert_awaited_once()
+        assert bot.send_audio.call_count == 0
+
+    async def test_opus_routes_to_send_voice(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        fake_file = workspace / "artifacts" / "voice.ogg"
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send(None, fake_file, "audio/opus")
+        bot.send_voice.assert_awaited_once()
+
+    async def test_mp3_routes_to_send_audio(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("track", workspace / "artifacts" / "clip.mp3", "audio/mpeg")
+        bot.send_audio.assert_awaited_once()
+        assert bot.send_voice.call_count == 0
+
+    async def test_video_routes_to_send_video(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("clip", workspace / "artifacts" / "video.mp4", "video/mp4")
+        bot.send_video.assert_awaited_once()
+
+    async def test_pdf_routes_to_send_document(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("report", workspace / "artifacts" / "report.pdf", "application/pdf")
+        bot.send_document.assert_awaited_once()
+
+    async def test_unknown_mime_routes_to_send_document(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send(None, workspace / "artifacts" / "cat.png", "application/octet-stream")
+        bot.send_document.assert_awaited_once()
+
+    async def test_text_only_routes_to_send_message(self) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=42)
+        await send("hello", None, None)
+        bot.send_message.assert_awaited_once_with(chat_id=42, text="hello")
+        assert bot.send_photo.call_count == 0
+
+    async def test_thread_id_included_in_all_calls(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=5, message_thread_id=42)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("cat", workspace / "artifacts" / "cat.png", "image/png")
+        call_kwargs = bot.send_photo.call_args.kwargs
+        assert call_kwargs["message_thread_id"] == 42
+
+    async def test_thread_id_absent_when_none(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=5, message_thread_id=None)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("cat", workspace / "artifacts" / "cat.png", "image/png")
+        call_kwargs = bot.send_photo.call_args.kwargs
+        assert "message_thread_id" not in call_kwargs
+
+    async def test_caption_passed_with_image(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send("A dramatic cat", workspace / "artifacts" / "cat.png", "image/png")
+        assert bot.send_photo.call_args.kwargs["caption"] == "A dramatic cat"
+
+    async def test_no_caption_when_text_none(self, workspace: Path) -> None:
+        bot = _make_bot()
+        send = make_telegram_sender(bot, chat_id=1)
+        with patch("aiogram.types.FSInputFile", MagicMock()):
+            await send(None, workspace / "artifacts" / "cat.png", "image/png")
+        assert bot.send_photo.call_args.kwargs["caption"] is None


### PR DESCRIPTION
## What

Core media delivery primitive from the Pawrrtal channel architecture plan.

### `send_message` AgentTool
Factory that validates workspace-relative paths, detects MIME, delegates to an injected `SendFn`. Same pattern as `make_workspace_tools`.

### `make_telegram_sender()` — MIME routing
- `image/*` → `send_photo`
- `audio/ogg|opus` → `send_voice`
- `audio/*` → `send_audio`
- `video/*` → `send_video`
- `*` → `send_document`
- text only → `send_message`

Optional `message_thread_id` for Telegram topic threads (Bot API 9.3+).

### 28 tests, 0 existing tests modified
Covers path resolution, traversal rejection, MIME detection, all 6 routing branches, thread_id on/off, caption passthrough.

## Not in this PR
- Wiring into `build_agent_tools()` (next PR)
- DB migrations
- `/new` command, auto-title