### PR TITLE
[10 · stack 5/7] feat(telegram): /new command — fresh conversation in same topic

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -35,6 +35,7 @@ from app.integrations.telegram.handlers import (
     TelegramSender,
     TelegramTurnContext,
     handle_model_command,
+    handle_new_command,
     handle_plain_message,
     handle_start_command,
     handle_stop_command,
@@ -123,6 +124,13 @@ def build_telegram_service() -> "TelegramService":
             task.cancel()  # type: ignore[union-attr]
         # handle_stop_command is a plain sync function — no await.
         reply = handle_stop_command(was_running=was_running)
+        await message.answer(reply)
+
+    @dispatcher.message(Command("new"))
+    async def _on_new(message: "Message") -> None:
+        sender = _sender_from_message(message)
+        async with async_session_maker() as session:
+            reply = await handle_new_command(sender=sender, session=session)
         await message.answer(reply)
 
     @dispatcher.message(Command("model"))

--- a/backend/app/integrations/telegram/handlers.py
+++ b/backend/app/integrations/telegram/handlers.py
@@ -96,6 +96,10 @@ _MODEL_UNKNOWN_PREFIX_MESSAGE = (
 )
 _MODEL_OK_MESSAGE = "Model switched to <code>{model_id}</code> ✅"
 _MODEL_FAIL_MESSAGE = "Couldn't update model — please try again."
+_NEW_NOT_BOUND_MESSAGE = (
+    "Connect your account first before starting a new conversation."
+)
+_NEW_OK_MESSAGE = "✨ New conversation started. What's on your mind?"
 
 
 @dataclass(frozen=True)
@@ -255,6 +259,57 @@ async def handle_plain_message(
         model_id=model_id,
         thread_id=sender.thread_id,
     )
+
+
+async def handle_new_command(
+    *,
+    sender: TelegramSender,
+    session: AsyncSession,
+) -> str:
+    """Create a fresh conversation for this sender, staying in the same topic.
+
+    ``/new`` inside a Telegram topic thread creates a new conversation
+    scoped to that thread — the reply stays in the same topic. In a plain
+    DM (no topics) it simply opens a blank slate, same as the web ``/new``.
+
+    Args:
+        sender: Normalized sender identity (carries ``thread_id``).
+        session: Async database session.
+
+    Returns:
+        Reply string the bot should send immediately.
+    """
+    nexus_user_id = await get_user_id_for_external(
+        provider=PROVIDER,
+        external_user_id=str(sender.user_id),
+        session=session,
+    )
+    if nexus_user_id is None:
+        return _NEW_NOT_BOUND_MESSAGE
+
+    from datetime import datetime  # noqa: PLC0415 — already imported by callers
+
+    from app.models import Conversation  # noqa: PLC0415
+
+    conversation = Conversation(
+        id=uuid.uuid4(),
+        user_id=nexus_user_id,
+        title="Telegram",
+        origin_channel="telegram",
+        telegram_thread_id=sender.thread_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    session.add(conversation)
+    await session.commit()
+
+    logger.info(
+        "TELEGRAM_NEW_CONVERSATION user_id=%s conversation_id=%s thread_id=%s",
+        nexus_user_id,
+        conversation.id,
+        sender.thread_id,
+    )
+    return _NEW_OK_MESSAGE
 
 
 def handle_stop_command(*, was_running: bool) -> str:


### PR DESCRIPTION
**Stack 5/7** on #162.

`/new` creates a new `Conversation` row scoped to the current `thread_id` (or NULL for plain DMs). The reply stays in the same Telegram topic thread. Behaviour matches the web `/new`: blank slate, same channel context.

- `handlers.py`: `handle_new_command()` creates the row and returns the reply string
- `bot.py`: `_on_new` dispatcher route wired up