### PR TITLE
[13 · stack 8/8] feat: web SendFn + pure generate_image tool

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
@@ -220,7 +221,26 @@ def get_chat_router() -> APIRouter:
         # per-agent / per-user permission gating will land).  Provider
         # files stay tool-agnostic; see
         # `.claude/rules/architecture/no-tools-in-providers.md`.
-        agent_tools = build_agent_tools(workspace_root=root, user_id=user.id)
+        # Web send_fn — lets the agent call send_message() to push text or
+        # files back to the user mid-turn.  Events are placed on a per-request
+        # queue and drained into the SSE stream after each provider event,
+        # keeping chat.py free of any tool-name coupling.
+        _web_send_queue: asyncio.Queue[StreamEvent] = asyncio.Queue()
+
+        async def _web_send_fn(
+            text: str | None,
+            file_path: Path | None,
+            mime: str | None,
+        ) -> None:
+            event: StreamEvent = {"type": "message", "content": text or ""}
+            if file_path is not None:
+                event["attachment"] = str(file_path.relative_to(root))
+                event["mime"] = mime
+            await _web_send_queue.put(event)
+
+        agent_tools = build_agent_tools(
+            workspace_root=root, user_id=user.id, send_fn=_web_send_fn
+        )
 
         # Load SOUL.md + AGENTS.md from the workspace as the agent's
         # system prompt.  The workspace is guaranteed by the 412 gate
@@ -277,6 +297,13 @@ def get_chat_router() -> APIRouter:
                             event_count += 1
                             aggregator.apply(artifact_event)
                             yield artifact_event
+                        # Drain side-channel events placed by send_message
+                        # tool during this iteration's tool execution.
+                        while not _web_send_queue.empty():
+                            side = _web_send_queue.get_nowait()
+                            event_count += 1
+                            aggregator.apply(side)
+                            yield side
                 except Exception as exc:
                     logger.exception(
                         "CHAT_ERR rid=%s conversation_id=%s model_id=%s after %d events",

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -62,9 +62,10 @@ def build_agent_tools(
             API key overrides for tools that call external services.
         send_fn: Optional channel delivery callback.  When supplied the
             ``send_message`` tool is added to the list so the agent can
-            proactively push text and files back to the user.  Absent
-            for callers that only need read/compute tools (e.g. the web
-            chat path, which handles delivery at the streaming layer).
+            proactively push text and files back to the user.  Both the
+            web path (via a per-request asyncio queue drained into the
+            SSE stream) and the Telegram path supply one; the distinction
+            is purely in how the callback delivers — not whether it exists.
 
     Returns:
         A fresh list of :class:`AgentTool` ready to hand to a provider.
@@ -101,9 +102,9 @@ def build_agent_tools(
     # SSE event (see ``app.api.chat`` and ``app.core.tools.artifact``).
     tools.append(make_artifact_tool())
 
-    # Channel delivery — only present when a SendFn was injected.  The
-    # Telegram bot passes one so the agent can call ``send_message`` to
-    # deliver files; the web chat path omits it because SSE handles that.
+    # Channel delivery — present for both web (asyncio-queue SSE drain)
+    # and Telegram (MIME-aware bot API calls).  The mechanism differs;
+    # the tool contract is identical.
     if send_fn is not None:
         tools.append(
             make_send_message_tool(workspace_root=workspace_root, send_fn=send_fn)

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -34,6 +34,7 @@ from app.core.config import settings
 from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
+from app.core.tools.image_gen_agent import make_image_gen_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
@@ -101,6 +102,16 @@ def build_agent_tools(
     # picks up artifact tool-calls and lifts the spec into a sibling
     # SSE event (see ``app.api.chat`` and ``app.core.tools.artifact``).
     tools.append(make_artifact_tool())
+
+    # Image generation — pure tool: generates PNG, saves to workspace,
+    # returns path.  The agent decides whether to send it via send_message.
+    # Capability-gated on OPENAI_CODEX_OAUTH_TOKEN being resolvable.
+    if user_id is not None:
+        codex_token = resolve_api_key(user_id, "OPENAI_CODEX_OAUTH_TOKEN")
+    else:
+        codex_token = None
+    if codex_token:
+        tools.append(make_image_gen_tool(workspace_root=workspace_root, user_id=user_id))
 
     # Channel delivery — present for both web (asyncio-queue SSE drain)
     # and Telegram (MIME-aware bot API calls).  The mechanism differs;

--- a/backend/app/core/keys.py
+++ b/backend/app/core/keys.py
@@ -49,6 +49,7 @@ OVERRIDABLE_KEYS: frozenset[str] = frozenset(
         "CLAUDE_CODE_OAUTH_TOKEN",
         "EXA_API_KEY",
         "XAI_API_KEY",
+        "OPENAI_CODEX_OAUTH_TOKEN",
     }
 )
 
@@ -61,6 +62,9 @@ _SETTINGS_ATTR_MAP: dict[str, str] = {
     "CLAUDE_CODE_OAUTH_TOKEN": "claude_code_oauth_token",
     "EXA_API_KEY": "exa_api_key",
     "XAI_API_KEY": "xai_api_key",
+    # OPENAI_CODEX_OAUTH_TOKEN intentionally absent — workspace-only, no
+    # global settings fallback.  resolve_api_key() returns None for keys
+    # missing from this map after the workspace lookup fails.
 }
 
 

--- a/backend/app/core/tools/image_gen.py
+++ b/backend/app/core/tools/image_gen.py
@@ -1,0 +1,187 @@
+"""Core image-generation logic via the OpenAI Codex Responses backend.
+
+This module handles the network call only.  The agent-loop adapter lives in
+:mod:`app.core.tools.image_gen_agent`.
+
+Auth path
+---------
+OpenAI Codex OAuth is used instead of a direct ``OPENAI_API_KEY``.  The
+bearer token is resolved in the following order:
+
+1. ``OPENAI_CODEX_OAUTH_TOKEN`` workspace / settings override.
+2. The ``$CODEX_HOME/auth.json`` file written by ``@openai/codex`` (or
+   OpenClaw's bundled Codex agent).  ``CODEX_HOME`` defaults to
+   ``~/.codex`` when the env var is absent.
+
+Wire shape
+----------
+Requests go to ``https://chatgpt.com/backend-api/codex/responses`` as a
+streaming Responses API call with the built-in ``image_generation`` tool.
+The generated image arrives as base64 in the ``response.completed`` SSE
+event inside the output's ``image_generation_call`` item.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Responses-API endpoint that backs Codex OAuth image generation.
+# The /codex sub-path is required — /backend-api/responses returns 403.
+_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+# The chat-completion model used by the Codex backend when the
+# image_generation tool is invoked.  gpt-5.5 is current as of 2026-04.
+_CODEX_BACKEND_MODEL = "gpt-5.5"
+
+# Maximum wait for a complete streamed image response (seconds).
+_DEFAULT_TIMEOUT_S = 180.0
+
+
+def resolve_codex_oauth_token(override: str | None = None) -> str:
+    """Return a usable Codex OAuth bearer token or raise ``RuntimeError``.
+
+    Resolution order:
+      1. ``override`` — caller-supplied value (e.g. from workspace env).
+      2. ``$CODEX_HOME/auth.json`` — written by ``@openai/codex`` / OpenClaw.
+
+    Args:
+        override: Optional pre-resolved token string.
+
+    Raises:
+        RuntimeError: When no token can be located.
+    """
+    if override:
+        return override
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    auth_file = codex_home / "auth.json"
+    if auth_file.exists():
+        try:
+            data = json.loads(auth_file.read_text())
+            token = data.get("tokens", {}).get("access_token", "")
+            if token:
+                logger.debug("image_gen: loaded Codex OAuth token from %s", auth_file)
+                return token
+        except Exception as exc:
+            logger.warning("image_gen: failed to read %s: %s", auth_file, exc)
+
+    raise RuntimeError(
+        "No Codex OAuth token found. "
+        "Either set OPENAI_CODEX_OAUTH_TOKEN in your workspace settings "
+        "or sign in with the Codex CLI (`codex auth`)."
+    )
+
+
+def _find_image_b64(output: list) -> str | None:
+    """Extract base64 PNG data from a Codex Responses output array."""
+    for item in output:
+        if item.get("type") == "image_generation_call":
+            return item.get("result")
+    return None
+
+
+async def _extract_b64_from_stream(response: httpx.Response) -> str | None:
+    """Consume an SSE stream from the Codex backend and return the image b64."""
+    async for raw_line in response.aiter_lines():
+        line = raw_line.strip()
+        if not line.startswith("data: "):
+            continue
+        data_str = line[6:]
+        if data_str == "[DONE]":
+            break
+        try:
+            event = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "response.completed":
+            continue
+        output = event.get("response", {}).get("output", [])
+        result = _find_image_b64(output)
+        if result:
+            return result
+    return None
+
+
+async def generate_image_via_codex(
+    prompt: str,
+    *,
+    oauth_token: str,
+    size: str = "1024x1024",
+    quality: str = "medium",
+) -> bytes:
+    """Call the Codex Responses backend to generate an image.
+
+    Uses the built-in ``image_generation`` tool in the Responses API.
+    The request streams SSE; we consume the stream until a
+    ``response.completed`` event carrying image data arrives.
+
+    Args:
+        prompt: Natural-language description of the desired image.
+        oauth_token: Valid Codex OAuth bearer token.
+        size: Image dimensions string (e.g. ``"1024x1024"``, ``"1024x1536"``).
+        quality: Generation quality — ``"low"``, ``"medium"``, or ``"high"``.
+
+    Returns:
+        Raw PNG bytes of the generated image.
+
+    Raises:
+        httpx.HTTPStatusError: On non-2xx response from the Codex backend.
+        ValueError: When the stream completes without yielding image data.
+    """
+    payload: dict = {
+        "model": _CODEX_BACKEND_MODEL,
+        "input": [{"role": "user", "content": prompt}],
+        "tools": [
+            {
+                "type": "image_generation",
+                "quality": quality,
+                "size": size,
+            }
+        ],
+        "stream": True,
+    }
+
+    headers = {
+        "Authorization": f"Bearer {oauth_token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "openai-intent": "agentic",
+    }
+
+    logger.info(
+        "image_gen: requesting %s %s quality=%s size=%s",
+        _CODEX_RESPONSES_URL,
+        _CODEX_BACKEND_MODEL,
+        quality,
+        size,
+    )
+
+    async with (
+        httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT_S) as client,
+        client.stream(
+            "POST",
+            _CODEX_RESPONSES_URL,
+            json=payload,
+            headers=headers,
+        ) as response,
+    ):
+        response.raise_for_status()
+
+        image_b64 = await _extract_b64_from_stream(response)
+
+    if not image_b64:
+        raise ValueError(
+            "Codex image generation stream ended without returning image data. "
+            "The model may not have invoked the image_generation tool."
+        )
+
+    logger.info("image_gen: received %d base64 chars", len(image_b64))
+    return base64.b64decode(image_b64)

--- a/backend/app/core/tools/image_gen_agent.py
+++ b/backend/app/core/tools/image_gen_agent.py
@@ -1,0 +1,179 @@
+"""Agent-loop adapter for the gpt-image-2 / Codex OAuth image-generation tool.
+
+Exposes :func:`make_image_gen_tool`, which returns an :class:`AgentTool`
+the agent can call as ``generate_image``.  The generated PNG is written to
+the user's workspace under ``generated_images/<timestamp>_<slug>.png`` and
+the tool result reports the saved path so the user (and the LLM) know where
+to find it.
+
+The actual HTTP call to the Codex Responses backend lives in the shared
+core (:mod:`app.core.tools.image_gen`) — this module only handles schema
+definition and the async wrapper the loop invokes.
+
+Usage::
+
+    from app.core.tools.image_gen_agent import make_image_gen_tool
+
+    tools = [make_image_gen_tool(workspace_root=path, user_id=user.id)]
+    context = AgentContext(system_prompt=..., messages=..., tools=tools)
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import uuid
+from pathlib import Path
+
+from app.core.agent_loop.types import AgentTool
+from app.core.keys import resolve_api_key
+from app.core.tools.image_gen import generate_image_via_codex, resolve_codex_oauth_token
+
+_TOOL_NAME = "generate_image"
+
+_TOOL_DESCRIPTION = """\
+Generate an image from a text description using gpt-image-2 via the \
+OpenAI Codex Responses API.
+
+The image is saved to the workspace under `generated_images/` and \
+the saved path is returned so you can reference or share it. \
+Use descriptive, detailed prompts for best results. \
+Requires an active Codex OAuth session — no separate OpenAI API key needed.\
+"""
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": (
+                "Detailed natural-language description of the image to generate. "
+                "Include style, colours, composition, and mood for best results."
+            ),
+        },
+        "size": {
+            "type": "string",
+            "description": (
+                "Image dimensions. Supported values: "
+                '"1024x1024" (square, default), '
+                '"1024x1536" (portrait), '
+                '"1536x1024" (landscape).'
+            ),
+            "default": "1024x1024",
+            "enum": ["1024x1024", "1024x1536", "1536x1024"],
+        },
+        "quality": {
+            "type": "string",
+            "description": (
+                'Generation quality. "low" is fastest; '
+                '"medium" balances speed and detail (default); '
+                '"high" produces the most detailed output.'
+            ),
+            "default": "medium",
+            "enum": ["low", "medium", "high"],
+        },
+        "filename": {
+            "type": "string",
+            "description": (
+                "Optional base filename (without extension). "
+                "If omitted a timestamped slug derived from the prompt is used."
+            ),
+        },
+    },
+    "required": ["prompt"],
+}
+
+# Characters that are safe in filenames (ASCII letters, digits, hyphen, underscore).
+_SAFE_CHARS = re.compile(r"[^a-z0-9_-]")
+
+_MAX_SLUG_LEN = 40
+
+
+def _make_slug(prompt: str) -> str:
+    """Derive a short filesystem-safe slug from the prompt."""
+    lower = prompt.lower()
+    slug = _SAFE_CHARS.sub("_", lower)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug[:_MAX_SLUG_LEN] or "image"
+
+
+def make_image_gen_tool(
+    *,
+    workspace_root: Path,
+    user_id: uuid.UUID | None = None,
+) -> AgentTool:
+    """Return an :class:`AgentTool` that generates images via Codex OAuth.
+
+    Args:
+        workspace_root: The user's workspace directory.  Generated images are
+            saved here under ``generated_images/``.
+        user_id: Authenticated user UUID, used to resolve the
+            ``OPENAI_CODEX_OAUTH_TOKEN`` workspace override if set.
+
+    Returns:
+        A configured :class:`AgentTool` ready to append to
+        ``AgentContext.tools``.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        prompt = str(kwargs.get("prompt") or "")
+        size = str(kwargs.get("size") or "1024x1024")
+        quality = str(kwargs.get("quality") or "medium")
+        custom_filename = kwargs.get("filename")
+
+        if not prompt:
+            return json.dumps({"error": "prompt is required"})
+
+        # Resolve Codex OAuth token: workspace override → auth.json fallback.
+        override_token: str | None = None
+        if user_id is not None:
+            override_token = resolve_api_key(user_id, "OPENAI_CODEX_OAUTH_TOKEN")
+
+        try:
+            oauth_token = resolve_codex_oauth_token(override_token)
+        except RuntimeError as exc:
+            return json.dumps({"error": str(exc)})
+
+        # Generate image bytes.
+        try:
+            image_bytes = await generate_image_via_codex(
+                prompt,
+                oauth_token=oauth_token,
+                size=size,
+                quality=quality,
+            )
+        except Exception as exc:
+            return json.dumps({"error": f"Image generation failed: {exc}"})
+
+        # Persist to workspace.
+        ts = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%dT%H%M%S")
+        if custom_filename:
+            slug = _SAFE_CHARS.sub("_", str(custom_filename).lower()).strip("_") or "image"
+        else:
+            slug = _make_slug(prompt)
+        filename = f"{ts}_{slug}.png"
+
+        out_dir = workspace_root / "generated_images"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / filename
+        out_path.write_bytes(image_bytes)
+
+        relative = out_path.relative_to(workspace_root)
+        return json.dumps(
+            {
+                "status": "success",
+                "path": str(relative),
+                "size_bytes": len(image_bytes),
+                "dimensions": size,
+                "quality": quality,
+                "message": f"Image saved to {relative}",
+            }
+        )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )


### PR DESCRIPTION
Closes #156.

## Commit 1 — web SendFn

The web chat path previously had no send_fn, meaning send_message was unavailable to the agent on web. Wires a per-request asyncio.Queue: _web_send_fn puts a StreamEvent on the queue, _guarded_stream drains it after each provider event. chat.py knows nothing about tool names.

## Commit 2 — pure generate_image tool

Ports PR #156 commit db1e2be with fixes: (1) no chat.py coupling — tool saves PNG, returns path, agent calls send_message; (2) nesting depth gate fixed — extracted helpers _find_image_b64 and _extract_b64_from_stream.

Capability-gated on OPENAI_CODEX_OAUTH_TOKEN in workspace env.

## Closes #156

PR #156 commit aa242b7 added _maybe_image_event() in chat.py keyed on the string generate_image — tool-name coupling in the streaming layer. This PR closes that and ships the correct architecture per media plan v5.

## Summary by Sourcery

Add web chat send function support and introduce a pure image generation agent tool backed by OpenAI Codex OAuth.

New Features:
- Enable a send_message-capable send_fn for the web chat path so agents can proactively push messages and files mid-turn.
- Add a generate_image agent tool that creates PNGs via the OpenAI Codex Responses API, saves them in the workspace, and returns their path to the agent.

Enhancements:
- Unify channel delivery semantics so both web and Telegram paths rely on the same send_message tool contract while differing only in delivery mechanism.
- Gate image generation tooling on the OPENAI_CODEX_OAUTH_TOKEN workspace credential and extend key resolution to support Codex OAuth tokens.