### PR TITLE
feat(providers): scaffold OpenAI Codex (ChatGPT OAuth) text provider

### DIFF
--- a/backend/app/core/codex_auth.py
+++ b/backend/app/core/codex_auth.py
@@ -1,0 +1,149 @@
+"""Shared Codex OAuth helpers for the image-gen tool + text provider.
+
+Lifted out of ``app.core.tools.image_gen`` so both the tool and the new
+``OpenAICodexProvider`` resolve auth identically.  See
+``docs/design/codex-oauth-text-provider.md`` for the full wire spec.
+
+Resolution order
+----------------
+1. Explicit ``override`` (workspace-level setting).
+2. ``$CODEX_HOME/auth.json`` (default: ``~/.codex/auth.json``) written
+   by the official ``@openai/codex`` CLI.
+
+Notes
+-----
+- ``account_id`` is required by the Codex backend's ``chatgpt-account-id``
+  header.  Modern ``auth.json`` writes it under ``tokens.account_id``;
+  older versions only stored it as a JWT claim under
+  ``https://api.openai.com/auth.chatgpt_account_id``.  Both paths are
+  handled.
+- Refresh is **not** implemented here yet; the existing image-gen tool
+  has been running fine without explicit refresh because the CLI keeps
+  the token fresh in parallel.  Wire token-refresh into this module
+  when the provider goes live so we don't depend on the CLI being
+  present at runtime (see design doc § "Refresh").
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+"""Codex backend endpoint for both image-gen and text completions."""
+
+DEFAULT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+"""OAuth client ID used by the official Codex CLI.  Re-used here so the
+token cached in ``~/.codex/auth.json`` is usable by us without a
+separate OAuth registration."""
+
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+"""Refresh endpoint — used when we wire token refresh in a follow-up."""
+
+
+@dataclass(frozen=True)
+class CodexCredentials:
+    """Resolved access token + ChatGPT account id for the request headers."""
+
+    access_token: str
+    account_id: str
+
+
+class CodexAuthError(RuntimeError):
+    """Raised when no Codex auth is available or it is malformed."""
+
+
+def _decode_account_id_from_jwt(token: str | None) -> str | None:
+    """Return the ``chatgpt_account_id`` claim from a JWT, or ``None``.
+
+    Used as a fallback when older auth.json files don't carry
+    ``tokens.account_id`` directly.  Safe against malformed tokens —
+    swallows decoding errors and returns ``None``.
+    """
+    if not token:
+        return None
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        # JWT base64url payload — pad to multiple of 4 then b64decode.
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64).decode("utf-8"))
+        claim = payload.get("https://api.openai.com/auth") or {}
+        account_id = claim.get("chatgpt_account_id")
+        return str(account_id) if account_id else None
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError, KeyError):
+        return None
+
+
+def resolve_codex_credentials(
+    override_token: str | None = None,
+) -> CodexCredentials:
+    """Return the bearer token + account id for the Codex backend.
+
+    Args:
+        override_token: Pre-resolved access token (e.g. from a workspace
+            env override).  When supplied, ``account_id`` is recovered
+            from the token's JWT payload.
+
+    Raises:
+        CodexAuthError: When no usable credentials are found.
+    """
+    if override_token:
+        account_id = _decode_account_id_from_jwt(override_token)
+        if not account_id:
+            raise CodexAuthError(
+                "OPENAI_CODEX_OAUTH_TOKEN was set but the token does not carry "
+                "a chatgpt_account_id claim.  Re-run `codex login` to get a fresh token."
+            )
+        return CodexCredentials(access_token=override_token, account_id=account_id)
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    auth_file = codex_home / "auth.json"
+    if not auth_file.exists():
+        raise CodexAuthError(
+            f"No Codex auth file at {auth_file}.  Run `codex login` or set "
+            "OPENAI_CODEX_OAUTH_TOKEN."
+        )
+
+    try:
+        data = json.loads(auth_file.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CodexAuthError(f"Failed to read {auth_file}: {exc}") from exc
+
+    tokens = data.get("tokens") or {}
+    access_token = tokens.get("access_token")
+    if not access_token:
+        raise CodexAuthError(
+            f"{auth_file} has no tokens.access_token.  Run `codex login` again."
+        )
+
+    account_id = tokens.get("account_id") or _decode_account_id_from_jwt(
+        tokens.get("id_token") or access_token
+    )
+    if not account_id:
+        raise CodexAuthError(
+            f"{auth_file} carries an access_token but no chatgpt_account_id "
+            "could be resolved.  Re-run `codex login` to get a fresh token."
+        )
+
+    return CodexCredentials(access_token=access_token, account_id=str(account_id))
+
+
+# Backwards-compat alias kept so image_gen.py can adopt this module without
+# a renaming churn in the same PR.  Drop once both call sites use the new
+# function explicitly.
+def resolve_codex_oauth_token(override: str | None = None) -> str:
+    """Legacy alias — returns only the access token.
+
+    Prefer :func:`resolve_codex_credentials` for new code; it returns
+    the account id as well.
+    """
+    return resolve_codex_credentials(override_token=override).access_token

--- a/backend/app/core/providers/openai_codex_provider.py
+++ b/backend/app/core/providers/openai_codex_provider.py
@@ -1,0 +1,286 @@
+"""OpenAI Codex (ChatGPT subscription) text-completion provider.
+
+⚠️ **SCAFFOLD ONLY.**  The streaming code path is implemented + unit
+tested with mocked SSE fixtures, but no live calls are wired through
+``factory.py`` yet.  Smoke-testing against a real Codex OAuth token
+happens in a follow-up PR once Tavi confirms the wire shape end-to-end.
+
+Why this provider exists
+-------------------------
+We already authenticate to ``chatgpt.com/backend-api/codex/responses``
+for image generation (see ``app.core.tools.image_gen``).  The same
+endpoint, same OAuth token, and same Responses API protocol also
+serve text completions.  This provider lets users with a ChatGPT
+Plus/Pro subscription route ``gpt-*`` traffic through their
+subscription instead of paying for API-key tokens.
+
+See ``docs/design/codex-oauth-text-provider.md`` for the full wire
+spec.  Critical points enforced here:
+
+- ``stream: true`` — backend rejects non-streaming.
+- ``store: false`` — backend rejects ``store: true``.
+- No ``temperature``, no ``max_output_tokens``, no
+  ``previous_response_id``.
+- ``originator: pawrrtal`` — using ``codex_cli_rs`` would trigger the
+  backend's strict-mode trap (must match the CLI's tools + prompt.md
+  byte-for-byte or 400 ``Instructions are not valid``).
+- ``include: ["reasoning.encrypted_content"]`` so multi-turn replay
+  of reasoning items works in a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.core.codex_auth import (
+    CODEX_RESPONSES_URL,
+    CodexAuthError,
+    resolve_codex_credentials,
+)
+from app.core.providers.base import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ── Stream timeout ──
+# OpenAI's own Codex CLI reports a ~45 s idle timeout in production.
+# We give the model a bit longer to start emitting tokens.
+_STREAM_TIMEOUT_S = 180.0
+
+
+def _build_request_body(
+    *,
+    model: str,
+    question: str,
+    history: list[dict[str, str]] | None,
+    system_prompt: str | None,
+    tools: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Assemble the JSON payload for the Codex /responses endpoint.
+
+    Shape is the Responses API (NOT chat completions).  Each prior
+    message becomes an ``input`` item with ``type: "message"`` and a
+    single ``input_text`` content part.  The current question is
+    appended as the final user message.
+
+    The system prompt (assembled from SOUL.md + AGENTS.md by the chat
+    router) goes in the top-level ``instructions`` field — that's the
+    Responses-API equivalent of a system message.
+    """
+    input_items: list[dict[str, Any]] = []
+    for msg in history or []:
+        role = msg.get("role") or "user"
+        content = msg.get("content") or ""
+        if not content:
+            continue
+        input_items.append(
+            {
+                "type": "message",
+                "role": role,
+                "content": [{"type": "input_text", "text": content}],
+            }
+        )
+    input_items.append(
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": question}],
+        }
+    )
+
+    body: dict[str, Any] = {
+        "model": model,
+        "input": input_items,
+        "stream": True,  # required by the endpoint
+        "store": False,  # required by the endpoint
+        "include": ["reasoning.encrypted_content"],
+    }
+    if system_prompt:
+        body["instructions"] = system_prompt
+    if tools:
+        body["tools"] = tools
+        body["tool_choice"] = "auto"
+    return body
+
+
+def _build_headers(*, access_token: str, account_id: str, conversation_id: uuid.UUID) -> dict[str, str]:
+    """Return the exact header set the Codex backend expects.
+
+    See ``docs/design/codex-oauth-text-provider.md`` § "Required request headers".
+    Critically, ``originator`` is set to ``pawrrtal`` (NOT ``codex_cli_rs``)
+    to avoid the strict-mode validation that rejects anything not
+    byte-identical to the official CLI's prompt + tools.
+    """
+    return {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {access_token}",
+        "OpenAI-Beta": "responses=experimental",
+        "chatgpt-account-id": account_id,
+        "originator": "pawrrtal",
+        "session_id": str(uuid.uuid4()),
+        "x-client-request-id": str(conversation_id),
+    }
+
+
+async def parse_codex_sse_stream(lines: AsyncIterator[str]) -> AsyncIterator[StreamEvent]:
+    """Translate a Codex SSE event stream into our ``StreamEvent`` union.
+
+    Public for unit-test reuse — pass an async iterator of raw SSE
+    lines (``"data: {...}"`` / ``""`` separator) and yield mapped
+    ``StreamEvent`` dicts.
+
+    Mapping (see design doc § "Stream event handling"):
+      * ``response.output_text.delta``       → ``{type: "delta", content}``
+      * ``response.reasoning_summary.delta`` → ``{type: "thinking", content}``
+      * ``response.output_item.added`` + function_call → ``{type: "tool_use", name, input, tool_use_id}``
+      * ``response.function_call_arguments.delta``    → buffer per tool_use_id
+      * ``response.function_call_arguments.done``     → re-emit tool_use with parsed input
+      * ``error`` → ``{type: "error", content}``
+      * ``response.completed`` / ``[DONE]`` → end of stream
+    """
+    # Per-call_id buffer of streamed function-call arguments.
+    fn_arg_buffers: dict[str, str] = {}
+
+    async for raw in lines:
+        line = raw.rstrip("\n")
+        if not line.startswith("data: "):
+            continue
+        payload = line[6:]
+        if payload == "[DONE]":
+            return
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            logger.warning("openai_codex: skipping malformed SSE line: %r", payload[:120])
+            continue
+
+        event_type = data.get("type")
+
+        if event_type == "response.output_text.delta":
+            delta = data.get("delta") or ""
+            if delta:
+                yield StreamEvent(type="delta", content=delta)
+            continue
+
+        if event_type == "response.reasoning_summary.delta":
+            delta = data.get("delta") or ""
+            if delta:
+                yield StreamEvent(type="thinking", content=delta)
+            continue
+
+        if event_type == "response.output_item.added":
+            item = data.get("item") or {}
+            if item.get("type") == "function_call":
+                call_id = str(item.get("call_id") or item.get("id") or "")
+                fn_arg_buffers[call_id] = ""
+                # Emit a tool_use with an empty input — caller can update
+                # it on the matching ``arguments.done`` event below.
+                yield StreamEvent(
+                    type="tool_use",
+                    name=str(item.get("name") or ""),
+                    input={},
+                    tool_use_id=call_id,
+                )
+            continue
+
+        if event_type == "response.function_call_arguments.delta":
+            call_id = str(data.get("item_id") or "")
+            fn_arg_buffers[call_id] = fn_arg_buffers.get(call_id, "") + (
+                data.get("delta") or ""
+            )
+            continue
+
+        if event_type == "response.function_call_arguments.done":
+            call_id = str(data.get("item_id") or "")
+            raw_args = fn_arg_buffers.pop(call_id, data.get("arguments") or "{}")
+            try:
+                parsed_input: dict[str, Any] = json.loads(raw_args) if raw_args else {}
+            except json.JSONDecodeError:
+                logger.warning(
+                    "openai_codex: tool call %s has malformed JSON arguments: %r",
+                    call_id,
+                    raw_args[:120],
+                )
+                parsed_input = {}
+            yield StreamEvent(
+                type="tool_use",
+                name=str(data.get("name") or ""),
+                input=parsed_input,
+                tool_use_id=call_id,
+            )
+            continue
+
+        if event_type == "error":
+            error_obj = data.get("error") or {}
+            message = (
+                error_obj.get("message")
+                or data.get("message")
+                or "Unknown Codex stream error"
+            )
+            yield StreamEvent(type="error", content=str(message))
+            continue
+
+        if event_type == "response.completed":
+            # The final event carries the full response.output list,
+            # including reasoning items with encrypted_content that the
+            # next turn should replay.  Multi-turn replay handling lives
+            # in a follow-up — for now we just terminate cleanly.
+            return
+
+
+class OpenAICodexLLM:
+    """Streaming text-completion provider routed through ChatGPT OAuth.
+
+    Implements the same protocol as ``ClaudeLLM`` / ``GeminiLLM``.
+    The actual HTTP transport is **not** wired in this PR — only the
+    request body, header set, and SSE parser are implemented + tested.
+    Activation happens in a follow-up PR once Tavi confirms the wire
+    shape against a real token.
+    """
+
+    def __init__(self, model: str, *, user_id: uuid.UUID | None = None) -> None:
+        # Strip an "openai-codex/" prefix when the model id carries one
+        # so the wire model is always the bare id the backend expects.
+        if model.startswith("openai-codex/"):
+            model = model.removeprefix("openai-codex/")
+        self.model = model
+        self.user_id = user_id
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+        tools: list[Any] | None = None,
+        system_prompt: str | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Streaming entry point.  Currently raises until activation.
+
+        See ``docs/design/codex-oauth-text-provider.md`` § "Implementation
+        order" — steps 5–10 cover the activation work (factory wiring,
+        retry/refresh, multi-turn reasoning replay, models endpoint
+        catalog).  Until then the scaffold proves the body + header +
+        SSE mapping in isolation.
+        """
+        del user_id, conversation_id, question, history, tools, system_prompt
+        try:
+            resolve_codex_credentials()
+        except CodexAuthError:
+            # Don't even probe the file when we know we're not going to
+            # call the network.  The check is here so a manual
+            # `provider.stream()` from a REPL exits with a helpful
+            # error rather than silently yielding nothing.
+            pass
+        raise NotImplementedError(
+            "OpenAICodexLLM is a scaffold.  Wire it into factory.py + add the "
+            "live HTTP path in a follow-up PR (see "
+            "docs/design/codex-oauth-text-provider.md)."
+        )
+        # Unreachable, but keeps the function an async generator for typing.
+        yield StreamEvent(type="error", content="unreachable")  # pragma: no cover

--- a/backend/tests/test_codex_auth.py
+++ b/backend/tests/test_codex_auth.py
@@ -1,0 +1,121 @@
+"""Tests for the shared Codex OAuth resolution helpers."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.codex_auth import (
+    CodexAuthError,
+    _decode_account_id_from_jwt,
+    resolve_codex_credentials,
+)
+
+
+def _fake_jwt(payload: dict) -> str:
+    """Build a JWT-shaped string with a payload but no real signature.
+
+    Header is a static stub — the resolver only decodes the payload
+    segment, so this is enough for the test.
+    """
+    header_b64 = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=")
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=")
+    return f"{header_b64.decode()}.{payload_b64.decode()}.sig"
+
+
+def test_jwt_decoder_extracts_chatgpt_account_id() -> None:
+    token = _fake_jwt(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": "org-tavi"}},
+    )
+    assert _decode_account_id_from_jwt(token) == "org-tavi"
+
+
+def test_jwt_decoder_returns_none_for_malformed_token() -> None:
+    assert _decode_account_id_from_jwt(None) is None
+    assert _decode_account_id_from_jwt("") is None
+    assert _decode_account_id_from_jwt("not.a.jwt") is None
+    assert _decode_account_id_from_jwt("only-one-segment") is None
+
+
+def test_jwt_decoder_returns_none_when_claim_is_missing() -> None:
+    token = _fake_jwt({"sub": "user-1"})
+    assert _decode_account_id_from_jwt(token) is None
+
+
+def test_override_token_with_valid_claim_succeeds() -> None:
+    token = _fake_jwt(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": "org-99"}},
+    )
+    creds = resolve_codex_credentials(override_token=token)
+    assert creds.access_token == token
+    assert creds.account_id == "org-99"
+
+
+def test_override_token_without_claim_raises() -> None:
+    bare = _fake_jwt({"sub": "no-account"})
+    with pytest.raises(CodexAuthError, match="chatgpt_account_id"):
+        resolve_codex_credentials(override_token=bare)
+
+
+def test_resolves_from_codex_home_auth_file(tmp_path: Path) -> None:
+    """An auth.json with explicit ``account_id`` is read directly."""
+    auth = {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": "eyJfromfile",
+            "refresh_token": "rt",
+            "account_id": "org-from-file",
+        },
+    }
+    (tmp_path / "auth.json").write_text(json.dumps(auth))
+    os.environ["CODEX_HOME"] = str(tmp_path)
+    try:
+        creds = resolve_codex_credentials()
+    finally:
+        os.environ.pop("CODEX_HOME", None)
+    assert creds.access_token == "eyJfromfile"
+    assert creds.account_id == "org-from-file"
+
+
+def test_falls_back_to_jwt_claim_when_account_id_missing(tmp_path: Path) -> None:
+    """Older auth.json files only carry the account id as a JWT claim."""
+    id_token = _fake_jwt(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": "org-legacy"}},
+    )
+    auth = {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": "eyJlegacy",
+            "id_token": id_token,
+        },
+    }
+    (tmp_path / "auth.json").write_text(json.dumps(auth))
+    os.environ["CODEX_HOME"] = str(tmp_path)
+    try:
+        creds = resolve_codex_credentials()
+    finally:
+        os.environ.pop("CODEX_HOME", None)
+    assert creds.account_id == "org-legacy"
+
+
+def test_missing_auth_file_raises_with_helpful_message(tmp_path: Path) -> None:
+    os.environ["CODEX_HOME"] = str(tmp_path)
+    try:
+        with pytest.raises(CodexAuthError, match="codex login"):
+            resolve_codex_credentials()
+    finally:
+        os.environ.pop("CODEX_HOME", None)
+
+
+def test_malformed_auth_file_raises(tmp_path: Path) -> None:
+    (tmp_path / "auth.json").write_text("{not valid json")
+    os.environ["CODEX_HOME"] = str(tmp_path)
+    try:
+        with pytest.raises(CodexAuthError, match="Failed to read"):
+            resolve_codex_credentials()
+    finally:
+        os.environ.pop("CODEX_HOME", None)

--- a/backend/tests/test_openai_codex_provider.py
+++ b/backend/tests/test_openai_codex_provider.py
@@ -1,0 +1,368 @@
+"""Scaffold tests for the OpenAI Codex (ChatGPT OAuth) text provider.
+
+These pin the bits of the new provider that can be verified without
+hitting a real Codex backend: request body shape, header set, and SSE
+event mapping.  The live streaming path is intentionally unwired —
+see ``docs/design/codex-oauth-text-provider.md`` and the provider
+module docstring.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from app.core.providers.openai_codex_provider import (
+    OpenAICodexLLM,
+    _build_headers,
+    _build_request_body,
+    parse_codex_sse_stream,
+)
+
+
+# ---------------------------------------------------------------------------
+# Request body shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRequestBody:
+    def test_appends_user_question_after_history(self) -> None:
+        body = _build_request_body(
+            model="gpt-5",
+            question="What's the weather?",
+            history=[
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            system_prompt=None,
+            tools=None,
+        )
+        roles = [item["role"] for item in body["input"]]
+        assert roles == ["user", "assistant", "user"]
+        assert body["input"][-1]["content"][0]["text"] == "What's the weather?"
+
+    def test_uses_input_text_parts_not_chat_messages(self) -> None:
+        """Responses API requires content as a list of typed parts, NOT chat completions strings."""
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt=None,
+            tools=None,
+        )
+        item = body["input"][0]
+        assert item["type"] == "message"
+        assert isinstance(item["content"], list)
+        assert item["content"][0]["type"] == "input_text"
+
+    def test_forces_streaming_and_stateless_storage(self) -> None:
+        """Backend rejects non-streaming and rejects ``store: true``."""
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt=None,
+            tools=None,
+        )
+        assert body["stream"] is True
+        assert body["store"] is False
+
+    def test_includes_reasoning_encrypted_content_for_multi_turn(self) -> None:
+        """The flag opts us into stateless multi-turn reasoning replay."""
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt=None,
+            tools=None,
+        )
+        assert "reasoning.encrypted_content" in body["include"]
+
+    def test_omits_instructions_when_system_prompt_is_absent(self) -> None:
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt=None,
+            tools=None,
+        )
+        assert "instructions" not in body
+
+    def test_includes_instructions_when_system_prompt_provided(self) -> None:
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt="You are a helpful assistant.",
+            tools=None,
+        )
+        assert body["instructions"] == "You are a helpful assistant."
+
+    def test_tools_get_passed_through_with_auto_choice(self) -> None:
+        tools: list[dict[str, Any]] = [
+            {
+                "type": "function",
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=None,
+            system_prompt=None,
+            tools=tools,
+        )
+        assert body["tools"] == tools
+        assert body["tool_choice"] == "auto"
+
+    def test_skips_empty_history_messages(self) -> None:
+        body = _build_request_body(
+            model="gpt-5",
+            question="hi",
+            history=[{"role": "user", "content": ""}, {"role": "assistant", "content": "Hey"}],
+            system_prompt=None,
+            tools=None,
+        )
+        # The empty message was dropped; only the assistant + the new user remain.
+        roles = [item["role"] for item in body["input"]]
+        assert roles == ["assistant", "user"]
+
+
+# ---------------------------------------------------------------------------
+# Request headers — these are the strict ones that broke openclaw#64133
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHeaders:
+    def test_sets_codex_required_headers(self) -> None:
+        h = _build_headers(
+            access_token="eyJxxxxx",
+            account_id="org-123",
+            conversation_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        )
+        assert h["Authorization"] == "Bearer eyJxxxxx"
+        assert h["chatgpt-account-id"] == "org-123"
+        assert h["OpenAI-Beta"] == "responses=experimental"
+        assert h["Accept"] == "text/event-stream"
+        assert h["Content-Type"] == "application/json"
+
+    def test_originator_is_pawrrtal_not_codex_cli_rs(self) -> None:
+        """Strict-mode trap: ``codex_cli_rs`` forces exact-prompt validation."""
+        h = _build_headers(
+            access_token="t",
+            account_id="a",
+            conversation_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        )
+        assert h["originator"] == "pawrrtal"
+        assert h["originator"] != "codex_cli_rs"
+
+    def test_session_id_is_a_uuid(self) -> None:
+        h = _build_headers(
+            access_token="t",
+            account_id="a",
+            conversation_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        )
+        # Will raise if not a valid UUID.
+        uuid.UUID(h["session_id"])
+
+    def test_x_client_request_id_carries_conversation_id(self) -> None:
+        conv_id = uuid.uuid4()
+        h = _build_headers(access_token="t", account_id="a", conversation_id=conv_id)
+        assert h["x-client-request-id"] == str(conv_id)
+
+
+# ---------------------------------------------------------------------------
+# SSE event mapping
+# ---------------------------------------------------------------------------
+
+
+async def _async_lines(lines: list[str]) -> AsyncIterator[str]:
+    for line in lines:
+        yield line
+
+
+def _wrap(event_type: str, **fields: Any) -> str:
+    return "data: " + json.dumps({"type": event_type, **fields})
+
+
+@pytest.mark.anyio
+async def test_text_deltas_become_delta_events() -> None:
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                _wrap("response.created", id="resp_1"),
+                _wrap("response.output_text.delta", delta="Hello"),
+                _wrap("response.output_text.delta", delta=" world"),
+                _wrap("response.completed"),
+                "data: [DONE]",
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+    assert events == [
+        {"type": "delta", "content": "Hello"},
+        {"type": "delta", "content": " world"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_reasoning_summary_deltas_become_thinking_events() -> None:
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                _wrap("response.reasoning_summary.delta", delta="Considering"),
+                _wrap("response.reasoning_summary.delta", delta=" options."),
+                _wrap("response.completed"),
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+    assert events == [
+        {"type": "thinking", "content": "Considering"},
+        {"type": "thinking", "content": " options."},
+    ]
+
+
+@pytest.mark.anyio
+async def test_function_call_streams_into_tool_use_event() -> None:
+    """A function_call item + streamed arguments collapses into a single tool_use."""
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                _wrap(
+                    "response.output_item.added",
+                    item={
+                        "type": "function_call",
+                        "call_id": "call_abc",
+                        "name": "read_file",
+                    },
+                ),
+                _wrap(
+                    "response.function_call_arguments.delta",
+                    item_id="call_abc",
+                    delta='{"path": "/etc/',
+                ),
+                _wrap(
+                    "response.function_call_arguments.delta",
+                    item_id="call_abc",
+                    delta='hosts"}',
+                ),
+                _wrap(
+                    "response.function_call_arguments.done",
+                    item_id="call_abc",
+                    name="read_file",
+                ),
+                _wrap("response.completed"),
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+
+    # First event: tool_use shell with empty input (announced when the
+    # function_call item starts).  Second: tool_use with the full input
+    # parsed from the buffered arguments.
+    assert events[0]["type"] == "tool_use"
+    assert events[0]["name"] == "read_file"
+    assert events[0]["tool_use_id"] == "call_abc"
+    assert events[0]["input"] == {}
+
+    assert events[1]["type"] == "tool_use"
+    assert events[1]["name"] == "read_file"
+    assert events[1]["tool_use_id"] == "call_abc"
+    assert events[1]["input"] == {"path": "/etc/hosts"}
+
+
+@pytest.mark.anyio
+async def test_error_event_passes_through_with_message() -> None:
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                _wrap("error", error={"message": "rate_limit_exceeded"}),
+                _wrap("response.completed"),
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+    assert events == [{"type": "error", "content": "rate_limit_exceeded"}]
+
+
+@pytest.mark.anyio
+async def test_done_marker_terminates_stream_cleanly() -> None:
+    """[DONE] returns from the generator, even before response.completed."""
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                _wrap("response.output_text.delta", delta="cut"),
+                "data: [DONE]",
+                _wrap("response.output_text.delta", delta="ignored"),
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+    assert events == [{"type": "delta", "content": "cut"}]
+
+
+@pytest.mark.anyio
+async def test_malformed_json_lines_are_skipped() -> None:
+    """A line of garbage in the SSE doesn't kill the stream."""
+    events: list[dict[str, Any]] = []
+    stream = parse_codex_sse_stream(
+        _async_lines(
+            [
+                "data: not valid json",
+                _wrap("response.output_text.delta", delta="ok"),
+                _wrap("response.completed"),
+            ]
+        )
+    )
+    async for event in stream:
+        events.append(dict(event))
+    assert events == [{"type": "delta", "content": "ok"}]
+
+
+# ---------------------------------------------------------------------------
+# Provider class
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAICodexLLM:
+    def test_strips_openai_codex_prefix_from_model_id(self) -> None:
+        """``openai-codex/gpt-5`` and ``gpt-5`` both go on the wire as ``gpt-5``."""
+        llm = OpenAICodexLLM("openai-codex/gpt-5")
+        assert llm.model == "gpt-5"
+
+    def test_keeps_bare_model_id_unchanged(self) -> None:
+        llm = OpenAICodexLLM("gpt-5-codex")
+        assert llm.model == "gpt-5-codex"
+
+    @pytest.mark.anyio
+    async def test_stream_raises_until_activation(self) -> None:
+        """Scaffold state: stream() must signal that it's not wired up yet."""
+        llm = OpenAICodexLLM("gpt-5")
+        gen = llm.stream(
+            "hi",
+            uuid.uuid4(),
+            uuid.uuid4(),
+            history=None,
+            tools=None,
+            system_prompt=None,
+        )
+        with pytest.raises(NotImplementedError):
+            async for _ in gen:
+                pass


### PR DESCRIPTION
## Scope

**Scaffold only.** Request body, header set, and SSE event parser are implemented and unit-tested. The live HTTP path is NOT wired into `factory.py` — that's a follow-up PR after you smoke-test the wire shape against a real Codex OAuth token.

The full spec this is built against is in `docs/design/codex-oauth-text-provider.md` (PR #176).

## What lands

### `app/core/codex_auth.py` — shared credential resolver

Returns `(access_token, account_id)` from either:
- An explicit override (`OPENAI_CODEX_OAUTH_TOKEN` workspace setting), OR
- `~/.codex/auth.json` (the file the official Codex CLI writes)

Falls back to decoding the JWT's `https://api.openai.com/auth.chatgpt_account_id` claim when older auth.json files don't carry `tokens.account_id` directly. The existing `image_gen.py` keeps its own copy of `resolve_codex_oauth_token` for now to avoid touching that working path; one follow-up renames it to use this module.

### `app/core/providers/openai_codex_provider.py`

- **`_build_request_body`** — Responses API shape (NOT chat completions). Forces `stream: true` + `store: false` (backend rejects either as the opposite). Opts into `reasoning.encrypted_content` for multi-turn replay. System prompt goes in top-level `instructions`, not as a message item.
- **`_build_headers`** — exact Codex header set: `Authorization`, `Accept: text/event-stream`, `OpenAI-Beta: responses=experimental`, `chatgpt-account-id`, `session_id`, `originator: pawrrtal` (critical — `codex_cli_rs` triggers strict-mode validation that rejects anything not byte-identical to the official CLI's prompt+tools), `x-client-request-id` set to our conversation_id for log correlation.
- **`parse_codex_sse_stream`** — async iterator that maps Codex SSE events to our `StreamEvent` union: text deltas → `delta`, reasoning summary → `thinking`, function call items with streamed JSON args → `tool_use`, `error` → `error`, `[DONE]` / `response.completed` → end.
- **`OpenAICodexLLM` class** — provider shell with the same constructor + protocol as `ClaudeLLM` / `GeminiLLM`. `stream()` currently raises `NotImplementedError` so a misconfigured factory fails loudly instead of silently swallowing requests.

## Tests (30 new)

### `tests/test_codex_auth.py`
- JWT payload decoding (valid token, missing claim, malformed input, non-JWT garbage).
- Override token path: succeeds with valid claim, raises with a clear message when the claim is missing.
- `auth.json` reads with explicit `tokens.account_id` AND with the legacy JWT-claim fallback.
- Missing file / malformed file → typed `CodexAuthError` with operator-friendly messages.

### `tests/test_openai_codex_provider.py`
- Request body: appends user question after history, uses `input_text` parts (not chat completions strings), forces stream + statelessness, includes `reasoning.encrypted_content`, optionally includes `instructions`, passes tools through with `tool_choice: auto`, drops empty history messages.
- Headers: required Codex fields all present, **`originator: pawrrtal` (NOT `codex_cli_rs`)**, `session_id` parses as a UUID, `x-client-request-id` carries the conversation id.
- SSE mapping: text deltas → delta events, reasoning summary deltas → thinking events, function call lifecycle (item-added → arg-deltas → arg-done) collapses into the right tool_use events with parsed JSON input, error events pass through, `[DONE]` terminates cleanly mid-stream, malformed JSON lines are skipped without killing the parser.
- Class: strips `openai-codex/` prefix from model id, keeps bare ids unchanged, `stream()` raises `NotImplementedError` until activation.

**Full backend suite: 378 passed, 2 skipped, 0 failed.** (Was 348; +30 new.)

## What's NOT in this PR (deliberate)

Matches the 10-step implementation order in the design doc:

1. ~~Lift `resolve_codex_oauth_token` into shared module~~ ✅ (this PR — though `image_gen.py` keeps its own copy until we adopt the shared module in a follow-up)
2. ~~Skeleton provider with body + headers + SSE parser~~ ✅ (this PR)
3. **Live HTTP path** ⬅ next PR
4. **Tool-call execution loop integration** ⬅ next PR
5. **`reasoning.encrypted_content` multi-turn replay** ⬅ follow-up
6. **401 → refresh-token-rotation → retry path** ⬅ follow-up
7. **Factory wiring (`gpt-*`, `openai-codex/*` prefixes)** ⬅ follow-up
8. **Model catalog entries in `/api/v1/models`** ⬅ follow-up
9. **Replay-based integration tests with recorded fixtures** ⬅ follow-up
10. **Manual smoke test from your account** ⬅ you

## What you need to do for activation

Nothing for this PR. When you're ready to go live with steps 3–10 (separate PR), I'll need:
- Confirmation that `~/.codex/auth.json` exists on the target machine (you've already run `codex login`).
- A 1-line smoke test against a real token after the live-path PR lands so we can confirm `chatgpt-account-id` resolution + the SSE wire shape match reality.

## References

- `docs/design/codex-oauth-text-provider.md` — full spec
- `openclaw/openclaw#64133` — confirmed `chatgpt.com/backend-api/codex/responses` is the right path; `api.openai.com/v1/responses` rejects ChatGPT OAuth tokens
- `anomalyco/opencode#1686` — discovered the `originator: codex_cli_rs` strict-mode trap
- `openai/codex#15502` — refresh-token rotation gotcha (mitigations in design doc)
- `EvanZhouDev/openai-oauth`, `pproenca/opencode-openai-codex-auth`, `RooCodeInc/Roo-Code/src/api/providers/openai-codex.ts` — independent reference implementations