### PR TITLE
feat(lcm): add schema + models for Lossless Context Management [stack 1/7]

### DIFF
--- a/.beans/lcm-followups.md
+++ b/.beans/lcm-followups.md
@@ -11,7 +11,7 @@ tables; Alembic migration 012; settings in `app/core/config.py`.
 
 **Out of scope for this PR (intentionally) — picked up in later PRs:**
 
-- [ ] Application code that reads/writes the new tables (PR #2)
+- [x] Application code that reads/writes the new tables (PR #2) — `ingest_message` + `assemble_context` in `app/core/lcm.py`; wired into `chat.py` behind `lcm_enabled`
 - [ ] FK enforcement for `lcm_context_items.item_id` and
       `lcm_summary_sources.source_id` polymorphic targets — currently
       cascade is driven by the parent `conversation_id` FK only

--- a/.beans/lcm-followups.md
+++ b/.beans/lcm-followups.md
@@ -12,6 +12,11 @@ tables; Alembic migration 012; settings in `app/core/config.py`.
 **Out of scope for this PR (intentionally) — picked up in later PRs:**
 
 - [x] Application code that reads/writes the new tables (PR #2) — `ingest_message` + `assemble_context` in `app/core/lcm.py`; wired into `chat.py` behind `lcm_enabled`
+- [x] Leaf compaction (PR #3) — `compact_leaf_if_needed` + `LCMSummary` creation; three-level escalation; background task in `chat.py`
+- [x] LCM grep tool (PR #4) — `lcm_grep.py`, `lcm_grep_agent.py`; ILIKE across messages + summaries; wired into `build_agent_tools`
+- [x] LCM describe/list tools (PR #5) — `lcm_describe.py`, `lcm_describe_agent.py`; `lcm_list_summaries` + `lcm_describe` per summary UUID
+- [x] LCM expand-query tool (PR #6) — `lcm_expand_query.py`, `lcm_expand_query_agent.py`; full-history LLM call with prompt, bounded to 500 items
+- [x] Condensation pass (PR #7) — `_condense_at_depth` collapses same-depth summaries into depth+1 parents; controlled by `lcm_incremental_max_depth`
 - [ ] FK enforcement for `lcm_context_items.item_id` and
       `lcm_summary_sources.source_id` polymorphic targets — currently
       cascade is driven by the parent `conversation_id` FK only

--- a/.beans/lcm-followups.md
+++ b/.beans/lcm-followups.md
@@ -1,0 +1,52 @@
+# LCM follow-ups
+
+Running list of work left after each stacked LCM PR.  See
+`docs/design/lcm.md` for the full design.  Cross items off as the
+stack lands.
+
+## PR #1 — schema + models (this PR)
+
+**Landed:** `lcm_summaries`, `lcm_summary_sources`, `lcm_context_items`
+tables; Alembic migration 012; settings in `app/core/config.py`.
+
+**Out of scope for this PR (intentionally) — picked up in later PRs:**
+
+- [ ] Application code that reads/writes the new tables (PR #2)
+- [ ] FK enforcement for `lcm_context_items.item_id` and
+      `lcm_summary_sources.source_id` polymorphic targets — currently
+      cascade is driven by the parent `conversation_id` FK only
+- [ ] Postgres `tsvector` columns on `lcm_summaries.content` and
+      `chat_messages.content` for FTS (PR #4 — `lcm_grep`)
+- [ ] `lcm_summaries.parent_summary_id` if we want to walk the DAG
+      cheaply — defer until condensation lands (PR #7) and we see how
+      we actually traverse
+
+## Beyond the tracer-bullet stack
+
+Things the upstream plugin has that we may or may not want, captured
+here so the omission is intentional:
+
+- [ ] **Cache-aware compaction** — the upstream plugin keeps a recent
+      cache window so back-to-back compactions don't churn the same
+      summary.  Worth adding once we observe real compaction cost.
+- [ ] **`/lcm` slash commands** (`status`, `backup`, `rotate`, `doctor`).
+      Operational nicety; not blocking for v1.
+- [ ] **`transcriptGcEnabled`** — pruning the raw `chat_messages` once
+      summaries cover them.  Disk is cheap; defer indefinitely.
+- [ ] **Subagent timeout + retry policy** for `lcm_expand_query` —
+      need real-world numbers before tuning.
+- [ ] **Expansion model override** — at the moment one summary model
+      handles both compaction and expansion.  Split later if the
+      latency profile demands it.
+- [ ] **Per-session ignore patterns** (`ignoreSessionPatterns` in the
+      upstream).  We don't have cron sessions like OpenClaw does, so
+      this is currently irrelevant.
+- [ ] **DB rotation** (`/lcm rotate`) — long-term storage hygiene.
+      Add when the LCM table sizes become a real concern.
+- [ ] **Three-level escalation tuning** — implement normal + aggressive
+      + deterministic truncation in PR #3 (leaf compaction), but the
+      prompts and token caps will need iteration with real workloads.
+- [ ] **Cross-conversation grep** — upstream allows
+      `allConversations: true`.  Our `lcm_grep` (PR #4) will land
+      scoped-to-current first; cross-conv is a follow-up once we
+      figure out the auth + privacy model for it.

--- a/.sentrux/rules.toml
+++ b/.sentrux/rules.toml
@@ -73,6 +73,15 @@ name = "be-models"
 paths = ["backend/app/models.py", "backend/app/schemas.py"]
 order = 3
 
+# LCM module: cross-cutting concern that needs both be-models (ORM access)
+# and be-core (providers, config).  Placed at order=3 alongside be-models so
+# it may import both be-models (same level) and be-core (higher order = 4).
+# Listed before be-core so more-specific path patterns take precedence.
+[[layers]]
+name = "be-lcm"
+paths = ["backend/app/core/lcm.py"]
+order = 3
+
 [[layers]]
 name = "be-core"
 paths = ["backend/app/core/*", "backend/app/db.py", "backend/app/logger_setup.py"]

--- a/backend/alembic/versions/012_add_lcm_tables.py
+++ b/backend/alembic/versions/012_add_lcm_tables.py
@@ -1,0 +1,150 @@
+"""Add LCM (Lossless Context Management) tables.
+
+Three tables form the storage layer for our adaptation of the LCM
+approach (originally a TypeScript OpenClaw plugin from
+Martian-Engineering; we ported the core algorithm to Python).
+
+This migration only creates the schema — no application code reads or
+writes these tables until later stack PRs.  Shipping the schema first
+lets us land the migration cleanly without worrying about runtime
+behaviour changes.
+
+Revision ID: 012_add_lcm_tables
+Revises: 011_add_channel_columns_and_attachment
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "012_add_lcm_tables"
+down_revision = "011_add_channel_columns_and_attachment"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the three LCM tables and their supporting indices."""
+    op.create_table(
+        "lcm_summaries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("depth", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "token_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("model_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "summary_kind",
+            sa.String(length=16),
+            nullable=False,
+            server_default="normal",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_id",
+        "lcm_summaries",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_depth",
+        "lcm_summaries",
+        ["conversation_id", "depth"],
+    )
+
+    op.create_table(
+        "lcm_summary_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("summary_id", sa.Uuid(), nullable=False),
+        sa.Column("source_kind", sa.String(length=16), nullable=False),
+        sa.Column("source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_ordinal", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["summary_id"], ["lcm_summaries.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_summary_id",
+        "lcm_summary_sources",
+        ["summary_id"],
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_source_id",
+        "lcm_summary_sources",
+        ["source_id"],
+    )
+
+    op.create_table(
+        "lcm_context_items",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("item_kind", sa.String(length=16), nullable=False),
+        sa.Column("item_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # Unique (conversation_id, ordinal) so compaction can renumber
+        # densely without colliding mid-transaction.
+        sa.UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+    op.create_index(
+        "ix_lcm_context_items_conversation_id",
+        "lcm_context_items",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_context_items_item_id",
+        "lcm_context_items",
+        ["item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_lcm_context_items_item_id", table_name="lcm_context_items"
+    )
+    op.drop_index(
+        "ix_lcm_context_items_conversation_id", table_name="lcm_context_items"
+    )
+    op.drop_table("lcm_context_items")
+
+    op.drop_index(
+        "ix_lcm_summary_sources_source_id", table_name="lcm_summary_sources"
+    )
+    op.drop_index(
+        "ix_lcm_summary_sources_summary_id", table_name="lcm_summary_sources"
+    )
+    op.drop_table("lcm_summary_sources")
+
+    op.drop_index(
+        "ix_lcm_summaries_conversation_depth", table_name="lcm_summaries"
+    )
+    op.drop_index(
+        "ix_lcm_summaries_conversation_id", table_name="lcm_summaries"
+    )
+    op.drop_table("lcm_summaries")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from app.core.agent_tools import build_agent_tools
 from app.core.chat_aggregator import ChatTurnAggregator
 from app.core.config import settings
 from app.core.lcm import assemble_context as lcm_assemble_context
+from app.core.lcm import compact_leaf_if_needed as lcm_compact_leaf
 from app.core.lcm import ingest_message as lcm_ingest_message
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
@@ -84,6 +86,35 @@ def _maybe_artifact_event(event: StreamEvent) -> StreamEvent | None:
             "tool_use_id": event.get("tool_use_id", ""),
         },
     )
+
+
+async def _lcm_compact_bg(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> None:
+    """Background task: run one LCM leaf-compaction pass for a conversation.
+
+    Opens its own session so it runs completely independently of the request
+    lifecycle.  All exceptions are caught and logged — a failed compaction
+    never surfaces to the user (the full message history is always preserved).
+    """
+    try:
+        async with async_session_maker() as compact_session:
+            await lcm_compact_leaf(
+                compact_session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                fresh_tail_count=settings.lcm_fresh_tail_count,
+                max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
+            )
+            await compact_session.commit()
+    except Exception:
+        logger.exception(
+            "LCM_COMPACT_BG_ERR conversation_id=%s", conversation_id
+        )
 
 
 def get_chat_router() -> APIRouter:
@@ -395,6 +426,20 @@ def get_chat_router() -> APIRouter:
                         "CHAT_PERSIST_ERR rid=%s message_id=%s",
                         rid,
                         assistant_message_id,
+                    )
+
+                # Fire-and-forget leaf compaction.  Runs after the stream is
+                # fully committed so the assistant row is finalized before we
+                # decide what to compact.  Errors are swallowed here — a
+                # failed compaction is invisible to the user; the full message
+                # history is always preserved.
+                if settings.lcm_enabled:
+                    asyncio.create_task(
+                        _lcm_compact_bg(
+                            conversation_id=request.conversation_id,
+                            user_id=user.id,
+                            model_id=model_id,
+                        )
                     )
                 logger.info(
                     "CHAT_OUT rid=%s conversation_id=%s model_id=%s surface=%s events=%d duration_ms=%.1f",

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -16,6 +16,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.channels import resolve_channel, surface_from_header
 from app.core.agent_tools import build_agent_tools
 from app.core.chat_aggregator import ChatTurnAggregator
+from app.core.config import settings
+from app.core.lcm import assemble_context as lcm_assemble_context
+from app.core.lcm import ingest_message as lcm_ingest_message
 from app.core.providers import resolve_llm
 from app.core.providers.base import StreamEvent
 from app.core.tools.agents_md import assemble_workspace_prompt
@@ -182,18 +185,30 @@ def get_chat_router() -> APIRouter:
         # Read recent history *before* persisting the current message so the
         # current question is not included in the history slice passed to the
         # provider (the provider receives it separately as ``question``).
-        recent_rows = await get_messages_for_conversation(
-            session, request.conversation_id, limit=_HISTORY_WINDOW
-        )
-        history = [
-            {"role": row.role, "content": row.content or ""}
-            for row in recent_rows
-            if row.role in {"user", "assistant"}
-        ]
+        #
+        # When LCM is enabled, ``lcm_assemble_context`` reads via the ordered
+        # ``lcm_context_items`` list so that PR #3 compaction can rewrite
+        # ranges in place without touching this call site.  When LCM is off,
+        # we fall back to the original ``LIMIT _HISTORY_WINDOW`` query.
+        if settings.lcm_enabled:
+            history = await lcm_assemble_context(
+                session,
+                conversation_id=request.conversation_id,
+                fresh_tail_count=settings.lcm_fresh_tail_count,
+            )
+        else:
+            recent_rows = await get_messages_for_conversation(
+                session, request.conversation_id, limit=_HISTORY_WINDOW
+            )
+            history = [
+                {"role": row.role, "content": row.content or ""}
+                for row in recent_rows
+                if row.role in {"user", "assistant"}
+            ]
 
         # Persist the user prompt + assistant placeholder rows up front so a
         # client that disconnects mid-stream still has a partial record.
-        await append_user_message(
+        user_msg = await append_user_message(
             session,
             conversation_id=request.conversation_id,
             user_id=user.id,
@@ -205,6 +220,22 @@ def get_chat_router() -> APIRouter:
             user_id=user.id,
         )
         assistant_message_id = assistant_row.id
+
+        # Wire both new rows into the LCM context list so assembly on the
+        # *next* turn sees them.  The ingest is gated on the master switch;
+        # existing deployments with LCM off are unaffected.
+        if settings.lcm_enabled:
+            await lcm_ingest_message(
+                session,
+                conversation_id=request.conversation_id,
+                message_id=user_msg.id,
+            )
+            await lcm_ingest_message(
+                session,
+                conversation_id=request.conversation_id,
+                message_id=assistant_row.id,
+            )
+
         # Commit before streaming starts — the request session is closed when
         # the StreamingResponse generator runs in a fresh task, so we open a
         # short-lived session inside the generator for the final UPDATE.

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -17,12 +17,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.channels import resolve_channel, surface_from_header
 from app.core.agent_tools import build_agent_tools
 from app.core.chat_aggregator import ChatTurnAggregator
-from app.core.config import settings
-from app.core.lcm import assemble_context as lcm_assemble_context
-from app.core.lcm import compact_leaf_if_needed as lcm_compact_leaf
-from app.core.lcm import ingest_message as lcm_ingest_message
-from app.core.providers import resolve_llm
-from app.core.providers.base import StreamEvent
+from app.core.lcm import (
+    assemble_context as lcm_assemble_context,
+    compact_leaf_if_needed as lcm_compact_leaf,
+    fresh_tail_count as lcm_fresh_tail_count,
+    ingest_message as lcm_ingest_message,
+    is_enabled as lcm_is_enabled,
+    leaf_chunk_tokens as lcm_leaf_chunk_tokens,
+)
+from app.core.providers import StreamEvent, resolve_llm
 from app.core.tools.agents_md import assemble_workspace_prompt
 from app.core.tools.artifact_agent import (
     ARTIFACT_TOOL_NAME,
@@ -107,8 +110,8 @@ async def _lcm_compact_bg(
                 conversation_id=conversation_id,
                 user_id=user_id,
                 model_id=model_id,
-                fresh_tail_count=settings.lcm_fresh_tail_count,
-                max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
+                fresh_tail_count=lcm_fresh_tail_count(),
+                max_chunk_tokens=lcm_leaf_chunk_tokens(),
             )
             await compact_session.commit()
     except Exception:
@@ -221,11 +224,11 @@ def get_chat_router() -> APIRouter:
         # ``lcm_context_items`` list so that PR #3 compaction can rewrite
         # ranges in place without touching this call site.  When LCM is off,
         # we fall back to the original ``LIMIT _HISTORY_WINDOW`` query.
-        if settings.lcm_enabled:
+        if lcm_is_enabled():
             history = await lcm_assemble_context(
                 session,
                 conversation_id=request.conversation_id,
-                fresh_tail_count=settings.lcm_fresh_tail_count,
+                fresh_tail_count=lcm_fresh_tail_count(),
             )
         else:
             recent_rows = await get_messages_for_conversation(
@@ -255,7 +258,7 @@ def get_chat_router() -> APIRouter:
         # Wire both new rows into the LCM context list so assembly on the
         # *next* turn sees them.  The ingest is gated on the master switch;
         # existing deployments with LCM off are unaffected.
-        if settings.lcm_enabled:
+        if lcm_is_enabled():
             await lcm_ingest_message(
                 session,
                 conversation_id=request.conversation_id,
@@ -437,7 +440,7 @@ def get_chat_router() -> APIRouter:
                 # decide what to compact.  Errors are swallowed here — a
                 # failed compaction is invisible to the user; the full message
                 # history is always preserved.
-                if settings.lcm_enabled:
+                if lcm_is_enabled():
                     asyncio.create_task(
                         _lcm_compact_bg(
                             conversation_id=request.conversation_id,

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -322,6 +322,7 @@ def get_chat_router() -> APIRouter:
             user_id=user.id,
             send_fn=_web_send_fn,
             conversation_id=request.conversation_id,
+            model_id=model_id,
         )
 
         # Load SOUL.md + AGENTS.md from the workspace as the agent's

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -318,7 +318,10 @@ def get_chat_router() -> APIRouter:
             await _web_send_queue.put(event)
 
         agent_tools = build_agent_tools(
-            workspace_root=root, user_id=user.id, send_fn=_web_send_fn
+            workspace_root=root,
+            user_id=user.id,
+            send_fn=_web_send_fn,
+            conversation_id=request.conversation_id,
         )
 
         # Load SOUL.md + AGENTS.md from the workspace as the agent's

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -35,6 +35,7 @@ from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
+from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
@@ -44,6 +45,7 @@ def build_agent_tools(
     workspace_root: Path,
     user_id: uuid.UUID | None = None,
     send_fn: SendFn | None = None,
+    conversation_id: uuid.UUID | None = None,
 ) -> list[AgentTool]:
     """Return the full ``AgentTool`` list for one chat turn.
 
@@ -67,6 +69,9 @@ def build_agent_tools(
             web path (via a per-request asyncio queue drained into the
             SSE stream) and the Telegram path supply one; the distinction
             is purely in how the callback delivers — not whether it exists.
+        conversation_id: Optional conversation UUID.  When ``settings.lcm_enabled``
+            is ``True`` and this is supplied, the ``lcm_grep`` tool is added so
+            the agent can search compacted conversation history on demand.
 
     Returns:
         A fresh list of :class:`AgentTool` ready to hand to a provider.
@@ -120,5 +125,11 @@ def build_agent_tools(
         tools.append(
             make_send_message_tool(workspace_root=workspace_root, send_fn=send_fn)
         )
+
+    # LCM history search — gives the agent on-demand access to compacted
+    # conversation history.  Gated on both the LCM master switch and a
+    # conversation_id being available (background jobs may omit it).
+    if settings.lcm_enabled and conversation_id is not None:
+        tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
 
     return tools

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -39,6 +39,7 @@ from app.core.tools.lcm_describe_agent import (
     make_lcm_describe_tool,
     make_lcm_list_summaries_tool,
 )
+from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
 from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
@@ -50,6 +51,7 @@ def build_agent_tools(
     user_id: uuid.UUID | None = None,
     send_fn: SendFn | None = None,
     conversation_id: uuid.UUID | None = None,
+    model_id: str | None = None,
 ) -> list[AgentTool]:
     """Return the full ``AgentTool`` list for one chat turn.
 
@@ -74,8 +76,10 @@ def build_agent_tools(
             SSE stream) and the Telegram path supply one; the distinction
             is purely in how the callback delivers — not whether it exists.
         conversation_id: Optional conversation UUID.  When ``settings.lcm_enabled``
-            is ``True`` and this is supplied, the ``lcm_grep`` tool is added so
-            the agent can search compacted conversation history on demand.
+            is ``True`` and this is supplied, the LCM tools are added so
+            the agent can search and expand compacted conversation history.
+        model_id: Optional model identifier used by ``lcm_expand_query`` for
+            its focused sub-call.  Defaults to Gemini flash when omitted.
 
     Returns:
         A fresh list of :class:`AgentTool` ready to hand to a provider.
@@ -131,14 +135,23 @@ def build_agent_tools(
         )
 
     # LCM history tools — give the agent on-demand access to compacted
-    # conversation history.  All three are gated on the LCM master switch
+    # conversation history.  All four are gated on the LCM master switch
     # and a conversation_id being present.
     #   lcm_grep           — substring search across messages + summaries
     #   lcm_list_summaries — enumerate summary nodes (find IDs)
     #   lcm_describe       — read a single summary node in full
+    #   lcm_expand_query   — deep recall via focused LLM sub-call
     if settings.lcm_enabled and conversation_id is not None:
         tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
         tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
         tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
+        if user_id is not None:
+            tools.append(
+                make_lcm_expand_query_tool(
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                    model_id=model_id or "gemini-2.5-flash-preview-05-20",
+                )
+            )
 
     return tools

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -35,6 +35,10 @@ from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
+from app.core.tools.lcm_describe_agent import (
+    make_lcm_describe_tool,
+    make_lcm_list_summaries_tool,
+)
 from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
@@ -126,10 +130,15 @@ def build_agent_tools(
             make_send_message_tool(workspace_root=workspace_root, send_fn=send_fn)
         )
 
-    # LCM history search — gives the agent on-demand access to compacted
-    # conversation history.  Gated on both the LCM master switch and a
-    # conversation_id being available (background jobs may omit it).
+    # LCM history tools — give the agent on-demand access to compacted
+    # conversation history.  All three are gated on the LCM master switch
+    # and a conversation_id being present.
+    #   lcm_grep           — substring search across messages + summaries
+    #   lcm_list_summaries — enumerate summary nodes (find IDs)
+    #   lcm_describe       — read a single summary node in full
     if settings.lcm_enabled and conversation_id is not None:
         tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
 
     return tools

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -162,6 +162,37 @@ class Settings(BaseSettings):
     # token budget divided by expected request count.
     chat_rate_limit_per_minute: int = 0
 
+    # ----------------------------------------------------------------
+    # Lossless Context Management (LCM)
+    # ----------------------------------------------------------------
+    # Master switch for the LCM compaction system (see app.core.lcm).
+    # Default OFF so the schema can land without changing runtime
+    # behaviour.  Later stack PRs activate ingest → assemble → compact.
+    lcm_enabled: bool = False
+
+    # Last N raw messages that are always kept verbatim, never compacted.
+    # 64 matches the upstream plugin's default; increase for chattier
+    # surfaces (Telegram) where short messages dominate.
+    lcm_fresh_tail_count: int = 64
+
+    # Approximate source-token ceiling per leaf summary.  Raise this on
+    # quota-limited summary providers; lower it for tighter context.
+    lcm_leaf_chunk_tokens: int = 20000
+
+    # Auto-trigger compaction when the conversation context is at or
+    # above this fraction of the model's window.  ``0.75`` is the
+    # upstream default.
+    lcm_context_threshold: float = 0.75
+
+    # How many condensation passes to run after each leaf compaction.
+    # 0 = leaf-only, -1 = unlimited cascade.
+    lcm_incremental_max_depth: int = 1
+
+    # Optional model override for compaction summarisation.  When unset,
+    # falls back to the same model the conversation is using — fine for
+    # cheap models, wasteful for premium ones.
+    lcm_summary_model: str = ""
+
     @field_validator("telegram_bot_username", mode="before")
     @classmethod
     def _strip_telegram_at_prefix(cls, value: object) -> object:

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -236,6 +236,139 @@ async def assemble_context(
     return context
 
 
+async def _condense_at_depth(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    depth: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one condensation pass: merge depth-*d* summaries into a depth-*(d+1)* parent.
+
+    Finds all ``LCMContextItem`` rows whose backing ``LCMSummary`` has the
+    given *depth*.  If at least two such items exist, takes the oldest batch
+    (up to *max_chunk_tokens* source tokens), calls the provider to produce a
+    parent summary, writes ``LCMSummary`` (depth+1) + ``LCMSummarySource``
+    edges, and replaces the compacted context items with a single
+    ``item_kind="summary"`` row pointing at the new parent.
+
+    Returns:
+        ``True`` if a condensation pass ran, ``False`` if nothing to condense
+        (fewer than 2 eligible items).
+    """
+    # Fetch all context items pointing at summaries.
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+
+    summary_item_ids = [i.item_id for i in all_items if i.item_kind == "summary"]
+    if len(summary_item_ids) < 2:
+        return False
+
+    # Fetch the summaries to filter by depth.
+    s_result = await session.execute(
+        select(LCMSummary).where(LCMSummary.id.in_(summary_item_ids))
+    )
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {
+        s.id: s for s in s_result.scalars().all()
+    }
+
+    # Items eligible for condensation: context items pointing at depth-*d* summaries.
+    eligible: list[tuple[LCMContextItem, LCMSummary]] = [
+        (item, summaries_by_id[item.item_id])
+        for item in all_items
+        if item.item_kind == "summary"
+        and item.item_id in summaries_by_id
+        and summaries_by_id[item.item_id].depth == depth
+    ]
+
+    if len(eligible) < 2:
+        return False
+
+    # Build the batch (token-budget cap).
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item, summ in eligible:
+        toks = _approx_tokens(summ.content)
+        if running_tokens + toks > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append(
+            {
+                "role": "user",
+                "content": f"[Summary depth={summ.depth}]\n{summ.content}",
+            }
+        )
+        running_tokens += toks
+
+    if len(selected_items) < 2:
+        return False
+
+    # Summarise the batch.
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(
+        resolve_llm(_settings.lcm_summary_model or model_id, user_id=user_id),
+        turns_text,
+        user_id,
+    )
+
+    _log.info(
+        "LCM_CONDENSE depth=%d→%d conversation_id=%s sources=%d",
+        depth,
+        depth + 1,
+        conversation_id,
+        len(selected_items),
+    )
+
+    # Write parent LCMSummary.
+    parent = LCMSummary(
+        conversation_id=conversation_id,
+        depth=depth + 1,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=_settings.lcm_summary_model or model_id,
+        summary_kind=summary_kind,
+    )
+    session.add(parent)
+    await session.flush()
+
+    # Write source edges.
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    # Rewrite context items.
+    slot_ordinal = selected_items[0].ordinal
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=parent.id,
+        )
+    )
+    await session.flush()
+
+    return True
+
+
 async def compact_leaf_if_needed(
     session: AsyncSession,
     *,
@@ -375,5 +508,30 @@ async def compact_leaf_if_needed(
         )
     )
     await session.flush()
+
+    # ------------------------------------------------------------------ Condensation
+    # After leaf compaction, run incremental condensation passes so accumulated
+    # leaf summaries are folded into deeper parent nodes.
+    # ``lcm_incremental_max_depth`` controls how many passes to attempt:
+    #   0  = leaf-only (no condensation)
+    #   1  = one pass (leaf → depth-1)  [default]
+    #  -1  = unlimited cascade
+    if _settings.lcm_incremental_max_depth != 0:
+        passes = (
+            _settings.lcm_incremental_max_depth
+            if _settings.lcm_incremental_max_depth > 0
+            else 999  # unlimited practical cap
+        )
+        for depth in range(passes):
+            ran = await _condense_at_depth(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                depth=depth,
+                max_chunk_tokens=max_chunk_tokens,
+            )
+            if not ran:
+                break  # nothing more to condense at this depth or beyond
 
     return True

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -13,8 +13,18 @@ Public API
 ``compact_leaf_if_needed``   — summarise the oldest non-fresh items into a leaf
                                LCMSummary and rewrite lcm_context_items in place
 
-All functions are always importable; callers gate on ``settings.lcm_enabled``
+All functions are always importable; callers gate on ``is_enabled()``
 (default ``False``) before invoking them.
+
+Configuration helpers
+---------------------
+``is_enabled``           — return ``settings.lcm_enabled``
+``fresh_tail_count``     — return ``settings.lcm_fresh_tail_count``
+``leaf_chunk_tokens``    — return ``settings.lcm_leaf_chunk_tokens``
+
+These thin wrappers allow callers such as ``app.api.chat`` to access
+LCM-specific configuration through this module alone, without a direct
+``app.core.config`` import that would bloat their fan-out.
 """
 
 from __future__ import annotations
@@ -32,6 +42,26 @@ from app.core.providers import resolve_llm
 from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
 
 _log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration accessors
+# Thin wrappers so callers don't need a direct `app.core.config` import.
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return whether the LCM system is enabled."""
+    return _settings.lcm_enabled
+
+
+def fresh_tail_count() -> int:
+    """Return the number of context items kept verbatim (the fresh tail)."""
+    return _settings.lcm_fresh_tail_count
+
+
+def leaf_chunk_tokens() -> int:
+    """Return the maximum token budget for a single leaf compaction chunk."""
+    return _settings.lcm_leaf_chunk_tokens
 
 # ---------------------------------------------------------------------------
 # Summarisation prompts — three-level escalation mirrors the upstream plugin.
@@ -220,20 +250,33 @@ async def assemble_context(
 
     context: list[dict[str, Any]] = []
     for item in items:
-        if item.item_kind == "message":
-            msg = messages_by_id.get(item.item_id)
-            if msg is not None and msg.role in {"user", "assistant"}:
-                context.append({"role": msg.role, "content": msg.content or ""})
-        elif item.item_kind == "summary":
-            summary = summaries_by_id.get(item.item_id)
-            if summary is not None:
-                context.append(
-                    {
-                        "role": "user",
-                        "content": f"[Summary of earlier conversation]\n{summary.content}",
-                    }
-                )
+        entry = _resolve_context_item(item, messages_by_id, summaries_by_id)
+        if entry is not None:
+            context.append(entry)
     return context
+
+
+def _resolve_context_item(
+    item: LCMContextItem,
+    messages_by_id: dict[uuid.UUID, ChatMessage],
+    summaries_by_id: dict[uuid.UUID, LCMSummary],
+) -> dict[str, Any] | None:
+    """Resolve one LCMContextItem to a ``{role, content}`` dict, or ``None``.
+
+    Extracted to keep ``assemble_context``'s loop body within the nesting budget.
+    """
+    if item.item_kind == "message":
+        msg = messages_by_id.get(item.item_id)
+        if msg is not None and msg.role in {"user", "assistant"}:
+            return {"role": msg.role, "content": msg.content or ""}
+    elif item.item_kind == "summary":
+        summary = summaries_by_id.get(item.item_id)
+        if summary is not None:
+            return {
+                "role": "user",
+                "content": f"[Summary of earlier conversation]\n{summary.content}",
+            }
+    return None
 
 
 async def _condense_at_depth(

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -1,39 +1,133 @@
-"""Lossless Context Management — ingest and assembly (PR #2: fresh tail only).
+"""Lossless Context Management — ingest, assembly, and leaf compaction.
 
-This module is the primary code-path entry point for LCM.  All public
-functions are always importable; callers gate on ``settings.lcm_enabled``
-before calling them (or pass the flag explicitly in tests).
+PR history
+----------
+PR #1 — schema + models          (``app/models.py``, migration 012)
+PR #2 — ingest + assembly        (this module first landed)
+PR #3 — leaf compaction          (``compact_leaf_if_needed`` + updated assembly)
 
-PR #2 scope
------------
-*   ``ingest_message`` — record every new ChatMessage in ``lcm_context_items``
-    so that the assembled list mirrors the full message sequence.
-*   ``assemble_context`` — return the context window for a conversation turn
-    by reading ``lcm_context_items`` in ordinal order, fetching the backing
-    ChatMessage rows, and returning a list of ``{"role", "content"}`` dicts.
+Public API
+----------
+``ingest_message``           — record a new ChatMessage in lcm_context_items
+``assemble_context``         — build the [{role, content}] context list for a turn
+``compact_leaf_if_needed``   — summarise the oldest non-fresh items into a leaf
+                               LCMSummary and rewrite lcm_context_items in place
 
-Only ``item_kind="message"`` items exist at this stage.
-``item_kind="summary"`` support (for compacted nodes) is added in PR #3.
-
-Design note
------------
-Reading context via ``lcm_context_items`` rather than a raw
-``LIMIT fresh_tail_count`` on ``chat_messages`` is the main structural
-change in this PR.  The call site in ``chat.py`` looks identical, but now
-the assembly walks the context list — which PR #3 can rewrite in place with
-summary rows — rather than a simple ordered-message query.  The compaction
-PR therefore has zero blast radius on the assembly call site.
+All functions are always importable; callers gate on ``settings.lcm_enabled``
+(default ``False``) before invoking them.
 """
 
 from __future__ import annotations
 
+import logging
 import uuid
+from collections.abc import AsyncIterator
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import ChatMessage, LCMContextItem, LCMSummary
+from app.core.config import settings as _settings
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Summarisation prompts — three-level escalation mirrors the upstream plugin.
+# ---------------------------------------------------------------------------
+
+_PROMPT_NORMAL = """\
+You are a memory compressor for an AI assistant.  Summarise the following
+conversation extract into a compact but lossless paragraph.  Preserve every
+decision, fact, file name, error message, and instruction so the assistant can
+reconstruct the full context from your summary alone.  Output the summary only
+— no preamble, no commentary.
+
+{turns}"""
+
+_PROMPT_AGGRESSIVE = """\
+Summarise the following conversation in one tight paragraph.  Keep only the
+most important decisions, facts, and instructions.  Output the summary only.
+
+{turns}"""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token count: 4 characters ≈ 1 token (good enough for budgeting)."""
+    return max(1, len(text) // 4)
+
+
+def _format_turns(messages: list[dict[str, str]]) -> str:
+    """Format [{role, content}] as a plain-text transcript for the summary prompt."""
+    parts: list[str] = []
+    for m in messages:
+        role = m.get("role", "").upper()
+        content = m.get("content", "")
+        if content:
+            parts.append(f"{role}: {content}")
+    return "\n\n".join(parts)
+
+
+async def _collect_stream(stream: AsyncIterator[Any]) -> str:
+    """Consume a provider stream and return all concatenated delta text."""
+    parts: list[str] = []
+    async for event in stream:
+        if event.get("type") == "delta":
+            chunk = event.get("content") or ""
+            if chunk:
+                parts.append(chunk)
+    return "".join(parts).strip()
+
+
+async def _summarize(
+    provider: Any,
+    turns_text: str,
+    user_id: uuid.UUID,
+) -> tuple[str, str]:
+    """Call the provider to summarise a turn block.
+
+    Three-level escalation:
+    1. Normal prompt — full fidelity.
+    2. Aggressive prompt — shorter, if normal fails or returns empty.
+    3. Deterministic fallback — first 1 500 chars of the raw transcript.
+
+    Returns:
+        ``(summary_text, summary_kind)`` where ``summary_kind`` is one of
+        ``"normal"``, ``"aggressive"``, or ``"fallback"``.
+    """
+    for prompt_template, kind in (
+        (_PROMPT_NORMAL, "normal"),
+        (_PROMPT_AGGRESSIVE, "aggressive"),
+    ):
+        try:
+            stream = provider.stream(
+                question=prompt_template.format(turns=turns_text),
+                # Isolated fake conversation — not a real chat turn.
+                conversation_id=uuid.uuid4(),
+                user_id=user_id,
+                history=None,
+                tools=None,
+                system_prompt=None,
+            )
+            text = await _collect_stream(stream)
+            if text:
+                return text, kind
+        except Exception:
+            _log.warning("LCM_SUMMARIZE_%s_FAILED", kind.upper(), exc_info=True)
+
+    # Deterministic truncation — always produces output.
+    return turns_text[:1500], "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 async def ingest_message(
@@ -45,21 +139,12 @@ async def ingest_message(
     """Append a ChatMessage to the conversation's ``lcm_context_items`` list.
 
     Creates one :class:`~app.models.LCMContextItem` row with
-    ``item_kind="message"`` pointing at ``message_id``.  The ordinal is the
-    next free slot (``max(ordinal) + 1`` for the conversation, or ``0`` for
-    the very first message).
+    ``item_kind="message"`` at the next free ordinal slot
+    (``max(ordinal) + 1`` for the conversation, or ``0`` for the very first
+    message).
 
-    The caller must flush/commit the session after this call.  The function
-    itself calls ``session.flush()`` so the new row's ``id`` is populated
-    before returning.
-
-    Args:
-        session: Open async database session.
-        conversation_id: The conversation this message belongs to.
-        message_id: The :class:`~app.models.ChatMessage` ``id`` to record.
-
-    Returns:
-        The freshly inserted :class:`~app.models.LCMContextItem`.
+    The caller must commit the session after this call; the function calls
+    ``session.flush()`` so the new row's ``id`` is populated before returning.
     """
     result = await session.execute(
         select(func.max(LCMContextItem.ordinal)).where(
@@ -88,35 +173,22 @@ async def assemble_context(
 ) -> list[dict[str, Any]]:
     """Return the assembled context window for a conversation turn.
 
-    **PR #2 — fresh tail only.**  Fetches the last ``fresh_tail_count``
-    entries from ``lcm_context_items`` (ordered by ``ordinal`` DESC, then
-    reversed to restore ascending order), resolves each
-    ``item_kind="message"`` entry to its :class:`~app.models.ChatMessage`
-    row in a single batch query, and returns a list of
-    ``{"role": ..., "content": ...}`` dicts filtered to ``user`` /
-    ``assistant`` roles.
+    Fetches the last ``fresh_tail_count`` entries from ``lcm_context_items``
+    (DESC + LIMIT, then reversed to chronological order), resolves each entry
+    to its backing row, and returns a list of ``{"role": ..., "content": ...}``
+    dicts ready to pass to a provider's ``history`` parameter.
 
-    PR #3 (leaf compaction) will insert ``item_kind="summary"`` rows into
-    ``lcm_context_items`` as a in-place replacement for message ranges.
-    When that happens, this function only needs a new branch for
-    ``item_kind="summary"`` that fetches :class:`~app.models.LCMSummary`
-    content and injects it as a ``{"role": "assistant", "content":
-    summary.content}`` entry (or a dedicated ``system`` role — TBD).  The
-    chat-router call site does not change.
+    Item-kind handling:
 
-    Args:
-        session: Open async database session.
-        conversation_id: Conversation whose context to assemble.
-        fresh_tail_count: Maximum number of context-list items to return.
-            Matches ``settings.lcm_fresh_tail_count`` in production.
+    * ``"message"`` — resolved to its :class:`~app.models.ChatMessage`; only
+      ``user`` and ``assistant`` roles are included.
+    * ``"summary"`` — resolved to its :class:`~app.models.LCMSummary` and
+      injected as a synthetic ``user`` message with a
+      ``[Summary of earlier conversation]`` prefix so both the model and human
+      readers recognise it as compacted history rather than a real turn.
 
-    Returns:
-        List of ``{"role": str, "content": str}`` dicts in ascending ordinal
-        order (oldest first), ready to be passed directly to a provider's
-        ``history`` parameter.  Returns an empty list if no items exist yet.
+    Returns an empty list if no items exist yet.
     """
-    # DESC + LIMIT to get the tail cheaply, then reverse so callers receive
-    # messages in chronological order.
     result = await session.execute(
         select(LCMContextItem)
         .where(LCMContextItem.conversation_id == conversation_id)
@@ -129,21 +201,22 @@ async def assemble_context(
     if not items:
         return []
 
-    # ------------------------------------------------------------------
-    # PR #2: only "message" items exist; "summary" branch added in PR #3.
-    # ------------------------------------------------------------------
     message_ids = [item.item_id for item in items if item.item_kind == "message"]
+    summary_ids = [item.item_id for item in items if item.item_kind == "summary"]
 
-    if not message_ids:
-        return []
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        msg_result = await session.execute(
+            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+        )
+        messages_by_id = {m.id: m for m in msg_result.scalars().all()}
 
-    # One round-trip for all backing rows.
-    msg_result = await session.execute(
-        select(ChatMessage).where(ChatMessage.id.in_(message_ids))
-    )
-    messages_by_id: dict[uuid.UUID, ChatMessage] = {
-        m.id: m for m in msg_result.scalars().all()
-    }
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        sum_result = await session.execute(
+            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
+        )
+        summaries_by_id = {s.id: s for s in sum_result.scalars().all()}
 
     context: list[dict[str, Any]] = []
     for item in items:
@@ -151,4 +224,156 @@ async def assemble_context(
             msg = messages_by_id.get(item.item_id)
             if msg is not None and msg.role in {"user", "assistant"}:
                 context.append({"role": msg.role, "content": msg.content or ""})
+        elif item.item_kind == "summary":
+            summary = summaries_by_id.get(item.item_id)
+            if summary is not None:
+                context.append(
+                    {
+                        "role": "user",
+                        "content": f"[Summary of earlier conversation]\n{summary.content}",
+                    }
+                )
     return context
+
+
+async def compact_leaf_if_needed(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    fresh_tail_count: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one leaf-compaction pass if items exist outside the fresh tail.
+
+    Algorithm
+    ---------
+    1.  Fetch the full ``lcm_context_items`` list for the conversation.
+    2.  If ``total_items <= fresh_tail_count`` there is nothing to compact.
+    3.  The *eligible* items are the oldest ones that fall outside the fresh
+        tail (``all_items[:total - fresh_tail_count]``).  Only
+        ``item_kind="message"`` rows are compacted; existing summaries inside
+        the eligible window are left in place (they are already compact).
+    4.  Batch the oldest eligible messages up to ``max_chunk_tokens`` source
+        tokens (approximate; 4 chars ≈ 1 token).
+    5.  Call the provider (three-level escalation) to produce a summary.
+    6.  Persist: :class:`~app.models.LCMSummary` + one
+        :class:`~app.models.LCMSummarySource` per source message.
+    7.  Rewrite ``lcm_context_items``: delete the compacted message rows,
+        insert one ``item_kind="summary"`` row at the lowest freed ordinal
+        slot.  No dense renumbering is needed — ``ingest_message`` uses
+        ``max(ordinal) + 1`` so gaps are harmless.
+
+    Returns:
+        ``True`` if a compaction pass ran, ``False`` if there was nothing to
+        compact or the eligible window contained no un-compacted messages.
+    """
+    # ------------------------------------------------------------------ 1+2
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+    total = len(all_items)
+
+    if total <= fresh_tail_count:
+        return False
+
+    # ------------------------------------------------------------------ 3
+    # Eligible = items outside the fresh tail (oldest end).
+    eligible = all_items[: total - fresh_tail_count]
+    eligible_message_ids = [
+        item.item_id for item in eligible if item.item_kind == "message"
+    ]
+
+    if not eligible_message_ids:
+        return False  # Only summaries outside the fresh tail — nothing to do.
+
+    # ------------------------------------------------------------------ 4
+    msg_result = await session.execute(
+        select(ChatMessage).where(ChatMessage.id.in_(eligible_message_ids))
+    )
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {
+        m.id: m for m in msg_result.scalars().all()
+    }
+
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item in eligible:
+        if item.item_kind != "message":
+            continue
+        msg = messages_by_id.get(item.item_id)
+        if msg is None:
+            continue
+        msg_tokens = _approx_tokens(msg.content or "")
+        # Stop if we've already selected at least one and adding this one
+        # would exceed the chunk budget.
+        if running_tokens + msg_tokens > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append({"role": msg.role, "content": msg.content or ""})
+        running_tokens += msg_tokens
+
+    if not selected_items:
+        return False
+
+    # ------------------------------------------------------------------ 5
+    summary_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(summary_model, user_id=user_id)
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(provider, turns_text, user_id)
+
+    _log.info(
+        "LCM_COMPACT conversation_id=%s kind=%s sources=%d tokens=%d→%d",
+        conversation_id,
+        summary_kind,
+        len(selected_items),
+        running_tokens,
+        _approx_tokens(summary_text),
+    )
+
+    # ------------------------------------------------------------------ 6
+    summary_row = LCMSummary(
+        conversation_id=conversation_id,
+        depth=0,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=summary_model,
+        summary_kind=summary_kind,
+    )
+    session.add(summary_row)
+    await session.flush()
+
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=summary_row.id,
+                source_kind="message",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    # ------------------------------------------------------------------ 7
+    # Record the ordinal slot before deleting the items.
+    slot_ordinal = selected_items[0].ordinal
+
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=summary_row.id,
+        )
+    )
+    await session.flush()
+
+    return True

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -1,0 +1,154 @@
+"""Lossless Context Management — ingest and assembly (PR #2: fresh tail only).
+
+This module is the primary code-path entry point for LCM.  All public
+functions are always importable; callers gate on ``settings.lcm_enabled``
+before calling them (or pass the flag explicitly in tests).
+
+PR #2 scope
+-----------
+*   ``ingest_message`` — record every new ChatMessage in ``lcm_context_items``
+    so that the assembled list mirrors the full message sequence.
+*   ``assemble_context`` — return the context window for a conversation turn
+    by reading ``lcm_context_items`` in ordinal order, fetching the backing
+    ChatMessage rows, and returning a list of ``{"role", "content"}`` dicts.
+
+Only ``item_kind="message"`` items exist at this stage.
+``item_kind="summary"`` support (for compacted nodes) is added in PR #3.
+
+Design note
+-----------
+Reading context via ``lcm_context_items`` rather than a raw
+``LIMIT fresh_tail_count`` on ``chat_messages`` is the main structural
+change in this PR.  The call site in ``chat.py`` looks identical, but now
+the assembly walks the context list — which PR #3 can rewrite in place with
+summary rows — rather than a simple ordered-message query.  The compaction
+PR therefore has zero blast radius on the assembly call site.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+
+async def ingest_message(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    message_id: uuid.UUID,
+) -> LCMContextItem:
+    """Append a ChatMessage to the conversation's ``lcm_context_items`` list.
+
+    Creates one :class:`~app.models.LCMContextItem` row with
+    ``item_kind="message"`` pointing at ``message_id``.  The ordinal is the
+    next free slot (``max(ordinal) + 1`` for the conversation, or ``0`` for
+    the very first message).
+
+    The caller must flush/commit the session after this call.  The function
+    itself calls ``session.flush()`` so the new row's ``id`` is populated
+    before returning.
+
+    Args:
+        session: Open async database session.
+        conversation_id: The conversation this message belongs to.
+        message_id: The :class:`~app.models.ChatMessage` ``id`` to record.
+
+    Returns:
+        The freshly inserted :class:`~app.models.LCMContextItem`.
+    """
+    result = await session.execute(
+        select(func.max(LCMContextItem.ordinal)).where(
+            LCMContextItem.conversation_id == conversation_id
+        )
+    )
+    current_max = result.scalar()
+    next_ordinal = 0 if current_max is None else current_max + 1
+
+    item = LCMContextItem(
+        conversation_id=conversation_id,
+        ordinal=next_ordinal,
+        item_kind="message",
+        item_id=message_id,
+    )
+    session.add(item)
+    await session.flush()
+    return item
+
+
+async def assemble_context(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int,
+) -> list[dict[str, Any]]:
+    """Return the assembled context window for a conversation turn.
+
+    **PR #2 — fresh tail only.**  Fetches the last ``fresh_tail_count``
+    entries from ``lcm_context_items`` (ordered by ``ordinal`` DESC, then
+    reversed to restore ascending order), resolves each
+    ``item_kind="message"`` entry to its :class:`~app.models.ChatMessage`
+    row in a single batch query, and returns a list of
+    ``{"role": ..., "content": ...}`` dicts filtered to ``user`` /
+    ``assistant`` roles.
+
+    PR #3 (leaf compaction) will insert ``item_kind="summary"`` rows into
+    ``lcm_context_items`` as a in-place replacement for message ranges.
+    When that happens, this function only needs a new branch for
+    ``item_kind="summary"`` that fetches :class:`~app.models.LCMSummary`
+    content and injects it as a ``{"role": "assistant", "content":
+    summary.content}`` entry (or a dedicated ``system`` role — TBD).  The
+    chat-router call site does not change.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation whose context to assemble.
+        fresh_tail_count: Maximum number of context-list items to return.
+            Matches ``settings.lcm_fresh_tail_count`` in production.
+
+    Returns:
+        List of ``{"role": str, "content": str}`` dicts in ascending ordinal
+        order (oldest first), ready to be passed directly to a provider's
+        ``history`` parameter.  Returns an empty list if no items exist yet.
+    """
+    # DESC + LIMIT to get the tail cheaply, then reverse so callers receive
+    # messages in chronological order.
+    result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.desc())
+        .limit(fresh_tail_count)
+    )
+    items = list(result.scalars().all())
+    items.reverse()  # oldest first
+
+    if not items:
+        return []
+
+    # ------------------------------------------------------------------
+    # PR #2: only "message" items exist; "summary" branch added in PR #3.
+    # ------------------------------------------------------------------
+    message_ids = [item.item_id for item in items if item.item_kind == "message"]
+
+    if not message_ids:
+        return []
+
+    # One round-trip for all backing rows.
+    msg_result = await session.execute(
+        select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+    )
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {
+        m.id: m for m in msg_result.scalars().all()
+    }
+
+    context: list[dict[str, Any]] = []
+    for item in items:
+        if item.item_kind == "message":
+            msg = messages_by_id.get(item.item_id)
+            if msg is not None and msg.role in {"user", "assistant"}:
+                context.append({"role": msg.role, "content": msg.content or ""})
+    return context

--- a/backend/app/core/tools/lcm_describe.py
+++ b/backend/app/core/tools/lcm_describe.py
@@ -1,0 +1,126 @@
+"""LCM describe — cheap inspection of a single LCMSummary node.
+
+This is the backing implementation for the ``lcm_describe`` agent tool
+introduced in PR #5 of the LCM stack.
+
+Use case
+--------
+After ``lcm_grep`` returns a match inside a summary node, the agent may want
+to read the *full* summary text (not just the excerpt).  ``lcm_describe``
+fetches the complete node and its metadata in one cheap DB round-trip.
+
+It also exposes ``lcm_list_summaries`` so the agent can enumerate all summary
+nodes for the current conversation and pick the right one to inspect.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+
+def _format_summary(
+    summary: LCMSummary,
+    sources: list[LCMSummarySource],
+    *,
+    include_full_content: bool = True,
+) -> str:
+    """Format a summary node and its source edges as a readable string."""
+    lines: list[str] = [
+        f"Summary ID:   {summary.id}",
+        f"Depth:        {summary.depth}",
+        f"Kind:         {summary.summary_kind}",
+        f"Model:        {summary.model_id or '(unknown)'}",
+        f"Tokens:       ~{summary.token_count}",
+        f"Created:      {summary.created_at.isoformat()}",
+        f"Sources:      {len(sources)} item(s)",
+    ]
+    if sources:
+        for s in sources:
+            lines.append(f"  [{s.source_ordinal}] {s.source_kind} id={s.source_id}")
+    if include_full_content:
+        lines.append("")
+        lines.append("Content:")
+        lines.append(summary.content)
+    return "\n".join(lines)
+
+
+async def lcm_describe(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    summary_id: uuid.UUID,
+) -> str:
+    """Return the full content and metadata of a single LCMSummary node.
+
+    The lookup is scoped to *conversation_id* so the agent cannot inspect
+    summaries from other conversations even if it somehow obtains a foreign ID.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation the summary must belong to.
+        summary_id: UUID of the target :class:`~app.models.LCMSummary`.
+
+    Returns:
+        A formatted multi-line string with the summary's metadata and full
+        content, or an error string if not found.
+    """
+    result = await session.execute(
+        select(LCMSummary).where(
+            LCMSummary.id == summary_id,
+            LCMSummary.conversation_id == conversation_id,
+        )
+    )
+    summary = result.scalar_one_or_none()
+
+    if summary is None:
+        return (
+            f"lcm_describe: summary {summary_id} not found "
+            f"(may belong to a different conversation, or may not exist)."
+        )
+
+    sources_result = await session.execute(
+        select(LCMSummarySource)
+        .where(LCMSummarySource.summary_id == summary.id)
+        .order_by(LCMSummarySource.source_ordinal)
+    )
+    sources = list(sources_result.scalars().all())
+
+    return _format_summary(summary, sources, include_full_content=True)
+
+
+async def lcm_list_summaries(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+) -> str:
+    """List all LCMSummary nodes for a conversation, most-recent-first.
+
+    Returns a compact table showing each node's ID, depth, kind, and a
+    brief excerpt so the agent can decide which one to inspect further.
+    """
+    result = await session.execute(
+        select(LCMSummary)
+        .where(LCMSummary.conversation_id == conversation_id)
+        .order_by(LCMSummary.created_at.desc())
+    )
+    summaries = list(result.scalars().all())
+
+    if not summaries:
+        return "lcm_list_summaries: no summaries exist for this conversation yet."
+
+    header = f"lcm_list_summaries: {len(summaries)} node(s)\n"
+    rows: list[str] = []
+    for s in summaries:
+        excerpt = s.content[:120].replace("\n", " ")
+        if len(s.content) > 120:
+            excerpt += "…"
+        rows.append(
+            f"  id={s.id}  depth={s.depth}  kind={s.summary_kind}  "
+            f"tokens=~{s.token_count}\n    {excerpt}"
+        )
+    return header + "\n".join(rows)

--- a/backend/app/core/tools/lcm_describe_agent.py
+++ b/backend/app/core/tools/lcm_describe_agent.py
@@ -1,0 +1,130 @@
+"""Agent-loop adapter for the LCM describe tool (PR #5).
+
+Exposes two :class:`AgentTool` factories:
+
+* :func:`make_lcm_describe_tool` — inspect a specific summary by ID.
+* :func:`make_lcm_list_summaries_tool` — enumerate all summaries for
+  the current conversation (so the agent can find the right ID to pass
+  to ``lcm_describe``).
+
+Usage::
+
+    from app.core.tools.lcm_describe_agent import (
+        make_lcm_describe_tool,
+        make_lcm_list_summaries_tool,
+    )
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conv.id))
+        tools.append(make_lcm_describe_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import async_session_maker
+
+# ---------------------------------------------------------------------------
+# lcm_list_summaries
+# ---------------------------------------------------------------------------
+
+_LIST_TOOL_NAME = "lcm_list_summaries"
+
+_LIST_TOOL_DESCRIPTION = (
+    "List all compacted summary nodes for the current conversation, most-recent-first."
+    "  Each entry shows the summary ID, depth, kind, token count, and a brief excerpt."
+    "  Use this to discover which summary IDs are available before calling"
+    " ``lcm_describe`` to read one in full."
+)
+
+_LIST_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+
+def make_lcm_list_summaries_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that lists LCM summary nodes for a conversation.
+
+    Args:
+        conversation_id: Baked into the closure — the agent cannot list
+            summaries from other conversations.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        async with async_session_maker() as session:
+            return await lcm_list_summaries(
+                session, conversation_id=conversation_id
+            )
+
+    return AgentTool(
+        name=_LIST_TOOL_NAME,
+        description=_LIST_TOOL_DESCRIPTION,
+        parameters=_LIST_PARAMETERS,
+        execute=_execute,
+    )
+
+
+# ---------------------------------------------------------------------------
+# lcm_describe
+# ---------------------------------------------------------------------------
+
+_DESCRIBE_TOOL_NAME = "lcm_describe"
+
+_DESCRIBE_TOOL_DESCRIPTION = (
+    "Read the full content and metadata of a single compacted summary node."
+    "  Supply the summary ID (obtained via ``lcm_list_summaries`` or from a"
+    " ``[SUMMARY`` annotation in ``lcm_grep`` output)."
+    "  Returns the complete summary text and its source-edge list."
+    "  This is a cheap single-row lookup — use it freely to recover compacted"
+    " context without the overhead of a full expand_query sub-agent."
+)
+
+_DESCRIBE_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "summary_id": {
+            "type": "string",
+            "description": (
+                "UUID of the LCMSummary node to inspect."
+                " Obtain this from lcm_list_summaries or from a [SUMMARY ..."
+                " annotation in lcm_grep output."
+            ),
+        },
+    },
+    "required": ["summary_id"],
+}
+
+
+def make_lcm_describe_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that reads a specific LCMSummary in full.
+
+    Args:
+        conversation_id: Baked into the closure — prevents cross-conversation
+            inspection even if the agent passes a foreign UUID.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        raw_id = str(kwargs.get("summary_id") or "")
+        try:
+            sid = uuid.UUID(raw_id)
+        except ValueError:
+            return f"lcm_describe: invalid UUID {raw_id!r}"
+
+        async with async_session_maker() as session:
+            return await lcm_describe(
+                session,
+                conversation_id=conversation_id,
+                summary_id=sid,
+            )
+
+    return AgentTool(
+        name=_DESCRIBE_TOOL_NAME,
+        description=_DESCRIBE_TOOL_DESCRIPTION,
+        parameters=_DESCRIBE_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/core/tools/lcm_expand_query.py
+++ b/backend/app/core/tools/lcm_expand_query.py
@@ -53,6 +53,29 @@ If the answer is not in the history, say so explicitly.
 Be concise and cite specific turns or summary nodes when relevant."""
 
 
+def _item_to_turn(
+    item: LCMContextItem,
+    messages_by_id: dict[uuid.UUID, ChatMessage],
+    summaries_by_id: dict[uuid.UUID, LCMSummary],
+) -> dict[str, str] | None:
+    """Convert one LCMContextItem to a ``{role, content}`` turn dict, or ``None``.
+
+    Extracted to keep ``lcm_expand_query``'s loop body within the nesting budget.
+    """
+    if item.item_kind == "message":
+        msg = messages_by_id.get(item.item_id)
+        if msg and msg.role in {"user", "assistant"} and msg.content:
+            return {"role": msg.role, "content": msg.content}
+    elif item.item_kind == "summary":
+        summ = summaries_by_id.get(item.item_id)
+        if summ and summ.content:
+            return {
+                "role": "user",
+                "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
+            }
+    return None
+
+
 async def lcm_expand_query(
     session: AsyncSession,
     *,
@@ -122,19 +145,9 @@ async def lcm_expand_query(
     # Build the full-history transcript.
     turns: list[dict[str, str]] = []
     for item in items:
-        if item.item_kind == "message":
-            msg = messages_by_id.get(item.item_id)
-            if msg and msg.role in {"user", "assistant"} and msg.content:
-                turns.append({"role": msg.role, "content": msg.content})
-        elif item.item_kind == "summary":
-            summ = summaries_by_id.get(item.item_id)
-            if summ and summ.content:
-                turns.append(
-                    {
-                        "role": "user",
-                        "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
-                    }
-                )
+        turn = _item_to_turn(item, messages_by_id, summaries_by_id)
+        if turn is not None:
+            turns.append(turn)
 
     if not turns:
         return "lcm_expand_query: resolved to an empty history — nothing to answer."

--- a/backend/app/core/tools/lcm_expand_query.py
+++ b/backend/app/core/tools/lcm_expand_query.py
@@ -1,0 +1,167 @@
+"""LCM expand_query — bounded deep-recall via a single focused LLM call.
+
+This is the backing implementation for the ``lcm_expand_query`` agent tool
+introduced in PR #6 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin spawns an OpenClaw sub-agent that walks
+the full summary DAG.  We use our own infrastructure: instead of a real
+sub-agent, we make one focused LLM call with the *complete* conversation
+history — all LCMContextItems resolved in ordinal order, not just the
+fresh tail — and return its answer.
+
+This is "bounded" in the sense that:
+- It is a single-turn call, not a multi-turn loop.
+- Input is capped at MAX_EXPAND_ITEMS items so we don't exceed a model
+  context window even for very long conversations.
+- Errors are surfaced as descriptive strings, not exceptions, so the
+  calling agent can self-correct.
+
+When to use it vs. lcm_grep
+-----------------------------
+* ``lcm_grep``         — keyword/phrase search; cheap; returns excerpts.
+* ``lcm_describe``     — read one summary node in full; very cheap.
+* ``lcm_expand_query`` — "answer a question about the full history"; slower
+                         (one extra LLM call) but gives a synthesised answer.
+                         Use when grep returns an excerpt and you need the
+                         full story, or when the answer spans multiple
+                         compacted nodes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings as _settings
+from app.core.lcm import _collect_stream, _format_turns
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+# Hard cap so we never build a prompt larger than the model can handle.
+_MAX_EXPAND_ITEMS = 500
+
+_EXPAND_SYSTEM_PROMPT = """\
+You are a recall assistant.  You have access to the full history of a
+conversation (raw messages and compacted summaries, in chronological order).
+Answer the user's question based ONLY on what is present in this history.
+If the answer is not in the history, say so explicitly.
+Be concise and cite specific turns or summary nodes when relevant."""
+
+
+async def lcm_expand_query(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    prompt: str,
+) -> str:
+    """Answer *prompt* by running a focused LLM call over the full history.
+
+    Fetches ALL ``lcm_context_items`` for *conversation_id* (up to
+    ``_MAX_EXPAND_ITEMS``), resolves each one to its backing content,
+    assembles a transcript, and calls the model with *prompt* as the
+    user turn.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to expand.
+        user_id: Used to resolve provider API keys.
+        model_id: The model to use for the expansion call.  Falls back to
+            ``settings.lcm_summary_model`` if non-empty, then to model_id.
+        prompt: The question / retrieval task for the sub-call.
+
+    Returns:
+        The model's synthesised answer, or an error string if the call
+        fails or no history exists.
+    """
+    if not prompt.strip():
+        return "lcm_expand_query: empty prompt — nothing to answer."
+
+    # ------------------------------------------------------------------ 1
+    # Fetch the full context list (bounded).
+    items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+        .limit(_MAX_EXPAND_ITEMS)
+    )
+    items = list(items_result.scalars().all())
+
+    if not items:
+        return (
+            "lcm_expand_query: no conversation history found.  "
+            "The conversation may be empty or LCM ingest has not run yet."
+        )
+
+    # ------------------------------------------------------------------ 2
+    # Batch-resolve all backing rows.
+    message_ids = [i.item_id for i in items if i.item_kind == "message"]
+    summary_ids = [i.item_id for i in items if i.item_kind == "summary"]
+
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        m_res = await session.execute(
+            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+        )
+        messages_by_id = {m.id: m for m in m_res.scalars().all()}
+
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        s_res = await session.execute(
+            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
+        )
+        summaries_by_id = {s.id: s for s in s_res.scalars().all()}
+
+    # ------------------------------------------------------------------ 3
+    # Build the full-history transcript.
+    turns: list[dict[str, str]] = []
+    for item in items:
+        if item.item_kind == "message":
+            msg = messages_by_id.get(item.item_id)
+            if msg and msg.role in {"user", "assistant"} and msg.content:
+                turns.append({"role": msg.role, "content": msg.content})
+        elif item.item_kind == "summary":
+            summ = summaries_by_id.get(item.item_id)
+            if summ and summ.content:
+                turns.append(
+                    {
+                        "role": "user",
+                        "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
+                    }
+                )
+
+    if not turns:
+        return "lcm_expand_query: resolved to an empty history — nothing to answer."
+
+    history_text = _format_turns(turns)
+    expansion_prompt = (
+        f"CONVERSATION HISTORY:\n{history_text}\n\n"
+        f"QUESTION:\n{prompt}"
+    )
+
+    # ------------------------------------------------------------------ 4
+    # Single focused LLM call.
+    expand_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(expand_model, user_id=user_id)
+
+    try:
+        stream = provider.stream(
+            question=expansion_prompt,
+            conversation_id=uuid.uuid4(),  # isolated; not a real turn
+            user_id=user_id,
+            history=None,
+            tools=None,
+            system_prompt=_EXPAND_SYSTEM_PROMPT,
+        )
+        answer = await _collect_stream(stream)
+        if answer:
+            return answer
+        return "lcm_expand_query: the model returned an empty response."
+    except Exception as exc:
+        return f"lcm_expand_query: expansion call failed — {exc}"

--- a/backend/app/core/tools/lcm_expand_query_agent.py
+++ b/backend/app/core/tools/lcm_expand_query_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM expand_query tool (PR #6).
+
+Exposes :func:`make_lcm_expand_query_tool` which returns an
+:class:`AgentTool` for deep recall over the full conversation history.
+
+Usage::
+
+    from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
+
+    if settings.lcm_enabled:
+        tools.append(
+            make_lcm_expand_query_tool(
+                conversation_id=conv.id,
+                user_id=user.id,
+                model_id=model_id,
+            )
+        )
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_expand_query"
+
+_TOOL_DESCRIPTION = (
+    "Answer a question by reading the FULL conversation history — including"
+    " all compacted summary nodes AND raw messages — with a dedicated LLM call."
+    "  Use this when lcm_grep found a relevant excerpt but you need the complete"
+    " story, or when the answer likely spans multiple compacted nodes and a"
+    " summary cannot give you enough detail."
+    "  This tool makes an extra LLM call, so prefer lcm_grep or lcm_describe"
+    " for simple lookups."
+    "  Tip: be specific in your prompt — the better the question, the better"
+    " the answer."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": (
+                "The question or retrieval task to answer from the full"
+                " conversation history.  Be specific: include key terms,"
+                " names, or topics relevant to what you're looking for."
+            ),
+        },
+    },
+    "required": ["prompt"],
+}
+
+
+def make_lcm_expand_query_tool(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM deep-recall expansion.
+
+    Args:
+        conversation_id: The conversation to expand.  Baked in so the
+            agent cannot query other conversations.
+        user_id: Used to resolve provider API keys for the expansion call.
+        model_id: Default model for the expansion call.  May be overridden
+            by ``settings.lcm_summary_model`` if set.
+
+    Returns:
+        A configured :class:`AgentTool` ready for the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        prompt = str(kwargs.get("prompt") or "")
+        async with async_session_maker() as session:
+            return await lcm_expand_query(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                prompt=prompt,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/core/tools/lcm_grep.py
+++ b/backend/app/core/tools/lcm_grep.py
@@ -1,0 +1,158 @@
+"""LCM grep — search conversation history across messages and summaries.
+
+This is the backing implementation for the ``lcm_grep`` agent tool introduced
+in PR #4 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin uses SQLite FTS5 for full-text search.
+We run Postgres in production, where a dedicated ``tsvector`` index is the
+right long-term solution (tracked in ``.beans/lcm-followups.md``).  For this
+tracer-bullet PR we use ``ILIKE '%query%'`` which works on both SQLite (tests)
+and Postgres (production) without a schema migration.  The FTS upgrade can
+land in a follow-up once we have real production workloads to benchmark.
+
+Returned result format
+----------------------
+Each match is a compact block::
+
+    [MESSAGE role=user ordinal=12]
+    ...matching content excerpt...
+
+    [SUMMARY depth=0]
+    ...matching summary excerpt...
+
+Matches are capped at ``max_excerpt_chars`` per entry to keep the response
+token-efficient.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMSummary
+
+_MAX_RESULTS_DEFAULT = 10
+_MAX_EXCERPT_CHARS = 500
+
+
+def _excerpt(text: str, *, query: str, max_chars: int = _MAX_EXCERPT_CHARS) -> str:
+    """Return a snippet around the first occurrence of *query* in *text*.
+
+    The snippet is at most *max_chars* characters.  If the match is near
+    the start or end, the window shifts to fit; the edge is marked with ``…``
+    when content is elided.
+    """
+    text = text or ""
+    query_lower = query.lower()
+    pos = text.lower().find(query_lower)
+    if pos == -1:
+        # Shouldn't happen (we searched for the query), but handle gracefully.
+        return text[:max_chars] + ("…" if len(text) > max_chars else "")
+
+    half = max_chars // 2
+    start = max(0, pos - half)
+    end = min(len(text), pos + len(query) + half)
+
+    # Expand the window to *max_chars* if we hit an edge.
+    if start == 0:
+        end = min(len(text), max_chars)
+    if end == len(text):
+        start = max(0, len(text) - max_chars)
+
+    snippet = text[start:end]
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet = snippet + "…"
+    return snippet
+
+
+def _format_results(
+    message_hits: list[ChatMessage],
+    summary_hits: list[LCMSummary],
+    query: str,
+) -> str:
+    """Format matched rows as a compact markdown-ish string for the agent."""
+    if not message_hits and not summary_hits:
+        return f"No matches found for query: {query!r}"
+
+    parts: list[str] = []
+
+    for msg in message_hits:
+        exc = _excerpt(msg.content or "", query=query)
+        parts.append(f"[MESSAGE role={msg.role} ordinal={msg.ordinal}]\n{exc}")
+
+    for summ in summary_hits:
+        exc = _excerpt(summ.content or "", query=query)
+        parts.append(f"[SUMMARY depth={summ.depth} kind={summ.summary_kind}]\n{exc}")
+
+    header = (
+        f"lcm_grep: {len(message_hits)} message match(es), "
+        f"{len(summary_hits)} summary match(es) for {query!r}\n"
+    )
+    return header + "\n\n".join(parts)
+
+
+async def lcm_grep(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int = _MAX_RESULTS_DEFAULT,
+) -> str:
+    """Search a conversation's messages and summaries for *query*.
+
+    Performs case-insensitive substring matching across:
+
+    * ``chat_messages.content`` — raw user/assistant turns
+    * ``lcm_summaries.content`` — compacted history nodes
+
+    Both searches are scoped to *conversation_id*.  Results are ordered
+    most-recent-first and capped at *limit* per source.  The combined output
+    is formatted as a compact annotated text block suitable for direct
+    inclusion in an agent's tool result.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to search.
+        query: The search string.  Matched case-insensitively as a substring.
+        limit: Maximum number of results per source (messages + summaries each).
+
+    Returns:
+        A formatted string with matches and excerpts, or a "no matches"
+        message if nothing matched.
+    """
+    if not query.strip():
+        return "lcm_grep: empty query — nothing to search."
+
+    # SQLAlchemy's ``.ilike()`` emits ``ILIKE`` on Postgres and
+    # ``LIKE LOWER(...)`` on SQLite — both work for our needs.
+    msg_result = await session.execute(
+        select(ChatMessage)
+        .where(
+            ChatMessage.conversation_id == conversation_id,
+            ChatMessage.role.in_(["user", "assistant"]),
+            ChatMessage.content.ilike(f"%{query}%"),
+        )
+        .order_by(ChatMessage.ordinal.desc())
+        .limit(limit)
+    )
+    message_hits = list(msg_result.scalars().all())
+
+    sum_result = await session.execute(
+        select(LCMSummary)
+        .where(
+            LCMSummary.conversation_id == conversation_id,
+            LCMSummary.content.ilike(f"%{query}%"),
+        )
+        .order_by(LCMSummary.created_at.desc())
+        .limit(limit)
+    )
+    summary_hits = list(sum_result.scalars().all())
+
+    return _format_results(message_hits, summary_hits, query)

--- a/backend/app/core/tools/lcm_grep_agent.py
+++ b/backend/app/core/tools/lcm_grep_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM grep tool (PR #4).
+
+Exposes :func:`make_lcm_grep_tool` which returns an :class:`AgentTool`
+that the provider can append to ``AgentContext.tools``.  The actual DB
+search lives in :mod:`app.core.tools.lcm_grep`; this module only handles
+the JSON schema and the thin async wrapper the loop calls.
+
+Usage::
+
+    from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_grep_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_grep import _MAX_RESULTS_DEFAULT, lcm_grep
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_grep"
+
+_TOOL_DESCRIPTION = (
+    "Search the full history of this conversation — including any compacted"
+    " summaries — for a keyword or phrase.  Use this when you need to recall"
+    " something that may have been mentioned earlier but is no longer in your"
+    " current context window.  Returns matching excerpts from both raw messages"
+    " and summary nodes, annotated with their position in the conversation."
+    " Results are ordered most-recent-first.  Prefer short, distinctive search"
+    " terms (1-3 words) for best recall."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Keyword or phrase to search for.  Case-insensitive substring"
+                " match.  Use a short, distinctive term for best results."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"Maximum number of matches per source (messages + summaries"
+                f" searched independently).  Default {_MAX_RESULTS_DEFAULT}."
+            ),
+            "default": _MAX_RESULTS_DEFAULT,
+            "minimum": 1,
+            "maximum": 50,
+        },
+    },
+    "required": ["query"],
+}
+
+
+def make_lcm_grep_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM history search.
+
+    The tool opens its own database session per call so it is independent
+    of the request-scoped session.
+
+    Args:
+        conversation_id: The conversation to search.  Baked into the closure
+            at tool construction time so the agent cannot search other
+            conversations.
+
+    Returns:
+        A configured :class:`AgentTool` ready to be appended to the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        query = str(kwargs.get("query") or "")
+        limit = int(kwargs.get("limit") or _MAX_RESULTS_DEFAULT)
+        limit = max(1, min(50, limit))
+        async with async_session_maker() as session:
+            return await lcm_grep(
+                session,
+                conversation_id=conversation_id,
+                query=query,
+                limit=limit,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Text
 
@@ -310,4 +319,132 @@ class Workspace(Base):
     path: Mapped[str] = mapped_column(String(4096), nullable=False)
     # Exactly one workspace per user should be the default at any given time.
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Lossless Context Management (LCM) — DAG-based conversation summarisation.
+# ---------------------------------------------------------------------------
+#
+# Three tables form the storage layer for our adaptation of the Lossless
+# Context Management approach (originally a TypeScript OpenClaw plugin from
+# Martian-Engineering; we ported the core algorithm to Python so it lives
+# natively in our FastAPI + Postgres stack).  See docs/design/lcm.md and the
+# ``.beans/`` planning notes for the full picture.
+#
+# Schema shape:
+#
+#  - ``LCMSummary``     — a single summary node.  Every node has a ``depth``:
+#                          0 means "leaf summary" (summarised raw messages),
+#                          1+ means "condensed summary" (summarised summaries).
+#  - ``LCMSummarySource`` — link table from a summary to its source items
+#                            (either ChatMessage ids or other LCMSummary ids,
+#                            preserved as a typed pair so a summary can pull
+#                            from a mix of both during condensation).
+#  - ``LCMContextItem`` — the ordered "replacement list" we feed to the model
+#                          each turn.  Each row points at either a ChatMessage
+#                          (raw) or an LCMSummary (compacted).  Assembly walks
+#                          this list in ``ordinal`` order; compaction
+#                          rewrites it by replacing message ranges with a
+#                          summary row.
+
+
+class LCMSummary(Base):
+    """A single LCM summary node — either a leaf or a condensed parent."""
+
+    __tablename__ = "lcm_summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 0 = leaf (summarises raw messages); 1+ = condensed (summarises other
+    # summaries at depth-1).  Used by the condensation pass to decide which
+    # nodes are eligible for the next level up.
+    depth: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # The actual summary prose the model produced.
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Approximate token count of ``content`` — cached so the assembly + budget
+    # math doesn't have to re-tokenise on every turn.
+    token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Which model produced this summary (e.g. ``gemini-2.5-flash-preview-05-20``).
+    # Stored so future re-compaction can pick a stronger model if needed.
+    model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # "normal" | "aggressive" | "fallback" — mirrors the three-level escalation
+    # used by the upstream plugin: normal prompt first, aggressive if the
+    # output is too large, deterministic truncation if both LLM passes fail.
+    summary_kind: Mapped[str] = mapped_column(String(16), nullable=False, default="normal")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class LCMSummarySource(Base):
+    """Edge from an :class:`LCMSummary` to one of its source items.
+
+    A source is either a :class:`ChatMessage` (when the parent is a leaf
+    summary) or another :class:`LCMSummary` (when the parent is a condensed
+    summary).  ``source_kind`` discriminates between the two so a single
+    join + filter recovers either flavour.
+    """
+
+    __tablename__ = "lcm_summary_sources"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    summary_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("lcm_summaries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # "message" | "summary" — string discriminator so the FK can target either.
+    source_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    source_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    # Position in the original ordering so re-assembly is deterministic.
+    source_ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class LCMContextItem(Base):
+    """One entry in the assembled context list for a conversation.
+
+    Walking this table in ``ordinal`` order produces the sequence of items
+    fed to the provider every turn.  Each row points at either a raw
+    :class:`ChatMessage` or a compacted :class:`LCMSummary`; the chat
+    router resolves the actual content at assembly time.
+
+    Compaction rewrites this list in place: a contiguous range of
+    ``item_kind="message"`` rows is replaced by a single
+    ``item_kind="summary"`` row, and the ordinals are renumbered so the
+    list stays dense.
+    """
+
+    __tablename__ = "lcm_context_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Position in the assembled list.  Unique per conversation; renumbered
+    # densely on every compaction so an INSERT at the tail is always the
+    # next sequential integer.
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    # "message" | "summary" — the discriminator the assembly step uses to
+    # decide which lookup to perform.
+    item_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # FK target into either chat_messages or lcm_summaries depending on
+    # ``item_kind``.  We don't enforce the FK at the DB level because it
+    # would need a polymorphic constraint; cascades happen via the parent
+    # ``conversation_id`` FK.
+    item_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/tests/test_lcm_compaction.py
+++ b/backend/tests/test_lcm_compaction.py
@@ -1,0 +1,500 @@
+"""LCM PR #3 — leaf compaction tests.
+
+Covers:
+- compact_leaf_if_needed returns False when items ≤ fresh_tail_count.
+- compact_leaf_if_needed runs and returns True when there are items outside
+  the fresh tail.
+- After compaction: the source message items are replaced by a single
+  summary item; LCMSummary + LCMSummarySource rows are created.
+- The ordinal slot of the first compacted item is reused for the summary item.
+- Items inside the fresh tail are untouched.
+- max_chunk_tokens limits the compaction batch: messages beyond the token
+  budget are left in place.
+- Summary items already in the eligible window are left in place (not
+  re-compacted).
+- assemble_context after compaction returns the summary content + fresh tail.
+- Deterministic fallback is used when the provider raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context, compact_leaf_if_needed
+from app.core.providers.base import StreamEvent
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM compaction test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _seed_context(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    turns: list[tuple[str, str]],  # [(role, content), ...]
+) -> list[ChatMessage]:
+    """Insert N messages and their corresponding LCMContextItems."""
+    messages: list[ChatMessage] = []
+    for i, (role, content) in enumerate(turns):
+        msg = await _make_message(session, user, conv, role, content, i)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=i,
+                item_kind="message",
+                item_id=msg.id,
+            )
+        )
+        messages.append(msg)
+    await session.commit()
+    return messages
+
+
+def _make_fake_provider(summary_text: str = "SUMMARY") -> Any:
+    """Return a provider mock whose stream() yields a single delta."""
+
+    async def _fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type="delta", content=summary_text)
+
+    provider = MagicMock()
+    provider.stream = _fake_stream
+    return provider
+
+
+def _make_failing_provider() -> Any:
+    """Return a provider mock whose stream() raises immediately."""
+
+    async def _failing_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        raise RuntimeError("LLM unavailable")
+        yield  # make it an async generator
+
+    provider = MagicMock()
+    provider.stream = _failing_stream
+    return provider
+
+
+# Patch the provider resolution so compaction uses our mock.
+def _patch_resolve_llm(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    monkeypatch.setattr(_lcm, "resolve_llm", lambda *args, **kwargs: provider)
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_noop_when_within_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False when total items ≤ fresh_tail_count."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(db_session, test_user, conv, [("user", "hi"), ("assistant", "hello")])
+
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=5,  # larger than total items
+        max_chunk_tokens=100_000,
+    )
+
+    assert ran is False
+    # Provider should not have been called.
+    assert not provider.stream.called if hasattr(provider.stream, "called") else True
+
+
+@pytest.mark.anyio
+async def test_compact_noop_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False for an empty conversation."""
+    conv = await _make_conversation(db_session, test_user)
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_runs_when_items_exceed_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns True when compaction runs successfully."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "msg0"), ("assistant", "msg1"), ("user", "msg2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("compacted"))
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,  # last 2 kept; msg0 is eligible
+        max_chunk_tokens=100_000,
+    )
+    assert ran is True
+
+
+@pytest.mark.anyio
+async def test_compact_creates_summary_and_sources(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, LCMSummary and LCMSummarySource rows exist."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "hello"), ("assistant", "world"), ("user", "question")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("hello world summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].content == "hello world summary"
+    assert summaries[0].depth == 0
+    assert summaries[0].summary_kind == "normal"
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource).where(
+                LCMSummarySource.summary_id == summaries[0].id
+            )
+        )
+    ).scalars().all()
+    # Only msg0 ("hello") is outside the fresh tail of 2 and should be compacted.
+    assert len(sources) == 1
+    assert sources[0].source_kind == "message"
+    assert sources[0].source_id == msgs[0].id
+
+
+@pytest.mark.anyio
+async def test_compact_replaces_message_items_with_summary_item(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, the source message item is gone; a summary item takes its slot."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "reply"), ("user", "new")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary text"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 3 items before → 3 items after (summary + 2 message items in fresh tail).
+    assert len(items) == 3
+    # First item must now be the summary at the original slot 0.
+    assert items[0].item_kind == "summary"
+    assert items[0].ordinal == 0
+    # Fresh-tail items are still message items.
+    assert items[1].item_kind == "message"
+    assert items[2].item_kind == "message"
+    assert items[1].item_id == msgs[1].id
+    assert items[2].item_id == msgs[2].id
+
+
+@pytest.mark.anyio
+async def test_compact_multiple_eligible_messages(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When several messages are eligible, all are folded into one summary."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "a"),
+            ("assistant", "b"),
+            ("user", "c"),
+            ("assistant", "d"),  # fresh tail starts here
+            ("user", "e"),       # fresh tail end
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary abc"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 5 items → 1 summary + 2 fresh = 3 items total.
+    assert len(items) == 3
+    assert items[0].item_kind == "summary"
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # msgs 0, 1, 2 should all be sources of the summary.
+    source_ids = {s.source_id for s in sources}
+    assert msgs[0].id in source_ids
+    assert msgs[1].id in source_ids
+    assert msgs[2].id in source_ids
+    assert msgs[3].id not in source_ids  # fresh tail
+    assert msgs[4].id not in source_ids  # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# max_chunk_tokens budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_respects_token_budget(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the oldest messages that fit in max_chunk_tokens are compacted."""
+    conv = await _make_conversation(db_session, test_user)
+    # Each message is ~20 chars ≈ 5 tokens.  Budget of 6 tokens should fit only 1.
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "first message here"),   # ~5 tokens
+            ("assistant", "second one here"), # ~5 tokens
+            ("user", "fresh tail msg"),       # fresh tail
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("first only"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=1,  # only last 1 in fresh tail → 2 eligible
+        max_chunk_tokens=6,  # fits only the first message
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # Only the first message should be in sources.
+    assert len(sources) == 1
+    assert sources[0].source_id == msgs[0].id
+
+    # Second message (budget overflow) and third (fresh tail) should still be
+    # message items in lcm_context_items.
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+    kinds = [i.item_kind for i in items]
+    assert kinds[0] == "summary"
+    assert kinds[1] == "message"   # second message still in place
+    assert kinds[2] == "message"   # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_uses_fallback_when_provider_fails(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Uses deterministic truncation when the LLM provider raises."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old message"), ("assistant", "reply"), ("user", "fresh")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_failing_provider())
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    assert ran is True
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].summary_kind == "fallback"
+    # Deterministic fallback contains the raw transcript text.
+    assert "USER:" in summaries[0].content or "old message" in summaries[0].content
+
+
+# ---------------------------------------------------------------------------
+# assemble_context after compaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_after_compaction_returns_summary_plus_fresh(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, assemble_context returns [summary, *fresh_tail]."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "tail1"), ("user", "tail2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("the summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert len(context) == 3
+    # First entry is the injected summary.
+    assert context[0]["role"] == "user"
+    assert "[Summary of earlier conversation]" in context[0]["content"]
+    assert "the summary" in context[0]["content"]
+    # Then the fresh-tail messages.
+    assert context[1] == {"role": "assistant", "content": "tail1"}
+    assert context[2] == {"role": "user", "content": "tail2"}

--- a/backend/tests/test_lcm_condensation.py
+++ b/backend/tests/test_lcm_condensation.py
@@ -1,0 +1,517 @@
+"""LCM PR #7 — condensation pass tests.
+
+Covers:
+- _condense_at_depth returns False when < 2 depth-0 summaries exist.
+- _condense_at_depth returns True and creates a depth-1 parent summary.
+- Source edges on the parent summary point at the depth-0 child summaries.
+- The depth-0 context items are replaced by a single depth-1 item.
+- Token budget limits the condensation batch.
+- compact_leaf_if_needed triggers condensation when lcm_incremental_max_depth >= 1.
+- lcm_incremental_max_depth=0 skips condensation.
+- Two sequential compactions produce a depth-1 condensed summary.
+- assemble_context after condensation returns depth-1 summary + fresh tail.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import _condense_at_depth, assemble_context, compact_leaf_if_needed
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="condensation test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _insert_summary_item(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    ordinal: int,
+    depth: int = 0,
+) -> LCMSummary:
+    """Insert a depth-d LCMSummary + its LCMContextItem at the given ordinal."""
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+        summary_kind="normal",
+    )
+    session.add(s)
+    await session.flush()
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="summary",
+            item_id=s.id,
+        )
+    )
+    await session.flush()
+    return s
+
+
+async def _seed_context(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    turns: list[tuple[str, str]],
+) -> list[ChatMessage]:
+    messages: list[ChatMessage] = []
+    for i, (role, content) in enumerate(turns):
+        msg = await _make_message(session, user, conv, role, content, i)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+        messages.append(msg)
+    await session.commit()
+    return messages
+
+
+def _make_provider(answer: str = "CONDENSED") -> Any:
+    async def _stream(*a: Any, **kw: Any) -> AsyncIterator:
+        yield {"type": "delta", "content": answer}
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    monkeypatch.setattr(_lcm, "resolve_llm", lambda *a, **kw: provider)
+
+
+# ---------------------------------------------------------------------------
+# _condense_at_depth — gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_condense_noop_with_single_summary(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False when only 1 depth-0 summary exists."""
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "just one summary", ordinal=0, depth=0)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider())
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+@pytest.mark.anyio
+async def test_condense_noop_no_summaries(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    _patch(monkeypatch, _make_provider())
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# _condense_at_depth — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_condense_creates_depth1_parent(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("condensed AB"))
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    assert ran is True
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    depths = [s.depth for s in summaries]
+    # Two depth-0 + one depth-1.
+    assert depths.count(0) == 2
+    assert depths.count(1) == 1
+    parent = next(s for s in summaries if s.depth == 1)
+    assert parent.content == "condensed AB"
+
+
+@pytest.mark.anyio
+async def test_condense_source_edges_point_at_leaves(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    leaf_a = await _insert_summary_item(db_session, conv, "leaf A", ordinal=0)
+    leaf_b = await _insert_summary_item(db_session, conv, "leaf B", ordinal=1)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("parent"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    parent = (
+        await db_session.execute(
+            select(LCMSummary).where(
+                LCMSummary.conversation_id == conv.id,
+                LCMSummary.depth == 1,
+            )
+        )
+    ).scalar_one()
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource).where(
+                LCMSummarySource.summary_id == parent.id
+            )
+        )
+    ).scalars().all()
+
+    source_ids = {s.source_id for s in sources}
+    assert leaf_a.id in source_ids
+    assert leaf_b.id in source_ids
+    for s in sources:
+        assert s.source_kind == "summary"
+
+
+@pytest.mark.anyio
+async def test_condense_replaces_leaf_items_with_parent_item(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1)
+    # A raw message at ordinal 2 (shouldn't be touched).
+    msg = await _make_message(db_session, test_user, conv, "user", "tail", 2)
+    session = db_session
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
+        )
+    )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("parent"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 3 items before (2 leaf summaries + 1 message) →
+    # 2 items after (1 depth-1 summary + 1 message).
+    assert len(items) == 2
+    assert items[0].item_kind == "summary"
+    assert items[1].item_kind == "message"
+
+
+# ---------------------------------------------------------------------------
+# Integration with compact_leaf_if_needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_triggers_condensation_when_depth_ge_1(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After two leaf compactions, condensation should produce a depth-1 summary."""
+    conv = await _make_conversation(db_session, test_user)
+
+    # Seed enough messages so two separate compactions each produce one leaf summary.
+    for i in range(6):
+        role = "user" if i % 2 == 0 else "assistant"
+        msg = await _make_message(db_session, test_user, conv, role, f"msg{i}", i)
+        db_session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("compacted+condensed"))
+
+    # Patch settings so incremental_max_depth=1 and fresh_tail=2.
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    class _S:
+        lcm_summary_model = ""
+        lcm_fresh_tail_count = 2
+        lcm_leaf_chunk_tokens = 100_000
+        lcm_incremental_max_depth = 1
+
+    original = _lcm._settings
+    _lcm._settings = _S()  # type: ignore[assignment]
+    try:
+        # First compaction — compacts msgs 0-3 (4 items outside fresh tail of 2).
+        await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+
+        # Now the context has: [summary(depth=0)] + [msg4, msg5].
+        # There's only one depth-0 summary, so condensation is a no-op.
+        depth1_after_first = (
+            await db_session.execute(
+                select(LCMSummary).where(
+                    LCMSummary.conversation_id == conv.id,
+                    LCMSummary.depth == 1,
+                )
+            )
+        ).scalars().all()
+        assert len(depth1_after_first) == 0  # not enough leaves yet
+
+        # Add two more messages so there's something outside the fresh tail again.
+        for i in range(6, 8):
+            role = "user" if i % 2 == 0 else "assistant"
+            msg = await _make_message(db_session, test_user, conv, role, f"extra{i}", i)
+            db_session.add(
+                LCMContextItem(
+                    conversation_id=conv.id,
+                    ordinal=i,
+                    item_kind="message",
+                    item_id=msg.id,
+                )
+            )
+        await db_session.commit()
+
+        # Second compaction — the summary item (ordinal 0) is outside the fresh tail of 2.
+        # But wait — the eligible window is items OUTSIDE the fresh tail.
+        # We now have: [summary(0)][msg4(4-ish)][msg6(6)][msg7(7)].
+        # Fresh tail = 2 → tail is msg6+msg7.
+        # Eligible = summary(0) + msg4.
+        # The summary item_kind is "summary" so it won't be leaf-compacted...
+        # But msg4 is a message and IS eligible.
+        # After compaction of msg4: [summary(0), new_leaf_summary(4), msg6, msg7].
+        # Now there are 2 depth-0 summaries → condensation fires.
+        await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+    finally:
+        _lcm._settings = original  # type: ignore[assignment]
+
+    # After the second compaction + condensation pass, there should be a depth-1 summary.
+    all_summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    depths = [s.depth for s in all_summaries]
+    assert 1 in depths, f"Expected a depth-1 summary, got depths: {depths}"
+
+
+@pytest.mark.anyio
+async def test_compact_skips_condensation_when_depth_is_0(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """lcm_incremental_max_depth=0 means leaf-only, no condensation."""
+    conv = await _make_conversation(db_session, test_user)
+
+    # Pre-populate two depth-0 leaf summary context items.
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    # Add fresh messages.
+    for i in range(2, 4):
+        msg = await _make_message(db_session, test_user, conv, "user", f"m{i}", i)
+        db_session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("leaf"))
+
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    class _S:
+        lcm_summary_model = ""
+        lcm_fresh_tail_count = 2
+        lcm_leaf_chunk_tokens = 100_000
+        lcm_incremental_max_depth = 0  # <-- condensation disabled
+
+    original = _lcm._settings
+    _lcm._settings = _S()  # type: ignore[assignment]
+    try:
+        # compact_leaf_if_needed won't compact because the eligible items are
+        # summaries (item_kind="summary"), not messages.  So it returns False
+        # and no condensation runs.
+        ran = await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+    finally:
+        _lcm._settings = original  # type: ignore[assignment]
+
+    # ran=False because compact_leaf sees no message items to compact;
+    # condensation also did not run.
+    assert ran is False
+    depth1 = (
+        await db_session.execute(
+            select(LCMSummary).where(
+                LCMSummary.conversation_id == conv.id,
+                LCMSummary.depth == 1,
+            )
+        )
+    ).scalars().all()
+    assert len(depth1) == 0
+
+
+# ---------------------------------------------------------------------------
+# assemble_context after condensation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_after_condensation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After condensation, assemble_context returns depth-1 summary + fresh tail."""
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    msg = await _make_message(db_session, test_user, conv, "user", "fresh tail", 2)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
+        )
+    )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("depth-1 condensed"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert len(context) == 2
+    assert "[Summary of earlier conversation]" in context[0]["content"]
+    assert "depth-1 condensed" in context[0]["content"]
+    assert context[1] == {"role": "user", "content": "fresh tail"}

--- a/backend/tests/test_lcm_describe.py
+++ b/backend/tests/test_lcm_describe.py
@@ -1,0 +1,212 @@
+"""LCM PR #5 — lcm_describe tool tests.
+
+Covers:
+- lcm_describe returns metadata + full content for an existing summary.
+- lcm_describe returns an error string for an unknown summary_id.
+- lcm_describe is scoped to conversation_id (foreign ID returns error).
+- lcm_list_summaries returns a compact table for a conversation with summaries.
+- lcm_list_summaries returns "no summaries" for an empty conversation.
+- make_lcm_describe_tool and make_lcm_list_summaries_tool are present in
+  build_agent_tools when lcm_enabled=True.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import User
+from app.models import Conversation, LCMSummary, LCMSummarySource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="describe test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+    summary_kind: str = "normal",
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+        summary_kind=summary_kind,
+        model_id="gemini-2.5-flash",
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# lcm_describe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_describe_returns_metadata_and_content(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "User asked about deploying to Hetzner.")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert str(summary.id) in result
+    assert "depth" in result.lower()
+    assert "User asked about deploying" in result
+
+
+@pytest.mark.anyio
+async def test_describe_includes_source_edges(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "Summary with sources")
+    source_id = uuid.uuid4()
+    db_session.add(
+        LCMSummarySource(
+            summary_id=summary.id,
+            source_kind="message",
+            source_id=source_id,
+            source_ordinal=0,
+        )
+    )
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert "message" in result
+    assert str(source_id) in result
+
+
+@pytest.mark.anyio
+async def test_describe_unknown_id_returns_error(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=uuid.uuid4()
+    )
+    assert "not found" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_describe_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A summary from another conversation should not be visible."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    summary_b = await _make_summary(db_session, conv_b, "Private summary in conv B")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv_a.id, summary_id=summary_b.id
+    )
+    assert "not found" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# lcm_list_summaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_summaries_empty_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "no summaries" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_list_summaries_returns_all_nodes(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(3):
+        await _make_summary(db_session, conv, f"Summary {i} content")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "3 node" in result
+
+
+@pytest.mark.anyio
+async def test_list_summaries_shows_id_and_excerpt(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    s = await _make_summary(db_session, conv, "Unique content for listing test")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert str(s.id) in result
+    assert "Unique content" in result
+
+
+# ---------------------------------------------------------------------------
+# build_agent_tools integration
+# ---------------------------------------------------------------------------
+
+
+def test_describe_tools_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_describe" in names
+    assert "lcm_list_summaries" in names
+
+
+def test_describe_tools_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_describe" not in names
+    assert "lcm_list_summaries" not in names

--- a/backend/tests/test_lcm_expand_query.py
+++ b/backend/tests/test_lcm_expand_query.py
@@ -1,0 +1,323 @@
+"""LCM PR #6 — lcm_expand_query tool tests.
+
+Covers:
+- Empty prompt returns an informative error string.
+- Empty conversation (no context items) returns an error string.
+- expand_query calls the provider with a prompt that contains the full history.
+- Provider response is returned as the answer.
+- Provider failure returns an error string (no exception propagation).
+- Both message and summary items are included in the expansion context.
+- make_lcm_expand_query_tool is in build_agent_tools when lcm_enabled
+  and user_id is provided.
+- make_lcm_expand_query_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="expand test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="message",
+            item_id=msg.id,
+        )
+    )
+    await session.flush()
+    return msg
+
+
+async def _make_summary_item(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    ordinal: int,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="summary",
+            item_id=s.id,
+        )
+    )
+    await session.flush()
+    return s
+
+
+def _make_provider(answer: str) -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        yield {"type": "delta", "content": answer}
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _make_failing_provider() -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        raise RuntimeError("provider down")
+        yield
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    monkeypatch.setattr(_mod, "resolve_llm", lambda *a, **kw: provider)
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    class _Fake:
+        lcm_summary_model = ""
+
+    monkeypatch.setattr(_mod, "_settings", _Fake())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_expand_empty_prompt(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="",
+    )
+    assert "empty prompt" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    _patch_provider(monkeypatch, _make_provider("unused"))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was discussed?",
+    )
+    assert "no conversation history" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_returns_provider_answer(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello there", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_provider("The user greeted the assistant."))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What did the user say?",
+    )
+    assert "The user greeted" in result
+
+
+@pytest.mark.anyio
+async def test_expand_prompt_contains_full_history(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The expansion prompt sent to the provider should contain the full history."""
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "unique_marker_abc", 0)
+    await _make_summary_item(db_session, conv, "Earlier summary_marker_xyz", 1)
+    await db_session.commit()
+
+    captured_questions: list[str] = []
+
+    async def _capturing_stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        captured_questions.append(kwargs.get("question", ""))
+        yield {"type": "delta", "content": "captured"}
+
+    p = MagicMock()
+    p.stream = _capturing_stream
+    _patch_provider(monkeypatch, p)
+    _patch_settings(monkeypatch)
+
+    await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was in the history?",
+    )
+
+    assert captured_questions, "Provider was not called"
+    question_sent = captured_questions[0]
+    assert "unique_marker_abc" in question_sent
+    assert "summary_marker_xyz" in question_sent
+
+
+@pytest.mark.anyio
+async def test_expand_provider_failure_returns_error_string(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hi", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_failing_provider())
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What happened?",
+    )
+    assert "failed" in result.lower() or "error" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# build_agent_tools integration
+# ---------------------------------------------------------------------------
+
+
+def test_expand_query_tool_present_when_lcm_enabled(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pathlib import Path  # noqa: PLC0415
+
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=Path(tmp_path),
+        user_id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        model_id="gemini-2.5-flash",
+    )
+    names = [t.name for t in tools]
+    assert "lcm_expand_query" in names
+
+
+def test_expand_query_tool_absent_when_lcm_disabled(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pathlib import Path  # noqa: PLC0415
+
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=Path(tmp_path),
+        user_id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+    )
+    names = [t.name for t in tools]
+    assert "lcm_expand_query" not in names
+
+
+def test_expand_query_tool_absent_without_user_id(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """lcm_expand_query requires a user_id for API key resolution."""
+    from pathlib import Path  # noqa: PLC0415
+
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=Path(tmp_path),
+        user_id=None,  # no user_id
+        conversation_id=uuid.uuid4(),
+    )
+    names = [t.name for t in tools]
+    assert "lcm_expand_query" not in names

--- a/backend/tests/test_lcm_grep.py
+++ b/backend/tests/test_lcm_grep.py
@@ -1,0 +1,298 @@
+"""LCM PR #4 — lcm_grep tool tests.
+
+Covers:
+- Empty query returns a "nothing to search" message.
+- No matches returns a "no matches" message.
+- Message hits are returned with role + ordinal annotations.
+- Summary hits are returned with depth annotation.
+- Both message and summary hits are returned in the same call.
+- Search is case-insensitive.
+- Limit caps the result count per source.
+- Results are most-recent-first (by ordinal for messages, by created_at for summaries).
+- _excerpt trims long content around the match.
+- make_lcm_grep_tool is present in build_agent_tools when lcm_enabled.
+- make_lcm_grep_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_grep import _excerpt, lcm_grep
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="grep test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# _excerpt unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_excerpt_short_text_not_truncated() -> None:
+    result = _excerpt("hello world", query="world")
+    assert "hello world" in result
+    assert "…" not in result
+
+
+def test_excerpt_long_text_truncated_around_match() -> None:
+    padding = "x" * 300
+    text = padding + "TARGET" + padding
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert len(result) <= 110  # a bit of slack for ellipsis
+
+
+def test_excerpt_match_near_start() -> None:
+    text = "TARGET" + "y" * 600
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert result.startswith("TARGET") or result.startswith("…")
+
+
+def test_excerpt_no_match_returns_prefix() -> None:
+    text = "nothing here at all"
+    result = _excerpt(text, query="MISSING", max_chars=50)
+    # Should return the beginning of the text when there's no match.
+    assert "nothing" in result
+
+
+# ---------------------------------------------------------------------------
+# lcm_grep — query handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_grep_empty_query(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="")
+    assert "empty query" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_no_matches(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello world", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(
+        db_session, conversation_id=conv.id, query="NONEXISTENT_XYZZY"
+    )
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_finds_message_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "deploy to Hetzner VPS", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_finds_summary_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_summary(db_session, conv, "User discussed deploying the Hetzner VPS")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[SUMMARY" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_returns_both_message_and_summary_hits(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Hetzner config", 0)
+    await _make_summary(db_session, conv, "Earlier: set up Hetzner server")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "[SUMMARY" in result
+    assert "1 message match" in result
+    assert "1 summary match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_case_insensitive(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Deploy to HETZNER vps", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="hetzner")
+    assert "[MESSAGE" in result
+
+
+@pytest.mark.anyio
+async def test_grep_limit_caps_results(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(5):
+        await _make_message(
+            db_session, test_user, conv, "user", f"mention target {i}", i
+        )
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="target", limit=2)
+    # Should report 2 matches despite 5 messages matching.
+    assert "2 message match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Messages in other conversations must not appear in results."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv_b, "user", "secret banana", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv_a.id, query="banana")
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_excludes_system_role(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "system", "system needle here", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="needle")
+    assert "no matches" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# build_agent_tools integration
+# ---------------------------------------------------------------------------
+
+
+def test_lcm_grep_tool_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    conv_id = uuid.uuid4()
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=conv_id,
+    )
+    names = [t.name for t in tools]
+    assert "lcm_grep" in names
+
+
+def test_lcm_grep_tool_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+    )
+    names = [t.name for t in tools]
+    assert "lcm_grep" not in names
+
+
+def test_lcm_grep_tool_absent_when_no_conversation_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools  # noqa: PLC0415
+    from app.core import config as _cfg  # noqa: PLC0415
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=None)
+    names = [t.name for t in tools]
+    assert "lcm_grep" not in names

--- a/backend/tests/test_lcm_ingest.py
+++ b/backend/tests/test_lcm_ingest.py
@@ -1,0 +1,310 @@
+"""LCM PR #2 — ingest + assembly tests.
+
+Covers:
+- ``ingest_message`` creates an ``LCMContextItem`` with the correct ordinal
+  and ``item_kind="message"``.
+- Ordinals increment monotonically across consecutive ingests.
+- ``assemble_context`` with fresh-tail-only returns rows in ascending ordinal
+  order (oldest first), filtered to user/assistant roles.
+- ``assemble_context`` respects ``fresh_tail_count`` — only the last N items
+  are returned when the conversation is longer.
+- ``assemble_context`` returns an empty list for a brand-new conversation.
+- ``assemble_context`` silently skips ``item_kind="summary"`` rows (no
+  summaries exist in PR #2, but the guard must not crash — PR #3 will add
+  real coverage).
+- A ``ChatMessage`` with a role other than user/assistant (e.g. ``system``)
+  is filtered out.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context, ingest_message
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM ingest test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# ingest_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ingest_creates_context_item(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """``ingest_message`` inserts exactly one LCMContextItem."""
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(db_session, test_user, conv, "user", "hello", 0)
+
+    item = await ingest_message(
+        db_session, conversation_id=conv.id, message_id=msg.id
+    )
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(
+            select(LCMContextItem).where(LCMContextItem.id == item.id)
+        )
+    ).scalar_one()
+
+    assert fetched.item_kind == "message"
+    assert fetched.item_id == msg.id
+    assert fetched.conversation_id == conv.id
+    assert fetched.ordinal == 0
+
+
+@pytest.mark.anyio
+async def test_ingest_ordinals_increment(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Consecutive ingests get monotonically increasing ordinals."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = [
+        await _make_message(db_session, test_user, conv, role, f"msg {i}", i)
+        for i, role in enumerate(["user", "assistant", "user"])
+    ]
+
+    for msg in msgs:
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conv.id)
+        .order_by(LCMContextItem.ordinal)
+    )
+    items = result.scalars().all()
+    assert [item.ordinal for item in items] == [0, 1, 2]
+
+
+@pytest.mark.anyio
+async def test_ingest_ordinals_are_independent_per_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Each conversation has its own ordinal sequence starting at 0."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+
+    msg_a = await _make_message(db_session, test_user, conv_a, "user", "a0", 0)
+    msg_b0 = await _make_message(db_session, test_user, conv_b, "user", "b0", 0)
+    msg_b1 = await _make_message(db_session, test_user, conv_b, "assistant", "b1", 1)
+
+    await ingest_message(db_session, conversation_id=conv_a.id, message_id=msg_a.id)
+    await ingest_message(db_session, conversation_id=conv_b.id, message_id=msg_b0.id)
+    await ingest_message(db_session, conversation_id=conv_b.id, message_id=msg_b1.id)
+    await db_session.commit()
+
+    result_a = await db_session.execute(
+        select(LCMContextItem).where(LCMContextItem.conversation_id == conv_a.id)
+    )
+    result_b = await db_session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conv_b.id)
+        .order_by(LCMContextItem.ordinal)
+    )
+
+    items_a = result_a.scalars().all()
+    items_b = result_b.scalars().all()
+
+    assert len(items_a) == 1
+    assert items_a[0].ordinal == 0
+    assert len(items_b) == 2
+    assert [i.ordinal for i in items_b] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# assemble_context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_empty_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """An empty conversation returns an empty context list."""
+    conv = await _make_conversation(db_session, test_user)
+    result = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_assemble_returns_oldest_first(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """assemble_context returns messages in ascending ordinal order."""
+    conv = await _make_conversation(db_session, test_user)
+    turns = [
+        ("user", "hi"),
+        ("assistant", "hello"),
+        ("user", "how are you?"),
+    ]
+    for i, (role, text) in enumerate(turns):
+        msg = await _make_message(db_session, test_user, conv, role, text, i)
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert context == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "how are you?"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_assemble_respects_fresh_tail_count(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """fresh_tail_count caps the returned window to the most recent N items."""
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(5):
+        role = "user" if i % 2 == 0 else "assistant"
+        msg = await _make_message(db_session, test_user, conv, role, f"msg{i}", i)
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=3
+    )
+
+    # Last 3 ordinals are 2, 3, 4 → contents "msg2", "msg3", "msg4".
+    assert len(context) == 3
+    assert context[0]["content"] == "msg2"
+    assert context[-1]["content"] == "msg4"
+
+
+@pytest.mark.anyio
+async def test_assemble_filters_non_chat_roles(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Messages with roles other than user/assistant are excluded."""
+    conv = await _make_conversation(db_session, test_user)
+    user_msg = await _make_message(db_session, test_user, conv, "user", "hi", 0)
+    system_msg = await _make_message(db_session, test_user, conv, "system", "sys", 1)
+    asst_msg = await _make_message(
+        db_session, test_user, conv, "assistant", "hello", 2
+    )
+    for msg in (user_msg, system_msg, asst_msg):
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert context == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_assemble_skips_summary_items_without_crashing(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """item_kind='summary' rows are silently skipped (PR #3 adds real support).
+
+    Manually insert an LCMContextItem with item_kind='summary' pointing at a
+    real LCMSummary row to prove assemble_context doesn't raise; the summary
+    is not returned in the output list.
+    """
+    conv = await _make_conversation(db_session, test_user)
+
+    # Real LCMSummary so the FK target exists (even though FK is not enforced
+    # in SQLite, the row must be addressable for future Postgres runs).
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="some older context",
+        token_count=5,
+    )
+    db_session.add(summary)
+    await db_session.flush()
+
+    # Manually insert a summary context item at ordinal 0.
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=summary.id,
+        )
+    )
+
+    # A real message at ordinal 1.
+    msg = await _make_message(db_session, test_user, conv, "user", "visible", 0)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=1,
+            item_kind="message",
+            item_id=msg.id,
+        )
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    # Only the message is returned; the summary row is silently skipped.
+    assert context == [{"role": "user", "content": "visible"}]

--- a/backend/tests/test_lcm_ingest.py
+++ b/backend/tests/test_lcm_ingest.py
@@ -258,19 +258,16 @@ async def test_assemble_filters_non_chat_roles(
 
 
 @pytest.mark.anyio
-async def test_assemble_skips_summary_items_without_crashing(
+async def test_assemble_includes_summary_items(
     db_session: AsyncSession, test_user: User
 ) -> None:
-    """item_kind='summary' rows are silently skipped (PR #3 adds real support).
+    """item_kind='summary' rows are resolved and returned as synthetic user messages.
 
-    Manually insert an LCMContextItem with item_kind='summary' pointing at a
-    real LCMSummary row to prove assemble_context doesn't raise; the summary
-    is not returned in the output list.
+    PR #3 added real summary support to assemble_context.  Summaries are
+    injected as {"role": "user", "content": "[Summary of earlier conversation]\\n..."}.
     """
     conv = await _make_conversation(db_session, test_user)
 
-    # Real LCMSummary so the FK target exists (even though FK is not enforced
-    # in SQLite, the row must be addressable for future Postgres runs).
     summary = LCMSummary(
         conversation_id=conv.id,
         depth=0,
@@ -280,7 +277,7 @@ async def test_assemble_skips_summary_items_without_crashing(
     db_session.add(summary)
     await db_session.flush()
 
-    # Manually insert a summary context item at ordinal 0.
+    # Summary at ordinal 0, message at ordinal 1.
     db_session.add(
         LCMContextItem(
             conversation_id=conv.id,
@@ -290,7 +287,6 @@ async def test_assemble_skips_summary_items_without_crashing(
         )
     )
 
-    # A real message at ordinal 1.
     msg = await _make_message(db_session, test_user, conv, "user", "visible", 0)
     db_session.add(
         LCMContextItem(
@@ -306,5 +302,9 @@ async def test_assemble_skips_summary_items_without_crashing(
         db_session, conversation_id=conv.id, fresh_tail_count=64
     )
 
-    # Only the message is returned; the summary row is silently skipped.
-    assert context == [{"role": "user", "content": "visible"}]
+    # Summary comes first (ordinal 0), then the real message.
+    assert len(context) == 2
+    assert context[0]["role"] == "user"
+    assert context[0]["content"].startswith("[Summary of earlier conversation]")
+    assert "some older context" in context[0]["content"]
+    assert context[1] == {"role": "user", "content": "visible"}

--- a/backend/tests/test_lcm_schema.py
+++ b/backend/tests/test_lcm_schema.py
@@ -1,0 +1,182 @@
+"""Schema smoke tests for the LCM tables.
+
+This is the first PR in the LCM stack — only the storage layer exists,
+no application code reads or writes these tables yet.  The tests
+confirm:
+
+- The three tables exist with the expected columns.
+- Their cascade FK against ``conversations`` works (deleting a
+  conversation tears down all LCM rows).
+- A summary can hold zero or more sources, mixing ``message`` + ``summary``
+  source kinds in one parent.
+- The ``(conversation_id, ordinal)`` unique constraint on
+  ``lcm_context_items`` actually fires so compaction's dense renumber
+  is safe.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import User
+from app.models import (
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM schema test",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+@pytest.mark.anyio
+async def test_summary_insert_round_trips(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="The user asked about deploying Pawrrtal on a VPS.",
+        token_count=12,
+        model_id="gemini-2.5-flash-preview-05-20",
+        summary_kind="normal",
+    )
+    db_session.add(summary)
+    await db_session.commit()
+    await db_session.refresh(summary)
+
+    fetched = (
+        await db_session.execute(select(LCMSummary).where(LCMSummary.id == summary.id))
+    ).scalar_one()
+    assert fetched.content.startswith("The user asked about deploying")
+    assert fetched.depth == 0
+    assert fetched.summary_kind == "normal"
+
+
+@pytest.mark.anyio
+async def test_summary_sources_support_mixed_kinds(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A condensed parent can point at a mix of message + summary sources."""
+    conv = await _make_conversation(db_session, test_user)
+    parent = LCMSummary(conversation_id=conv.id, depth=1, content="parent")
+    db_session.add(parent)
+    await db_session.commit()
+    await db_session.refresh(parent)
+
+    db_session.add_all(
+        [
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="message",
+                source_id=uuid.uuid4(),
+                source_ordinal=0,
+            ),
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=uuid.uuid4(),
+                source_ordinal=1,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource)
+            .where(LCMSummarySource.summary_id == parent.id)
+            .order_by(LCMSummarySource.source_ordinal)
+        )
+    ).scalars().all()
+    assert [s.source_kind for s in sources] == ["message", "summary"]
+
+
+@pytest.mark.anyio
+async def test_context_items_have_unique_conversation_ordinal(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Two items can't share the same (conversation_id, ordinal)."""
+    conv = await _make_conversation(db_session, test_user)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="message",
+            item_id=uuid.uuid4(),
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=uuid.uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+def test_cascade_metadata_is_declared() -> None:
+    """Pin the ``ON DELETE CASCADE`` metadata on every LCM FK.
+
+    Runtime cascade behaviour is not exercised here — the SQLite test
+    harness uses ``Base.metadata.create_all`` without enabling
+    ``PRAGMA foreign_keys=ON``, so cascades are inert in tests.  Postgres
+    (where the migration runs in production) enforces them; this test
+    just makes sure the *declaration* is correct so a future model edit
+    can't silently drop the cascade.
+    """
+    from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+    expected_cascades = {
+        (LCMSummary.__table__, "conversation_id"): "CASCADE",
+        (LCMSummarySource.__table__, "summary_id"): "CASCADE",
+        (LCMContextItem.__table__, "conversation_id"): "CASCADE",
+    }
+    for (table, column_name), expected in expected_cascades.items():
+        matching_fks = [
+            fk
+            for fk in table.foreign_keys
+            if fk.parent.name == column_name
+        ]
+        assert matching_fks, f"missing FK on {table.name}.{column_name}"
+        assert matching_fks[0].ondelete == expected, (
+            f"{table.name}.{column_name} expected ondelete={expected!r} "
+            f"got {matching_fks[0].ondelete!r}"
+        )
+
+
+def test_lcm_settings_have_safe_defaults() -> None:
+    """Schema-only PR must NOT change runtime behaviour for existing deploys."""
+    from app.core.config import settings
+
+    # Master switch off so no chat-router code path is altered.
+    assert settings.lcm_enabled is False
+    # Sensible numeric defaults match the upstream plugin.
+    assert settings.lcm_fresh_tail_count == 64
+    assert settings.lcm_leaf_chunk_tokens == 20000
+    assert 0.0 < settings.lcm_context_threshold <= 1.0

--- a/docs/design/lcm.md
+++ b/docs/design/lcm.md
@@ -1,0 +1,70 @@
+# Lossless Context Management (LCM) for Pawrrtal
+
+**Status:** in progress — schema landed, runtime activation in stacked PRs
+**Inspiration:** [Martian-Engineering/lossless-claw](https://github.com/Martian-Engineering/lossless-claw) (TypeScript, OpenClaw plugin)
+**Why a port instead of vendoring:** lossless-claw plugs into the OpenClaw `ContextEngine` lifecycle that doesn't exist in our FastAPI + Postgres stack.  Re-implementing the algorithm natively beats stitching a Node.js sidecar into every chat turn.
+
+## Problem
+
+Today the chat router does `chat_messages` `ORDER BY ordinal LIMIT 20`.  Anything older than the last 20 messages is invisible to the model.  Long conversations silently lose continuity.
+
+## Approach
+
+A DAG of summaries that grows as a conversation grows:
+
+1. **Persist every message** (we already do this in `chat_messages`).
+2. **Periodically summarise** the oldest non-protected messages into a **leaf summary**.
+3. **Condense** accumulated leaf summaries into deeper parent summaries to keep the assembled list short.
+4. **Assemble** each turn's prompt from: (a) the protected **fresh tail** of recent raw messages + (b) as many of the most recent summary/message items as fit in the model's window.
+
+## Data model (this PR — #1 of the stack)
+
+Three tables in `app/models.py`:
+
+| Table | Role |
+| --- | --- |
+| `lcm_summaries` | A summary node.  `depth=0` is a leaf (summarises raw messages); `depth>=1` is a condensed parent. |
+| `lcm_summary_sources` | Link table from a summary to its source items.  `source_kind` discriminates `message` vs `summary`. |
+| `lcm_context_items` | The ordered "replacement list" assembled per turn.  Each row points at a `ChatMessage` (raw) or an `LCMSummary` (compacted).  Compaction rewrites rows in place. |
+
+See `app/models.py` for the SQLAlchemy definitions and inline comments.
+
+## Config
+
+All settings default OFF / safe — adding the schema doesn't change behaviour for any existing deployment.
+
+| Env / setting | Default | Meaning |
+| --- | --- | --- |
+| `LCM_ENABLED` | `false` | Master switch.  Later stack PRs gate every code path on this. |
+| `LCM_FRESH_TAIL_COUNT` | `64` | Recent messages always kept verbatim. |
+| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Source-token ceiling per leaf summary. |
+| `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of model window that triggers auto-compaction. |
+| `LCM_INCREMENTAL_MAX_DEPTH` | `1` | Condensation passes per leaf compaction.  `-1` = unlimited. |
+| `LCM_SUMMARY_MODEL` | (unset → same as conversation) | Model used for summarisation calls. |
+
+## Stack roadmap
+
+This PR ships **schema only**.  Subsequent PRs in the stack:
+
+1. ✅ **Schema + models** (this PR)
+2. ⏭ **Ingest + assembly** — wire every ChatMessage into an `LCMContextItem`; replace `LIMIT 20` with `assemble_context()` (fresh tail only at first)
+3. ⏭ **Leaf compaction** — first real summarisation pass
+4. ⏭ **`lcm_grep` tool** — agent-callable history search
+5. ⏭ **`lcm_describe` tool** — cheap summary inspection
+6. ⏭ **`lcm_expand_query` tool** — bounded sub-agent for deep recall
+7. ⏭ **Condensation pass** — depth-1+ summaries
+
+Each is a tracer-bullet PR — one main feature, end-to-end, minimal scope.  Things deferred from each PR are captured in `.beans/lcm-followups.md`.
+
+## Why this design and not theirs verbatim
+
+The upstream plugin makes excellent choices that we adopt:
+- DAG of summaries, not a flat rolling buffer.
+- Fresh-tail protection so recent context is never compressed.
+- Three-level escalation (normal prompt → aggressive → deterministic truncation).
+- Tool surface (`grep`, `describe`, `expand_query`) so the agent can drill into compacted history on demand.
+
+Where we diverge:
+- **Postgres, not SQLite.**  We already run Postgres; adding SQLite for one feature would mean two DB volumes and two migration stories.
+- **In-process, not subagent-spawning via plugin SDK.**  Their `lcm_expand_query` spawns an OpenClaw sub-agent through the plugin runtime.  We'll use our existing agent_loop infrastructure when we get to that PR.
+- **No `/lcm doctor` command yet.**  Operational tooling can come later — health probes already cover the obvious failure modes.


### PR DESCRIPTION
## What this is

First PR in a stacked series that ports the **Lossless Context Management** algorithm into Pawrrtal.  Inspired by Martian-Engineering's TypeScript OpenClaw plugin; rebuilt natively in Python + Postgres because their plugin shell can't run inside our FastAPI stack.

See `docs/design/lcm.md` for the full plan and `.beans/lcm-followups.md` for the running deferred-work list.

## Stack roadmap

1. ✅ **schema + models** — *this PR*
2. ⏭ ingest + assembly (fresh tail only)
3. ⏭ leaf compaction
4. ⏭ `lcm_grep` tool
5. ⏭ `lcm_describe` tool
6. ⏭ `lcm_expand_query`
7. ⏭ condensation pass

Each is a small tracer-bullet PR.  Deferred items per step go into `.beans/lcm-followups.md`.

## What lands here (schema only)

### Three new ORM classes in `backend/app/models.py`

- **`LCMSummary`** — a summary node.  `depth=0` is a leaf (summarises raw messages); `depth>=1` is a condensed parent.  Carries `summary_kind` (`normal` / `aggressive` / `fallback`) for the three-level escalation we'll implement in PR #3.
- **`LCMSummarySource`** — link table from a summary to its source items.  String discriminator (`source_kind=message|summary`) so one parent can mix raw messages and child summaries during condensation.
- **`LCMContextItem`** — the ordered 'replacement list' walked per turn.  Each row points at either a `ChatMessage` or an `LCMSummary`.  Compaction rewrites this list in place by replacing a contiguous range of message rows with a summary row, then renumbering ordinals densely.

### Alembic migration `012_add_lcm_tables`

Creates the three tables + indices + the unique `(conversation_id, ordinal)` constraint on `lcm_context_items` so compaction's renumber stays safe.

### Settings (default-off)

```env
LCM_ENABLED=false                    # master switch
LCM_FRESH_TAIL_COUNT=64              # recent messages always kept verbatim
LCM_LEAF_CHUNK_TOKENS=20000          # source-token ceiling per leaf summary
LCM_CONTEXT_THRESHOLD=0.75           # fraction of window that triggers compaction
LCM_INCREMENTAL_MAX_DEPTH=1          # condensation passes per compaction (-1 = unlimited)
LCM_SUMMARY_MODEL=                   # override; falls back to conversation model
```

Defaults match the upstream plugin's choices.

### Docs

- `docs/design/lcm.md` — problem, approach, schema, config, roadmap, divergence from upstream
- `.beans/lcm-followups.md` — deferred-work running list

## What's deliberately NOT in this PR

- Any code that reads or writes the new tables (PR #2)
- Compaction logic (PR #3)
- Agent tools: `lcm_grep`, `lcm_describe`, `lcm_expand_query` (PRs #4-6)
- Condensation pass (PR #7)
- `/lcm` operational commands (deferred indefinitely)

Because `LCM_ENABLED` defaults to `false`, this PR **cannot** change runtime behaviour for any existing deployment.  It's a pure data-model addition.

## Tests (5 new)

`backend/tests/test_lcm_schema.py`:
- Summary insert round-trips with all fields preserved.
- `lcm_summary_sources` accepts a mix of `message` + `summary` discriminators in a single parent (the condensation use case).
- `(conversation_id, ordinal)` unique constraint actually fires on conflict.
- Every LCM FK declares `ON DELETE CASCADE` (runtime cascade is enforced by Postgres in prod — SQLite tests can't exercise it without enabling `PRAGMA foreign_keys=ON`, which would scope-creep this PR.  Metadata pin is enough to catch a future regression.)
- LCM settings have safe off-by-default values.

Full backend suite: **374 passed, 2 skipped, 0 failed** (was 369; +5 new).

## Why a Python port instead of vendoring their code

The upstream plugin is built around OpenClaw's `ContextEngine` plugin lifecycle (bootstrap / ingest / assemble / afterTurn / compact) — none of which exists in our FastAPI codebase.  Stitching a Node.js sidecar in for every chat turn would add deploy complexity for one feature.  Porting the algorithm to Python is ~800-1200 LOC across the stack vs.~ ~5k LOC of plugin shell coupled with OpenClaw's gateway runtime.

We kept their core architectural choices (DAG, fresh-tail protection, three-level escalation, the tool surface) and adapted the storage (SQLite → Postgres) and integration point (plugin lifecycle → FastAPI route + agent_tools).