### PR TITLE
[09 · stack 4/7] feat(telegram): wire workspace + tools + MIME sender into message handler

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -23,6 +23,7 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.channels import ChannelMessage, resolve_channel
@@ -156,6 +157,31 @@ def build_telegram_service() -> "TelegramService":
         context: TelegramTurnContext = result
         thinking_msg = await message.answer("⏳")
 
+        # Resolve the user's default workspace so the agent has filesystem
+        # access.  If onboarding hasn't completed (no workspace), we fall
+        # back to an empty tool list so the turn still works.
+        from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+        from app.channels.telegram import make_telegram_sender  # noqa: PLC0415
+        from app.crud.workspace import get_default_workspace  # noqa: PLC0415
+
+        async with async_session_maker() as ws_session:
+            workspace = await get_default_workspace(context.nexus_user_id, ws_session)
+
+        tg_sender = make_telegram_sender(
+            message.bot,
+            message.chat.id,
+            message_thread_id=context.thread_id,
+        )
+        agent_tools = (
+            build_agent_tools(
+                workspace_root=Path(workspace.path),
+                user_id=context.nexus_user_id,
+                send_fn=tg_sender,
+            )
+            if workspace is not None
+            else []
+        )
+
         channel_message: ChannelMessage = {
             "user_id": context.nexus_user_id,
             "conversation_id": context.conversation_id,
@@ -178,6 +204,7 @@ def build_telegram_service() -> "TelegramService":
                 context.conversation_id,
                 context.nexus_user_id,
                 history=[],
+                tools=agent_tools or None,
             )
             async for _ in channel.deliver(raw_stream, channel_message):
                 pass  # delivery is a side-effect; nothing yielded by TelegramChannel


### PR DESCRIPTION
**Stack 4/7** on #161.

The Telegram `_on_message` handler now:
1. Looks up the user's default workspace via DB
2. Creates `make_telegram_sender(bot, chat_id, message_thread_id=thread_id)` as the `SendFn`
3. Calls `build_agent_tools(workspace_root, user_id, send_fn=tg_sender)`
4. Passes `tools=agent_tools` to `provider.stream()`

The agent can now use workspace filesystem tools and `send_message` (file/image/audio delivery) on every Telegram turn. Falls back to empty tools if onboarding not complete.

## Summary by Sourcery

Integrate Telegram message handling with user workspaces and agent tools so Telegram turns can use workspace-aware tools and rich media sending.

New Features:
- Resolve a Telegram user’s default workspace and construct agent tools for each turn based on that workspace and user context.
- Wire a Telegram-specific sender into the agent so tools can send files and other media back through Telegram during streaming responses.

Enhancements:
- Fall back to running the Telegram agent without tools when the user has no default workspace configured, ensuring onboarding users can still interact.