### PR TITLE
fix(onboarding): persist wizard completion so it never re-opens on subsequent loads

### DIFF
--- a/frontend/features/onboarding/v2/OnboardingFlow.tsx
+++ b/frontend/features/onboarding/v2/OnboardingFlow.tsx
@@ -50,6 +50,13 @@ export const OPEN_ONBOARDING_SERVER_STEP_EVENT = 'ai-nexus:open-onboarding-serve
 export const E2E_SKIP_ONBOARDING_STORAGE_KEY = 'pawrrtal:e2e-skip-onboarding';
 export const E2E_SKIP_ONBOARDING_QUERY_PARAM = 'e2e_skip_onboarding';
 
+/**
+ * Persisted when the user completes the onboarding wizard via {@link finish}.
+ * Prevents the wizard from re-opening on subsequent page loads.
+ * Clear this key to re-trigger the wizard (e.g. from Settings → Onboarding).
+ */
+export const ONBOARDING_COMPLETE_STORAGE_KEY = 'pawrrtal:onboarding-v2-complete';
+
 /** Wizard step IDs in render order. */
 const STEP_IDS = ['identity', 'server', 'context', 'personality', 'messaging'] as const;
 type StepId = (typeof STEP_IDS)[number];
@@ -73,6 +80,20 @@ function shouldSkipOnboardingForE2E(): boolean {
 	}
 	const searchParams = new URLSearchParams(window.location.search);
 	return searchParams.get(E2E_SKIP_ONBOARDING_QUERY_PARAM) === '1';
+}
+
+/**
+ * Returns true when the user has already completed the onboarding wizard
+ * in this browser. Safe to call on the server — the window guard returns
+ * false during SSR so the modal hydrates correctly.
+ */
+function hasCompletedOnboarding(): boolean {
+	if (typeof window === 'undefined') return false;
+	try {
+		return window.localStorage.getItem(ONBOARDING_COMPLETE_STORAGE_KEY) === '1';
+	} catch {
+		return false;
+	}
 }
 
 /** Props for {@link OnboardingFlow}. */
@@ -106,8 +127,10 @@ export function OnboardingFlow({
 	// mode. Production users' `initialOpen=true` survives unchanged
 	// because the skip helper short-circuits to false without the flag.
 	const [open, setOpen] = useState<boolean>(() => {
-		if (initialOpen && shouldSkipOnboardingForE2E()) return false;
-		return initialOpen;
+		if (!initialOpen) return false;
+		if (shouldSkipOnboardingForE2E()) return false;
+		if (hasCompletedOnboarding()) return false;
+		return true;
 	});
 	const [step, setStep] = useState<StepId>('identity');
 	const remotePersonalization = useGetPersonalization();
@@ -157,6 +180,11 @@ export function OnboardingFlow({
 	}, [step]);
 
 	const finish = useCallback(() => {
+		try {
+			window.localStorage.setItem(ONBOARDING_COMPLETE_STORAGE_KEY, '1');
+		} catch {
+			/* quota / private browsing — ignore */
+		}
 		setOpen(false);
 		// Reset to step 1 so re-opening from the workspace selector starts
 		// fresh — without this the user would land on whatever step they


### PR DESCRIPTION
## What

After the user completes all 5 onboarding steps, `finish()` now writes `pawrrtal:onboarding-v2-complete = '1'` to localStorage. The `useState` lazy initializer checks this flag before opening, so the wizard never auto-opens again on page reload.

## Why

The wizard was mounted with `initialOpen={true}` in `app-layout.tsx` but `finish()` only called `setOpen(false)` — nothing persisted. Every page load re-triggered the full 5-step flow.

## How

- New exported constant `ONBOARDING_COMPLETE_STORAGE_KEY` so E2E fixtures / Settings can clear it to re-trigger
- `hasCompletedOnboarding()` helper (SSR-safe, catches private-browsing exceptions)
- `finish()` persists the flag before closing
- `useState` initializer: checks E2E skip flag first, then completion flag

Re-opening manually still works via the `OPEN_ONBOARDING_FLOW_EVENT` custom event dispatched by workspace selector → Add Workspace.