### PR TITLE
feat(lcm): wire all LCM tools into build_agent_tools [10/11]

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -318,7 +318,11 @@ def get_chat_router() -> APIRouter:
             await _web_send_queue.put(event)
 
         agent_tools = build_agent_tools(
-            workspace_root=root, user_id=user.id, send_fn=_web_send_fn
+            workspace_root=root,
+            user_id=user.id,
+            send_fn=_web_send_fn,
+            conversation_id=request.conversation_id,
+            model_id=model_id,
         )
 
         # Load SOUL.md + AGENTS.md from the workspace as the agent's

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -35,6 +35,12 @@ from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
+from app.core.tools.lcm_describe_agent import (
+    make_lcm_describe_tool,
+    make_lcm_list_summaries_tool,
+)
+from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
+from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
@@ -44,6 +50,8 @@ def build_agent_tools(
     workspace_root: Path,
     user_id: uuid.UUID | None = None,
     send_fn: SendFn | None = None,
+    conversation_id: uuid.UUID | None = None,
+    model_id: str | None = None,
 ) -> list[AgentTool]:
     """Return the full ``AgentTool`` list for one chat turn.
 
@@ -120,5 +128,21 @@ def build_agent_tools(
         tools.append(
             make_send_message_tool(workspace_root=workspace_root, send_fn=send_fn)
         )
+
+    # LCM history tools — give the agent on-demand access to compacted
+    # conversation history.  All four are gated on the LCM master switch
+    # and a conversation_id being present.
+    if settings.lcm_enabled and conversation_id is not None:
+        tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
+        if user_id is not None:
+            tools.append(
+                make_lcm_expand_query_tool(
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                    model_id=model_id or "gemini-2.5-flash-preview-05-20",
+                )
+            )
 
     return tools

--- a/backend/tests/test_lcm_agent_tools.py
+++ b/backend/tests/test_lcm_agent_tools.py
@@ -1,0 +1,142 @@
+"""build_agent_tools wiring tests for all LCM tools.
+
+These tests were deferred from PRs 7–9 because they require
+build_agent_tools to accept conversation_id and model_id (this PR).
+
+Covers:
+- lcm_grep is present when lcm_enabled=True and conversation_id is set
+- lcm_grep is absent when lcm_enabled=False
+- lcm_grep is absent when conversation_id is None
+- lcm_describe and lcm_list_summaries are present/absent under the same gates
+- lcm_expand_query is present only when user_id is also provided
+- lcm_expand_query is absent when user_id is None
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def test_lcm_grep_tool_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    assert "lcm_grep" in [t.name for t in tools]
+
+
+def test_lcm_grep_tool_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    assert "lcm_grep" not in [t.name for t in tools]
+
+
+def test_lcm_grep_tool_absent_when_no_conversation_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=None)
+    assert "lcm_grep" not in [t.name for t in tools]
+
+
+def test_describe_tools_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_list_summaries" in names
+    assert "lcm_describe" in names
+
+
+def test_describe_tools_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_list_summaries" not in names
+    assert "lcm_describe" not in names
+
+
+def test_expand_query_tool_present_when_user_id_provided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    assert "lcm_expand_query" in [t.name for t in tools]
+
+
+def test_expand_query_tool_absent_without_user_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    # user_id=None → expand_query should NOT be present (it needs user_id for
+    # the LLM sub-call).
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=None,
+    )
+    assert "lcm_expand_query" not in [t.name for t in tools]
+
+
+def test_expand_query_tool_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    assert "lcm_expand_query" not in [t.name for t in tools]


### PR DESCRIPTION
## What lands here

Connects the four LCM tools (PRs 7–9) into `build_agent_tools` and passes the required context from `chat.py`.

### `backend/app/core/agent_tools.py`
Two new parameters on `build_agent_tools`:
- `conversation_id: uuid.UUID | None = None`
- `model_id: str | None = None`

When `settings.lcm_enabled` is `True` and `conversation_id` is set, four tools are appended:
```
lcm_grep           — always added
lcm_list_summaries — always added
lcm_describe       — always added
lcm_expand_query   — only added if user_id is also set (requires it for the LLM sub-call)
```

### `backend/app/api/chat.py`
Passes `conversation_id=request.conversation_id` and `model_id=model_id` to `build_agent_tools` so the tools are scoped to the current turn's conversation.

### Tests (9 in `test_lcm_agent_tools.py`) — deferred from PRs 7–9
- `lcm_grep` present when `lcm_enabled=True` + `conversation_id` set
- `lcm_grep` absent when `lcm_enabled=False`
- `lcm_grep` absent when `conversation_id=None`
- `lcm_describe` + `lcm_list_summaries` present/absent under same gates
- `lcm_expand_query` present when `user_id` provided
- `lcm_expand_query` absent when `user_id=None`
- `lcm_expand_query` absent when `lcm_enabled=False`