### PR TITLE
[12 · stack 7/7] feat(api): GET /api/v1/workspaces/default/serve/{path} — workspace artifacts

### DIFF
--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -15,11 +15,14 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
+import mimetypes
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.crud.workspace import list_workspaces
+from app.crud.workspace import get_default_workspace, list_workspaces
 from app.db import User, get_async_session
 from app.models import Workspace
 from app.schemas import (
@@ -249,5 +252,62 @@ def get_workspace_router() -> APIRouter:
             )
 
         target.unlink()
+
+    # ------------------------------------------------------------------
+    # Serve binary file from the default workspace
+    # ------------------------------------------------------------------
+
+    @router.get(
+        "/default/serve/{file_path:path}",
+        response_class=FileResponse,
+        summary="Serve a binary file from the user's default workspace",
+    )
+    async def serve_default_workspace_file(
+        file_path: str,
+        user: User = Depends(current_active_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> FileResponse:
+        """Serve a file from the user's default workspace with its detected MIME type.
+
+        Unlike the text-only ``GET /{workspace_id}/files/{file_path}`` endpoint,
+        this route returns raw bytes (``FileResponse``) so the frontend can render
+        images, audio, and other binary artifacts that agents produce via the
+        ``send_message`` tool.
+
+        Path traversal is blocked: the resolved target must stay inside the
+        workspace root or the request is rejected with 400.
+
+        Args:
+            file_path: Workspace-relative path (e.g. ``artifacts/chart.png``).
+
+        Returns:
+            The file streamed with the appropriate ``Content-Type`` header.
+        """
+        ws = await get_default_workspace(user.id, session)
+        if ws is None:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="No default workspace found.  Complete onboarding first.",
+            )
+
+        root = Path(ws.path).resolve()
+        target = _safe_child(root, file_path)
+
+        if not target.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            )
+        if target.is_dir():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Path is a directory, not a file",
+            )
+
+        mime, _ = mimetypes.guess_type(str(target))
+        return FileResponse(
+            path=str(target),
+            media_type=mime or "application/octet-stream",
+            filename=target.name,
+        )
 
     return router

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -186,6 +186,52 @@ async def _safe_edit(
 # ---------------------------------------------------------------------------
 
 
+async def _dispatch_media(
+    bot: "Bot",
+    chat_id: int | str,
+    file_path: Path,
+    mime: str | None,
+    caption: str | None,
+    thread_kwargs: "dict[str, Any]",
+) -> None:
+    """Route a file to the correct aiogram send method based on MIME type.
+
+    Extracted from :func:`make_telegram_sender` so the closure stays at
+    nesting depth ≤ 3 (project limit enforced by ``scripts/check-nesting.py``).
+
+    Args:
+        bot: Live aiogram ``Bot`` instance.
+        chat_id: Target Telegram chat ID.
+        file_path: Absolute path to the file to send.
+        mime: Detected MIME type string, or ``None`` for unknown.
+        caption: Optional text caption shown below the media.
+        thread_kwargs: Dict containing ``message_thread_id`` when topics are
+            enabled, empty otherwise.
+    """
+    from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy; aiogram is optional
+
+    file = FSInputFile(file_path)
+    m = (mime or "").lower()
+
+    # Early-return pattern keeps each branch flat (avoids elif-chain AST
+    # nesting which trips the check-nesting.py depth-3 budget).
+    if m.startswith("image/"):
+        await bot.send_photo(chat_id=chat_id, photo=file, caption=caption, **thread_kwargs)
+        return
+    if m in ("audio/ogg", "audio/opus"):
+        # Telegram renders ogg/opus as an in-chat voice note.
+        await bot.send_voice(chat_id=chat_id, voice=file, caption=caption, **thread_kwargs)
+        return
+    if m.startswith("audio/"):
+        await bot.send_audio(chat_id=chat_id, audio=file, caption=caption, **thread_kwargs)
+        return
+    if m.startswith("video/"):
+        await bot.send_video(chat_id=chat_id, video=file, caption=caption, **thread_kwargs)
+        return
+    # Fallback — send as a downloadable document.
+    await bot.send_document(chat_id=chat_id, document=file, caption=caption, **thread_kwargs)
+
+
 def make_telegram_sender(
     bot: "Bot",
     chat_id: int | str,
@@ -229,59 +275,16 @@ def make_telegram_sender(
             thread_kwargs["message_thread_id"] = message_thread_id
 
         if file_path is None:
-            # Text-only delivery.
-            await bot.send_message(
-                chat_id=chat_id,
-                text=text or "",
-                **thread_kwargs,
-            )
+            await bot.send_message(chat_id=chat_id, text=text or "", **thread_kwargs)
             return
 
-        from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy import; aiogram optional
-
-        file = FSInputFile(file_path)
-        caption = text or None
-        m = (mime or "").lower()
-
-        if m.startswith("image/"):
-            await bot.send_photo(
-                chat_id=chat_id,
-                photo=file,
-                caption=caption,
-                **thread_kwargs,
-            )
-            return
-        if m in ("audio/ogg", "audio/opus"):
-            # Telegram renders ogg/opus as an in-chat voice note.
-            await bot.send_voice(
-                chat_id=chat_id,
-                voice=file,
-                caption=caption,
-                **thread_kwargs,
-            )
-            return
-        if m.startswith("audio/"):
-            await bot.send_audio(
-                chat_id=chat_id,
-                audio=file,
-                caption=caption,
-                **thread_kwargs,
-            )
-            return
-        if m.startswith("video/"):
-            await bot.send_video(
-                chat_id=chat_id,
-                video=file,
-                caption=caption,
-                **thread_kwargs,
-            )
-            return
-        # Fallback — send as a downloadable document.
-        await bot.send_document(
+        await _dispatch_media(
+            bot=bot,
             chat_id=chat_id,
-            document=file,
-            caption=caption,
-            **thread_kwargs,
+            file_path=file_path,
+            mime=mime,
+            caption=text or None,
+            thread_kwargs=thread_kwargs,
         )
 
     return _send

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -186,52 +186,6 @@ async def _safe_edit(
 # ---------------------------------------------------------------------------
 
 
-async def _dispatch_media(
-    bot: "Bot",
-    chat_id: int | str,
-    file_path: Path,
-    mime: str | None,
-    caption: str | None,
-    thread_kwargs: "dict[str, Any]",
-) -> None:
-    """Route a file to the correct aiogram send method based on MIME type.
-
-    Extracted from :func:`make_telegram_sender` so the closure stays at
-    nesting depth ≤ 3 (project limit enforced by ``scripts/check-nesting.py``).
-
-    Args:
-        bot: Live aiogram ``Bot`` instance.
-        chat_id: Target Telegram chat ID.
-        file_path: Absolute path to the file to send.
-        mime: Detected MIME type string, or ``None`` for unknown.
-        caption: Optional text caption shown below the media.
-        thread_kwargs: Dict containing ``message_thread_id`` when topics are
-            enabled, empty otherwise.
-    """
-    from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy; aiogram is optional
-
-    file = FSInputFile(file_path)
-    m = (mime or "").lower()
-
-    # Early-return pattern keeps each branch flat (avoids elif-chain AST
-    # nesting which trips the check-nesting.py depth-3 budget).
-    if m.startswith("image/"):
-        await bot.send_photo(chat_id=chat_id, photo=file, caption=caption, **thread_kwargs)
-        return
-    if m in ("audio/ogg", "audio/opus"):
-        # Telegram renders ogg/opus as an in-chat voice note.
-        await bot.send_voice(chat_id=chat_id, voice=file, caption=caption, **thread_kwargs)
-        return
-    if m.startswith("audio/"):
-        await bot.send_audio(chat_id=chat_id, audio=file, caption=caption, **thread_kwargs)
-        return
-    if m.startswith("video/"):
-        await bot.send_video(chat_id=chat_id, video=file, caption=caption, **thread_kwargs)
-        return
-    # Fallback — send as a downloadable document.
-    await bot.send_document(chat_id=chat_id, document=file, caption=caption, **thread_kwargs)
-
-
 def make_telegram_sender(
     bot: "Bot",
     chat_id: int | str,
@@ -275,16 +229,59 @@ def make_telegram_sender(
             thread_kwargs["message_thread_id"] = message_thread_id
 
         if file_path is None:
-            await bot.send_message(chat_id=chat_id, text=text or "", **thread_kwargs)
+            # Text-only delivery.
+            await bot.send_message(
+                chat_id=chat_id,
+                text=text or "",
+                **thread_kwargs,
+            )
             return
 
-        await _dispatch_media(
-            bot=bot,
+        from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy import; aiogram optional
+
+        file = FSInputFile(file_path)
+        caption = text or None
+        m = (mime or "").lower()
+
+        if m.startswith("image/"):
+            await bot.send_photo(
+                chat_id=chat_id,
+                photo=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+            return
+        if m in ("audio/ogg", "audio/opus"):
+            # Telegram renders ogg/opus as an in-chat voice note.
+            await bot.send_voice(
+                chat_id=chat_id,
+                voice=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+            return
+        if m.startswith("audio/"):
+            await bot.send_audio(
+                chat_id=chat_id,
+                audio=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+            return
+        if m.startswith("video/"):
+            await bot.send_video(
+                chat_id=chat_id,
+                video=file,
+                caption=caption,
+                **thread_kwargs,
+            )
+            return
+        # Fallback — send as a downloadable document.
+        await bot.send_document(
             chat_id=chat_id,
-            file_path=file_path,
-            mime=mime,
-            caption=text or None,
-            thread_kwargs=thread_kwargs,
+            document=file,
+            caption=caption,
+            **thread_kwargs,
         )
 
     return _send


### PR DESCRIPTION
**Stack 7/7** on #164.

Adds `GET /api/v1/workspaces/default/serve/{file_path:path}` to the workspace router.

Differs from the existing `/{workspace_id}/files/{path}` (text-only JSON) endpoint:
- Uses the **default** workspace — no workspace_id param needed by the frontend
- Returns `FileResponse` (raw bytes) with detected `Content-Type`
- Frontend can `<img src="/api/v1/workspaces/default/serve/artifacts/chart.png">` directly

Path traversal blocked via the existing `_safe_child` helper.