### PR TITLE
feat(lcm): lcm_expand_query — deep recall tool [9/11]

### DIFF
--- a/backend/app/core/tools/lcm_expand_query.py
+++ b/backend/app/core/tools/lcm_expand_query.py
@@ -1,0 +1,167 @@
+"""LCM expand_query — bounded deep-recall via a single focused LLM call.
+
+This is the backing implementation for the ``lcm_expand_query`` agent tool
+introduced in PR #6 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin spawns an OpenClaw sub-agent that walks
+the full summary DAG.  We use our own infrastructure: instead of a real
+sub-agent, we make one focused LLM call with the *complete* conversation
+history — all LCMContextItems resolved in ordinal order, not just the
+fresh tail — and return its answer.
+
+This is "bounded" in the sense that:
+- It is a single-turn call, not a multi-turn loop.
+- Input is capped at MAX_EXPAND_ITEMS items so we don't exceed a model
+  context window even for very long conversations.
+- Errors are surfaced as descriptive strings, not exceptions, so the
+  calling agent can self-correct.
+
+When to use it vs. lcm_grep
+-----------------------------
+* ``lcm_grep``         — keyword/phrase search; cheap; returns excerpts.
+* ``lcm_describe``     — read one summary node in full; very cheap.
+* ``lcm_expand_query`` — "answer a question about the full history"; slower
+                         (one extra LLM call) but gives a synthesised answer.
+                         Use when grep returns an excerpt and you need the
+                         full story, or when the answer spans multiple
+                         compacted nodes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings as _settings
+from app.core.lcm import _collect_stream, _format_turns
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+# Hard cap so we never build a prompt larger than the model can handle.
+_MAX_EXPAND_ITEMS = 500
+
+_EXPAND_SYSTEM_PROMPT = """\
+You are a recall assistant.  You have access to the full history of a
+conversation (raw messages and compacted summaries, in chronological order).
+Answer the user's question based ONLY on what is present in this history.
+If the answer is not in the history, say so explicitly.
+Be concise and cite specific turns or summary nodes when relevant."""
+
+
+async def lcm_expand_query(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    prompt: str,
+) -> str:
+    """Answer *prompt* by running a focused LLM call over the full history.
+
+    Fetches ALL ``lcm_context_items`` for *conversation_id* (up to
+    ``_MAX_EXPAND_ITEMS``), resolves each one to its backing content,
+    assembles a transcript, and calls the model with *prompt* as the
+    user turn.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to expand.
+        user_id: Used to resolve provider API keys.
+        model_id: The model to use for the expansion call.  Falls back to
+            ``settings.lcm_summary_model`` if non-empty, then to model_id.
+        prompt: The question / retrieval task for the sub-call.
+
+    Returns:
+        The model's synthesised answer, or an error string if the call
+        fails or no history exists.
+    """
+    if not prompt.strip():
+        return "lcm_expand_query: empty prompt — nothing to answer."
+
+    # ------------------------------------------------------------------ 1
+    # Fetch the full context list (bounded).
+    items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+        .limit(_MAX_EXPAND_ITEMS)
+    )
+    items = list(items_result.scalars().all())
+
+    if not items:
+        return (
+            "lcm_expand_query: no conversation history found.  "
+            "The conversation may be empty or LCM ingest has not run yet."
+        )
+
+    # ------------------------------------------------------------------ 2
+    # Batch-resolve all backing rows.
+    message_ids = [i.item_id for i in items if i.item_kind == "message"]
+    summary_ids = [i.item_id for i in items if i.item_kind == "summary"]
+
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        m_res = await session.execute(
+            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+        )
+        messages_by_id = {m.id: m for m in m_res.scalars().all()}
+
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        s_res = await session.execute(
+            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
+        )
+        summaries_by_id = {s.id: s for s in s_res.scalars().all()}
+
+    # ------------------------------------------------------------------ 3
+    # Build the full-history transcript.
+    turns: list[dict[str, str]] = []
+    for item in items:
+        if item.item_kind == "message":
+            msg = messages_by_id.get(item.item_id)
+            if msg and msg.role in {"user", "assistant"} and msg.content:
+                turns.append({"role": msg.role, "content": msg.content})
+        elif item.item_kind == "summary":
+            summ = summaries_by_id.get(item.item_id)
+            if summ and summ.content:
+                turns.append(
+                    {
+                        "role": "user",
+                        "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
+                    }
+                )
+
+    if not turns:
+        return "lcm_expand_query: resolved to an empty history — nothing to answer."
+
+    history_text = _format_turns(turns)
+    expansion_prompt = (
+        f"CONVERSATION HISTORY:\n{history_text}\n\n"
+        f"QUESTION:\n{prompt}"
+    )
+
+    # ------------------------------------------------------------------ 4
+    # Single focused LLM call.
+    expand_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(expand_model, user_id=user_id)
+
+    try:
+        stream = provider.stream(
+            question=expansion_prompt,
+            conversation_id=uuid.uuid4(),  # isolated; not a real turn
+            user_id=user_id,
+            history=None,
+            tools=None,
+            system_prompt=_EXPAND_SYSTEM_PROMPT,
+        )
+        answer = await _collect_stream(stream)
+        if answer:
+            return answer
+        return "lcm_expand_query: the model returned an empty response."
+    except Exception as exc:
+        return f"lcm_expand_query: expansion call failed — {exc}"

--- a/backend/app/core/tools/lcm_expand_query_agent.py
+++ b/backend/app/core/tools/lcm_expand_query_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM expand_query tool (PR #6).
+
+Exposes :func:`make_lcm_expand_query_tool` which returns an
+:class:`AgentTool` for deep recall over the full conversation history.
+
+Usage::
+
+    from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
+
+    if settings.lcm_enabled:
+        tools.append(
+            make_lcm_expand_query_tool(
+                conversation_id=conv.id,
+                user_id=user.id,
+                model_id=model_id,
+            )
+        )
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_expand_query"
+
+_TOOL_DESCRIPTION = (
+    "Answer a question by reading the FULL conversation history — including"
+    " all compacted summary nodes AND raw messages — with a dedicated LLM call."
+    "  Use this when lcm_grep found a relevant excerpt but you need the complete"
+    " story, or when the answer likely spans multiple compacted nodes and a"
+    " summary cannot give you enough detail."
+    "  This tool makes an extra LLM call, so prefer lcm_grep or lcm_describe"
+    " for simple lookups."
+    "  Tip: be specific in your prompt — the better the question, the better"
+    " the answer."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": (
+                "The question or retrieval task to answer from the full"
+                " conversation history.  Be specific: include key terms,"
+                " names, or topics relevant to what you're looking for."
+            ),
+        },
+    },
+    "required": ["prompt"],
+}
+
+
+def make_lcm_expand_query_tool(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM deep-recall expansion.
+
+    Args:
+        conversation_id: The conversation to expand.  Baked in so the
+            agent cannot query other conversations.
+        user_id: Used to resolve provider API keys for the expansion call.
+        model_id: Default model for the expansion call.  May be overridden
+            by ``settings.lcm_summary_model`` if set.
+
+    Returns:
+        A configured :class:`AgentTool` ready for the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        prompt = str(kwargs.get("prompt") or "")
+        async with async_session_maker() as session:
+            return await lcm_expand_query(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                prompt=prompt,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/tests/test_lcm_expand_query.py
+++ b/backend/tests/test_lcm_expand_query.py
@@ -1,0 +1,258 @@
+"""LCM PR #6 — lcm_expand_query tool tests.
+
+Covers:
+- Empty prompt returns an informative error string.
+- Empty conversation (no context items) returns an error string.
+- expand_query calls the provider with a prompt that contains the full history.
+- Provider response is returned as the answer.
+- Provider failure returns an error string (no exception propagation).
+- Both message and summary items are included in the expansion context.
+- make_lcm_expand_query_tool is in build_agent_tools when lcm_enabled
+  and user_id is provided.
+- make_lcm_expand_query_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+)
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="expand test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="message",
+            item_id=msg.id,
+        )
+    )
+    await session.flush()
+    return msg
+
+
+async def _make_summary_item(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    ordinal: int,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="summary",
+            item_id=s.id,
+        )
+    )
+    await session.flush()
+    return s
+
+
+def _make_provider(answer: str) -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        yield {"type": "delta", "content": answer}
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _make_failing_provider() -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        raise RuntimeError("provider down")
+        yield
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    monkeypatch.setattr(_mod, "resolve_llm", lambda *a, **kw: provider)
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    class _Fake:
+        lcm_summary_model = ""
+
+    monkeypatch.setattr(_mod, "_settings", _Fake())
+
+
+
+# Tests
+
+
+
+@pytest.mark.anyio
+async def test_expand_empty_prompt(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="",
+    )
+    assert "empty prompt" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    _patch_provider(monkeypatch, _make_provider("unused"))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was discussed?",
+    )
+    assert "no conversation history" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_returns_provider_answer(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello there", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_provider("The user greeted the assistant."))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What did the user say?",
+    )
+    assert "The user greeted" in result
+
+
+@pytest.mark.anyio
+async def test_expand_prompt_contains_full_history(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The expansion prompt sent to the provider should contain the full history."""
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "unique_marker_abc", 0)
+    await _make_summary_item(db_session, conv, "Earlier summary_marker_xyz", 1)
+    await db_session.commit()
+
+    captured_questions: list[str] = []
+
+    async def _capturing_stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        captured_questions.append(kwargs.get("question", ""))
+        yield {"type": "delta", "content": "captured"}
+
+    p = MagicMock()
+    p.stream = _capturing_stream
+    _patch_provider(monkeypatch, p)
+    _patch_settings(monkeypatch)
+
+    await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was in the history?",
+    )
+
+    assert captured_questions, "Provider was not called"
+    question_sent = captured_questions[0]
+    assert "unique_marker_abc" in question_sent
+    assert "summary_marker_xyz" in question_sent
+
+
+@pytest.mark.anyio
+async def test_expand_provider_failure_returns_error_string(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hi", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_failing_provider())
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What happened?",
+    )
+    assert "failed" in result.lower() or "error" in result.lower()
+
+


### PR DESCRIPTION
## What lands here

Gives the agent the ability to ask a focused question against the full conversation history, including all compacted summaries.

### `backend/app/core/tools/lcm_expand_query.py`
- `_MAX_EXPAND_ITEMS = 500` — hard upper bound on items fetched to prevent runaway memory use
- `lcm_expand_query(session, *, conversation_id, user_id, model_id, prompt) -> str`
  1. Fetches ALL `lcm_context_items` (bounded to 500)
  2. Resolves each to its backing `ChatMessage` or `LCMSummary`
  3. Builds a full plain-text transcript (messages + summaries in ordinal order)
  4. Makes **one focused LLM call** with `prompt` as the question
  5. Returns the answer string, or an error prefix if the call fails

This is the "deep recall" path — slower than `lcm_grep` but can synthesise across the entire history.

### `backend/app/core/tools/lcm_expand_query_agent.py`
`make_lcm_expand_query_tool(*, conversation_id, user_id, model_id)` — `AgentTool` wrapper. Requires `user_id` (needed for the provider call). Parameter: `prompt` (required).

Not wired into `build_agent_tools` yet — that's PR 10.

### Tests (5 in `test_lcm_expand_query.py`)
empty prompt → validation error · empty conversation → no-history message · provider answer returned verbatim · full history (messages + summaries) included in prompt · provider failure returns error string (no exception raised to caller)