### PR TITLE
[06 · stack 1/7] feat(db): migration 011 — channel columns + attachment fields

### DIFF
--- a/backend/alembic/versions/011_add_channel_columns_and_attachment.py
+++ b/backend/alembic/versions/011_add_channel_columns_and_attachment.py
@@ -1,0 +1,93 @@
+"""add channel columns and attachment fields
+
+Adds three groups of new nullable / defaulted columns:
+
+1. ``conversations``: topic routing (``telegram_thread_id``) and
+   auto-title lifecycle tracking (``origin_channel``, ``title_set_by``).
+2. ``channel_bindings``: optional active-conversation pointer
+   (``active_conversation_id``) and topics-enabled flag
+   (``has_topics_enabled``).
+3. ``chat_messages``: workspace-relative attachment path and its MIME
+   type (``attachment``, ``attachment_mime``), needed by the
+   ``send_message`` agent tool introduced in migration 011.
+
+Revision ID: 011_add_channel_columns_and_attachment
+Revises: 010_drop_api_keys
+Create Date: 2026-05-10
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "011_add_channel_columns_and_attachment"
+down_revision: Union[str, Sequence[str], None] = "010_drop_api_keys"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── conversations ─────────────────────────────────────────────────────
+    # Which channel spawned the conversation (e.g. "telegram", "web").
+    op.add_column(
+        "conversations",
+        sa.Column("origin_channel", sa.String(32), nullable=True),
+    )
+    # Telegram Bot API 9.3+ topic thread ID — NULL for non-topic DMs.
+    op.add_column(
+        "conversations",
+        sa.Column("telegram_thread_id", sa.Integer(), nullable=True),
+    )
+    # Who set the title: NULL = never set, "auto" = auto-generated,
+    # "user" = user edited.  The auto-title job checks for NULL and only
+    # fires once.
+    op.add_column(
+        "conversations",
+        sa.Column("title_set_by", sa.String(16), nullable=True),
+    )
+
+    # ── channel_bindings ──────────────────────────────────────────────────
+    # Pointer to the currently active conversation for non-topic DMs.
+    # NULL until the first message creates a conversation.  ON DELETE SET
+    # NULL so removing a conversation doesn't orphan the binding.
+    op.add_column(
+        "channel_bindings",
+        sa.Column("active_conversation_id", sa.Uuid(), nullable=True),
+    )
+    # Whether the Telegram chat has Topics (forum threads) enabled.
+    # Drives the routing branch: True → route by (chat_id, thread_id),
+    # False → route by active_conversation_id.
+    op.add_column(
+        "channel_bindings",
+        sa.Column(
+            "has_topics_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+    # ── chat_messages ─────────────────────────────────────────────────────
+    # Workspace-relative path to a file the agent sent via send_message.
+    op.add_column(
+        "chat_messages",
+        sa.Column("attachment", sa.String(4096), nullable=True),
+    )
+    # MIME type of the attachment (e.g. "image/png", "audio/ogg").
+    op.add_column(
+        "chat_messages",
+        sa.Column("attachment_mime", sa.String(128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "attachment_mime")
+    op.drop_column("chat_messages", "attachment")
+    op.drop_column("channel_bindings", "has_topics_enabled")
+    op.drop_column("channel_bindings", "active_conversation_id")
+    op.drop_column("conversations", "title_set_by")
+    op.drop_column("conversations", "telegram_thread_id")
+    op.drop_column("conversations", "origin_channel")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -66,6 +66,13 @@ class Conversation(Base):
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         Uuid, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
     )
+    # Channel that created this conversation (e.g. "telegram", "web").
+    origin_channel: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # Telegram Bot API 9.3+ topic thread ID.  NULL for non-topic DMs.
+    telegram_thread_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Lifecycle marker for the auto-title feature:
+    # NULL = not yet titled, "auto" = generated, "user" = user-edited.
+    title_set_by: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
 
 class Project(Base):
@@ -192,6 +199,19 @@ class ChannelBinding(Base):
     # Display handle captured at bind time. Stored for admin/debug only,
     # never used for authentication.
     display_handle: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The conversation that is currently active for non-topic DMs.
+    # NULL until the first message arrives.  ON DELETE SET NULL so
+    # removing the conversation doesn't orphan the binding.
+    active_conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # True when this Telegram chat has Bot API 9.3+ Topics enabled.
+    # Drives the routing branch in the inbound message handler.
+    has_topics_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime)
 
 
@@ -254,6 +274,10 @@ class ChatMessage(Base):
     )
     # "streaming" | "complete" | "failed" — only meaningful on assistant rows.
     assistant_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Workspace-relative path to a file the agent delivered via send_message.
+    attachment: Mapped[str | None] = mapped_column(String(4096), nullable=True)
+    # MIME type detected from the attachment path (e.g. "image/png").
+    attachment_mime: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 


### PR DESCRIPTION
**Stack 1/7** on #158.

Adds three groups of columns:
- `conversations`: `origin_channel`, `telegram_thread_id`, `title_set_by` — enables topic-aware routing and auto-title lifecycle
- `channel_bindings`: `active_conversation_id`, `has_topics_enabled` — drives the inbound routing branch
- `chat_messages`: `attachment`, `attachment_mime` — persists files sent via the `send_message` tool

All additive / nullable or server-defaulted. Safe to deploy without downtime.