### PR TITLE
feat(lcm): compact_leaf_if_needed [5/11]

### DIFF
--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -1,9 +1,11 @@
-"""Lossless Context Management — ingest and assembly.
+"""Lossless Context Management — ingest, assembly, and leaf compaction.
 
 Public API
 ----------
-``ingest_message``   — record a new ChatMessage in lcm_context_items
-``assemble_context`` — build the [{role, content}] context list for a turn
+``ingest_message``         — record a new ChatMessage in lcm_context_items
+``assemble_context``       — build the [{role, content}] context list for a turn
+``compact_leaf_if_needed`` — summarise the oldest non-fresh items into a leaf
+                             LCMSummary and rewrite lcm_context_items in place
 
 All functions are always importable; callers gate on ``settings.lcm_enabled``
 (default ``False``) before invoking them.
@@ -13,12 +15,15 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import ChatMessage, LCMContextItem, LCMSummary
+from app.core.config import settings as _settings
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
 
 _log = logging.getLogger(__name__)
 
@@ -132,3 +137,236 @@ async def assemble_context(
                     }
                 )
     return context
+
+
+# ---------------------------------------------------------------------------
+# Summarisation prompts — three-level escalation mirrors the upstream plugin.
+# ---------------------------------------------------------------------------
+
+_PROMPT_NORMAL = """\
+You are a memory compressor for an AI assistant.  Summarise the following
+conversation extract into a compact but lossless paragraph.  Preserve every
+decision, fact, file name, error message, and instruction so the assistant can
+reconstruct the full context from your summary alone.  Output the summary only
+— no preamble, no commentary.
+
+{turns}"""
+
+_PROMPT_AGGRESSIVE = """\
+Summarise the following conversation in one tight paragraph.  Keep only the
+most important decisions, facts, and instructions.  Output the summary only.
+
+{turns}"""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token count: 4 characters ≈ 1 token (good enough for budgeting)."""
+    return max(1, len(text) // 4)
+
+
+def _format_turns(messages: list[dict[str, str]]) -> str:
+    """Format [{role, content}] as a plain-text transcript for the summary prompt."""
+    parts: list[str] = []
+    for m in messages:
+        role = m.get("role", "").upper()
+        content = m.get("content", "")
+        if content:
+            parts.append(f"{role}: {content}")
+    return "\n\n".join(parts)
+
+
+async def _collect_stream(stream: AsyncIterator[Any]) -> str:
+    """Consume a provider stream and return all concatenated delta text."""
+    parts: list[str] = []
+    async for event in stream:
+        if event.get("type") == "delta":
+            chunk = event.get("content") or ""
+            if chunk:
+                parts.append(chunk)
+    return "".join(parts).strip()
+
+
+async def _summarize(
+    provider: Any,
+    turns_text: str,
+    user_id: uuid.UUID,
+) -> tuple[str, str]:
+    """Call the provider to summarise a turn block.
+
+    Three-level escalation:
+    1. Normal prompt — full fidelity.
+    2. Aggressive prompt — shorter, if normal fails or returns empty.
+    3. Deterministic fallback — first 1 500 chars of the raw transcript.
+
+    Returns:
+        ``(summary_text, summary_kind)`` where ``summary_kind`` is one of
+        ``"normal"``, ``"aggressive"``, or ``"fallback"``.
+    """
+    for prompt_template, kind in (
+        (_PROMPT_NORMAL, "normal"),
+        (_PROMPT_AGGRESSIVE, "aggressive"),
+    ):
+        try:
+            stream = provider.stream(
+                question=prompt_template.format(turns=turns_text),
+                conversation_id=uuid.uuid4(),
+                user_id=user_id,
+                history=None,
+                tools=None,
+                system_prompt=None,
+            )
+            text = await _collect_stream(stream)
+            if text:
+                return text, kind
+        except Exception:
+            _log.warning("LCM_SUMMARIZE_%s_FAILED", kind.upper(), exc_info=True)
+
+    # Deterministic truncation — always produces output.
+    return turns_text[:1500], "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Compaction
+# ---------------------------------------------------------------------------
+
+
+async def compact_leaf_if_needed(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    fresh_tail_count: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one leaf-compaction pass if items exist outside the fresh tail.
+
+    Algorithm
+    ---------
+    1.  Fetch the full ``lcm_context_items`` list for the conversation.
+    2.  If ``total_items <= fresh_tail_count`` there is nothing to compact.
+    3.  The *eligible* items are the oldest ones that fall outside the fresh
+        tail (``all_items[:total - fresh_tail_count]``).  Only
+        ``item_kind="message"`` rows are compacted; existing summaries inside
+        the eligible window are left in place (they are already compact).
+    4.  Batch the oldest eligible messages up to ``max_chunk_tokens`` source
+        tokens (approximate; 4 chars ≈ 1 token).
+    5.  Call the provider (three-level escalation) to produce a summary.
+    6.  Persist: :class:`~app.models.LCMSummary` + one
+        :class:`~app.models.LCMSummarySource` per source message.
+    7.  Rewrite ``lcm_context_items``: delete the compacted message rows,
+        insert one ``item_kind="summary"`` row at the lowest freed ordinal
+        slot.  Gaps are harmless — ``ingest_message`` uses max(ordinal)+1.
+
+    Returns:
+        ``True`` if a compaction pass ran, ``False`` if there was nothing to
+        compact or the eligible window contained no un-compacted messages.
+    """
+    # ------------------------------------------------------------------ 1+2
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+    total = len(all_items)
+
+    if total <= fresh_tail_count:
+        return False
+
+    # ------------------------------------------------------------------ 3
+    eligible = all_items[: total - fresh_tail_count]
+    eligible_message_ids = [
+        item.item_id for item in eligible if item.item_kind == "message"
+    ]
+
+    if not eligible_message_ids:
+        return False  # Only summaries outside the fresh tail — nothing to do.
+
+    # ------------------------------------------------------------------ 4
+    msg_result = await session.execute(
+        select(ChatMessage).where(ChatMessage.id.in_(eligible_message_ids))
+    )
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {
+        m.id: m for m in msg_result.scalars().all()
+    }
+
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item in eligible:
+        if item.item_kind != "message":
+            continue
+        msg = messages_by_id.get(item.item_id)
+        if msg is None:
+            continue
+        msg_tokens = _approx_tokens(msg.content or "")
+        if running_tokens + msg_tokens > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append({"role": msg.role, "content": msg.content or ""})
+        running_tokens += msg_tokens
+
+    if not selected_items:
+        return False
+
+    # ------------------------------------------------------------------ 5
+    summary_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(summary_model, user_id=user_id)
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(provider, turns_text, user_id)
+
+    _log.info(
+        "LCM_COMPACT conversation_id=%s kind=%s sources=%d tokens=%d→%d",
+        conversation_id,
+        summary_kind,
+        len(selected_items),
+        running_tokens,
+        _approx_tokens(summary_text),
+    )
+
+    # ------------------------------------------------------------------ 6
+    summary_row = LCMSummary(
+        conversation_id=conversation_id,
+        depth=0,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=summary_model,
+        summary_kind=summary_kind,
+    )
+    session.add(summary_row)
+    await session.flush()
+
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=summary_row.id,
+                source_kind="message",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    # ------------------------------------------------------------------ 7
+    slot_ordinal = selected_items[0].ordinal
+
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=summary_row.id,
+        )
+    )
+    await session.flush()
+    return True

--- a/backend/tests/test_lcm_compaction.py
+++ b/backend/tests/test_lcm_compaction.py
@@ -1,0 +1,500 @@
+"""LCM PR #3 — leaf compaction tests.
+
+Covers:
+- compact_leaf_if_needed returns False when items ≤ fresh_tail_count.
+- compact_leaf_if_needed runs and returns True when there are items outside
+  the fresh tail.
+- After compaction: the source message items are replaced by a single
+  summary item; LCMSummary + LCMSummarySource rows are created.
+- The ordinal slot of the first compacted item is reused for the summary item.
+- Items inside the fresh tail are untouched.
+- max_chunk_tokens limits the compaction batch: messages beyond the token
+  budget are left in place.
+- Summary items already in the eligible window are left in place (not
+  re-compacted).
+- assemble_context after compaction returns the summary content + fresh tail.
+- Deterministic fallback is used when the provider raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context, compact_leaf_if_needed
+from app.core.providers.base import StreamEvent
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM compaction test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _seed_context(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    turns: list[tuple[str, str]],  # [(role, content), ...]
+) -> list[ChatMessage]:
+    """Insert N messages and their corresponding LCMContextItems."""
+    messages: list[ChatMessage] = []
+    for i, (role, content) in enumerate(turns):
+        msg = await _make_message(session, user, conv, role, content, i)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=i,
+                item_kind="message",
+                item_id=msg.id,
+            )
+        )
+        messages.append(msg)
+    await session.commit()
+    return messages
+
+
+def _make_fake_provider(summary_text: str = "SUMMARY") -> Any:
+    """Return a provider mock whose stream() yields a single delta."""
+
+    async def _fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type="delta", content=summary_text)
+
+    provider = MagicMock()
+    provider.stream = _fake_stream
+    return provider
+
+
+def _make_failing_provider() -> Any:
+    """Return a provider mock whose stream() raises immediately."""
+
+    async def _failing_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        raise RuntimeError("LLM unavailable")
+        yield  # make it an async generator
+
+    provider = MagicMock()
+    provider.stream = _failing_stream
+    return provider
+
+
+# Patch the provider resolution so compaction uses our mock.
+def _patch_resolve_llm(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    monkeypatch.setattr(_lcm, "resolve_llm", lambda *args, **kwargs: provider)
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_noop_when_within_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False when total items ≤ fresh_tail_count."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(db_session, test_user, conv, [("user", "hi"), ("assistant", "hello")])
+
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=5,  # larger than total items
+        max_chunk_tokens=100_000,
+    )
+
+    assert ran is False
+    # Provider should not have been called.
+    assert not provider.stream.called if hasattr(provider.stream, "called") else True
+
+
+@pytest.mark.anyio
+async def test_compact_noop_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False for an empty conversation."""
+    conv = await _make_conversation(db_session, test_user)
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_runs_when_items_exceed_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns True when compaction runs successfully."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "msg0"), ("assistant", "msg1"), ("user", "msg2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("compacted"))
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,  # last 2 kept; msg0 is eligible
+        max_chunk_tokens=100_000,
+    )
+    assert ran is True
+
+
+@pytest.mark.anyio
+async def test_compact_creates_summary_and_sources(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, LCMSummary and LCMSummarySource rows exist."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "hello"), ("assistant", "world"), ("user", "question")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("hello world summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].content == "hello world summary"
+    assert summaries[0].depth == 0
+    assert summaries[0].summary_kind == "normal"
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource).where(
+                LCMSummarySource.summary_id == summaries[0].id
+            )
+        )
+    ).scalars().all()
+    # Only msg0 ("hello") is outside the fresh tail of 2 and should be compacted.
+    assert len(sources) == 1
+    assert sources[0].source_kind == "message"
+    assert sources[0].source_id == msgs[0].id
+
+
+@pytest.mark.anyio
+async def test_compact_replaces_message_items_with_summary_item(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, the source message item is gone; a summary item takes its slot."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "reply"), ("user", "new")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary text"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 3 items before → 3 items after (summary + 2 message items in fresh tail).
+    assert len(items) == 3
+    # First item must now be the summary at the original slot 0.
+    assert items[0].item_kind == "summary"
+    assert items[0].ordinal == 0
+    # Fresh-tail items are still message items.
+    assert items[1].item_kind == "message"
+    assert items[2].item_kind == "message"
+    assert items[1].item_id == msgs[1].id
+    assert items[2].item_id == msgs[2].id
+
+
+@pytest.mark.anyio
+async def test_compact_multiple_eligible_messages(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When several messages are eligible, all are folded into one summary."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "a"),
+            ("assistant", "b"),
+            ("user", "c"),
+            ("assistant", "d"),  # fresh tail starts here
+            ("user", "e"),       # fresh tail end
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary abc"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 5 items → 1 summary + 2 fresh = 3 items total.
+    assert len(items) == 3
+    assert items[0].item_kind == "summary"
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # msgs 0, 1, 2 should all be sources of the summary.
+    source_ids = {s.source_id for s in sources}
+    assert msgs[0].id in source_ids
+    assert msgs[1].id in source_ids
+    assert msgs[2].id in source_ids
+    assert msgs[3].id not in source_ids  # fresh tail
+    assert msgs[4].id not in source_ids  # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# max_chunk_tokens budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_respects_token_budget(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the oldest messages that fit in max_chunk_tokens are compacted."""
+    conv = await _make_conversation(db_session, test_user)
+    # Each message is ~20 chars ≈ 5 tokens.  Budget of 6 tokens should fit only 1.
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "first message here"),   # ~5 tokens
+            ("assistant", "second one here"), # ~5 tokens
+            ("user", "fresh tail msg"),       # fresh tail
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("first only"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=1,  # only last 1 in fresh tail → 2 eligible
+        max_chunk_tokens=6,  # fits only the first message
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # Only the first message should be in sources.
+    assert len(sources) == 1
+    assert sources[0].source_id == msgs[0].id
+
+    # Second message (budget overflow) and third (fresh tail) should still be
+    # message items in lcm_context_items.
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+    kinds = [i.item_kind for i in items]
+    assert kinds[0] == "summary"
+    assert kinds[1] == "message"   # second message still in place
+    assert kinds[2] == "message"   # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_uses_fallback_when_provider_fails(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Uses deterministic truncation when the LLM provider raises."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old message"), ("assistant", "reply"), ("user", "fresh")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_failing_provider())
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    assert ran is True
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].summary_kind == "fallback"
+    # Deterministic fallback contains the raw transcript text.
+    assert "USER:" in summaries[0].content or "old message" in summaries[0].content
+
+
+# ---------------------------------------------------------------------------
+# assemble_context after compaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_after_compaction_returns_summary_plus_fresh(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, assemble_context returns [summary, *fresh_tail]."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "tail1"), ("user", "tail2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("the summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert len(context) == 3
+    # First entry is the injected summary.
+    assert context[0]["role"] == "user"
+    assert "[Summary of earlier conversation]" in context[0]["content"]
+    assert "the summary" in context[0]["content"]
+    # Then the fresh-tail messages.
+    assert context[1] == {"role": "assistant", "content": "tail1"}
+    assert context[2] == {"role": "user", "content": "tail2"}


### PR DESCRIPTION
## What lands here

Adds leaf compaction to `backend/app/core/lcm.py`.

### Private helpers (module-level for monkeypatch testability)
- `_approx_tokens(text)` — 4 chars ≈ 1 token rough estimate
- `_format_turns(messages)` — `[{role, content}]` → plain-text transcript
- `_collect_stream(stream)` — drains a provider async stream → `str`
- `_summarize(provider, turns_text, user_id)` — **three-level escalation**: normal prompt → aggressive prompt → deterministic 1500-char truncation. Returns `(text, kind)`.

### `compact_leaf_if_needed(session, *, conversation_id, user_id, model_id, fresh_tail_count, max_chunk_tokens) -> bool`
1. Fetches all `lcm_context_items` in ordinal order
2. Returns `False` immediately if `total ≤ fresh_tail_count` (nothing to compact)
3. Eligible = oldest items outside the fresh tail that are `item_kind="message"` (existing summaries already compact)
4. Batches up to `max_chunk_tokens` of those messages
5. Calls the provider via three-level escalation
6. Writes `LCMSummary` (depth=0) + `LCMSummarySource` edges
7. Replaces compacted context items with one `item_kind="summary"` row

Not wired into `chat.py` yet — that's PR 6.

### Tests (9 in `test_lcm_compaction.py`)
noop on empty conversation · noop when total ≤ fresh_tail · creates summary + source edges · replaces message items with summary item · handles multiple eligible messages · token-budget cap respected · falls back to truncation on provider error · assemble returns summary + fresh tail after compaction · noop when only summaries outside tail