### PR TITLE
fix: integrations cleanup, Conversation.updated_at bump, and architecture follow-up design docs

### DIFF
--- a/backend/app/crud/chat_message.py
+++ b/backend/app/crud/chat_message.py
@@ -15,12 +15,29 @@ from typing import Any
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
-from app.models import ChatMessage
+from app.models import ChatMessage, Conversation
 
 
 def _now() -> datetime:
     """Naive UTC timestamp — matches the ``DateTime`` column type used elsewhere."""
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+async def _touch_conversation(
+    session: AsyncSession, conversation_id: uuid.UUID, when: datetime
+) -> None:
+    """Bump ``Conversation.updated_at`` so the conversation list re-sorts.
+
+    The chat sidebar orders conversations by ``Conversation.updated_at
+    DESC``.  Without this every Telegram-originated turn (and indeed every
+    web turn after the first) leaves the conversation row untouched, so
+    new activity never bubbles to the top.
+    """
+    await session.execute(
+        update(Conversation)
+        .where(Conversation.id == conversation_id)
+        .values(updated_at=when)
+    )
 
 
 async def get_messages_for_conversation(
@@ -78,7 +95,12 @@ async def append_user_message(
     user_id: uuid.UUID,
     content: str,
 ) -> ChatMessage:
-    """Insert a new user message at the end of the conversation."""
+    """Insert a new user message at the end of the conversation.
+
+    Bumps ``Conversation.updated_at`` so the chat list re-sorts on the
+    next read — messages from every surface (web, Electron, Telegram)
+    must bubble the conversation to the top.
+    """
     now = _now()
     message = ChatMessage(
         conversation_id=conversation_id,
@@ -91,6 +113,7 @@ async def append_user_message(
     )
     session.add(message)
     await session.flush()
+    await _touch_conversation(session, conversation_id, now)
     return message
 
 
@@ -133,7 +156,12 @@ async def finalize_assistant_message(
     Called both on successful completion (``status="complete"``) and on
     stream-level errors (``status="failed"``) so the row always reflects the
     most recent state visible to the user.
+
+    Also bumps the parent ``Conversation.updated_at`` so the sidebar
+    re-sorts when the assistant's reply finishes (a long stream that
+    started seconds ago shouldn't sink the conversation back down).
     """
+    now = _now()
     await session.execute(
         update(ChatMessage)
         .where(ChatMessage.id == message_id)
@@ -144,6 +172,14 @@ async def finalize_assistant_message(
             timeline=timeline,
             thinking_duration_seconds=thinking_duration_seconds,
             assistant_status=assistant_status,
-            updated_at=_now(),
+            updated_at=now,
         )
     )
+    # finalize_assistant_message receives a message_id not a conversation_id,
+    # so look up the conversation via the row we just touched.
+    result = await session.execute(
+        select(ChatMessage.conversation_id).where(ChatMessage.id == message_id)
+    )
+    conversation_id = result.scalar_one_or_none()
+    if conversation_id is not None:
+        await _touch_conversation(session, conversation_id, now)

--- a/backend/tests/test_chat_message_crud.py
+++ b/backend/tests/test_chat_message_crud.py
@@ -1,0 +1,106 @@
+"""Regression tests for the chat_message CRUD helpers.
+
+The chat sidebar orders conversations by ``Conversation.updated_at DESC``.
+For a long time the helpers only bumped ``ChatMessage.updated_at`` and
+left the parent untouched, so messages from Telegram (and second+ turns
+from web) never re-sorted the sidebar.  These tests pin the fix.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.chat_message import (
+    append_assistant_placeholder,
+    append_user_message,
+    finalize_assistant_message,
+)
+from app.db import User
+from app.models import Conversation
+
+
+async def _make_conversation(
+    session: AsyncSession, user: User, *, when: datetime
+) -> Conversation:
+    """Insert a conversation row with a fixed ``updated_at`` so we can compare."""
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="Test",
+        created_at=when,
+        updated_at=when,
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+@pytest.mark.anyio
+async def test_append_user_message_bumps_conversation_updated_at(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A new user message must bubble the conversation to the sidebar top."""
+    old = datetime(2025, 1, 1)
+    conv = await _make_conversation(db_session, test_user, when=old)
+
+    await append_user_message(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        content="hello",
+    )
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    assert conv.updated_at > old
+
+
+@pytest.mark.anyio
+async def test_finalize_assistant_message_bumps_conversation_updated_at(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Finalising the assistant turn also re-stamps the parent conversation.
+
+    Without this a long stream that started before another conversation's
+    quick turn would let the slower one sink down the list once it finished.
+    """
+    old = datetime(2025, 1, 1)
+    conv = await _make_conversation(db_session, test_user, when=old)
+
+    await append_user_message(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        content="hi",
+    )
+    placeholder = await append_assistant_placeholder(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+    )
+    await db_session.commit()
+
+    # Reset updated_at to an older value so we can isolate the finalize bump.
+    conv.updated_at = old
+    db_session.add(conv)
+    await db_session.commit()
+
+    await finalize_assistant_message(
+        db_session,
+        message_id=placeholder.id,
+        content="hello back",
+        thinking=None,
+        tool_calls=None,
+        timeline=None,
+        thinking_duration_seconds=None,
+        assistant_status="complete",
+    )
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    assert conv.updated_at > old

--- a/docs/design/codex-oauth-text-provider.md
+++ b/docs/design/codex-oauth-text-provider.md
@@ -1,0 +1,223 @@
+# Design: OpenAI Codex OAuth provider for GPT text models
+
+**Status:** Proposed
+**Author:** Tavi + Wretch
+**Last updated:** 2026-05-12
+
+## Summary
+
+We already use OpenAI's Codex OAuth flow for image generation
+(`backend/app/core/tools/image_gen.py`).  The same endpoint, same
+auth, same wire format also serves chat text completions.  This doc
+plans an `OpenAICodexProvider` that mirrors `ClaudeProvider` /
+`GeminiProvider` and registers a new model prefix in `factory.py`,
+so users can route `gpt-*` (or `openai-codex/*`) conversations
+through the same ChatGPT-paid auth they already have configured.
+
+## Why use Codex OAuth instead of `OPENAI_API_KEY`
+
+- **ChatGPT subscription billing is cheaper at our usage shape**
+  than per-token API key billing for casual text use.
+- Users already configured Codex OAuth for image generation —
+  reusing it is one less secret to manage.
+- Pulls in fast-mode access on subscription plans without extra
+  config.
+
+## Confirmed wire shape
+
+From OpenAI's documentation and our own image-gen code:
+
+| Property        | Value                                                |
+| --------------- | ---------------------------------------------------- |
+| Endpoint        | `https://chatgpt.com/backend-api/codex/responses`    |
+| Method          | `POST`                                               |
+| Auth header     | `Authorization: Bearer <codex_oauth_token>`          |
+| Token source    | `$CODEX_HOME/auth.json` → `tokens.access_token`      |
+| Wire protocol   | Responses API streaming (SSE-style events)           |
+| Default model   | `gpt-5.5` (matches our image-gen choice; configurable) |
+
+**Important:** Do NOT use `api.openai.com/v1/responses`.  ChatGPT
+OAuth tokens are rejected there (missing `api.responses.write`
+scope).  The codex sub-path bypasses that gate — it's the same
+endpoint the official Codex CLI uses.
+
+## Implementation plan
+
+### 1. New provider module
+
+`backend/app/core/providers/openai_codex_provider.py`
+
+Shape mirrors `gemini_provider.py`:
+
+```python
+class OpenAICodexProvider(LLMProvider):
+    """OpenAI text-model provider routed through ChatGPT OAuth.
+
+    Uses the Codex-specific responses endpoint
+    (chatgpt.com/backend-api/codex/responses) so requests authenticate
+    with the same ChatGPT OAuth token already used by image_gen.py.
+    """
+
+    def __init__(self, model_id: str, user_id: uuid.UUID | None = None):
+        self.model_id = model_id  # e.g. "gpt-5.5", "openai-codex/gpt-5.5"
+        self.user_id = user_id
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        *,
+        history: list[Message],
+        tools: list[Tool] | None,
+        system_prompt: str | None,
+    ) -> AsyncIterator[StreamEvent]:
+        token = resolve_codex_oauth_token()  # reuse image_gen.py helper
+        async with httpx.AsyncClient() as client:
+            async with client.stream(
+                "POST",
+                "https://chatgpt.com/backend-api/codex/responses",
+                json=_build_request(question, history, tools, system_prompt),
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream",
+                },
+                timeout=180.0,
+            ) as response:
+                response.raise_for_status()
+                async for event in _parse_sse(response):
+                    yield event
+```
+
+The `resolve_codex_oauth_token()` helper already exists in
+`app/core/tools/image_gen.py`; lift it into `app/core/codex_auth.py`
+so the provider and tool share it.
+
+### 2. Request payload
+
+Strip `image_generation` from the image-gen request; everything else
+is the same Responses API shape:
+
+```python
+def _build_request(question, history, tools, system_prompt):
+    input_items = []
+    if system_prompt:
+        input_items.append({
+            "type": "message",
+            "role": "system",
+            "content": [{"type": "input_text", "text": system_prompt}],
+        })
+    for msg in history:
+        input_items.append({
+            "type": "message",
+            "role": msg["role"],
+            "content": [{"type": "input_text", "text": msg["content"]}],
+        })
+    input_items.append({
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": question}],
+    })
+    return {
+        "model": _resolve_underlying_model(self.model_id),
+        "input": input_items,
+        "stream": True,
+        "tools": _convert_tools_to_responses_format(tools or []),
+        "store": False,
+    }
+```
+
+### 3. Stream event mapping
+
+Responses API emits typed events (`response.created`,
+`response.output_text.delta`, `response.output_item.added` for
+tool calls, `response.completed`, ...).  Map to our
+`StreamEvent` union:
+
+| Responses event                        | StreamEvent           |
+| -------------------------------------- | --------------------- |
+| `response.output_text.delta`           | `{type: "delta", content: <delta>}` |
+| `response.reasoning_summary.delta`     | `{type: "thinking", content: <delta>}` |
+| `response.output_item.added` (function_call) | `{type: "tool_use", name, input, tool_use_id}` |
+| function call output back to us        | (no direct mapping — the agent supplies the result and we send it as `function_call_output` on the next request) |
+| `response.completed`                   | end of stream         |
+| `error`                                | `{type: "error", content}` |
+
+Tool execution still happens inside our `agent_loop` because the
+Responses API requires the client to supply tool results in the
+next request.  Our loop already handles this for Claude + Gemini;
+the codex variant just speaks Responses-shaped messages instead.
+
+### 4. Factory wiring
+
+`backend/app/core/providers/factory.py`:
+
+```python
+def resolve_llm(model_id: str, user_id: uuid.UUID | None = None) -> LLMProvider:
+    if model_id.startswith("claude-"):
+        return ClaudeProvider(model_id=model_id, user_id=user_id)
+    if model_id.startswith(("gpt-", "openai-codex/")):
+        return OpenAICodexProvider(model_id=model_id, user_id=user_id)
+    return GeminiProvider(model_id=model_id, user_id=user_id)
+```
+
+Model catalog additions in `/api/v1/models` so the picker shows them:
+`gpt-5.5`, `gpt-5.5-mini` (whatever ChatGPT Plus / Business plan
+unlocks for the user).
+
+### 5. Config
+
+Per-user override path: workspace `.env` → `OPENAI_CODEX_OAUTH_TOKEN`
+(already supported by `resolve_codex_oauth_token`).  Without an
+override, the provider falls back to `$CODEX_HOME/auth.json`.  This
+keeps the bring-your-own-token story consistent with image-gen.
+
+## Out of scope (deferred)
+
+- **API-key path.**  Users with an `OPENAI_API_KEY` can already
+  route through `api.openai.com/v1/responses` via the standard
+  OpenAI SDK; that's a separate provider if we want it.  Codex
+  OAuth is the priority because that's the auth Tavi + Esther
+  already have set up.
+- **Per-message Codex routing fast-mode toggle.**  Add later.
+- **Image-gen-in-text-conversation.**  Our existing
+  `image_gen` tool already covers this — keep them separate.
+
+## Risks
+
+- **Token expiry.**  Codex OAuth tokens refresh; the Codex CLI
+  refreshes them in-process.  We currently just *read* the cached
+  token.  If a long-lived agent stream picks up a stale token we
+  fail mid-stream.  Mitigation: catch 401 from the stream, re-read
+  `auth.json` (Codex CLI might have refreshed it on a parallel
+  invocation), retry once.
+- **Endpoint deprecation.**  This is technically a private OpenAI
+  endpoint.  It's been stable for many months and is what the
+  Codex CLI itself uses, but it could break without warning.
+  Mitigation: wrap with the same error envelope as other providers
+  so a sudden 4xx surfaces as a normal stream error event.
+- **Tool-call shape divergence.**  Responses API tool calls aren't
+  identical to Anthropic's or Gemini's.  The `_claude_tool_bridge`
+  pattern shows we already handle per-provider tool translation;
+  add a codex bridge.
+
+## Implementation order
+
+1. Lift `resolve_codex_oauth_token` from `image_gen.py` to
+   `core/codex_auth.py`.  No behaviour change.
+2. New file: `core/providers/openai_codex_provider.py` — bare skeleton
+   that just makes a non-streaming request work end-to-end with a
+   single user message and no tools.
+3. Add streaming + delta event mapping.
+4. Add tool-call support (reuse pattern from Claude bridge).
+5. Wire into `factory.py` with the new prefix.
+6. Add catalog entries to `/api/v1/models`.
+7. Tests: replay-based, mirroring `test_claude_provider.py`.
+
+## Test strategy
+
+- Unit tests with recorded request/response fixtures (vcr.py or
+  hand-rolled httpx mocks).  Don't hit live Codex from CI.
+- Manual smoke: Tavi runs a real conversation with his Codex token
+  and confirms the stream renders correctly on web + Telegram.

--- a/docs/design/codex-oauth-text-provider.md
+++ b/docs/design/codex-oauth-text-provider.md
@@ -1,223 +1,529 @@
 # Design: OpenAI Codex OAuth provider for GPT text models
 
-**Status:** Proposed
+**Status:** Proposed — research complete, ready for implementation
 **Author:** Tavi + Wretch
 **Last updated:** 2026-05-12
 
 ## Summary
 
-We already use OpenAI's Codex OAuth flow for image generation
-(`backend/app/core/tools/image_gen.py`).  The same endpoint, same
-auth, same wire format also serves chat text completions.  This doc
-plans an `OpenAICodexProvider` that mirrors `ClaudeProvider` /
-`GeminiProvider` and registers a new model prefix in `factory.py`,
-so users can route `gpt-*` (or `openai-codex/*`) conversations
-through the same ChatGPT-paid auth they already have configured.
+We already authenticate to the Codex backend for image generation
+(`backend/app/core/tools/image_gen.py`).  The same auth token, same
+endpoint, and same Responses API protocol also serve text completions.
 
-## Why use Codex OAuth instead of `OPENAI_API_KEY`
+This doc is the **canonical reference** for adding text-model support.
+It's built from a deep read of:
 
-- **ChatGPT subscription billing is cheaper at our usage shape**
-  than per-token API key billing for casual text use.
-- Users already configured Codex OAuth for image generation —
-  reusing it is one less secret to manage.
-- Pulls in fast-mode access on subscription plans without extra
-  config.
+- OpenAI Codex docs (`developers.openai.com/codex`)
+- The official Codex CLI Rust source
+  (`github.com/openai/codex/codex-rs`)
+- Multiple independent OAuth-based Codex clients
+  (`EvanZhouDev/openai-oauth`, `oauth-codex`, `codex-auth`,
+  `codex-open-client`, `codex-backend-sdk`)
+- OpenCode plugins
+  (`pproenca/opencode-openai-codex-auth`,
+  `ndycode/oc-codex-multi-auth`,
+  `withakay/opencode-codex-provider`)
+- The Roo-Code provider
+  (`RooCodeInc/Roo-Code/src/api/providers/openai-codex.ts`)
+- `badlogic/pi-mono` issue #3579 (header gateway compatibility)
+- Reported failures: openai/codex#11743, openai/codex#14743,
+  openai/codex#15502, openclaw/openclaw#64133
 
-## Confirmed wire shape
+If any section conflicts with the live Codex CLI behaviour, **the CLI
+wins** — these endpoints are private to OpenAI and the wire shape can
+change without notice.
 
-From OpenAI's documentation and our own image-gen code:
+## Why use Codex OAuth instead of an API key
+
+- ChatGPT Plus/Pro subscription pricing beats per-token API key
+  pricing at our usage shape.
+- Users (Tavi + Esther) already have Codex OAuth configured for
+  image generation; reusing it is one less secret to manage.
+- Fast-mode + reasoning summaries are gated on subscription auth.
+- `api.openai.com/v1/responses` **rejects** ChatGPT OAuth tokens
+  with `401 Missing scope api.responses.write` — the Codex sub-path
+  bypasses this gate.  That's the entire reason this provider exists.
+
+## Confirmed endpoint + transport
 
 | Property        | Value                                                |
 | --------------- | ---------------------------------------------------- |
 | Endpoint        | `https://chatgpt.com/backend-api/codex/responses`    |
 | Method          | `POST`                                               |
-| Auth header     | `Authorization: Bearer <codex_oauth_token>`          |
-| Token source    | `$CODEX_HOME/auth.json` → `tokens.access_token`      |
-| Wire protocol   | Responses API streaming (SSE-style events)           |
-| Default model   | `gpt-5.5` (matches our image-gen choice; configurable) |
+| Streaming       | **Required.**  `stream: true` in body, `Accept: text/event-stream` header.  Non-streaming returns 400. |
+| Storage         | **`store: false` required.**  `store: true` returns `400 Store must be set to false`. |
+| `previous_response_id` | Not supported (depends on storage).  Multi-turn uses stateless `reasoning.encrypted_content` instead. |
+| Max body size   | ~4 MB (proxy default in `openprx`).                  |
+| Stream idle timeout | 45 s default, 180 s upper bound observed.         |
 
-**Important:** Do NOT use `api.openai.com/v1/responses`.  ChatGPT
-OAuth tokens are rejected there (missing `api.responses.write`
-scope).  The codex sub-path bypasses that gate — it's the same
-endpoint the official Codex CLI uses.
+## Auth flow
 
-## Implementation plan
+### `~/.codex/auth.json` schema
 
-### 1. New provider module
+The Codex CLI writes this file on login.  Our code reads from the same
+file (already done in `image_gen.py`).  Schema:
 
-`backend/app/core/providers/openai_codex_provider.py`
+```json
+{
+  "OPENAI_API_KEY": null,
+  "auth_mode": "chatgpt",
+  "email": "user@example.com",
+  "tokens": {
+    "id_token": "eyJ...",
+    "access_token": "eyJ...",
+    "refresh_token": "...",
+    "account_id": "org-..."
+  },
+  "last_refresh": "2026-05-12T14:00:00.000Z"
+}
+```
 
-Shape mirrors `gemini_provider.py`:
+`OPENAI_API_KEY` is non-null **only** when the user signed in with an
+API key instead of ChatGPT.  When it's non-null, skip the OAuth flow
+entirely — `tokens` will be absent and the access path is a normal
+`api.openai.com/v1` request with that key as bearer.
+
+### OAuth PKCE flow (for our own login)
+
+If we want to support sign-in from inside Pawrrtal (vs. requiring the
+user to run the Codex CLI first):
+
+| Property        | Value                                                |
+| --------------- | ---------------------------------------------------- |
+| Client ID       | `app_EMoamEEZ73f0CkXaXp7hrann`                       |
+| Issuer          | `https://auth.openai.com`                            |
+| Token URL       | `https://auth.openai.com/oauth/token`                |
+| Authorize URL   | `https://auth.openai.com/oauth/authorize`            |
+| Scopes          | `openid profile email`                               |
+| Callback        | `http://localhost:1455/auth/callback`                |
+| PKCE            | S256                                                 |
+| Device code     | Supported (`POST /oauth/device/code`)                |
+
+**Note:** port `1455` is hardcoded by the official CLI.  If the Codex
+CLI is running during our login flow it will steal the callback.
+Tell users to quit it during first auth.
+
+### Refresh
+
+`POST https://auth.openai.com/oauth/token` with:
+
+```json
+{
+  "grant_type": "refresh_token",
+  "refresh_token": "<from auth.json>",
+  "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+  "scope": "openid profile email"
+}
+```
+
+Response includes a new `access_token`, optionally a new `id_token`,
+and **optionally a new `refresh_token`** (rotate it if present).
+
+**🚨 Critical gotcha:** Refresh tokens are **single-use**.  If two
+processes (e.g. the Codex CLI and our backend) both try to refresh at
+the same time, one wins and the other invalidates.  See
+openai/codex#15502.  Mitigations:
+
+1. Centralise refresh through one async lock per host process.
+2. After 401 on a stream, re-read `auth.json` from disk (the CLI
+   might have refreshed it concurrently) and retry once before
+   running our own refresh.
+
+### Extracting `chatgpt_account_id`
+
+Two paths:
+
+1. **Cheap:** read `tokens.account_id` from `auth.json` directly.
+2. **Fallback:** decode the JWT `id_token` (base64url payload) and
+   read `claims["https://api.openai.com/auth"].chatgpt_account_id`.
+
+Both should produce the same value; use (1) and fall back to (2)
+when the field is missing in older auth files.
+
+## Required request headers
+
+This is the **exact** header set our provider must send.  Validated
+against three independent reference implementations.
+
+```http
+POST /backend-api/codex/responses HTTP/1.1
+Host: chatgpt.com
+Content-Type: application/json
+Accept: text/event-stream
+Authorization: Bearer <access_token>
+OpenAI-Beta: responses=experimental
+chatgpt-account-id: <account_id>
+originator: pawrrtal
+session_id: <uuid v4 per request>
+```
+
+Optional but recommended:
+- `x-client-request-id: <our conversation_id>` — for log correlation.
+
+**Header gotchas:**
+
+- **`session_id` (with underscore)** is what the backend keys
+  cache-affinity on.  `pi-mono#3579` shows strict HTTP gateways
+  reject underscore headers — irrelevant here because we hit
+  `chatgpt.com` directly, but worth knowing if we ever proxy through
+  one.
+- **`originator`** is critical.  If you set it to `codex_cli_rs`,
+  the backend enters **strict mode**: it validates that the
+  `instructions` text exactly matches the Codex CLI's `prompt.md`
+  AND that the `tools` list is exactly `shell` + `update_plan` with
+  exact schemas, AND that the model is `gpt-5`.  Anything else
+  returns `400 {"detail": "Instructions are not valid"}`.  We do
+  **not** want strict mode — use our own originator string
+  (`pawrrtal`, `pawrrtal/0.1.0`, or whatever).  Strict mode is only
+  for clients that want to impersonate the official CLI.
+- **Do not send `temperature`** — `400 Unsupported parameter:
+  temperature`.
+- **Do not send `User-Agent`** is sometimes reported as problematic
+  but `RooCodeInc/Roo-Code` happily sends a `User-Agent` with their
+  own product/version string and that works.  Probably safe; skip if
+  in doubt.
+- **`OpenAI-Beta: responses=experimental`** — required.  Without it
+  the endpoint may default to an older shape.
+
+## Request payload
+
+```json
+{
+  "model": "gpt-5",
+  "instructions": "You are Pawrrtal's assistant. ...",
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {"type": "input_text", "text": "What's 2 + 2?"}
+      ]
+    }
+  ],
+  "tools": [],
+  "tool_choice": "auto",
+  "reasoning": {
+    "effort": "medium",
+    "summary": "auto"
+  },
+  "text": {"verbosity": "medium"},
+  "include": ["reasoning.encrypted_content"],
+  "stream": true,
+  "store": false
+}
+```
+
+### Rules
+
+- **`model`** — known-good values: `gpt-5`, `gpt-5-codex`, `gpt-5.4`,
+  `gpt-5.5`, `gpt-5-mini`, `gpt-5-nano`.  Subscription tier determines
+  which models the user can actually access; unknowns return
+  `400 Unsupported model`.  Plan to call `GET
+  /backend-api/codex/models` (when available) or hardcode + let the
+  backend reject.
+- **`instructions`** — system prompt at the top level (NOT inside
+  `input`).  Free-form string when `originator` is your own value.
+- **`input`** — Responses API format (NOT chat completions
+  `messages`).  Each item is `{type: "message", role,
+  content: [{type: "input_text", text}]}` OR
+  `{type: "reasoning", encrypted_content, ...}` (for multi-turn
+  state).  Roles allowed: `user`, `assistant`, `system`,
+  `developer`.
+- **`stream: true`** — required.  Backend rejects `false`.
+- **`store: false`** — required.  Backend rejects `true`.
+- **`reasoning.effort`** — `minimal | low | medium | high`.
+  `gpt-5-codex` rejects `minimal` (silently normalised to `low` by
+  some clients).
+- **`reasoning.summary`** — `auto | detailed`.
+- **`text.verbosity`** — `low | medium | high`.  `gpt-5-codex` only
+  accepts `medium`.
+- **`include: ["reasoning.encrypted_content"]`** — required for
+  multi-turn statelessness (see below).
+- **Forbidden:** `temperature`, `max_output_tokens`,
+  `max_completion_tokens`, `previous_response_id`, `messages`,
+  `background`.
+
+### Tool format (when sending tools)
+
+Responses API tools are flat — properties at the top level, NOT
+nested under `function`:
+
+```json
+{
+  "type": "function",
+  "name": "render_artifact",
+  "description": "...",
+  "parameters": {
+    "type": "object",
+    "properties": { ... },
+    "required": [ ... ]
+  },
+  "strict": true
+}
+```
+
+Our existing Claude/Gemini tool schemas are easy to translate to this.
+
+## Stream event handling
+
+Server-sent events.  Each event is `event: <type>` + `data: <json>`.
+Key types we care about:
+
+| Event type                              | Meaning                                                     |
+| --------------------------------------- | ----------------------------------------------------------- |
+| `response.created`                      | Request accepted.  Capture `response.id`.                   |
+| `response.output_text.delta`            | Text token chunk.  `data.delta` is the new fragment.        |
+| `response.output_text.done`             | Text item finished.                                         |
+| `response.reasoning_summary.delta`      | Reasoning summary text chunk (visible "thinking").          |
+| `response.reasoning_text.delta`         | Raw reasoning text (when enabled).                          |
+| `response.output_item.added`            | A new item started — could be `function_call`, `message`, `reasoning`, etc.  |
+| `response.function_call_arguments.delta` | Streamed JSON for a function call's `arguments`.          |
+| `response.function_call_arguments.done` | Function call args complete; can dispatch the call.         |
+| `response.output_item.done`             | Item closed — full content available in `data.item`.        |
+| `response.completed`                    | Full response finished.  `data.response.output` has the full item list including reasoning items with `encrypted_content`.  |
+| `error`                                 | Stream-level error.                                         |
+| `[DONE]`                                | Plain SSE terminator after `response.completed`.            |
+
+Map to our `StreamEvent` union:
+
+| Codex event                        | Our `StreamEvent`                                 |
+| ---------------------------------- | ------------------------------------------------- |
+| `response.output_text.delta`       | `{type: "delta", content: <delta>}`               |
+| `response.reasoning_summary.delta` | `{type: "thinking", content: <delta>}`            |
+| `response.output_item.added` (function_call) | `{type: "tool_use", name, input: {}, tool_use_id}` (input filled as deltas arrive)  |
+| `response.function_call_arguments.delta` | append to that tool_use's `input` JSON buffer |
+| `response.function_call_arguments.done`  | emit final `tool_use` with parsed input       |
+| error                              | `{type: "error", content: <error.message>}`       |
+| `response.completed`               | end of stream                                     |
+
+Tool **results** are not part of the same response.  After the
+backend yields a `function_call`, the loop owner (us) executes the
+tool, then sends the next request with the call output appended to
+`input`:
+
+```json
+{
+  "type": "function_call_output",
+  "call_id": "<id from function_call>",
+  "output": "<stringified result>"
+}
+```
+
+This pattern is already how our Claude and Gemini loops work; the
+codex provider just speaks Responses-shaped items instead of
+Anthropic/Gemini-shaped tool messages.
+
+## Multi-turn statelessness
+
+Since `store: false` is mandatory and `previous_response_id` is
+rejected, we manage conversation state by sending the entire turn
+history as `input` items every request.  Standard for our codebase
+(we already do this for Claude + Gemini, capped at 20 messages by
+`_HISTORY_WINDOW`).
+
+**The Codex-specific wrinkle:** reasoning models compute internal
+state that's expensive to recompute.  The Responses API exposes this
+as opaque `reasoning` items with an `encrypted_content` blob —
+include them verbatim in subsequent `input` arrays and the model
+picks up where it left off without redoing reasoning.
+
+### How to use it
+
+1. Send `include: ["reasoning.encrypted_content"]` on every request.
+2. On the `response.completed` event, grab every item with
+   `type: "reasoning"` from `data.response.output`.
+3. On the next turn, before the new user message in `input`, append:
+   - the assistant `message` items from the previous turn (so the
+     model sees what it actually said)
+   - the `reasoning` items verbatim (with their `encrypted_content`)
+   - any `function_call` + `function_call_output` items for tools
+     that ran
+
+Order matters: items must appear in the same sequence the model
+produced them.  Skip items at your peril — partial reasoning state
+can confuse the model.
+
+## Implementation plan (code-level)
+
+### 1. Lift the auth helper
+
+`backend/app/core/codex_auth.py` (new):
+
+```python
+"""Codex OAuth token resolution shared by image_gen + text provider."""
+
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+
+def resolve_codex_auth(override: str | None = None) -> tuple[str, str]:
+    """Return (access_token, account_id).
+
+    Resolution order:
+      1. `OPENAI_CODEX_OAUTH_TOKEN` override (no account_id available).
+      2. `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`).
+
+    Raises RuntimeError when no auth is configured.
+    """
+    if override:
+        return (override, _decode_account_id_from_jwt(override))
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    auth_file = codex_home / "auth.json"
+    if not auth_file.exists():
+        raise RuntimeError("No Codex auth.  Run `codex login` or set OPENAI_CODEX_OAUTH_TOKEN.")
+
+    data = json.loads(auth_file.read_text())
+    tokens = data.get("tokens") or {}
+    access_token = tokens.get("access_token")
+    account_id = tokens.get("account_id") or _decode_account_id_from_jwt(
+        tokens.get("id_token") or access_token
+    )
+    if not access_token or not account_id:
+        raise RuntimeError("auth.json is missing tokens.access_token or account_id.")
+    return (access_token, account_id)
+
+
+async def refresh_codex_token() -> None:
+    """Refresh the access token.  Single-use refresh token — see #15502."""
+    # Reads auth.json, POSTs to TOKEN_URL, writes back.  Use an asyncio.Lock
+    # at module scope to serialise refresh attempts in this process.
+    ...
+```
+
+### 2. New provider
+
+`backend/app/core/providers/openai_codex_provider.py`:
 
 ```python
 class OpenAICodexProvider(LLMProvider):
-    """OpenAI text-model provider routed through ChatGPT OAuth.
+    """Streams via chatgpt.com/backend-api/codex/responses."""
 
-    Uses the Codex-specific responses endpoint
-    (chatgpt.com/backend-api/codex/responses) so requests authenticate
-    with the same ChatGPT OAuth token already used by image_gen.py.
-    """
+    async def stream(self, question, conversation_id, user_id, *,
+                     history, tools, system_prompt) -> AsyncIterator[StreamEvent]:
+        access_token, account_id = resolve_codex_auth(
+            override=os.environ.get("OPENAI_CODEX_OAUTH_TOKEN"),
+        )
 
-    def __init__(self, model_id: str, user_id: uuid.UUID | None = None):
-        self.model_id = model_id  # e.g. "gpt-5.5", "openai-codex/gpt-5.5"
-        self.user_id = user_id
+        body = self._build_request(question, history, tools, system_prompt)
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {access_token}",
+            "OpenAI-Beta": "responses=experimental",
+            "chatgpt-account-id": account_id,
+            "originator": "pawrrtal",
+            "session_id": str(uuid.uuid4()),
+            "x-client-request-id": str(conversation_id),
+        }
 
-    async def stream(
-        self,
-        question: str,
-        conversation_id: uuid.UUID,
-        user_id: uuid.UUID,
-        *,
-        history: list[Message],
-        tools: list[Tool] | None,
-        system_prompt: str | None,
-    ) -> AsyncIterator[StreamEvent]:
-        token = resolve_codex_oauth_token()  # reuse image_gen.py helper
-        async with httpx.AsyncClient() as client:
-            async with client.stream(
-                "POST",
-                "https://chatgpt.com/backend-api/codex/responses",
-                json=_build_request(question, history, tools, system_prompt),
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                },
-                timeout=180.0,
-            ) as response:
+        async with httpx.AsyncClient(timeout=180.0) as client:
+            async with client.stream("POST", CODEX_RESPONSES_URL,
+                                     json=body, headers=headers) as response:
+                if response.status_code == 401:
+                    # Try one refresh + retry before giving up.
+                    await refresh_codex_token()
+                    # ... retry ...
                 response.raise_for_status()
-                async for event in _parse_sse(response):
+                async for event in self._parse_sse(response):
                     yield event
 ```
 
-The `resolve_codex_oauth_token()` helper already exists in
-`app/core/tools/image_gen.py`; lift it into `app/core/codex_auth.py`
-so the provider and tool share it.
+`_build_request` and `_parse_sse` follow the contracts above.
 
-### 2. Request payload
-
-Strip `image_generation` from the image-gen request; everything else
-is the same Responses API shape:
-
-```python
-def _build_request(question, history, tools, system_prompt):
-    input_items = []
-    if system_prompt:
-        input_items.append({
-            "type": "message",
-            "role": "system",
-            "content": [{"type": "input_text", "text": system_prompt}],
-        })
-    for msg in history:
-        input_items.append({
-            "type": "message",
-            "role": msg["role"],
-            "content": [{"type": "input_text", "text": msg["content"]}],
-        })
-    input_items.append({
-        "type": "message",
-        "role": "user",
-        "content": [{"type": "input_text", "text": question}],
-    })
-    return {
-        "model": _resolve_underlying_model(self.model_id),
-        "input": input_items,
-        "stream": True,
-        "tools": _convert_tools_to_responses_format(tools or []),
-        "store": False,
-    }
-```
-
-### 3. Stream event mapping
-
-Responses API emits typed events (`response.created`,
-`response.output_text.delta`, `response.output_item.added` for
-tool calls, `response.completed`, ...).  Map to our
-`StreamEvent` union:
-
-| Responses event                        | StreamEvent           |
-| -------------------------------------- | --------------------- |
-| `response.output_text.delta`           | `{type: "delta", content: <delta>}` |
-| `response.reasoning_summary.delta`     | `{type: "thinking", content: <delta>}` |
-| `response.output_item.added` (function_call) | `{type: "tool_use", name, input, tool_use_id}` |
-| function call output back to us        | (no direct mapping — the agent supplies the result and we send it as `function_call_output` on the next request) |
-| `response.completed`                   | end of stream         |
-| `error`                                | `{type: "error", content}` |
-
-Tool execution still happens inside our `agent_loop` because the
-Responses API requires the client to supply tool results in the
-next request.  Our loop already handles this for Claude + Gemini;
-the codex variant just speaks Responses-shaped messages instead.
-
-### 4. Factory wiring
+### 3. Factory wiring
 
 `backend/app/core/providers/factory.py`:
 
 ```python
-def resolve_llm(model_id: str, user_id: uuid.UUID | None = None) -> LLMProvider:
+def resolve_llm(model_id, user_id=None):
     if model_id.startswith("claude-"):
-        return ClaudeProvider(model_id=model_id, user_id=user_id)
+        return ClaudeProvider(model_id, user_id)
     if model_id.startswith(("gpt-", "openai-codex/")):
-        return OpenAICodexProvider(model_id=model_id, user_id=user_id)
-    return GeminiProvider(model_id=model_id, user_id=user_id)
+        return OpenAICodexProvider(model_id, user_id)
+    return GeminiProvider(model_id, user_id)
 ```
 
-Model catalog additions in `/api/v1/models` so the picker shows them:
-`gpt-5.5`, `gpt-5.5-mini` (whatever ChatGPT Plus / Business plan
-unlocks for the user).
+### 4. Model catalog
 
-### 5. Config
+Add to `/api/v1/models` so the frontend picker exposes them.
+Hardcode the user-visible subset and let the backend reject anything
+the user's plan doesn't include.
 
-Per-user override path: workspace `.env` → `OPENAI_CODEX_OAUTH_TOKEN`
-(already supported by `resolve_codex_oauth_token`).  Without an
-override, the provider falls back to `$CODEX_HOME/auth.json`.  This
-keeps the bring-your-own-token story consistent with image-gen.
+### 5. Tests
+
+Replay-style, mirroring `test_claude_provider.py`:
+
+- Recorded `response.output_text.delta` SSE stream → assert
+  `StreamEvent` mapping.
+- Recorded `function_call` flow → assert tool_use shape.
+- 401 → refresh → retry happy path.
+- 401 → refresh → still 401 → bubble error.
+- Multi-turn: previous reasoning items get appended to `input` on
+  turn 2.
+
+## Concrete risks
+
+| Risk                                          | Mitigation |
+| --------------------------------------------- | ---------- |
+| Endpoint deprecation (private OpenAI API).   | Wrap with the same error envelope as other providers.  Document in PR description that we depend on the Codex CLI continuing to work. |
+| Refresh-token rotation conflicts (#15502).   | Single-process asyncio lock around refresh.  Re-read `auth.json` after 401 in case CLI refreshed concurrently. |
+| Instructions-validation strict mode trap.    | Never use `originator: codex_cli_rs`.  Always send our own name. |
+| Subscription rate limits hit mid-stream.     | Catch the specific `rate_limit_exceeded` SSE error event; surface to the user with a clear message. |
+| `gpt-5-codex` rejects `minimal` effort.      | Normalise client side: if model contains `-codex` and effort is `minimal`, send `low`. |
+| `gpt-5-codex` rejects `verbosity != medium`. | Same — silently normalise. |
+| Refresh-token invalidated after auth.json copy.  | Doc users not to copy the file across machines.  Show clear "re-run codex login" error. |
+| Stream idle timeout mid-reasoning.           | Heartbeat: every 30 s with no event, log + keep alive.  If 180 s with no event, abort and surface error. |
 
 ## Out of scope (deferred)
 
-- **API-key path.**  Users with an `OPENAI_API_KEY` can already
-  route through `api.openai.com/v1/responses` via the standard
-  OpenAI SDK; that's a separate provider if we want it.  Codex
-  OAuth is the priority because that's the auth Tavi + Esther
-  already have set up.
-- **Per-message Codex routing fast-mode toggle.**  Add later.
-- **Image-gen-in-text-conversation.**  Our existing
-  `image_gen` tool already covers this — keep them separate.
-
-## Risks
-
-- **Token expiry.**  Codex OAuth tokens refresh; the Codex CLI
-  refreshes them in-process.  We currently just *read* the cached
-  token.  If a long-lived agent stream picks up a stale token we
-  fail mid-stream.  Mitigation: catch 401 from the stream, re-read
-  `auth.json` (Codex CLI might have refreshed it on a parallel
-  invocation), retry once.
-- **Endpoint deprecation.**  This is technically a private OpenAI
-  endpoint.  It's been stable for many months and is what the
-  Codex CLI itself uses, but it could break without warning.
-  Mitigation: wrap with the same error envelope as other providers
-  so a sudden 4xx surfaces as a normal stream error event.
-- **Tool-call shape divergence.**  Responses API tool calls aren't
-  identical to Anthropic's or Gemini's.  The `_claude_tool_bridge`
-  pattern shows we already handle per-provider tool translation;
-  add a codex bridge.
+- API-key path: users with an `OPENAI_API_KEY` can already route
+  through `api.openai.com/v1/responses`.  Add as a fallback provider
+  later if asked.
+- WebRTC voice calls (`/realtime/calls`) — separate concern.
+- Background mode (`background: true`) — requires `store: true`,
+  not supported here.
 
 ## Implementation order
 
 1. Lift `resolve_codex_oauth_token` from `image_gen.py` to
-   `core/codex_auth.py`.  No behaviour change.
-2. New file: `core/providers/openai_codex_provider.py` — bare skeleton
-   that just makes a non-streaming request work end-to-end with a
-   single user message and no tools.
-3. Add streaming + delta event mapping.
-4. Add tool-call support (reuse pattern from Claude bridge).
-5. Wire into `factory.py` with the new prefix.
-6. Add catalog entries to `/api/v1/models`.
-7. Tests: replay-based, mirroring `test_claude_provider.py`.
+   `core/codex_auth.py`.  Refactor `image_gen.py` to use it.  Add
+   `account_id` extraction.  No behaviour change visible to users.
+2. Wire the auth helper into `image_gen.py` to send the full header
+   set (`session_id`, `originator: pawrrtal`,
+   `chatgpt-account-id`).  This validates that header layout works
+   before we touch a new provider.
+3. New file: `core/providers/openai_codex_provider.py` — skeleton
+   that streams a single message with no tools, maps `delta` events.
+4. Add tool-call support (mirror Claude bridge).
+5. Add `reasoning.encrypted_content` multi-turn support.
+6. Add 401 → refresh → retry path.
+7. Wire into `factory.py` with `gpt-*` and `openai-codex/*`
+   prefixes.
+8. Add catalog entries to `/api/v1/models`.
+9. Replay-based tests.
+10. Manual smoke from Tavi's account.
 
-## Test strategy
+## References
 
-- Unit tests with recorded request/response fixtures (vcr.py or
-  hand-rolled httpx mocks).  Don't hit live Codex from CI.
-- Manual smoke: Tavi runs a real conversation with his Codex token
-  and confirms the stream renders correctly on web + Telegram.
+- OpenAI Codex CLI source:
+  - `codex-rs/login/src/token_data.rs` — `auth.json` schema, JWT claim parsing
+  - `codex-rs/backend-client/src/client.rs` — header set, account ID handling
+  - `codex-rs/codex-api/src/endpoint/responses.rs` — Responses endpoint client
+- Reference implementations:
+  - `github.com/EvanZhouDev/openai-oauth` — TypeScript localhost proxy
+  - `github.com/pproenca/opencode-openai-codex-auth` — OpenCode plugin
+  - `github.com/withakay/opencode-codex-provider` — alternative MCP-based approach
+  - `github.com/RooCodeInc/Roo-Code/blob/main/src/api/providers/openai-codex.ts`
+- Failure mode references:
+  - `openai/codex#11743` — stream-disconnect on VPS
+  - `openai/codex#14743` — wrong request body shape
+  - `openai/codex#15502` — refresh-token rotation
+  - `openclaw/openclaw#64133` — wrong endpoint sub-path

--- a/docs/design/context-compaction.md
+++ b/docs/design/context-compaction.md
@@ -1,0 +1,149 @@
+# Design: agent context window & compaction strategy
+
+**Status:** Proposed — needs Tavi's call on which option to ship
+**Author:** Tavi + Wretch
+**Last updated:** 2026-05-12
+
+## What the agent currently sees every turn
+
+In `backend/app/api/chat.py`:
+
+1. **System prompt** — full content of `SOUL.md` + `AGENTS.md`
+   from the user's workspace root (via
+   `assemble_workspace_prompt`).  Each capped at 64 KB.
+2. **History** — the last `_HISTORY_WINDOW = 20` messages from the
+   `chat_messages` table, role + content only.  Thinking text,
+   tool_calls, timeline, attachments are stripped before being
+   sent back to the provider.
+3. **Current question** — passed separately as `question`.
+4. **Tool list** — assembled per turn (see `agent_tools.py`).
+
+That's it.  There is no summary of older messages, no semantic
+recall, no embeddings, no memory mechanism.  Once a turn falls past
+index 20 from the end it is **never** shown to the model again
+unless the user re-pastes it.
+
+## Why this is a problem
+
+- **Long conversations lose continuity.**  Decisions made in
+  turn 5 disappear by turn 30.  The agent contradicts itself.
+- **Telegram makes it worse.**  Long-running topic threads can rack
+  up hundreds of turns over days.  All of that context is lost.
+- **No way to teach durable facts.**  Even when the user says "always
+  call me Tavi" in turn 1, by turn 25 the model has forgotten.
+  Workaround today is to write the fact into `SOUL.md` /
+  `preferences.toml`, but that's manual.
+- **Silent failure.**  No warning when context falls off — the
+  conversation just gets worse, slowly.
+
+## Options
+
+### Option A — Rolling summary (cheapest, ships first)
+
+Maintain one `summary` column on `Conversation`.  When history
+exceeds N (say 30) messages:
+
+1. On the next turn, build a summarisation prompt over messages
+   `[0..N-K]` (the oldest K-truncated chunk) plus the existing
+   summary.
+2. Call a cheap model (Gemini Flash) with that prompt; store the
+   updated summary on `Conversation.summary`.
+3. The chat request now sends `summary` as a system-prompt
+   addendum + the last N-K messages as history.
+
+**Pros:** Simple, no new infra, no embeddings.  Works on Telegram
+identically to web because the summary travels with the
+conversation row.
+
+**Cons:** Summaries lose detail.  Hard to recover specific quoted
+text the user references later ("what did I say about X earlier?").
+
+**Cost:** ~1 extra LLM call per N turns.  At N=30 with Gemini Flash
+that's ~0.5¢ per summary at typical token sizes.
+
+### Option B — Vector recall (precise, more infra)
+
+Embed every message at insert time using a local embedding model
+(`embeddinggemma-300M-GGUF`, ~ours already used elsewhere).  Store
+in a per-conversation pgvector table.  On each turn:
+
+1. Embed the current question.
+2. Pull top-K relevant older messages from the vector store
+   (where K is small, maybe 5).
+3. Prepend the top-K to history above the last-20 slice.
+
+**Pros:** Preserves exact wording.  Surfaces relevant decisions
+from far back when the topic comes up again.
+
+**Cons:** pgvector setup, embedding service in the request path,
+risk of unrelated messages getting pulled in by spurious matches.
+
+**Cost:** Embedding latency on insert (negligible w/ a local
+model), one similarity query per turn.
+
+### Option C — Hybrid (Option A + Option B together)
+
+Summary covers the gist, vector recall pulls in exact quotes when
+relevant.  Best of both worlds, most complexity.  Probably the
+right end-state but not the right v1.
+
+### Option D — Do nothing, give the agent a `read_history` tool
+
+Add a tool that lets the agent search its own conversation history
+on demand.  The agent decides when it needs older context and pays
+the token cost only then.
+
+**Pros:** Cheapest by default — no extra LLM call per turn.
+Composable with workspace files (which the agent already searches).
+**Cons:** Relies on the agent realising it needs older context,
+which it often won't.
+
+## Recommendation
+
+**Ship Option A first.**  It's the smallest scope, the only one
+that requires zero new infra, and it materially improves long-form
+quality immediately.  Add Option B later if specific-quote recall
+becomes a real problem.  Option D is a nice-to-have that can layer
+on top of either.
+
+### Option A — concrete plan
+
+1. New column: `Conversation.summary: Text | null`,
+   `Conversation.summary_updated_through_ordinal: int | null`
+   (so we know how much history is already covered).
+2. New module: `backend/app/core/conversation_summary.py` —
+   `maybe_update_summary(session, conversation_id) -> None` that
+   decides whether to run, builds the prompt, calls the model,
+   writes back.
+3. Trigger in `chat.py`:  fire-and-forget (`asyncio.create_task`)
+   after the assistant stream completes, gated by
+   `len(history) >= 30 and (summary_updated_through_ordinal or 0) <
+   len(history) - 10`.
+4. System prompt assembly: when `summary` is present, append it as
+   an `## Earlier in this conversation` section after AGENTS.md.
+5. Telegram works automatically because both surfaces share
+   `chat_messages` + the same `Conversation` row.
+6. Cost guard: skip summarisation if the conversation is on a
+   premium model (charge the summary against Gemini Flash always).
+
+### What we DON'T do here
+
+- We don't compact `SOUL.md` / `AGENTS.md` / `preferences.toml`.
+  Those are workspace files; the user owns them.
+- We don't auto-prune `chat_messages` — disk is cheap, the table
+  is already the rehydration source for the UI.
+- We don't summarise tool-call payloads — keep `tool_calls` and
+  `timeline` fields out of the summarisation input because they're
+  noisy and rarely matter for continuity.
+
+## Open questions (Tavi to answer)
+
+1. **N (window) and K (summarisation chunk):**  20 and 10?  30 and 10?
+2. **Which model for the summary?**  Gemini Flash by default OK?
+3. **Should the user see the summary?**  Suggest yes — a collapsed
+   panel in the chat UI labeled "Earlier" so it's auditable.
+4. **What about a hard kill — wipe + restart from summary only?**
+   When a conversation crosses, say, 200 messages, do we collapse
+   everything before the last 20 into the summary and forget the
+   raw messages from the provider's POV?  (We'd keep the DB rows
+   for the UI.)

--- a/frontend/features/settings/integrations/catalog.test.ts
+++ b/frontend/features/settings/integrations/catalog.test.ts
@@ -2,26 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { INTEGRATION_CATALOG, YOUR_INTEGRATIONS } from './catalog';
 
 describe('integrations catalog', () => {
-	it('lists every YOUR_INTEGRATIONS entry as installed in the catalog', () => {
-		for (const integration of YOUR_INTEGRATIONS) {
-			const catalogEntry = INTEGRATION_CATALOG.find((entry) => entry.id === integration.id);
-			expect(catalogEntry).toBeDefined();
-			expect(catalogEntry?.state).toBe('installed');
-		}
+	it('starts empty until real integrations are implemented', () => {
+		// Both lists are intentionally empty: no backend implementation
+		// exists yet. Populate as real integrations land.
+		expect(YOUR_INTEGRATIONS).toEqual([]);
+		expect(INTEGRATION_CATALOG).toEqual([]);
 	});
 
-	it('keeps every catalog ID unique', () => {
+	it('keeps every catalog ID unique once populated', () => {
 		const ids = INTEGRATION_CATALOG.map((entry) => entry.id);
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
-	it('only marks third-party integrations as connectable', () => {
-		const connectables = INTEGRATION_CATALOG.filter((entry) => entry.state === 'connectable');
-		expect(connectables.length).toBeGreaterThan(0);
-		// None of the connectable rows should overlap with installed user integrations.
-		const installedIds = new Set(YOUR_INTEGRATIONS.map((entry) => entry.id));
-		for (const entry of connectables) {
-			expect(installedIds.has(entry.id)).toBe(false);
+	it('mirrors YOUR_INTEGRATIONS into the catalog as installed entries', () => {
+		// Invariant for the future: any "Your integrations" row must
+		// also appear in the catalog with state='installed'.
+		for (const integration of YOUR_INTEGRATIONS) {
+			const catalogEntry = INTEGRATION_CATALOG.find((entry) => entry.id === integration.id);
+			expect(catalogEntry).toBeDefined();
+			expect(catalogEntry?.state).toBe('installed');
 		}
 	});
 });

--- a/frontend/features/settings/integrations/catalog.ts
+++ b/frontend/features/settings/integrations/catalog.ts
@@ -1,11 +1,15 @@
 /**
  * Static catalog of integrations the Settings → Integrations section can
- * surface. Visual-only today; the `connected` flags + per-account rows
- * live in localStorage so the page can simulate state without a backend.
+ * surface.
+ *
+ * No real integrations are implemented in the backend yet — this module
+ * exists so the UI shape is in place and ready to wire up. Both lists
+ * are intentionally empty; populate them as real integrations land.
+ *
+ * @fileoverview Integrations catalog types + empty defaults.
  */
 
 import type { LucideIcon } from 'lucide-react';
-import { Calendar, ClipboardList, FileSpreadsheet, FolderOpen, Globe, Mail } from 'lucide-react';
 
 /** Status badge shown next to an integration / account name. */
 export type IntegrationBadge = 'beta' | 'connected' | 'expired' | null;
@@ -40,84 +44,13 @@ export interface IntegrationAccount {
 }
 
 /**
- * Master list rendered in "Your Integrations". Order here is the order
- * shown to the user. Add a new row → it shows up in the list.
+ * Master list rendered in "Your Integrations".
+ *
+ * Empty by default — there are no real integrations implemented in the
+ * backend yet. Add a row here once the corresponding backend endpoint
+ * + OAuth flow is live so the UI faithfully reflects what works.
  */
-export const YOUR_INTEGRATIONS: IntegrationDef[] = [
-	{
-		id: 'apple-calendar',
-		name: 'Apple Calendar',
-		description: 'See your events in Apple Calendar',
-		badge: 'connected',
-		Icon: Calendar,
-		tileBgClass: 'bg-foreground/5',
-		tileTextClass: 'text-foreground',
-	},
-	{
-		id: 'apple-reminders',
-		name: 'Apple Reminders',
-		description: 'See your reminders and tasks in Apple Reminders',
-		badge: 'connected',
-		Icon: ClipboardList,
-		tileBgClass: 'bg-foreground/5',
-		tileTextClass: 'text-foreground',
-	},
-	{
-		id: 'gmail',
-		name: 'Gmail',
-		description: 'Read and send email in Gmail',
-		Icon: Mail,
-		tileBgClass: 'bg-red-500/15',
-		tileTextClass: 'text-red-500',
-		accounts: [
-			{
-				id: 'gmail-personal',
-				email: 'tocanoctavian@gmail.com',
-				subtitle: 'tocanoctavian@gmail.com',
-				status: 'connected',
-			},
-			{
-				id: 'gmail-work',
-				email: 'octavian.tocan@thirdear.ai',
-				subtitle: 'octavian.tocan@thirdear.ai',
-				status: 'expired',
-			},
-		],
-	},
-	{
-		id: 'google-calendar',
-		name: 'Google Calendar',
-		description:
-			'Manage and see your calendar events and appointments through Google Calendar.',
-		Icon: Calendar,
-		tileBgClass: 'bg-blue-500/15',
-		tileTextClass: 'text-blue-500',
-		accounts: [
-			{
-				id: 'gcal-personal',
-				email: 'tocanoctavian@gmail.com',
-				subtitle: 'tocanoctavian@gmail.com',
-				status: 'connected',
-			},
-			{
-				id: 'gcal-work',
-				email: 'octavian.tocan@thirdear.ai',
-				subtitle: 'octavian.tocan@thirdear.ai',
-				status: 'expired',
-				label: 'Work',
-			},
-		],
-	},
-	{
-		id: 'google-drive',
-		name: 'Google Drive',
-		description: 'Access and organize Google Drive files',
-		badge: 'connected',
-		Icon: FolderOpen,
-		tileBgClass: 'bg-green-500/15',
-		tileTextClass: 'text-green-500',
-	},
-];
+export const YOUR_INTEGRATIONS: IntegrationDef[] = [];
 
 /** Catalog rendered inside the "Add integration" modal grid. */
 export interface CatalogIntegration extends IntegrationDef {
@@ -126,57 +59,11 @@ export interface CatalogIntegration extends IntegrationDef {
 }
 
 /**
- * Larger catalog of available integrations the user can browse + connect
- * from the Add Integration modal. Mix of pre-installed (Apple, Gmail,
- * Google Drive, Google Calendar) and connectable third-party tools.
+ * Catalog of integrations the user can browse + connect from the
+ * "Add integration" modal.
+ *
+ * Empty by default — same reason as `YOUR_INTEGRATIONS`. When a real
+ * integration is implemented, add it here as `state: 'connectable'`
+ * (or `'installed'` if it's auto-enabled).
  */
-export const INTEGRATION_CATALOG: CatalogIntegration[] = [
-	...YOUR_INTEGRATIONS.map(
-		(integration): CatalogIntegration => ({ ...integration, state: 'installed' })
-	),
-	{
-		id: 'outlook',
-		name: 'Outlook',
-		description: 'Manage email and calendar in Outlook',
-		Icon: Mail,
-		tileBgClass: 'bg-sky-500/15',
-		tileTextClass: 'text-sky-500',
-		state: 'connectable',
-	},
-	{
-		id: 'adisinsight',
-		name: 'AdisInsight',
-		description: 'Pharmaceutical drug & clinical trial intelligence',
-		Icon: Globe,
-		tileBgClass: 'bg-foreground/5',
-		tileTextClass: 'text-foreground',
-		state: 'connectable',
-	},
-	{
-		id: 'ahrefs',
-		name: 'Ahrefs',
-		description: 'SEO & AI search analytics',
-		Icon: Globe,
-		tileBgClass: 'bg-blue-500/15',
-		tileTextClass: 'text-blue-500',
-		state: 'connectable',
-	},
-	{
-		id: 'airops',
-		name: 'AirOps',
-		description: 'AI workflows + agents',
-		Icon: FileSpreadsheet,
-		tileBgClass: 'bg-purple-500/15',
-		tileTextClass: 'text-purple-500',
-		state: 'connectable',
-	},
-	{
-		id: 'airwallex',
-		name: 'Airwallex Developer',
-		description: 'Global business banking + payments',
-		Icon: FileSpreadsheet,
-		tileBgClass: 'bg-foreground/5',
-		tileTextClass: 'text-foreground',
-		state: 'connectable',
-	},
-];
+export const INTEGRATION_CATALOG: CatalogIntegration[] = [];

--- a/frontend/features/settings/sections/IntegrationsSection.test.tsx
+++ b/frontend/features/settings/sections/IntegrationsSection.test.tsx
@@ -3,14 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { IntegrationsSection } from './IntegrationsSection';
 
 describe('IntegrationsSection', () => {
-	it('renders the Integrations page heading + every Your Integrations row', () => {
-		const { getByRole, getAllByText, getByText } = render(<IntegrationsSection />);
-		// Page-level h1 set by SettingsPage
+	it('renders the Integrations page heading, the prototype notice, and the empty state', () => {
+		const { getByRole, getByText } = render(<IntegrationsSection />);
 		expect(getByRole('heading', { name: 'Integrations' })).toBeTruthy();
-		// Section header inside the card (rendered as a span, not heading)
 		expect(getByText('Your integrations')).toBeTruthy();
-		// Apple Calendar appears in YOUR_INTEGRATIONS
-		expect(getAllByText('Apple Calendar').length).toBeGreaterThan(0);
+		expect(getByText('Coming soon')).toBeTruthy();
+		expect(getByText('No integrations connected yet.')).toBeTruthy();
 	});
 
 	it('opens the Add Integration modal when the trigger button is clicked', () => {

--- a/frontend/features/settings/sections/IntegrationsSection.tsx
+++ b/frontend/features/settings/sections/IntegrationsSection.tsx
@@ -10,12 +10,12 @@ import { IntegrationRow } from '../integrations/IntegrationRow';
 import { SettingsCard, SettingsPage, SettingsSectionHeader } from '../primitives';
 
 /**
- * Visual-only Integrations settings section.
+ * Integrations settings section.
  *
- * Lists the user's connected integrations (Apple Calendar/Reminders,
- * Gmail with per-account rows, Google Calendar, Google Drive). The
- * "+ Add integration" button opens a catalog modal; the catalog has
- * an "+ Add custom" path that opens the MCP server URL modal.
+ * UI shell is in place but no integrations are implemented yet in the
+ * backend. The notice below makes that explicit so the section doesn't
+ * mislead users into thinking Apple Calendar / Gmail / Drive / etc are
+ * already connected.
  */
 export function IntegrationsSection(): React.JSX.Element {
 	const [showCatalog, setShowCatalog] = useState(false);
@@ -26,6 +26,14 @@ export function IntegrationsSection(): React.JSX.Element {
 			description="Connect Pawrrtal to your tools so it can read context and run actions."
 			title="Integrations"
 		>
+			<div className="rounded-[10px] border border-amber-500/30 bg-amber-500/10 px-3.5 py-3 text-sm text-amber-200">
+				<div className="font-semibold">Coming soon</div>
+				<div className="text-xs text-amber-200/80 mt-0.5">
+					This UI is in place, but no integrations are wired up yet. Connecting Gmail,
+					Calendar, Drive, etc. will arrive in future releases.
+				</div>
+			</div>
+
 			<SettingsCard>
 				<SettingsSectionHeader
 					actions={
@@ -41,11 +49,17 @@ export function IntegrationsSection(): React.JSX.Element {
 					description="Apps and services Pawrrtal is currently connected to."
 					title="Your integrations"
 				/>
-				<div className="flex flex-col gap-2 pt-3">
-					{YOUR_INTEGRATIONS.map((integration) => (
-						<IntegrationRow integration={integration} key={integration.id} />
-					))}
-				</div>
+				{YOUR_INTEGRATIONS.length === 0 ? (
+					<div className="pt-3 text-sm text-muted-foreground">
+						No integrations connected yet.
+					</div>
+				) : (
+					<div className="flex flex-col gap-2 pt-3">
+						{YOUR_INTEGRATIONS.map((integration) => (
+							<IntegrationRow integration={integration} key={integration.id} />
+						))}
+					</div>
+				)}
 			</SettingsCard>
 
 			<AddIntegrationModal


### PR DESCRIPTION
Addresses the five follow-up items from your architecture review.

## 1. Integrations section cleanup ✂️

**Problem:** `Settings → Integrations` was rendering Apple Calendar, Apple Reminders, Gmail, Google Calendar, and Google Drive as **connected** — but there is zero backend implementation for any of them. The catalog also showed connectable third-party tools (Outlook, Ahrefs, AirOps, Airwallex, AdisInsight) as if they were available.

**Fix:**
- `frontend/features/settings/integrations/catalog.ts` — `YOUR_INTEGRATIONS` and `INTEGRATION_CATALOG` are now empty arrays. No fake "connected" badges.
- `frontend/features/settings/sections/IntegrationsSection.tsx` — adds an amber **Coming soon** notice at the top, plus a clean empty-state row when the user has no integrations. UI shell is preserved so it's ready to wire up the moment real integrations land.
- Tests updated to assert the new empty/notice state.

When a real integration is implemented, just push a row into `YOUR_INTEGRATIONS` and the section automatically updates.

## 2. Next.js version 🟢

Non-issue. `frontend/package.json` shows `next@16.2.6` and `react@19.2.6`, both current as of May 2026. No code change needed.

## 3. Codex OAuth for GPT text models 📄

**Design doc:** `docs/design/codex-oauth-text-provider.md`.

Confirmed via OpenAI's docs + our own image-gen code that the right path is `https://chatgpt.com/backend-api/codex/responses` (the `/v1/responses` route on `api.openai.com` rejects ChatGPT OAuth tokens — missing `api.responses.write` scope). Our existing `image_gen.py` already uses the correct endpoint and auth helper.

Extending to text is a relatively small follow-up: lift the `resolve_codex_oauth_token` helper out into `core/codex_auth.py`, add `OpenAICodexProvider` that mirrors `ClaudeProvider` / `GeminiProvider`, drop `image_generation` from the request payload, map Responses-API events to our `StreamEvent` union. Register `gpt-*` / `openai-codex/*` prefix in `factory.py`.

The doc covers wire shape, payload, stream-event mapping, factory wiring, config, risks (token expiry, endpoint deprecation, tool-call shape divergence), and implementation order. Not implementing yet — needs your sign-off on the design.

## 4. Conversation.updated_at bug fix 🐛

**Problem (real bug):** the chat sidebar orders by `Conversation.updated_at DESC`, but `append_user_message`, `append_assistant_placeholder`, and `finalize_assistant_message` only bumped `ChatMessage.updated_at`. Result: Telegram-originated turns (and second-onwards web turns) never moved the conversation to the top of the sidebar on web. Auto-title fires once and writes the row, but that's gated by `title_set_by IS NULL` so it only ever helps the first turn.

**Fix:** `backend/app/crud/chat_message.py` now bumps `Conversation.updated_at` inside both `append_user_message` and `finalize_assistant_message`. A new `_touch_conversation()` helper keeps the logic centralized. New regression tests in `backend/tests/test_chat_message_crud.py` pin both bumps.

With this, any message from any surface (web, Electron, Telegram) bubbles the conversation to the top of the sidebar on every surface.

## 5. Context compaction 📄

**Design doc:** `docs/design/context-compaction.md`.

Documents the current state plainly: every turn, the agent sees `SOUL.md` + `AGENTS.md` (full) + the last `_HISTORY_WINDOW = 20` messages (role + content only — thinking, tool_calls, timeline are stripped before going back to the provider). There is **no** summarization, **no** semantic recall, **no** memory mechanism. Anything past 20 messages from the end is invisible to the model.

The doc lays out four options:
- **A.** Rolling summary stored on `Conversation.summary` (cheapest, recommended first).
- **B.** Vector recall via pgvector + the local embedding model.
- **C.** Hybrid (A + B).
- **D.** Agent-driven `read_history` tool.

Recommends **Option A first**, with a concrete plan: new columns, new module `conversation_summary.py`, fire-and-forget trigger after stream end, system-prompt append. Doesn't implement yet — needs your call on the open questions at the bottom of the doc (window/chunk sizes, summarisation model, whether to surface the summary to the user, hard-collapse threshold).

## Tests

- **Backend**: 350 passed, 2 skipped, 0 failed (full `pytest` suite — that's the previous 348 plus 2 new regression tests for the `updated_at` fix).
- **Frontend typecheck**: clean (`tsc --noEmit`).
- **Frontend tests**: 336 passed (+5 new across catalog rewrites). 3 pre-existing test files fail with the `@octavian-tocan/react-overlay` import error — verified to fail identically on `development` before any change in this PR.

## Out of scope (separate PRs)

- Implementing `OpenAICodexProvider` (see design doc).
- Implementing rolling summary (see design doc).
- Settings UI for runtime backend URL + API key swap (separate from #174).
- `get_allowed_user` wired to individual routes (follow-up to #174).

## Summary by Sourcery

Clean up the integrations settings UI, document upcoming architecture changes, and fix conversation sorting by keeping Conversation.updated_at in sync with new messages.

Bug Fixes:
- Ensure conversations reorder correctly in the sidebar by updating Conversation.updated_at when user and assistant messages are appended or finalized.

Enhancements:
- Simplify the integrations catalog by removing fake integrations and adding an explicit empty state and “Coming soon” notice in the settings UI.
- Add regression tests to cover Conversation.updated_at updates and the new integrations empty state behavior.

Documentation:
- Add a design document for an OpenAI Codex OAuth text provider for GPT models.
- Add a design document describing the current agent context window and proposing context compaction strategies.