### PR TITLE
feat(lcm): lcm_describe + lcm_list_summaries tools [8/11]

### DIFF
--- a/backend/app/core/tools/lcm_describe.py
+++ b/backend/app/core/tools/lcm_describe.py
@@ -1,0 +1,126 @@
+"""LCM describe — cheap inspection of a single LCMSummary node.
+
+This is the backing implementation for the ``lcm_describe`` agent tool
+introduced in PR #5 of the LCM stack.
+
+Use case
+--------
+After ``lcm_grep`` returns a match inside a summary node, the agent may want
+to read the *full* summary text (not just the excerpt).  ``lcm_describe``
+fetches the complete node and its metadata in one cheap DB round-trip.
+
+It also exposes ``lcm_list_summaries`` so the agent can enumerate all summary
+nodes for the current conversation and pick the right one to inspect.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+
+def _format_summary(
+    summary: LCMSummary,
+    sources: list[LCMSummarySource],
+    *,
+    include_full_content: bool = True,
+) -> str:
+    """Format a summary node and its source edges as a readable string."""
+    lines: list[str] = [
+        f"Summary ID:   {summary.id}",
+        f"Depth:        {summary.depth}",
+        f"Kind:         {summary.summary_kind}",
+        f"Model:        {summary.model_id or '(unknown)'}",
+        f"Tokens:       ~{summary.token_count}",
+        f"Created:      {summary.created_at.isoformat()}",
+        f"Sources:      {len(sources)} item(s)",
+    ]
+    if sources:
+        for s in sources:
+            lines.append(f"  [{s.source_ordinal}] {s.source_kind} id={s.source_id}")
+    if include_full_content:
+        lines.append("")
+        lines.append("Content:")
+        lines.append(summary.content)
+    return "\n".join(lines)
+
+
+async def lcm_describe(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    summary_id: uuid.UUID,
+) -> str:
+    """Return the full content and metadata of a single LCMSummary node.
+
+    The lookup is scoped to *conversation_id* so the agent cannot inspect
+    summaries from other conversations even if it somehow obtains a foreign ID.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation the summary must belong to.
+        summary_id: UUID of the target :class:`~app.models.LCMSummary`.
+
+    Returns:
+        A formatted multi-line string with the summary's metadata and full
+        content, or an error string if not found.
+    """
+    result = await session.execute(
+        select(LCMSummary).where(
+            LCMSummary.id == summary_id,
+            LCMSummary.conversation_id == conversation_id,
+        )
+    )
+    summary = result.scalar_one_or_none()
+
+    if summary is None:
+        return (
+            f"lcm_describe: summary {summary_id} not found "
+            f"(may belong to a different conversation, or may not exist)."
+        )
+
+    sources_result = await session.execute(
+        select(LCMSummarySource)
+        .where(LCMSummarySource.summary_id == summary.id)
+        .order_by(LCMSummarySource.source_ordinal)
+    )
+    sources = list(sources_result.scalars().all())
+
+    return _format_summary(summary, sources, include_full_content=True)
+
+
+async def lcm_list_summaries(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+) -> str:
+    """List all LCMSummary nodes for a conversation, most-recent-first.
+
+    Returns a compact table showing each node's ID, depth, kind, and a
+    brief excerpt so the agent can decide which one to inspect further.
+    """
+    result = await session.execute(
+        select(LCMSummary)
+        .where(LCMSummary.conversation_id == conversation_id)
+        .order_by(LCMSummary.created_at.desc())
+    )
+    summaries = list(result.scalars().all())
+
+    if not summaries:
+        return "lcm_list_summaries: no summaries exist for this conversation yet."
+
+    header = f"lcm_list_summaries: {len(summaries)} node(s)\n"
+    rows: list[str] = []
+    for s in summaries:
+        excerpt = s.content[:120].replace("\n", " ")
+        if len(s.content) > 120:
+            excerpt += "…"
+        rows.append(
+            f"  id={s.id}  depth={s.depth}  kind={s.summary_kind}  "
+            f"tokens=~{s.token_count}\n    {excerpt}"
+        )
+    return header + "\n".join(rows)

--- a/backend/app/core/tools/lcm_describe_agent.py
+++ b/backend/app/core/tools/lcm_describe_agent.py
@@ -1,0 +1,130 @@
+"""Agent-loop adapter for the LCM describe tool (PR #5).
+
+Exposes two :class:`AgentTool` factories:
+
+* :func:`make_lcm_describe_tool` — inspect a specific summary by ID.
+* :func:`make_lcm_list_summaries_tool` — enumerate all summaries for
+  the current conversation (so the agent can find the right ID to pass
+  to ``lcm_describe``).
+
+Usage::
+
+    from app.core.tools.lcm_describe_agent import (
+        make_lcm_describe_tool,
+        make_lcm_list_summaries_tool,
+    )
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conv.id))
+        tools.append(make_lcm_describe_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import async_session_maker
+
+# ---------------------------------------------------------------------------
+# lcm_list_summaries
+# ---------------------------------------------------------------------------
+
+_LIST_TOOL_NAME = "lcm_list_summaries"
+
+_LIST_TOOL_DESCRIPTION = (
+    "List all compacted summary nodes for the current conversation, most-recent-first."
+    "  Each entry shows the summary ID, depth, kind, token count, and a brief excerpt."
+    "  Use this to discover which summary IDs are available before calling"
+    " ``lcm_describe`` to read one in full."
+)
+
+_LIST_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+
+def make_lcm_list_summaries_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that lists LCM summary nodes for a conversation.
+
+    Args:
+        conversation_id: Baked into the closure — the agent cannot list
+            summaries from other conversations.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        async with async_session_maker() as session:
+            return await lcm_list_summaries(
+                session, conversation_id=conversation_id
+            )
+
+    return AgentTool(
+        name=_LIST_TOOL_NAME,
+        description=_LIST_TOOL_DESCRIPTION,
+        parameters=_LIST_PARAMETERS,
+        execute=_execute,
+    )
+
+
+# ---------------------------------------------------------------------------
+# lcm_describe
+# ---------------------------------------------------------------------------
+
+_DESCRIBE_TOOL_NAME = "lcm_describe"
+
+_DESCRIBE_TOOL_DESCRIPTION = (
+    "Read the full content and metadata of a single compacted summary node."
+    "  Supply the summary ID (obtained via ``lcm_list_summaries`` or from a"
+    " ``[SUMMARY`` annotation in ``lcm_grep`` output)."
+    "  Returns the complete summary text and its source-edge list."
+    "  This is a cheap single-row lookup — use it freely to recover compacted"
+    " context without the overhead of a full expand_query sub-agent."
+)
+
+_DESCRIBE_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "summary_id": {
+            "type": "string",
+            "description": (
+                "UUID of the LCMSummary node to inspect."
+                " Obtain this from lcm_list_summaries or from a [SUMMARY ..."
+                " annotation in lcm_grep output."
+            ),
+        },
+    },
+    "required": ["summary_id"],
+}
+
+
+def make_lcm_describe_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that reads a specific LCMSummary in full.
+
+    Args:
+        conversation_id: Baked into the closure — prevents cross-conversation
+            inspection even if the agent passes a foreign UUID.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        raw_id = str(kwargs.get("summary_id") or "")
+        try:
+            sid = uuid.UUID(raw_id)
+        except ValueError:
+            return f"lcm_describe: invalid UUID {raw_id!r}"
+
+        async with async_session_maker() as session:
+            return await lcm_describe(
+                session,
+                conversation_id=conversation_id,
+                summary_id=sid,
+            )
+
+    return AgentTool(
+        name=_DESCRIBE_TOOL_NAME,
+        description=_DESCRIBE_TOOL_DESCRIPTION,
+        parameters=_DESCRIBE_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/tests/test_lcm_describe.py
+++ b/backend/tests/test_lcm_describe.py
@@ -1,0 +1,180 @@
+"""LCM PR #5 — lcm_describe tool tests.
+
+Covers:
+- lcm_describe returns metadata + full content for an existing summary.
+- lcm_describe returns an error string for an unknown summary_id.
+- lcm_describe is scoped to conversation_id (foreign ID returns error).
+- lcm_list_summaries returns a compact table for a conversation with summaries.
+- lcm_list_summaries returns "no summaries" for an empty conversation.
+- make_lcm_describe_tool and make_lcm_list_summaries_tool are present in
+  build_agent_tools when lcm_enabled=True.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import User
+from app.models import Conversation, LCMSummary, LCMSummarySource
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="describe test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+    summary_kind: str = "normal",
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+        summary_kind=summary_kind,
+        model_id="gemini-2.5-flash",
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+
+# lcm_describe
+
+
+
+@pytest.mark.anyio
+async def test_describe_returns_metadata_and_content(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "User asked about deploying to Hetzner.")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert str(summary.id) in result
+    assert "depth" in result.lower()
+    assert "User asked about deploying" in result
+
+
+@pytest.mark.anyio
+async def test_describe_includes_source_edges(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "Summary with sources")
+    source_id = uuid.uuid4()
+    db_session.add(
+        LCMSummarySource(
+            summary_id=summary.id,
+            source_kind="message",
+            source_id=source_id,
+            source_ordinal=0,
+        )
+    )
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert "message" in result
+    assert str(source_id) in result
+
+
+@pytest.mark.anyio
+async def test_describe_unknown_id_returns_error(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=uuid.uuid4()
+    )
+    assert "not found" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_describe_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A summary from another conversation should not be visible."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    summary_b = await _make_summary(db_session, conv_b, "Private summary in conv B")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv_a.id, summary_id=summary_b.id
+    )
+    assert "not found" in result.lower()
+
+
+
+# lcm_list_summaries
+
+
+
+@pytest.mark.anyio
+async def test_list_summaries_empty_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "no summaries" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_list_summaries_returns_all_nodes(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(3):
+        await _make_summary(db_session, conv, f"Summary {i} content")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "3 node" in result
+
+
+@pytest.mark.anyio
+async def test_list_summaries_shows_id_and_excerpt(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    s = await _make_summary(db_session, conv, "Unique content for listing test")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert str(s.id) in result
+    assert "Unique content" in result
+
+
+


### PR DESCRIPTION
## What lands here

Gives the agent the ability to enumerate and inspect the LCM summary DAG.

### `backend/app/core/tools/lcm_describe.py`
- `lcm_list_summaries(session, *, conversation_id) -> str` — lists all `LCMSummary` nodes for a conversation: id, depth, token_count, summary_kind, created_at, and a 100-char excerpt. Used by the agent to discover summary IDs before calling `lcm_describe`.
- `lcm_describe(session, *, conversation_id, summary_id) -> str` — returns full content + metadata for one summary node, plus all source edges (kind, source_id, ordinal). Scoped to the conversation so cross-conversation reads are impossible.

### `backend/app/core/tools/lcm_describe_agent.py`
- `make_lcm_list_summaries_tool(*, conversation_id)` — `AgentTool` with no parameters
- `make_lcm_describe_tool(*, conversation_id)` — `AgentTool` with `summary_id` (UUID string) parameter; validates the UUID before querying

Not wired into `build_agent_tools` yet — that's PR 10.

### Tests (7 in `test_lcm_describe.py`)
describe returns metadata + full content · describe includes source edges · describe returns not-found for unknown id · describe scoped to conversation · list empty conversation · list populated conversation · list shows id and excerpt per node