### PR TITLE
feat(lcm): lcm_grep — keyword search tool [7/11]

### DIFF
--- a/backend/app/core/tools/lcm_grep.py
+++ b/backend/app/core/tools/lcm_grep.py
@@ -1,0 +1,158 @@
+"""LCM grep — search conversation history across messages and summaries.
+
+This is the backing implementation for the ``lcm_grep`` agent tool introduced
+in PR #4 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin uses SQLite FTS5 for full-text search.
+We run Postgres in production, where a dedicated ``tsvector`` index is the
+right long-term solution (tracked in ``.beans/lcm-followups.md``).  For this
+tracer-bullet PR we use ``ILIKE '%query%'`` which works on both SQLite (tests)
+and Postgres (production) without a schema migration.  The FTS upgrade can
+land in a follow-up once we have real production workloads to benchmark.
+
+Returned result format
+----------------------
+Each match is a compact block::
+
+    [MESSAGE role=user ordinal=12]
+    ...matching content excerpt...
+
+    [SUMMARY depth=0]
+    ...matching summary excerpt...
+
+Matches are capped at ``max_excerpt_chars`` per entry to keep the response
+token-efficient.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMSummary
+
+_MAX_RESULTS_DEFAULT = 10
+_MAX_EXCERPT_CHARS = 500
+
+
+def _excerpt(text: str, *, query: str, max_chars: int = _MAX_EXCERPT_CHARS) -> str:
+    """Return a snippet around the first occurrence of *query* in *text*.
+
+    The snippet is at most *max_chars* characters.  If the match is near
+    the start or end, the window shifts to fit; the edge is marked with ``…``
+    when content is elided.
+    """
+    text = text or ""
+    query_lower = query.lower()
+    pos = text.lower().find(query_lower)
+    if pos == -1:
+        # Shouldn't happen (we searched for the query), but handle gracefully.
+        return text[:max_chars] + ("…" if len(text) > max_chars else "")
+
+    half = max_chars // 2
+    start = max(0, pos - half)
+    end = min(len(text), pos + len(query) + half)
+
+    # Expand the window to *max_chars* if we hit an edge.
+    if start == 0:
+        end = min(len(text), max_chars)
+    if end == len(text):
+        start = max(0, len(text) - max_chars)
+
+    snippet = text[start:end]
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet = snippet + "…"
+    return snippet
+
+
+def _format_results(
+    message_hits: list[ChatMessage],
+    summary_hits: list[LCMSummary],
+    query: str,
+) -> str:
+    """Format matched rows as a compact markdown-ish string for the agent."""
+    if not message_hits and not summary_hits:
+        return f"No matches found for query: {query!r}"
+
+    parts: list[str] = []
+
+    for msg in message_hits:
+        exc = _excerpt(msg.content or "", query=query)
+        parts.append(f"[MESSAGE role={msg.role} ordinal={msg.ordinal}]\n{exc}")
+
+    for summ in summary_hits:
+        exc = _excerpt(summ.content or "", query=query)
+        parts.append(f"[SUMMARY depth={summ.depth} kind={summ.summary_kind}]\n{exc}")
+
+    header = (
+        f"lcm_grep: {len(message_hits)} message match(es), "
+        f"{len(summary_hits)} summary match(es) for {query!r}\n"
+    )
+    return header + "\n\n".join(parts)
+
+
+async def lcm_grep(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int = _MAX_RESULTS_DEFAULT,
+) -> str:
+    """Search a conversation's messages and summaries for *query*.
+
+    Performs case-insensitive substring matching across:
+
+    * ``chat_messages.content`` — raw user/assistant turns
+    * ``lcm_summaries.content`` — compacted history nodes
+
+    Both searches are scoped to *conversation_id*.  Results are ordered
+    most-recent-first and capped at *limit* per source.  The combined output
+    is formatted as a compact annotated text block suitable for direct
+    inclusion in an agent's tool result.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to search.
+        query: The search string.  Matched case-insensitively as a substring.
+        limit: Maximum number of results per source (messages + summaries each).
+
+    Returns:
+        A formatted string with matches and excerpts, or a "no matches"
+        message if nothing matched.
+    """
+    if not query.strip():
+        return "lcm_grep: empty query — nothing to search."
+
+    # SQLAlchemy's ``.ilike()`` emits ``ILIKE`` on Postgres and
+    # ``LIKE LOWER(...)`` on SQLite — both work for our needs.
+    msg_result = await session.execute(
+        select(ChatMessage)
+        .where(
+            ChatMessage.conversation_id == conversation_id,
+            ChatMessage.role.in_(["user", "assistant"]),
+            ChatMessage.content.ilike(f"%{query}%"),
+        )
+        .order_by(ChatMessage.ordinal.desc())
+        .limit(limit)
+    )
+    message_hits = list(msg_result.scalars().all())
+
+    sum_result = await session.execute(
+        select(LCMSummary)
+        .where(
+            LCMSummary.conversation_id == conversation_id,
+            LCMSummary.content.ilike(f"%{query}%"),
+        )
+        .order_by(LCMSummary.created_at.desc())
+        .limit(limit)
+    )
+    summary_hits = list(sum_result.scalars().all())
+
+    return _format_results(message_hits, summary_hits, query)

--- a/backend/app/core/tools/lcm_grep_agent.py
+++ b/backend/app/core/tools/lcm_grep_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM grep tool (PR #4).
+
+Exposes :func:`make_lcm_grep_tool` which returns an :class:`AgentTool`
+that the provider can append to ``AgentContext.tools``.  The actual DB
+search lives in :mod:`app.core.tools.lcm_grep`; this module only handles
+the JSON schema and the thin async wrapper the loop calls.
+
+Usage::
+
+    from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_grep_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_grep import _MAX_RESULTS_DEFAULT, lcm_grep
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_grep"
+
+_TOOL_DESCRIPTION = (
+    "Search the full history of this conversation — including any compacted"
+    " summaries — for a keyword or phrase.  Use this when you need to recall"
+    " something that may have been mentioned earlier but is no longer in your"
+    " current context window.  Returns matching excerpts from both raw messages"
+    " and summary nodes, annotated with their position in the conversation."
+    " Results are ordered most-recent-first.  Prefer short, distinctive search"
+    " terms (1-3 words) for best recall."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Keyword or phrase to search for.  Case-insensitive substring"
+                " match.  Use a short, distinctive term for best results."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"Maximum number of matches per source (messages + summaries"
+                f" searched independently).  Default {_MAX_RESULTS_DEFAULT}."
+            ),
+            "default": _MAX_RESULTS_DEFAULT,
+            "minimum": 1,
+            "maximum": 50,
+        },
+    },
+    "required": ["query"],
+}
+
+
+def make_lcm_grep_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM history search.
+
+    The tool opens its own database session per call so it is independent
+    of the request-scoped session.
+
+    Args:
+        conversation_id: The conversation to search.  Baked into the closure
+            at tool construction time so the agent cannot search other
+            conversations.
+
+    Returns:
+        A configured :class:`AgentTool` ready to be appended to the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        query = str(kwargs.get("query") or "")
+        limit = int(kwargs.get("limit") or _MAX_RESULTS_DEFAULT)
+        limit = max(1, min(50, limit))
+        async with async_session_maker() as session:
+            return await lcm_grep(
+                session,
+                conversation_id=conversation_id,
+                query=query,
+                limit=limit,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/tests/test_lcm_grep.py
+++ b/backend/tests/test_lcm_grep.py
@@ -1,0 +1,251 @@
+"""LCM PR #4 — lcm_grep tool tests.
+
+Covers:
+- Empty query returns a "nothing to search" message.
+- No matches returns a "no matches" message.
+- Message hits are returned with role + ordinal annotations.
+- Summary hits are returned with depth annotation.
+- Both message and summary hits are returned in the same call.
+- Search is case-insensitive.
+- Limit caps the result count per source.
+- Results are most-recent-first (by ordinal for messages, by created_at for summaries).
+- _excerpt trims long content around the match.
+- make_lcm_grep_tool is present in build_agent_tools when lcm_enabled.
+- make_lcm_grep_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_grep import _excerpt, lcm_grep
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMSummary,
+)
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="grep test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+
+# _excerpt unit tests
+
+
+
+def test_excerpt_short_text_not_truncated() -> None:
+    result = _excerpt("hello world", query="world")
+    assert "hello world" in result
+    assert "…" not in result
+
+
+def test_excerpt_long_text_truncated_around_match() -> None:
+    padding = "x" * 300
+    text = padding + "TARGET" + padding
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert len(result) <= 110  # a bit of slack for ellipsis
+
+
+def test_excerpt_match_near_start() -> None:
+    text = "TARGET" + "y" * 600
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert result.startswith("TARGET") or result.startswith("…")
+
+
+def test_excerpt_no_match_returns_prefix() -> None:
+    text = "nothing here at all"
+    result = _excerpt(text, query="MISSING", max_chars=50)
+    # Should return the beginning of the text when there's no match.
+    assert "nothing" in result
+
+
+
+# lcm_grep — query handling
+
+
+
+@pytest.mark.anyio
+async def test_grep_empty_query(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="")
+    assert "empty query" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_no_matches(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello world", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(
+        db_session, conversation_id=conv.id, query="NONEXISTENT_XYZZY"
+    )
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_finds_message_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "deploy to Hetzner VPS", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_finds_summary_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_summary(db_session, conv, "User discussed deploying the Hetzner VPS")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[SUMMARY" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_returns_both_message_and_summary_hits(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Hetzner config", 0)
+    await _make_summary(db_session, conv, "Earlier: set up Hetzner server")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "[SUMMARY" in result
+    assert "1 message match" in result
+    assert "1 summary match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_case_insensitive(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Deploy to HETZNER vps", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="hetzner")
+    assert "[MESSAGE" in result
+
+
+@pytest.mark.anyio
+async def test_grep_limit_caps_results(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(5):
+        await _make_message(
+            db_session, test_user, conv, "user", f"mention target {i}", i
+        )
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="target", limit=2)
+    # Should report 2 matches despite 5 messages matching.
+    assert "2 message match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Messages in other conversations must not appear in results."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv_b, "user", "secret banana", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv_a.id, query="banana")
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_excludes_system_role(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "system", "system needle here", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="needle")
+    assert "no matches" in result.lower()
+
+
+
+# build_agent_tools integration
+
+
+


### PR DESCRIPTION
## What lands here

Gives the agent the ability to search compacted conversation history by keyword.

### `backend/app/core/tools/lcm_grep.py`
- `_excerpt(text, query, max_chars=500)` — finds the first match position and extracts a centred context window around it
- `lcm_grep(session, *, conversation_id, query, limit=10) -> str` — case-insensitive (`ILIKE`) search across both `chat_messages.content` and `lcm_summaries.content` for the conversation. Returns a formatted hit list with source kind, role/depth, and excerpt. Only `user`/`assistant` message roles are returned.

### `backend/app/core/tools/lcm_grep_agent.py`
`make_lcm_grep_tool(*, conversation_id)` — `AgentTool` wrapper. Opens its own DB session. Parameters: `query` (required), `limit` (optional, default 10).

Not wired into `build_agent_tools` yet — that's PR 10.

### Tests (13 in `test_lcm_grep.py`)
excerpt window logic · empty query → validation message · no matches → no-matches message · finds message hit with excerpt · finds summary hit · returns both kinds · case-insensitive · limit cap · scoped to conversation · system/tool roles excluded