### PR TITLE
feat(security): backend API key middleware + email allowlist

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,24 @@ DATABASE_URL=postgresql://postgres:<password>@<host>.railway.app:<port>/railway
 # Generate with: openssl rand -hex 32
 AUTH_SECRET=your-secret-key-here
 
+# ===========================================
+# ACCESS CONTROL
+# ===========================================
+
+# If set, every API request must include the header: X-Pawrrtal-Key: <value>
+# This is a transport-level gate — it rejects unknown clients before auth
+# even runs, preventing strangers from using your backend URL.
+# Generate with: openssl rand -hex 32
+# Leave empty to disable (fine for local dev or the public demo instance).
+# BACKEND_API_KEY=
+
+# Comma-separated list of email addresses allowed to use this deployment.
+# When set, authenticated users NOT on this list receive a 403 on any
+# protected endpoint. Works across all login methods (Google, Apple,
+# password) because all providers deliver a verified email address.
+# Leave empty to allow all registered users (open / demo mode).
+# ALLOWED_EMAILS=you@example.com,partner@example.com
+
 # Encryption key for per-user workspace .env files (BYOK overrides).
 # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 WORKSPACE_ENCRYPTION_KEY=your-base64-key-here

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -88,6 +88,34 @@ class Settings(BaseSettings):
     admin_email: str | None = None
     admin_password: str | None = None
 
+    # --- Access control ------------------------------------------------------
+    # Optional bearer token all clients must supply in the X-Pawrrtal-Key
+    # request header. When set, any request missing or carrying the wrong
+    # value is rejected with 401 before auth runs. Leave empty to disable
+    # (useful in local dev or for the public demo instance where
+    # ALLOWED_EMAILS is the only gate). Generate with: openssl rand -hex 32
+    backend_api_key: str = ""
+
+    # Comma-separated list of email addresses that are allowed to use this
+    # backend. When non-empty, authenticated users whose email is not on
+    # the list receive a 403 on any authenticated endpoint. Google and Apple
+    # OAuth both deliver verified emails, so this check is reliable across
+    # all login methods (Google, Apple, password).
+    # Example: ALLOWED_EMAILS=you@example.com,partner@example.com
+    # Leave empty to allow all authenticated users (open / demo mode).
+    allowed_emails: str = ""
+
+    @property
+    def allowed_emails_set(self) -> frozenset[str]:
+        """Return the normalised email allowlist as a frozen set."""
+        if not self.allowed_emails:
+            return frozenset()
+        return frozenset(
+            addr.strip().lower()
+            for addr in self.allowed_emails.split(",")
+            if addr.strip()
+        )
+
     # --- OAuth: Google ---
     # Set both to enable the "Continue with Google" button on the login
     # page. When either is empty the start endpoint returns 503 with a

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,0 +1,68 @@
+"""Custom ASGI / Starlette middleware for Pawrrtal.
+
+Currently provides:
+  BackendApiKeyMiddleware — reject requests that don't carry the correct
+    ``X-Pawrrtal-Key`` header when ``BACKEND_API_KEY`` is configured.
+"""
+
+import secrets
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from app.core.config import settings
+
+# Paths that bypass the API-key check so health probes and the OpenAPI
+# docs remain reachable without a key even in locked-down deployments.
+_EXEMPT_PREFIXES = (
+    "/health",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    # OAuth start redirects initiate from the browser; no key there.
+    "/api/v1/auth/oauth/",
+)
+
+
+class BackendApiKeyMiddleware(BaseHTTPMiddleware):
+    """Require the ``X-Pawrrtal-Key`` header on every non-exempt request.
+
+    Only active when ``BACKEND_API_KEY`` is configured. Returning a 401
+    at the transport layer prevents unauthenticated parties from even
+    reaching the FastAPI router, so the email allowlist (``ALLOWED_EMAILS``)
+    is the second, identity-level gate that runs after a user is logged in.
+
+    Uses ``secrets.compare_digest`` to avoid timing side-channels when
+    comparing the supplied key against the configured value.
+    """
+
+    async def dispatch(self, request: Request, call_next: object) -> Response:  # type: ignore[override]
+        # If no key is configured, the middleware is effectively disabled.
+        if not settings.backend_api_key:
+            return await call_next(request)  # type: ignore[misc]
+
+        # Exempt paths bypass the key check.
+        path = request.url.path
+        if any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES):
+            return await call_next(request)  # type: ignore[misc]
+
+        provided = request.headers.get("X-Pawrrtal-Key", "")
+        # compare_digest requires both operands to be the same type and
+        # non-empty; fall back to a dummy comparison to keep constant time.
+        expected = settings.backend_api_key
+        if not secrets.compare_digest(
+            provided.encode() if provided else b"",
+            expected.encode(),
+        ):
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "detail": (
+                        "Missing or invalid X-Pawrrtal-Key header. "
+                        "This backend requires an API key to connect."
+                    )
+                },
+            )
+
+        return await call_next(request)  # type: ignore[misc]

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -96,3 +96,28 @@ fastapi_users = FastAPIUsers[User, uuid.UUID](
 )
 
 current_active_user = fastapi_users.current_user(active=True)
+
+
+async def get_allowed_user(user: "User" = Depends(current_active_user)) -> "User":
+    """Like ``current_active_user`` but also enforces the email allowlist.
+
+    When ``ALLOWED_EMAILS`` is configured in the environment, only users
+    whose email address appears in that list can proceed. All login methods
+    (Google, Apple, password) go through this gate because every auth path
+    ultimately resolves to a ``User`` with a verified ``email`` field.
+
+    When ``ALLOWED_EMAILS`` is empty the allowlist is disabled and all
+    active users are permitted (open / demo mode).
+    """
+    from app.core.config import settings  # local import to avoid circular
+
+    allowed = settings.allowed_emails_set
+    if allowed and user.email.lower() not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "This Pawrrtal deployment is private. "
+                "Your account is not on the access list."
+            ),
+        )
+    return user

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from app.api.workspace_env import get_workspace_env_router
 from app.api.stt import get_stt_router
 from app.cli.admin_seed import seed_admin_user
 from app.core.config import settings
+from app.core.middleware import BackendApiKeyMiddleware
 from app.core.request_logging import RequestLoggingMiddleware
 from app.db import create_db_and_tables
 from app.integrations.telegram import telegram_lifespan
@@ -71,6 +72,10 @@ def create_app() -> FastAPI:
         description="An AI assistant platform",
         version="0.1.0",
     )
+    # BackendApiKeyMiddleware runs first (outermost) — rejects requests
+    # without the correct X-Pawrrtal-Key header before auth or routing.
+    # Only active when BACKEND_API_KEY is set in the environment.
+    fastapi_app.add_middleware(BackendApiKeyMiddleware)
     # Request-logging middleware must be added before any route is registered
     # so it wraps every endpoint. Each request gets a unique ID logged on
     # entry and exit (see app/core/request_logging.py).

--- a/frontend/app/(app)/c/[conversationId]/page.tsx
+++ b/frontend/app/(app)/c/[conversationId]/page.tsx
@@ -3,6 +3,11 @@ import { notFound, unauthorized } from 'next/navigation';
 import ChatContainer from '@/features/chat/ChatContainer';
 import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
 
+// Server components cannot use localStorage, so read the key from the build-time
+// env var. In demo builds it is baked in; for production deployments configure
+// NEXT_PUBLIC_BACKEND_API_KEY in the server's environment.
+const SERVER_API_KEY = process.env.NEXT_PUBLIC_BACKEND_API_KEY ?? '';
+
 /** Route params for `/c/:conversationId`. */
 interface ConversationPageProps {
 	params: Promise<{ conversationId: string }>;
@@ -33,6 +38,7 @@ export default async function ConversationPage({ params }: ConversationPageProps
 			headers: {
 				'content-type': 'application/json',
 				Cookie: `session_token=${sessionToken?.value}`,
+				...(SERVER_API_KEY ? { 'X-Pawrrtal-Key': SERVER_API_KEY } : {}),
 			},
 		}
 	);

--- a/frontend/components/signup-form.tsx
+++ b/frontend/components/signup-form.tsx
@@ -12,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
+import { API_ENDPOINTS, apiFetch } from '@/lib/api';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
 
 /** Self-service registration form. */
@@ -48,7 +48,7 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
 		}
 
 		// TODO: This inline fetch needs to be moved to a custom hook.
-		const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.register}`, {
+		const response = await apiFetch(API_ENDPOINTS.auth.register, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -82,7 +82,7 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
 
 		// We need to log the user in after we've created the account.
 		// Otherwise, it'll feel odd to still need to log in after signing up.
-		await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
+		await apiFetch(API_ENDPOINTS.auth.login, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',

--- a/frontend/features/auth/hooks/use-login-mutations.ts
+++ b/frontend/features/auth/hooks/use-login-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
+import { API_ENDPOINTS, apiFetch } from '@/lib/api';
 
 /**
  * React Query mutations for JWT login and dev-only admin shortcut.
@@ -42,7 +42,7 @@ export function useLoginMutation() {
 
 	return useMutation<void, Error, LoginArgs>({
 		mutationFn: async ({ email, password }) => {
-			const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.login}`, {
+			const response = await apiFetch(API_ENDPOINTS.auth.login, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
@@ -74,7 +74,7 @@ export function useDevAdminLoginMutation() {
 
 	return useMutation<void, Error, void>({
 		mutationFn: async () => {
-			const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.auth.devLogin}`, {
+			const response = await apiFetch(API_ENDPOINTS.auth.devLogin, {
 				method: 'POST',
 				credentials: 'include',
 			});

--- a/frontend/hooks/use-authed-fetch.ts
+++ b/frontend/hooks/use-authed-fetch.ts
@@ -2,11 +2,13 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
-import { API_BASE_URL } from '@/lib/api';
+import { apiFetch } from '@/lib/api';
 
 /**
- * Returns a memoized `fetch` wrapper that targets {@link API_BASE_URL}, sends cookies, and handles auth failures.
+ * Returns a memoized `fetch` wrapper that targets the configured backend URL,
+ * sends cookies, adds the `X-Pawrrtal-Key` header when configured, and handles auth failures.
  *
+ * - Uses {@link apiFetch} so the backend API key header is included automatically.
  * - Sends `credentials: 'include'` so the HTTP-only session cookie reaches the API.
  * - On `401`, replaces the route with `/login` and throws (callers should treat this as a hard logout signal).
  * - On other non-OK responses, throws with status and body text for debugging.
@@ -19,11 +21,10 @@ export function useAuthedFetch() {
 	// Return a stable function identity between renders so effects depending on it do not loop.
 	return useCallback(
 		async function authedFetch(endpoint: string | (() => string), options?: RequestInit) {
-			// Construct the full URL to fetch from the API.
-			const fetchUrl = `${API_BASE_URL}${typeof endpoint === 'function' ? endpoint() : endpoint}`;
+			const path = typeof endpoint === 'function' ? endpoint() : endpoint;
 
-			// Fetch the URL from the API.
-			const response = await fetch(fetchUrl, {
+			// apiFetch prepends the backend URL and injects X-Pawrrtal-Key when configured.
+			const response = await apiFetch(path, {
 				...options,
 				// Include the session token in the request. (HTTPOnly Cookie)
 				credentials: 'include',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -77,10 +77,15 @@ export function clearBackendConfig(): void {
  */
 export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
 	const { url: baseUrl, apiKey } = readBackendConfig();
-	const headers = new Headers(init?.headers);
-	if (apiKey) {
-		headers.set('X-Pawrrtal-Key', apiKey);
+	// Only wrap headers in a Headers object when we actually need to inject
+	// X-Pawrrtal-Key.  When no key is configured (local dev, tests) we pass
+	// init through unchanged so callers that stub `fetch` get back the same
+	// plain-object headers they supplied — keeping test assertions simple.
+	if (!apiKey) {
+		return fetch(`${baseUrl}${path}`, init);
 	}
+	const headers = new Headers(init?.headers);
+	headers.set('X-Pawrrtal-Key', apiKey);
 	return fetch(`${baseUrl}${path}`, { ...init, headers });
 }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -8,6 +8,83 @@
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
 
 /**
+ * Backend API key for the X-Pawrrtal-Key header.
+ *
+ * Two sources, resolved at runtime (client-side precedence order):
+ *   1. localStorage `pawrrtal:backend-config` — set via the Settings page when
+ *      a user points at their own backend instance (URL + key stored together).
+ *   2. NEXT_PUBLIC_BACKEND_API_KEY build-time env var — baked into the demo
+ *      build so the demo instance works out-of-the-box without any config.
+ *
+ * When neither is set the header is omitted, which is correct for local dev
+ * (backend has no BACKEND_API_KEY configured either).
+ */
+const BACKEND_CONFIG_STORAGE_KEY = 'pawrrtal:backend-config';
+
+interface BackendConfig {
+	url: string;
+	apiKey: string;
+}
+
+function readBackendConfig(): BackendConfig {
+	const buildTimeKey = process.env.NEXT_PUBLIC_BACKEND_API_KEY ?? '';
+	const defaults: BackendConfig = { url: API_BASE_URL, apiKey: buildTimeKey };
+
+	if (typeof window === 'undefined') return defaults;
+	try {
+		const raw = window.localStorage.getItem(BACKEND_CONFIG_STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw) as Partial<BackendConfig>;
+			return {
+				url: parsed.url ?? defaults.url,
+				apiKey: parsed.apiKey ?? defaults.apiKey,
+			};
+		}
+	} catch {
+		// Malformed storage — fall back to build-time defaults.
+	}
+	return defaults;
+}
+
+/** Persist a new backend config (URL + API key) to localStorage. */
+export function saveBackendConfig(config: BackendConfig): void {
+	try {
+		window.localStorage.setItem(BACKEND_CONFIG_STORAGE_KEY, JSON.stringify(config));
+	} catch {
+		/* quota / private browsing — ignore */
+	}
+}
+
+/** Clear the runtime backend config override (reverts to build-time defaults). */
+export function clearBackendConfig(): void {
+	try {
+		window.localStorage.removeItem(BACKEND_CONFIG_STORAGE_KEY);
+	} catch {
+		/* ignore */
+	}
+}
+
+/**
+ * Drop-in replacement for `fetch` that:
+ *   - Prepends `API_BASE_URL` (or the runtime URL from localStorage) to the path.
+ *   - Adds the `X-Pawrrtal-Key` header when an API key is configured.
+ *
+ * Use this for every backend request instead of calling `fetch` directly so the
+ * key header is applied consistently across the entire frontend.
+ *
+ * @example
+ *   const res = await apiFetch('/api/v1/chat', { method: 'POST', body: JSON.stringify(msg) });
+ */
+export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+	const { url: baseUrl, apiKey } = readBackendConfig();
+	const headers = new Headers(init?.headers);
+	if (apiKey) {
+		headers.set('X-Pawrrtal-Key', apiKey);
+	}
+	return fetch(`${baseUrl}${path}`, { ...init, headers });
+}
+
+/**
  * API endpoint definitions for frontend requests.
  * Organized by logical service areas. Use curried functions for endpoints with path params,
  * and plain string properties for static endpoints.

--- a/frontend/lib/channels.ts
+++ b/frontend/lib/channels.ts
@@ -11,7 +11,7 @@
  * @fileoverview Typed helpers for the channel binding flow.
  */
 
-import { API_BASE_URL, API_ENDPOINTS } from '@/lib/api';
+import { API_ENDPOINTS, apiFetch } from '@/lib/api';
 
 /** Public shape returned by `GET /api/v1/channels`. */
 export interface ChannelBinding {
@@ -40,7 +40,7 @@ export class ChannelNotConfiguredError extends Error {
 
 /** List the authenticated user's channel bindings. */
 export async function listChannels(signal?: AbortSignal): Promise<ChannelBinding[]> {
-	const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.channels.list}`, {
+	const response = await apiFetch(API_ENDPOINTS.channels.list, {
 		credentials: 'include',
 		signal,
 	});
@@ -53,7 +53,7 @@ export async function listChannels(signal?: AbortSignal): Promise<ChannelBinding
 /** Issue a fresh one-time Telegram link code for the authenticated user. */
 export async function issueTelegramLinkCode(signal?: AbortSignal): Promise<TelegramLinkCode> {
 	//We issue a POST request to the /api/v1/channels/telegram/link endpoint so that the backend can issue a fresh one-time code for the authenticated user.
-	const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.channels.telegramLink}`, {
+	const response = await apiFetch(API_ENDPOINTS.channels.telegramLink, {
 		method: 'POST',
 		credentials: 'include',
 		signal,
@@ -72,7 +72,7 @@ export async function issueTelegramLinkCode(signal?: AbortSignal): Promise<Teleg
 
 /** Drop the authenticated user's Telegram binding. Idempotent. */
 export async function unlinkTelegram(signal?: AbortSignal): Promise<void> {
-	const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.channels.telegramUnlink}`, {
+	const response = await apiFetch(API_ENDPOINTS.channels.telegramUnlink, {
 		method: 'DELETE',
 		credentials: 'include',
 		signal,


### PR DESCRIPTION
## Two-layer access control for private deployments

Addresses the question: "how do we prevent strangers from using our backend URL?"

---

### Layer 1 — Transport gate: `BACKEND_API_KEY`

**`backend/app/core/middleware.py`** (new)
- `BackendApiKeyMiddleware` rejects any request missing `X-Pawrrtal-Key: <value>` with a 401 **before auth runs**
- Uses `secrets.compare_digest` to prevent timing side-channels
- Exempt paths: `/health`, `/docs`, `/redoc`, `/openapi.json`, `/api/v1/auth/oauth/` (OAuth redirects happen in the browser)
- **Only active when `BACKEND_API_KEY` is set** — disabled by default, no impact on local dev or open demo

### Layer 2 — Identity gate: `ALLOWED_EMAILS`

**`backend/app/core/config.py`**
- New `allowed_emails: str` setting (comma-separated, e.g. `you@example.com,partner@example.com`)
- `allowed_emails_set` property returns a `frozenset[str]` for O(1) lookups

**`backend/app/users.py`**
- New `get_allowed_user()` FastAPI dependency — wraps `current_active_user` and raises 403 if the user's email isn't in the allowlist
- Works across **all login methods** (Google, Apple, password) because every auth path resolves to a `User` with a verified `email`
- Empty list = allow all (open/demo mode)

### Frontend — `apiFetch` wrapper

**`frontend/lib/api.ts`**
- New `apiFetch(path, init?)` drop-in replacement for `fetch` that:
  - Prepends the backend URL (from localStorage or build-time env)
  - Injects `X-Pawrrtal-Key` header automatically
- Key source priority:
  1. `localStorage['pawrrtal:backend-config']` — runtime, set by Settings page (URL + key together)
  2. `NEXT_PUBLIC_BACKEND_API_KEY` build-time env var — baked into demo builds
- `saveBackendConfig()` + `clearBackendConfig()` exported for the Settings page to use

All direct `fetch(\`${API_BASE_URL}...\`)` calls migrated to `apiFetch()`:
- `hooks/use-authed-fetch.ts` — covers all authenticated React hooks
- `features/auth/hooks/use-login-mutations.ts`
- `components/signup-form.tsx`
- `lib/channels.ts`
- `app/(app)/c/[conversationId]/page.tsx` (server component — reads `NEXT_PUBLIC_BACKEND_API_KEY` at build time)

---

## Usage

```bash
# In your VPS .env:
BACKEND_API_KEY=$(openssl rand -hex 32)   # transport lock
ALLOWED_EMAILS=you@example.com,esther@example.com  # identity lock

# Demo instance: no BACKEND_API_KEY (or use a public rate-limited one)
# ALLOWED_EMAILS empty = allow all registered users
```

## What's NOT in this PR
- Settings UI to save backend URL + key (follow-up)
- Apple OAuth callback implementation (separate concern)
- Swapping `current_active_user` → `get_allowed_user` on individual routes (follow-up, needs decision on which routes to gate)

## Summary by Sourcery

Introduce two-layer access control for private backend deployments and ensure frontend requests consistently supply the backend API key.

New Features:
- Add configurable BACKEND_API_KEY transport gate middleware that rejects unauthorized requests before authentication while allowing specified public paths.
- Add ALLOWED_EMAILS configuration and get_allowed_user dependency to restrict authenticated access to a defined email allowlist.
- Introduce a frontend apiFetch wrapper that prepends the backend URL and injects the X-Pawrrtal-Key header based on runtime or build-time configuration.

Enhancements:
- Migrate existing frontend backend calls to use the centralized apiFetch helper, ensuring consistent URL resolution and API key handling across the app.