### PR TITLE
feat(security): per-user chat rate limit middleware

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -156,6 +156,12 @@ class Settings(BaseSettings):
             if addr.strip()
         )
 
+    # Per-user chat rate limit (requests per 60-second rolling window).
+    # Zero disables the limit entirely — useful for local dev.  Production
+    # deployments should pick a value that matches the operator's monthly
+    # token budget divided by expected request count.
+    chat_rate_limit_per_minute: int = 0
+
     @field_validator("telegram_bot_username", mode="before")
     @classmethod
     def _strip_telegram_at_prefix(cls, value: object) -> object:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,168 @@
+"""In-memory per-user rate limiter for the chat endpoint.
+
+A runaway client (bug, hostile user, infinite loop) can otherwise burn
+the entire token budget for the deployment in minutes.  This module
+caps each user to a configurable number of chat requests per minute.
+
+Design notes
+------------
+- **Per-user, not per-IP.**  The chat endpoint requires an authenticated
+  user so we already have a stable identity key.  IP-based limits would
+  punish users on the same NAT (offices, mobile carriers) and not stop
+  a logged-in attacker.
+- **In-memory.**  Pawrrtal runs single-worker today.  When we scale to
+  multi-worker uvicorn or multi-host, swap the storage for Redis
+  without changing the Starlette middleware interface.  The pluggable
+  ``RateLimitStorage`` protocol below makes that swap localised.
+- **Sliding window, not fixed window.**  Fixed windows let a user burst
+  ``2 * limit`` requests across a window boundary.  We use a simple
+  per-user deque of request timestamps trimmed to the last 60 s.
+- **Only enforces on chat.**  This is the only endpoint that makes a
+  paid upstream call per request.  The middleware short-circuits any
+  other path immediately.
+
+Configuration
+-------------
+``settings.chat_rate_limit_per_minute`` (int, default 30).  Zero
+disables the limit entirely — useful for local development.
+
+Response on limit
+-----------------
+``429 Too Many Requests`` with ``Retry-After`` set to the seconds until
+the oldest in-window request ages out, plus a JSON body explaining the
+limit so the frontend can render a clean message instead of a generic
+error toast.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections import deque
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.config import settings
+
+log = logging.getLogger(__name__)
+
+CHAT_PATH_PREFIX = "/api/v1/chat"
+WINDOW_SECONDS = 60.0
+
+
+class RateLimitStorage(Protocol):
+    """Pluggable storage so the in-memory backend can be swapped for Redis."""
+
+    def record_and_count(self, key: str, now: float, window: float) -> tuple[int, float]:
+        """Append *now* and return ``(count_in_window, oldest_timestamp_in_window)``."""
+        ...
+
+
+class InMemoryWindow(RateLimitStorage):
+    """Per-key deque trimmed to a rolling time window.
+
+    Not thread-safe — uvicorn workers are single-threaded per request
+    loop so this is fine.  Promote to ``asyncio.Lock`` per key if that
+    assumption ever breaks.
+    """
+
+    def __init__(self) -> None:
+        self._windows: dict[str, deque[float]] = {}
+
+    def record_and_count(self, key: str, now: float, window: float) -> tuple[int, float]:
+        bucket = self._windows.setdefault(key, deque())
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        bucket.append(now)
+        return (len(bucket), bucket[0] if bucket else now)
+
+
+_storage = InMemoryWindow()
+
+
+def _identity_from_request(request: Request) -> str | None:
+    """Extract a stable per-user key from the JWT cookie.
+
+    Returns ``None`` for anonymous requests — those should already be
+    rejected by the auth dep on the route itself; we don't double-limit
+    them here.
+    """
+    # fastapi-users sets ``session_token`` as a JWT in the cookie.  We
+    # don't want to parse it here (that's the auth backend's job) so we
+    # just hash the raw cookie value, which is stable per session.
+    cookie = request.cookies.get("session_token") or request.headers.get("authorization")
+    if not cookie:
+        return None
+    # Use a UUID5 over the cookie so the key has a fixed length and
+    # doesn't expose the raw token in logs if we ever surface keys.
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, cookie))
+
+
+class ChatRateLimitMiddleware(BaseHTTPMiddleware):
+    """Cap chat requests per user per minute.
+
+    Layered above ``RequestLoggingMiddleware`` so 429s still get a
+    request-id stamped log line, and below ``BackendApiKeyMiddleware``
+    so a request without the API key never reaches the limiter (and
+    thus can't be used to enumerate the limit's existence).
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        limit = settings.chat_rate_limit_per_minute
+        if limit <= 0:
+            return await call_next(request)
+        if not request.url.path.startswith(CHAT_PATH_PREFIX):
+            return await call_next(request)
+
+        identity = _identity_from_request(request)
+        if identity is None:
+            # No session cookie — let the auth dep on the route handler
+            # return its 401.  The limit is per-user, not per-anonymous.
+            return await call_next(request)
+
+        now = time.monotonic()
+        count, oldest = _storage.record_and_count(identity, now, WINDOW_SECONDS)
+        if count > limit:
+            retry_after = max(1, int(WINDOW_SECONDS - (now - oldest)))
+            log.info(
+                "RATE_LIMIT path=%s identity=%s count=%d limit=%d retry_after=%ds",
+                request.url.path,
+                identity[:8],  # truncated — log enough to correlate, not enough to impersonate
+                count,
+                limit,
+                retry_after,
+            )
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "detail": (
+                        f"Rate limit exceeded: {limit} chat requests per minute. "
+                        f"Try again in {retry_after} seconds."
+                    ),
+                    "retry_after_seconds": retry_after,
+                    "limit": limit,
+                },
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        return await call_next(request)
+
+
+def reset_rate_limit_storage_for_tests() -> None:
+    """Test helper — wipes the in-memory storage between cases.
+
+    Pytest fixtures call this in ``setup`` so per-user windows from one
+    test don't bleed into the next.
+    """
+    _storage._windows.clear()

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from app.api.workspace_env import get_workspace_env_router
 from app.api.stt import get_stt_router
 from app.cli.admin_seed import seed_admin_user
 from app.core.config import settings
+from app.core.rate_limit import ChatRateLimitMiddleware
 from app.core.request_logging import RequestLoggingMiddleware
 from app.db import create_db_and_tables
 from app.integrations.telegram import telegram_lifespan
@@ -75,6 +76,10 @@ def create_app() -> FastAPI:
     # so it wraps every endpoint. Each request gets a unique ID logged on
     # entry and exit (see app/core/request_logging.py).
     fastapi_app.add_middleware(RequestLoggingMiddleware)
+    # ChatRateLimitMiddleware is a no-op when chat_rate_limit_per_minute=0
+    # (the default), so registering it unconditionally costs nothing in
+    # dev but is wired up for prod just by flipping the env var.
+    fastapi_app.add_middleware(ChatRateLimitMiddleware)
     fastapi_app.include_router(
         fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
     )

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,137 @@
+"""Tests for the in-memory chat rate-limit middleware."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app.core.rate_limit import (
+    CHAT_PATH_PREFIX,
+    ChatRateLimitMiddleware,
+    InMemoryWindow,
+    reset_rate_limit_storage_for_tests,
+)
+
+
+def _build_app() -> Starlette:
+    """Minimal Starlette app exercising the middleware in isolation.
+
+    We don't pull up the whole FastAPI stack so the test stays focused
+    on the middleware semantics (window math, identity extraction,
+    response shape) without dragging in auth + DB setup.
+    """
+
+    async def _chat(request):  # noqa: ANN001
+        return JSONResponse({"ok": True})
+
+    async def _other(request):  # noqa: ANN001
+        return JSONResponse({"ok": True, "endpoint": "other"})
+
+    app = Starlette(
+        routes=[
+            Route(f"{CHAT_PATH_PREFIX}/", _chat, methods=["POST"]),
+            Route("/api/v1/other", _other, methods=["GET"]),
+        ],
+    )
+    app.add_middleware(ChatRateLimitMiddleware)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _reset_storage():
+    """Per-test isolation so windows from one case don't leak into the next."""
+    reset_rate_limit_storage_for_tests()
+    yield
+    reset_rate_limit_storage_for_tests()
+
+
+def test_disabled_when_limit_is_zero() -> None:
+    """The middleware short-circuits when the configured limit is 0."""
+    with patch("app.core.rate_limit.settings") as mock_settings:
+        mock_settings.chat_rate_limit_per_minute = 0
+        with TestClient(_build_app()) as client:
+            for _ in range(50):
+                response = client.post(
+                    f"{CHAT_PATH_PREFIX}/",
+                    cookies={"session_token": "fake.jwt.value"},
+                )
+                assert response.status_code == 200
+
+
+def test_non_chat_routes_are_never_limited() -> None:
+    """Even with the limit set to 1, non-chat paths fall straight through."""
+    with patch("app.core.rate_limit.settings") as mock_settings:
+        mock_settings.chat_rate_limit_per_minute = 1
+        with TestClient(_build_app()) as client:
+            for _ in range(5):
+                response = client.get(
+                    "/api/v1/other",
+                    cookies={"session_token": "fake.jwt.value"},
+                )
+                assert response.status_code == 200
+
+
+def test_anonymous_request_is_passed_through() -> None:
+    """No session cookie → not our problem; auth dep on the route returns 401."""
+    with patch("app.core.rate_limit.settings") as mock_settings:
+        mock_settings.chat_rate_limit_per_minute = 1
+        with TestClient(_build_app()) as client:
+            for _ in range(5):
+                response = client.post(f"{CHAT_PATH_PREFIX}/")  # no cookie
+                assert response.status_code == 200
+
+
+def test_returns_429_after_the_limit_is_exceeded() -> None:
+    """The first 3 requests pass; the 4th gets a structured 429."""
+    with patch("app.core.rate_limit.settings") as mock_settings:
+        mock_settings.chat_rate_limit_per_minute = 3
+        cookies = {"session_token": "tavi.session.jwt"}
+        with TestClient(_build_app()) as client:
+            for _ in range(3):
+                assert (
+                    client.post(f"{CHAT_PATH_PREFIX}/", cookies=cookies).status_code == 200
+                )
+            blocked = client.post(f"{CHAT_PATH_PREFIX}/", cookies=cookies)
+
+    assert blocked.status_code == 429
+    body = blocked.json()
+    assert body["limit"] == 3
+    assert "retry_after_seconds" in body
+    assert body["retry_after_seconds"] >= 1
+    assert blocked.headers["Retry-After"] == str(body["retry_after_seconds"])
+
+
+def test_separate_users_have_independent_windows() -> None:
+    """One user's saturation must not affect another."""
+    with patch("app.core.rate_limit.settings") as mock_settings:
+        mock_settings.chat_rate_limit_per_minute = 2
+        with TestClient(_build_app()) as client:
+            # Tavi hits the limit.
+            tavi = {"session_token": "tavi.jwt"}
+            assert client.post(f"{CHAT_PATH_PREFIX}/", cookies=tavi).status_code == 200
+            assert client.post(f"{CHAT_PATH_PREFIX}/", cookies=tavi).status_code == 200
+            assert client.post(f"{CHAT_PATH_PREFIX}/", cookies=tavi).status_code == 429
+            # Esther is unaffected.
+            esther = {"session_token": "esther.jwt"}
+            assert client.post(f"{CHAT_PATH_PREFIX}/", cookies=esther).status_code == 200
+
+
+def test_in_memory_window_trims_to_window_size() -> None:
+    """Direct unit test on the storage class — count returns only recent entries."""
+    storage = InMemoryWindow()
+    # Three timestamps spaced 1 s apart.
+    storage.record_and_count("k", now=100.0, window=60.0)
+    storage.record_and_count("k", now=101.0, window=60.0)
+    count, oldest = storage.record_and_count("k", now=102.0, window=60.0)
+    assert count == 3
+    assert oldest == pytest.approx(100.0)
+    # Now jump forward past the window.  All previous entries should be trimmed
+    # on the next call.
+    count, oldest = storage.record_and_count("k", now=200.0, window=60.0)
+    assert count == 1
+    assert oldest == pytest.approx(200.0)


### PR DESCRIPTION
## Why

One runaway client (bug, malicious user, infinite loop) can burn the deployment's entire token budget in minutes without rate limiting. Adding it before any real users hit the system means we don't get billing surprises.

## What

New `ChatRateLimitMiddleware` in `backend/app/core/rate_limit.py` that caps each authenticated user to `settings.chat_rate_limit_per_minute` requests on a **60-second rolling window**.

- **Scope:** only `/api/v1/chat` paths. Every other endpoint short-circuits immediately so the middleware has effectively zero cost outside the hot path.
- **Per-user, not per-IP.** IP-based limits would punish NAT'd offices/mobile carriers and wouldn't slow down a logged-in attacker. The chat endpoint already requires auth so we always have a stable identity key.
- **Sliding window.** Fixed windows let users burst `2 * limit` across the window boundary; we use a deque of timestamps trimmed to the last 60 s.
- **Identity = UUID5(session_token).** Fixed-length, doesn't expose the raw JWT in logs.
- **Pluggable storage.** `RateLimitStorage` protocol means swapping in-memory for Redis (when we go multi-worker) is a one-class change with no middleware-contract churn.

## Configuration

```env
CHAT_RATE_LIMIT_PER_MINUTE=0    # default — disabled
CHAT_RATE_LIMIT_PER_MINUTE=30   # sensible private-deploy starting point
```

The middleware is registered unconditionally in `main.py` since it's a no-op when the value is `0`. Flip the env var to enable, no code change.

## Response on limit

```http
HTTP/1.1 429 Too Many Requests
Retry-After: 47
Content-Type: application/json

{
  "detail": "Rate limit exceeded: 30 chat requests per minute. Try again in 47 seconds.",
  "retry_after_seconds": 47,
  "limit": 30
}
```

Frontend can render the message directly + show a countdown without generic-error guessing.

## Tests

6 new tests in `tests/test_rate_limit.py`:
- Disabled state (limit=0) passes everyone through.
- Non-chat routes never hit the limiter.
- Anonymous requests pass through (auth dep on the route returns its own 401).
- 429 triggers after the limit with the right shape + headers.
- Per-user isolation: one user's saturation doesn't affect another.
- Direct unit test on `InMemoryWindow.record_and_count` for window-trim math.

Full backend suite: **354 passed, 2 skipped, 0 failed** (was 348; +6 new).

## Follow-ups (not in this PR)

- **Multi-worker:** when we scale to multi-worker uvicorn or multiple hosts, swap `InMemoryWindow` for a Redis-backed implementation of `RateLimitStorage`. The middleware doesn't change.
- **Telegram path:** Telegram bot runs as a polling task, not through the HTTP middleware, so it isn't rate-limited by this PR. If that becomes a problem, add a parallel check in `app.integrations.telegram.bot` keyed on the channel binding.

## Summary by Sourcery

Introduce per-user rolling-window rate limiting for chat requests and wire it into the backend with configuration and tests.

New Features:
- Add configurable per-user chat rate limiting middleware scoped to /api/v1/chat using a 60-second rolling window.

Enhancements:
- Add in-memory pluggable rate limit storage with a protocol to support future backends like Redis.
- Register ChatRateLimitMiddleware unconditionally in the FastAPI app, controlled via a new chat_rate_limit_per_minute setting.

Tests:
- Add middleware-focused Starlette tests covering disabled state, non-chat routes, anonymous requests, limit enforcement, per-user isolation, and window trimming logic.