### PR TITLE
[11 · stack 6/7] feat(telegram): auto-title first turn + sync topic name via editForumTopic

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -232,6 +233,21 @@ def build_telegram_service() -> "TelegramService":
         finally:
             _running_tasks.pop(chat_id, None)
 
+        # Auto-title: derive a title from the first user message and
+        # rename the Telegram topic thread to match.  Fires once only
+        # (gated by title_set_by IS NULL).  Errors are swallowed so a
+        # topic-rename failure never breaks the conversation.
+        try:
+            await _maybe_set_auto_title(
+                bot=message.bot,
+                conversation_id=context.conversation_id,
+                user_text=message.text,
+                chat_id=message.chat.id,
+                thread_id=context.thread_id,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("TELEGRAM_AUTO_TITLE_FAILED", exc_info=True)
+
     return TelegramService(bot=bot, dispatcher=dispatcher)
 
 
@@ -259,6 +275,94 @@ def _extract_start_payload(text: str) -> str | None:
     if len(parts) < 2:
         return None
     return parts[1].strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Auto-title helpers (module-level, not inside build_telegram_service)
+# ---------------------------------------------------------------------------
+
+
+def _generate_title(text: str, max_len: int = 48) -> str:
+    """Derive a short title from the first user message.
+
+    Strips leading slash-command prefixes (e.g. leftovers from ``/new``),
+    truncates to *max_len* characters, appends an ellipsis when truncated,
+    and falls back to ``"Telegram"`` for empty input.
+    """
+    cleaned = text.strip()
+    # Strip a leading /command (shouldn't normally reach here, but belt-and-
+    # suspenders: the user might type "/new hello" as their first message).
+    if cleaned.startswith("/"):
+        # Keep everything after the first word (the command itself).
+        cleaned = cleaned.split(None, 1)[1] if " " in cleaned else ""
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return "Telegram"
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - 1] + "…"
+
+
+async def _maybe_set_auto_title(
+    *,
+    bot: "Bot",
+    conversation_id: "uuid.UUID",
+    user_text: str,
+    chat_id: int,
+    thread_id: int | None,
+) -> None:
+    """Generate and persist an auto-title for a conversation's first turn.
+
+    Fires once only — gated by ``title_set_by IS NULL``.  On success sets
+    ``title_set_by = 'auto'`` so the gate is never tripped again for this
+    conversation.  If the conversation lives in a Telegram topic thread,
+    also calls ``editForumTopic`` to rename the thread to match, giving
+    users a readable label in their Telegram topic list.
+
+    Args:
+        bot: Live aiogram ``Bot`` instance.
+        conversation_id: UUID of the conversation to maybe-title.
+        user_text: The user's first message — used to derive the title.
+        chat_id: Telegram chat ID (needed for ``editForumTopic``).
+        thread_id: Telegram topic thread ID, or ``None`` for plain DMs.
+    """
+    async with async_session_maker() as session:
+        from app.models import Conversation  # noqa: PLC0415
+
+        conv = await session.get(Conversation, conversation_id)
+        if conv is None or conv.title_set_by is not None:
+            return  # already titled — nothing to do
+
+        title = _generate_title(user_text)
+        conv.title = title
+        conv.title_set_by = "auto"
+        await session.commit()
+
+    logger.info(
+        "TELEGRAM_AUTO_TITLE conversation_id=%s title=%r thread_id=%s",
+        conversation_id,
+        title,
+        thread_id,
+    )
+
+    # Rename the Telegram topic thread so the user sees the derived title
+    # in their Topics list.  Only possible when the chat has topics enabled
+    # and the bot has the necessary admin rights — errors are logged as
+    # warnings and swallowed so the feature degrades gracefully.
+    if thread_id is not None:
+        try:
+            await bot.edit_forum_topic(
+                chat_id=chat_id,
+                message_thread_id=thread_id,
+                name=title,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "TELEGRAM_EDIT_TOPIC_FAILED chat_id=%s thread_id=%s error=%s",
+                chat_id,
+                thread_id,
+                exc,
+            )
 
 
 @asynccontextmanager


### PR DESCRIPTION
**Stack 6/7** on #163.

After each Telegram turn completes, `_maybe_set_auto_title` fires:
1. Reads the conversation — if `title_set_by IS NULL` (never titled), derives a short title from the user's first message
2. Persists: `conversation.title = title`, `title_set_by = "auto"`
3. If the conversation lives in a topic thread (`thread_id` set), calls `bot.edit_forum_topic(...)` to rename the Telegram topic

Gate ensures it fires **exactly once** per conversation. `editForumTopic` errors are caught and logged as warnings (degrades gracefully if bot lacks admin rights).