### PR TITLE
[08 · stack 3/7] feat(telegram): thread-id routing — topics land in correct conversation

### DIFF
--- a/backend/app/crud/channel.py
+++ b/backend/app/crud/channel.py
@@ -246,6 +246,7 @@ async def get_or_create_telegram_conversation_full(
     *,
     user_id: uuid.UUID,
     session: AsyncSession,
+    thread_id: int | None = None,
 ) -> "Conversation":
     """Like :func:`get_or_create_telegram_conversation` but returns the full row.
 
@@ -255,11 +256,17 @@ async def get_or_create_telegram_conversation_full(
     Args:
         user_id: Nexus user who owns the conversation.
         session: Async database session.
+        thread_id: Telegram topic thread ID (Bot API 9.3+).  When set,
+            the query scopes to conversations with a matching
+            ``telegram_thread_id``; otherwise it falls back to the
+            legacy ``title.like("Telegram%")`` lookup for plain DMs.
 
     Returns:
         The resolved or newly created ``Conversation`` ORM row.
     """
-    return await _get_or_create_telegram_conv_row(user_id=user_id, session=session)
+    return await _get_or_create_telegram_conv_row(
+        user_id=user_id, session=session, thread_id=thread_id
+    )
 
 
 async def update_conversation_model(
@@ -298,21 +305,44 @@ async def _get_or_create_telegram_conv_row(
     *,
     user_id: uuid.UUID,
     session: AsyncSession,
+    thread_id: int | None = None,
 ) -> "Conversation":
-    """Internal helper: find or create the Telegram conversation row."""
+    """Internal helper: find or create the Telegram conversation row.
+
+    Routing branches:
+    - ``thread_id`` set → query by ``(user_id, telegram_thread_id)``; each
+      Telegram topic gets its own independent conversation.
+    - ``thread_id`` None → legacy DM mode; find the most recently updated
+      conversation whose title starts with "Telegram" and has no thread ID.
+    """
     from sqlalchemy import select  # already imported at module level; re-import safe
 
     from app.models import Conversation  # noqa: PLC0415
 
-    stmt = (
-        select(Conversation)
-        .where(
-            Conversation.user_id == user_id,
-            Conversation.title.like("Telegram%"),
+    if thread_id is not None:
+        # Topic mode — one conversation per thread.
+        stmt = (
+            select(Conversation)
+            .where(
+                Conversation.user_id == user_id,
+                Conversation.telegram_thread_id == thread_id,
+            )
+            .order_by(Conversation.created_at.desc())
+            .limit(1)
         )
-        .order_by(Conversation.updated_at.desc())
-        .limit(1)
-    )
+    else:
+        # Legacy DM mode — reuse the existing Telegram conversation.
+        stmt = (
+            select(Conversation)
+            .where(
+                Conversation.user_id == user_id,
+                Conversation.title.like("Telegram%"),
+                Conversation.telegram_thread_id.is_(None),
+            )
+            .order_by(Conversation.updated_at.desc())
+            .limit(1)
+        )
+
     result = await session.execute(stmt)
     existing = result.scalar_one_or_none()
     if existing is not None:
@@ -324,6 +354,8 @@ async def _get_or_create_telegram_conv_row(
         id=uuid.uuid4(),
         user_id=user_id,
         title="Telegram",
+        origin_channel="telegram",
+        telegram_thread_id=thread_id,
         created_at=datetime.now(),
         updated_at=datetime.now(),
     )

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -212,6 +212,9 @@ def _sender_from_message(message: "Message") -> TelegramSender:
         chat_id=message.chat.id,
         username=user.username,
         full_name=user.full_name,
+        # Bot API 9.3+: present when the message lives in a topic thread.
+        # None for ordinary DMs without topics enabled.
+        thread_id=message.message_thread_id,
     )
 
 

--- a/backend/app/integrations/telegram/handlers.py
+++ b/backend/app/integrations/telegram/handlers.py
@@ -110,6 +110,8 @@ class TelegramSender:
     chat_id: int
     username: str | None
     full_name: str | None
+    # Telegram Bot API 9.3+ topic thread ID.  None when topics not enabled.
+    thread_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -129,6 +131,9 @@ class TelegramTurnContext:
 
     model_id: str
     """Model to use for this turn (default or conversation override)."""
+
+    thread_id: int | None = None
+    """Telegram topic thread ID, forwarded from the sender. None for plain DMs."""
 
 
 async def handle_start_command(
@@ -230,15 +235,17 @@ async def handle_plain_message(
     conversation = await get_or_create_telegram_conversation_full(
         user_id=nexus_user_id,
         session=session,
+        thread_id=sender.thread_id,
     )
 
     model_id = conversation.model_id or _DEFAULT_MODEL
 
     logger.info(
-        "TELEGRAM_TURN user_id=%s conversation_id=%s model=%s text_len=%d",
+        "TELEGRAM_TURN user_id=%s conversation_id=%s model=%s thread_id=%s text_len=%d",
         nexus_user_id,
         conversation.id,
         model_id,
+        sender.thread_id,
         len(text),
     )
 
@@ -246,6 +253,7 @@ async def handle_plain_message(
         nexus_user_id=nexus_user_id,
         conversation_id=conversation.id,
         model_id=model_id,
+        thread_id=sender.thread_id,
     )
 
 
@@ -314,6 +322,7 @@ async def handle_model_command(
     conversation = await get_or_create_telegram_conversation_full(
         user_id=nexus_user_id,
         session=session,
+        thread_id=sender.thread_id,
     )
 
     updated = await update_conversation_model(


### PR DESCRIPTION
**Stack 3/7** on #160.

- `TelegramSender`: adds `thread_id: int | None = None` (from `message.message_thread_id`)
- `TelegramTurnContext`: adds `thread_id` forwarded from sender
- `bot.py` `_sender_from_message`: extracts `message.message_thread_id`
- `crud/channel.py` `_get_or_create_telegram_conv_row`: two routing branches
  - topic mode (`thread_id` set): query by `(user_id, telegram_thread_id)` → one conversation per topic
  - legacy DM mode (`thread_id` None): existing behaviour unchanged