### PR TITLE
feat(lcm): ORM models + Alembic migration [2/11]

### DIFF
--- a/backend/alembic/versions/012_add_lcm_tables.py
+++ b/backend/alembic/versions/012_add_lcm_tables.py
@@ -1,0 +1,150 @@
+"""Add LCM (Lossless Context Management) tables.
+
+Three tables form the storage layer for our adaptation of the LCM
+approach (originally a TypeScript OpenClaw plugin from
+Martian-Engineering; we ported the core algorithm to Python).
+
+This migration only creates the schema — no application code reads or
+writes these tables until later stack PRs.  Shipping the schema first
+lets us land the migration cleanly without worrying about runtime
+behaviour changes.
+
+Revision ID: 012_add_lcm_tables
+Revises: 011_add_channel_columns_and_attachment
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "012_add_lcm_tables"
+down_revision = "011_add_channel_columns_and_attachment"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the three LCM tables and their supporting indices."""
+    op.create_table(
+        "lcm_summaries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("depth", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "token_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("model_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "summary_kind",
+            sa.String(length=16),
+            nullable=False,
+            server_default="normal",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_id",
+        "lcm_summaries",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_depth",
+        "lcm_summaries",
+        ["conversation_id", "depth"],
+    )
+
+    op.create_table(
+        "lcm_summary_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("summary_id", sa.Uuid(), nullable=False),
+        sa.Column("source_kind", sa.String(length=16), nullable=False),
+        sa.Column("source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_ordinal", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["summary_id"], ["lcm_summaries.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_summary_id",
+        "lcm_summary_sources",
+        ["summary_id"],
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_source_id",
+        "lcm_summary_sources",
+        ["source_id"],
+    )
+
+    op.create_table(
+        "lcm_context_items",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("item_kind", sa.String(length=16), nullable=False),
+        sa.Column("item_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # Unique (conversation_id, ordinal) so compaction can renumber
+        # densely without colliding mid-transaction.
+        sa.UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+    op.create_index(
+        "ix_lcm_context_items_conversation_id",
+        "lcm_context_items",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_context_items_item_id",
+        "lcm_context_items",
+        ["item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_lcm_context_items_item_id", table_name="lcm_context_items"
+    )
+    op.drop_index(
+        "ix_lcm_context_items_conversation_id", table_name="lcm_context_items"
+    )
+    op.drop_table("lcm_context_items")
+
+    op.drop_index(
+        "ix_lcm_summary_sources_source_id", table_name="lcm_summary_sources"
+    )
+    op.drop_index(
+        "ix_lcm_summary_sources_summary_id", table_name="lcm_summary_sources"
+    )
+    op.drop_table("lcm_summary_sources")
+
+    op.drop_index(
+        "ix_lcm_summaries_conversation_depth", table_name="lcm_summaries"
+    )
+    op.drop_index(
+        "ix_lcm_summaries_conversation_id", table_name="lcm_summaries"
+    )
+    op.drop_table("lcm_summaries")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Text
 
@@ -310,4 +310,102 @@ class Workspace(Base):
     path: Mapped[str] = mapped_column(String(4096), nullable=False)
     # Exactly one workspace per user should be the default at any given time.
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class LCMSummary(Base):
+    """A single LCM summary node — either a leaf or a condensed parent."""
+
+    __tablename__ = "lcm_summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 0 = leaf (summarises raw messages); 1+ = condensed (summarises other
+    # summaries at depth-1).  Used by the condensation pass to decide which
+    # nodes are eligible for the next level up.
+    depth: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # The actual summary prose the model produced.
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Approximate token count of ``content`` — cached so the assembly + budget
+    # math doesn't have to re-tokenise on every turn.
+    token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Which model produced this summary (e.g. ``gemini-2.5-flash-preview-05-20``).
+    # Stored so future re-compaction can pick a stronger model if needed.
+    model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # "normal" | "aggressive" | "fallback" — mirrors the three-level escalation
+    # used by the upstream plugin: normal prompt first, aggressive if the
+    # output is too large, deterministic truncation if both LLM passes fail.
+    summary_kind: Mapped[str] = mapped_column(String(16), nullable=False, default="normal")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class LCMSummarySource(Base):
+    """Edge from an :class:`LCMSummary` to one of its source items.
+
+    A source is either a :class:`ChatMessage` (when the parent is a leaf
+    summary) or another :class:`LCMSummary` (when the parent is a condensed
+    summary).  ``source_kind`` discriminates between the two so a single
+    join + filter recovers either flavour.
+    """
+
+    __tablename__ = "lcm_summary_sources"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    summary_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("lcm_summaries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # "message" | "summary" — string discriminator so the FK can target either.
+    source_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    source_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    # Position in the original ordering so re-assembly is deterministic.
+    source_ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class LCMContextItem(Base):
+    """One entry in the assembled context list for a conversation.
+
+    Walking this table in ``ordinal`` order produces the sequence of items
+    fed to the provider every turn.  Each row points at either a raw
+    :class:`ChatMessage` or a compacted :class:`LCMSummary`; the chat
+    router resolves the actual content at assembly time.
+
+    Compaction rewrites this list in place: a contiguous range of
+    ``item_kind="message"`` rows is replaced by a single
+    ``item_kind="summary"`` row, and the ordinals are renumbered so the
+    list stays dense.
+    """
+
+    __tablename__ = "lcm_context_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Position in the assembled list.  Gaps are harmless; ingest_message
+    # uses max(ordinal)+1 so no dense renumbering after compaction.
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    # "message" | "summary" — the discriminator the assembly step uses to
+    # decide which lookup to perform.
+    item_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # FK target into either chat_messages or lcm_summaries depending on
+    # ``item_kind``.  Cascades happen via the parent conversation_id FK.
+    item_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/tests/test_lcm_schema.py
+++ b/backend/tests/test_lcm_schema.py
@@ -1,0 +1,172 @@
+"""Schema smoke tests for the LCM tables.
+
+This is the first PR in the LCM stack — only the storage layer exists,
+no application code reads or writes these tables yet.  The tests
+confirm:
+
+- The three tables exist with the expected columns.
+- Their cascade FK against ``conversations`` works (deleting a
+  conversation tears down all LCM rows).
+- A summary can hold zero or more sources, mixing ``message`` + ``summary``
+  source kinds in one parent.
+- The ``(conversation_id, ordinal)`` unique constraint on
+  ``lcm_context_items`` actually fires so compaction's dense renumber
+  is safe.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import User
+from app.models import (
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM schema test",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+@pytest.mark.anyio
+async def test_summary_insert_round_trips(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="The user asked about deploying Pawrrtal on a VPS.",
+        token_count=12,
+        model_id="gemini-2.5-flash-preview-05-20",
+        summary_kind="normal",
+    )
+    db_session.add(summary)
+    await db_session.commit()
+    await db_session.refresh(summary)
+
+    fetched = (
+        await db_session.execute(select(LCMSummary).where(LCMSummary.id == summary.id))
+    ).scalar_one()
+    assert fetched.content.startswith("The user asked about deploying")
+    assert fetched.depth == 0
+    assert fetched.summary_kind == "normal"
+
+
+@pytest.mark.anyio
+async def test_summary_sources_support_mixed_kinds(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A condensed parent can point at a mix of message + summary sources."""
+    conv = await _make_conversation(db_session, test_user)
+    parent = LCMSummary(conversation_id=conv.id, depth=1, content="parent")
+    db_session.add(parent)
+    await db_session.commit()
+    await db_session.refresh(parent)
+
+    db_session.add_all(
+        [
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="message",
+                source_id=uuid.uuid4(),
+                source_ordinal=0,
+            ),
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=uuid.uuid4(),
+                source_ordinal=1,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource)
+            .where(LCMSummarySource.summary_id == parent.id)
+            .order_by(LCMSummarySource.source_ordinal)
+        )
+    ).scalars().all()
+    assert [s.source_kind for s in sources] == ["message", "summary"]
+
+
+@pytest.mark.anyio
+async def test_context_items_have_unique_conversation_ordinal(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Two items can't share the same (conversation_id, ordinal)."""
+    conv = await _make_conversation(db_session, test_user)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="message",
+            item_id=uuid.uuid4(),
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=uuid.uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+def test_cascade_metadata_is_declared() -> None:
+    """Pin the ``ON DELETE CASCADE`` metadata on every LCM FK.
+
+    Runtime cascade behaviour is not exercised here — the SQLite test
+    harness uses ``Base.metadata.create_all`` without enabling
+    ``PRAGMA foreign_keys=ON``, so cascades are inert in tests.  Postgres
+    (where the migration runs in production) enforces them; this test
+    just makes sure the *declaration* is correct so a future model edit
+    can't silently drop the cascade.
+    """
+    from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+    expected_cascades = {
+        (LCMSummary.__table__, "conversation_id"): "CASCADE",
+        (LCMSummarySource.__table__, "summary_id"): "CASCADE",
+        (LCMContextItem.__table__, "conversation_id"): "CASCADE",
+    }
+    for (table, column_name), expected in expected_cascades.items():
+        matching_fks = [
+            fk
+            for fk in table.foreign_keys
+            if fk.parent.name == column_name
+        ]
+        assert matching_fks, f"missing FK on {table.name}.{column_name}"
+        assert matching_fks[0].ondelete == expected, (
+            f"{table.name}.{column_name} expected ondelete={expected!r} "
+            f"got {matching_fks[0].ondelete!r}"
+        )
+
+


### PR DESCRIPTION
## What lands here

Three new SQLAlchemy ORM classes in `backend/app/models.py` and the matching Alembic migration.

### Models

**`LCMSummary`** — A summary node produced by the compaction or condensation pass.
- `depth`: 0 = leaf (summarises raw messages), 1+ = condensed (summarises other summaries)
- `content`: The summary text
- `token_count`: Cached approximate token count used for budget maths
- `model_id`: Which model produced this summary
- `summary_kind`: `"normal"` | `"aggressive"` | `"fallback"` — mirrors the three-level escalation

**`LCMSummarySource`** — Edge from a summary to one of its source items.
- `source_kind`: `"message"` | `"summary"` — discriminator so a single parent can reference either type
- `source_id`: UUID of the source (points into `chat_messages` or `lcm_summaries`)
- `source_ordinal`: Position in the original ordering for deterministic re-assembly

**`LCMContextItem`** — The ordered context list for a conversation. Walking this table in `ordinal` order produces the sequence fed to the provider each turn.
- `item_kind`: `"message"` | `"summary"`
- `item_id`: UUID pointing at either a `ChatMessage` or `LCMSummary`
- Unique constraint on `(conversation_id, ordinal)`

### Migration `012_add_lcm_tables.py`
Creates all three tables with indices and a `UNIQUE (conversation_id, ordinal)` constraint on `lcm_context_items`. All FKs reference `conversations.id` with `ON DELETE CASCADE`.

### Tests (4 in `test_lcm_schema.py`)
- Round-trip insert + read back
- Summary sources mixing message + summary kinds in one parent
- Unique constraint actually fires on duplicate `(conversation_id, ordinal)`
- CASCADE FK is declared on every LCM relationship