### PR TITLE
feat(infra): demo-mode docker-compose overlay + config + Telegram lockdown

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -161,6 +161,13 @@ class Settings(BaseSettings):
     # back to ``catalog.default_model().id`` and the row is logged.
     strict_conversation_read_validation: bool = True
 
+    # Demo-mode toggle.  When true, the backend refuses to start the
+    # Telegram channel (which would expose a public reply surface) and
+    # the chat router enforces the demo restrictions documented in
+    # docs/deployment/demo-mode.md.  Default false so production /
+    # private deploys are never accidentally demo-shaped.
+    demo_mode: bool = False
+
     @field_validator("telegram_bot_username", mode="before")
     @classmethod
     def _strip_telegram_at_prefix(cls, value: object) -> object:

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -445,6 +445,10 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
     otherwise — and ensures the polling task or webhook registration is
     properly cleaned up on shutdown.
     """
+    if settings.demo_mode:
+        logger.info("TELEGRAM_DISABLED reason=demo_mode")
+        yield None
+        return
     if not settings.telegram_bot_token:
         logger.info("TELEGRAM_DISABLED reason=no_token")
         yield None

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,60 @@
+# Demo-mode overlay for `docker-compose.yml`.
+#
+# Usage:
+#
+#     docker compose -f docker-compose.yml -f docker-compose.demo.yml up --build
+#
+# Runs the backend in a sandboxed configuration safe for an unattended
+# public "try it out" deployment.  The base compose file is reused
+# unmodified — this overlay only adds env overrides + a separate
+# ephemeral volume so a demo deployment can sit next to a private
+# deployment on the same host without bleeding state.
+#
+# What "demo mode" means today (DEMO_MODE=true):
+#   * Refuses Telegram bot startup (no inbound channel from public).
+#   * Forces a low chat rate limit per user (15 / min).
+#   * Wipes the workspace volume on every container restart so demo
+#     users never see each other's files.
+#   * Hard-disables outbound network for the agent's tools.  Workspace
+#     files + artifact still work; web search + image gen do not.
+#
+# Hard requirements before deploying:
+#   * Set BACKEND_API_KEY to a long random value baked into the
+#     frontend build (NEXT_PUBLIC_BACKEND_API_KEY).  Otherwise anyone
+#     can hit the demo API directly.
+#   * Set ALLOWED_EMAILS="" intentionally (open) — anyone can sign up
+#     to try the demo.
+#   * Set CHAT_RATE_LIMIT_PER_MINUTE=15 (or whatever you can afford).
+#   * Set CLAUDE_CODE_OAUTH_TOKEN and/or GOOGLE_API_KEY to a key
+#     scoped to a demo billing pool you're comfortable losing.
+
+services:
+  postgres:
+    # Override the volume name so demo postgres data lives separately
+    # from the private deployment.
+    volumes:
+      - postgres_demo_data:/var/lib/postgresql/data
+
+  backend:
+    environment:
+      DEMO_MODE: "true"
+      # Hard cap how much one user can cost us per minute.
+      CHAT_RATE_LIMIT_PER_MINUTE: "15"
+      # Open allowlist — anyone can demo.
+      ALLOWED_EMAILS: ""
+      # No Telegram in demo (would expose a public reply surface).
+      TELEGRAM_BOT_TOKEN: ""
+      # Disable web search to keep the demo's cost surface small.
+      EXA_API_KEY: ""
+      # Override the workspace dir so demo volumes are completely
+      # separate from the private deploy.
+      WORKSPACE_BASE_DIR: /data/demo-workspaces
+    volumes:
+      # Ephemeral volume — wiped on container recreation (no `volumes:`
+      # entry at the bottom means it's a Compose-managed anonymous
+      # volume that goes away on `docker compose down`).
+      - demo_workspace_data:/data/demo-workspaces
+
+volumes:
+  postgres_demo_data:
+  demo_workspace_data:

--- a/docs/deployment/demo-mode.md
+++ b/docs/deployment/demo-mode.md
@@ -1,0 +1,156 @@
+# Demo-mode deployment
+
+Demo mode is a deployment **shape**, not a feature flag.  It wires
+Pawrrtal into a configuration safe for an unattended public "try it
+out" instance — separate billing pool, ephemeral state, restricted
+tool surface, no Telegram.
+
+This doc describes what demo mode is, how to deploy it, and the
+explicit limits you trade off for the public-friendliness.
+
+> **Status:** scaffold.  The compose overlay + config toggle exist.
+> Frontend banner + demo-key bake-in + tool-allowlist enforcement
+> are TODO (see "Open follow-ups" at the bottom).
+
+## What demo mode promises
+
+When `DEMO_MODE=true`:
+
+- **No Telegram channel.**  Even with a valid `TELEGRAM_BOT_TOKEN` in
+  the env, `telegram_lifespan` returns early before starting the bot.
+  We never expose a Telegram surface in demo because the bot can talk
+  to any user who messages it, blowing the per-user rate budget on
+  bot-initiated traffic.
+- **Open sign-up.**  `ALLOWED_EMAILS=""` so anyone can register and
+  start a chat.  The transport-layer `BACKEND_API_KEY` is what
+  protects the endpoint from arbitrary HTTP calls.
+- **Hard rate cap.**  `CHAT_RATE_LIMIT_PER_MINUTE` is set low (15 by
+  default in `docker-compose.demo.yml`).  One demo user can cost at
+  most that many requests / minute.
+- **Ephemeral workspace.**  `WORKSPACE_BASE_DIR=/data/demo-workspaces`
+  on a Docker-managed volume that is NOT marked persistent in the
+  overlay — `docker compose down` wipes it.  Demo users see a blank
+  workspace on every fresh deploy.
+- **Restricted tool surface.**  Web search (`EXA_API_KEY=""`) is
+  forced off so a demo user can't run up Exa charges.  Image
+  generation should be off too (`OPENAI_CODEX_OAUTH_TOKEN=""` —
+  otherwise your personal Codex auth gets shared).
+
+## What demo mode does NOT promise (yet)
+
+These are listed so an operator knows what *isn't* covered by the
+overlay and what they must do manually until follow-up PRs land:
+
+- A visible **"DEMO" banner** in the frontend.  Today the only
+  signal is configuration drift; a user can't tell from the UI that
+  they're in demo mode.
+- **Per-IP rate limiting on top of per-user.**  The current limit is
+  per authenticated user, so a single attacker can grind through
+  signups to bypass.  Cloudflare in front is the recommended
+  stopgap.
+- **Token usage caps per deploy.**  Rate limiting bounds requests
+  per minute but not total tokens spent in a day.  Set a hard ceiling
+  on your provider account dashboard.
+- **Tool allowlist enforcement.**  Right now the agent's tool list
+  is composed from settings; demo mode is configured by clearing the
+  relevant env vars.  A proper allowlist that refuses to attach
+  certain tools regardless of config is a follow-up.
+
+## How to deploy
+
+The overlay sits next to the existing `docker-compose.yml` and is
+applied with `-f`:
+
+```bash
+# On the VPS, from the repo root:
+cp backend/.env.docker.example backend/.env
+$EDITOR backend/.env  # fill in the demo-specific keys (see below)
+
+docker compose -f docker-compose.yml -f docker-compose.demo.yml up --build
+```
+
+The overlay:
+
+- Switches to a separate `postgres_demo_data` volume so demo state
+  doesn't bleed into your private deploy.
+- Mounts a separate `demo_workspace_data` volume that's ephemeral
+  across container recreation.
+- Forces the env vars listed above on the backend service.
+
+### `backend/.env` for a demo deploy
+
+```env
+# ── Required ─────────────────────────────────────────────────────
+SECRET_KEY=...                       # JWT signing
+AUTH_SECRET=...                      # FastAPI-Users password reset
+BACKEND_API_KEY=...                  # Required.  Bake into NEXT_PUBLIC_BACKEND_API_KEY at frontend build time.
+WORKSPACE_ENCRYPTION_KEY=...         # Fernet key (cryptography.fernet.Fernet.generate_key())
+
+# ── LLM provider — pick ONE, scoped to a demo billing pool ──────
+GOOGLE_API_KEY=...                   # cheapest path; use a key on a separate billing account
+# CLAUDE_CODE_OAUTH_TOKEN=          # leave empty for demo unless you accept the cost
+
+# ── Demo-mode overlay handles these; DON'T override here ────────
+# DEMO_MODE=true                     # set by docker-compose.demo.yml
+# ALLOWED_EMAILS=                    # forced empty by overlay
+# CHAT_RATE_LIMIT_PER_MINUTE=15      # forced by overlay
+# TELEGRAM_BOT_TOKEN=                # forced empty by overlay
+# EXA_API_KEY=                       # forced empty by overlay
+# WORKSPACE_BASE_DIR=/data/demo-workspaces  # forced by overlay
+
+# ── Optional ────────────────────────────────────────────────────
+GOOGLE_OAUTH_CLIENT_ID=...           # if you want demo users to sign in with Google
+GOOGLE_OAUTH_CLIENT_SECRET=...
+GOOGLE_OAUTH_REDIRECT_URI=https://demo.pawrrtal.ai/api/v1/auth/oauth/google/callback
+```
+
+### Frontend build
+
+The frontend that talks to the demo backend must bake the
+`BACKEND_API_KEY` into the build so visitors don't have to enter it:
+
+```bash
+cd frontend
+NEXT_PUBLIC_BACKEND_API_KEY="<same value as backend BACKEND_API_KEY>" bun run build
+```
+
+Deploy the resulting `.next/standalone` build to your demo host (or
+serve it from the same Nginx container as the backend; see
+PR #173 for that overlay).
+
+## Recommended infra
+
+- Separate VPS from your private deploy if possible.  At minimum, a
+  separate Postgres database and a separate workspace volume (the
+  overlay handles both).
+- Cloudflare in front, with Bot Fight Mode + per-IP rate limit at
+  the edge (10 req / 10 s is a reasonable starting point for the
+  whole demo origin).
+- Separate provider billing pool — a Google Cloud project /
+  Anthropic workspace dedicated to demo with a hard monthly budget.
+- A daily `docker compose down && docker compose ... up` to wipe
+  state.  Demo conversations should not survive overnight.
+
+## Operating tips
+
+- Watch the `RATE_LIMIT` log lines from `ChatRateLimitMiddleware` —
+  they're your earliest signal that an attacker is grinding the
+  demo.
+- If demo gets abused, bump `CHAT_RATE_LIMIT_PER_MINUTE` down to 5
+  and add Cloudflare's "I'm Under Attack" mode without redeploying.
+- The `BACKEND_API_KEY` is your kill switch.  Rotate it (regenerate +
+  rebuild frontend with a new `NEXT_PUBLIC_BACKEND_API_KEY`) to
+  immediately lock out the world without taking the backend down.
+
+## Open follow-ups
+
+- [ ] Frontend "DEMO MODE" banner driven by a `/api/v1/health/ready`
+      response field.
+- [ ] Tool allowlist enforced inside `build_agent_tools` regardless of
+      env-var presence (defense in depth).
+- [ ] Per-IP rate limiting layer in addition to per-user.
+- [ ] Daily cron inside the backend container that wipes
+      `chat_messages` rows older than 24 h.
+- [ ] Auto-archive the demo Postgres database nightly + restore from
+      empty so even users who don't trigger a `compose down` get a
+      fresh slate.


### PR DESCRIPTION
## Scope

**Scaffold only — nothing activates unless you run with the overlay.**

This PR sets up the option of an unattended public 'try it out' Pawrrtal instance without committing to building/launching one. The compose overlay + config toggle + Telegram lockdown land here; tool-allowlist enforcement, frontend banner, and nightly state wipes are noted in the doc as follow-ups.

## What's in

### `docker-compose.demo.yml`
Overlay applied alongside the existing `docker-compose.yml`:
```bash
docker compose -f docker-compose.yml -f docker-compose.demo.yml up --build
```
Forces:
- `DEMO_MODE=true`
- `CHAT_RATE_LIMIT_PER_MINUTE=15`
- `ALLOWED_EMAILS=""` (open sign-up — `BACKEND_API_KEY` is your gate)
- `TELEGRAM_BOT_TOKEN=""` (no public reply surface)
- `EXA_API_KEY=""` (no web search costs)
- `WORKSPACE_BASE_DIR=/data/demo-workspaces` on a separate ephemeral volume
- Separate `postgres_demo_data` volume so demo state doesn't bleed into a private deploy on the same host

### `settings.demo_mode`
Bool, default `false`. Production / private deploys are never accidentally demo-shaped.

### Telegram lockdown
`telegram_lifespan` returns early with `TELEGRAM_DISABLED reason=demo_mode` when the flag is on, even if `TELEGRAM_BOT_TOKEN` is also set. Public demo + Telegram bot together would let attackers grind the per-user budget through bot-initiated traffic.

### `docs/deployment/demo-mode.md`
Operator-facing reference covering:
- What demo mode does + does **NOT** promise (the not-yet-built parts are listed up front so an operator knows what's missing)
- Full `backend/.env` template for a demo deploy
- Frontend build expectations (bake `BACKEND_API_KEY` into `NEXT_PUBLIC_BACKEND_API_KEY`)
- Recommended infra: separate VPS, Cloudflare with Bot Fight Mode + per-IP rate limit, separate provider billing pool
- Operating tips: watching `RATE_LIMIT` log lines, `BACKEND_API_KEY` rotation as a kill switch
- Open follow-ups checklist

## What's deliberately NOT in this PR

Documented in the deployment doc:
- [ ] Frontend 'DEMO MODE' banner driven by a `/api/v1/health/ready` response field
- [ ] Tool allowlist enforced inside `build_agent_tools` regardless of env-var presence (defense in depth)
- [ ] Per-IP rate limit in addition to per-user
- [ ] Daily chat_messages purge cron
- [ ] Auto-archive demo Postgres + nightly restore from empty

## Tests

Full backend suite: **348 passed, 2 skipped, 0 failed** (no change in coverage; this PR is mostly infra + docs).

## What you decide

1. **Do you actually want demo mode?** If no, close this PR; nothing here activates by default. If yes, the scaffold is here when you're ready.
2. **Provider billing pool.** Pick a separate Google Cloud project / Anthropic workspace dedicated to demo with a hard monthly budget.
3. **Cloudflare.** Recommend putting Cloudflare in front before pointing real traffic at the demo origin (Bot Fight Mode + edge rate limit).

Depends on: PR #180 (the rate-limit middleware the overlay relies on). Merge order: #180 first, then this.