### PR TITLE
feat(lcm): condensation pass [11/11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added Lossless Context Management (LCM): a DAG-based conversation compaction system that summarises older turns into queryable `LCMSummary` nodes while preserving a verbatim fresh tail. Off by default behind `lcm_enabled`; opt-in via six new settings (`lcm_fresh_tail_count`, `lcm_leaf_chunk_tokens`, `lcm_context_threshold`, `lcm_incremental_max_depth`, `lcm_summary_model`).
+- Added four LCM agent tools (`lcm_grep`, `lcm_describe`, `lcm_list_summaries`, `lcm_expand_query`) so the agent can search, enumerate, inspect, and synthesise across compacted history when context grows past the fresh tail.
+- Added background leaf compaction after every chat turn, plus a condensation pass that folds same-depth summaries into deeper parent nodes (configurable up to an unlimited cascade).
+- Added provider-native replay state: the agent loop now forwards opaque `provider_state` from `LLMDoneEvent` onto the assistant message so Gemini can replay `ModelContent` (preserving `thought_signature` bytes) on follow-up tool turns without leaking the slot into transcripts or persistence.
+- Added migration `015_add_lcm_tables` (`lcm_summaries`, `lcm_summary_sources`, `lcm_context_items`) with the unique `(conversation_id, ordinal)` constraint and cascade FKs from each LCM table to `conversations`.
 - Added startup refresh for Telegram slash commands so the bot menu matches the current server build.
 - Added verbose Telegram delivery for tool activity and thinking events.
 - Fixed default workspace creation races so losing inserts clean up their seeded directory asynchronously.

--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -65,6 +65,18 @@ ignore_imports =
     app.core.governance.cost_tracker -> app.models
     app.core.scheduler.scheduler -> app.models
     app.core.event_bus.handlers -> app.crud.workspace
+    ; LCM (Stack B / PRs #186–#196) owns three ORM tables
+    ; (lcm_summaries, lcm_summary_sources, lcm_context_items) and must
+    ; read/write them directly to assemble context, compact leaves, and
+    ; condense same-depth summaries.  Same shape as the governance and
+    ; exporter grandfathers above — flatten in a follow-up (e.g. inject
+    ; a Protocol the caller satisfies, or move the side-effect into the
+    ; api/crud layer).
+    app.core.lcm -> app.models
+    app.core.lcm.condense -> app.models
+    app.core.tools.lcm_describe -> app.models
+    app.core.tools.lcm_grep -> app.models
+    app.core.tools.lcm_expand_query -> app.models
 
 ; --- Contract 2: the legacy db ↔ models cycle is the one cycle sentrux
 ; allows (max_cycles = 1). Pin it explicitly so any *new* cycle fails CI. -

--- a/backend/alembic/versions/015_add_lcm_tables.py
+++ b/backend/alembic/versions/015_add_lcm_tables.py
@@ -1,0 +1,150 @@
+"""Add LCM (Lossless Context Management) tables.
+
+Three tables form the storage layer for our adaptation of the LCM
+approach (originally a TypeScript OpenClaw plugin from
+Martian-Engineering; we ported the core algorithm to Python).
+
+This migration only creates the schema — no application code reads or
+writes these tables until later stack PRs.  Shipping the schema first
+lets us land the migration cleanly without worrying about runtime
+behaviour changes.
+
+Revision ID: 015_add_lcm_tables
+Revises: 014_drop_active_conversation_id
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "015_add_lcm_tables"
+down_revision = "014_drop_active_conversation_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the three LCM tables and their supporting indices."""
+    op.create_table(
+        "lcm_summaries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("depth", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "token_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("model_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "summary_kind",
+            sa.String(length=16),
+            nullable=False,
+            server_default="normal",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_id",
+        "lcm_summaries",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_summaries_conversation_depth",
+        "lcm_summaries",
+        ["conversation_id", "depth"],
+    )
+
+    op.create_table(
+        "lcm_summary_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("summary_id", sa.Uuid(), nullable=False),
+        sa.Column("source_kind", sa.String(length=16), nullable=False),
+        sa.Column("source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_ordinal", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["summary_id"], ["lcm_summaries.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_summary_id",
+        "lcm_summary_sources",
+        ["summary_id"],
+    )
+    op.create_index(
+        "ix_lcm_summary_sources_source_id",
+        "lcm_summary_sources",
+        ["source_id"],
+    )
+
+    op.create_table(
+        "lcm_context_items",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("item_kind", sa.String(length=16), nullable=False),
+        sa.Column("item_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # Unique (conversation_id, ordinal) so compaction can renumber
+        # densely without colliding mid-transaction.
+        sa.UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+    op.create_index(
+        "ix_lcm_context_items_conversation_id",
+        "lcm_context_items",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_context_items_item_id",
+        "lcm_context_items",
+        ["item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_lcm_context_items_item_id", table_name="lcm_context_items"
+    )
+    op.drop_index(
+        "ix_lcm_context_items_conversation_id", table_name="lcm_context_items"
+    )
+    op.drop_table("lcm_context_items")
+
+    op.drop_index(
+        "ix_lcm_summary_sources_source_id", table_name="lcm_summary_sources"
+    )
+    op.drop_index(
+        "ix_lcm_summary_sources_summary_id", table_name="lcm_summary_sources"
+    )
+    op.drop_table("lcm_summary_sources")
+
+    op.drop_index(
+        "ix_lcm_summaries_conversation_depth", table_name="lcm_summaries"
+    )
+    op.drop_index(
+        "ix_lcm_summaries_conversation_id", table_name="lcm_summaries"
+    )
+    op.drop_table("lcm_summaries")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -272,6 +272,8 @@ def get_chat_router() -> APIRouter:
             user_id=user.id,
             send_fn=_web_send_fn,
             surface=surface,
+            conversation_id=request.conversation_id,
+            model_id=model_id,
         )
 
         def _artifact_hook(event: StreamEvent) -> list[StreamEvent]:

--- a/backend/app/channels/_turn_cost.py
+++ b/backend/app/channels/_turn_cost.py
@@ -1,0 +1,79 @@
+"""Per-turn cost-ledger write — extracted from ``turn_runner``.
+
+Keeps ``app.channels.turn_runner`` under the 500-line module budget
+while keeping the cost-ledger write tightly bound to the turn lifecycle
+(same DB session as the assistant-message persist so a failed commit
+leaves no orphaned ledger row).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.chat_aggregator import ChatTurnAggregator
+from app.core.config import settings
+from app.core.governance.cost_tracker import (
+    PostgresCostLedger,
+    record_turn_cost,
+)
+from app.core.providers.model_id import parse_model_id
+
+logger = logging.getLogger(__name__)
+
+
+async def record_turn_cost_if_enabled(
+    *,
+    session: AsyncSession,
+    aggregator: ChatTurnAggregator,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    model_id: str,
+    surface: str,
+    log_tag: str,
+) -> None:
+    """Append the turn's spend to ``cost_ledger`` (PR 04).
+
+    No-op when cost tracking is disabled or the aggregator saw zero
+    usage events (early failures, errors before the terminal turn).
+    Catches and logs DB errors so a ledger write failure never leaves
+    the assistant row unpersisted — the caller commits in the same
+    transaction.
+
+    Pass plain values rather than a ``ChatTurnInput`` so this module
+    has no import dependency on ``turn_runner`` (sentrux disallows the
+    cycle, even via ``TYPE_CHECKING``).
+    """
+    if not settings.cost_tracker_enabled:
+        return
+    if (
+        aggregator.total_input_tokens <= 0
+        and aggregator.total_output_tokens <= 0
+        and aggregator.total_cost_usd <= 0
+    ):
+        return
+    try:
+        provider_slug = parse_model_id(model_id).host.value if model_id else "unknown"
+    except Exception:
+        provider_slug = "unknown"
+    ledger = PostgresCostLedger(session=session)
+    try:
+        await record_turn_cost(
+            ledger,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            provider=provider_slug,
+            model_id=model_id,
+            input_tokens=aggregator.total_input_tokens,
+            output_tokens=aggregator.total_output_tokens,
+            cost_usd=aggregator.total_cost_usd,
+            surface=surface,
+        )
+    except Exception:
+        logger.exception(
+            "%s_COST_LEDGER_ERR conversation_id=%s",
+            log_tag,
+            conversation_id,
+        )

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -23,6 +23,8 @@ from app.core.governance.cost_tracker import (
     record_turn_cost,
 )
 from app.core.governance.workspace_context import load_workspace_context
+from app.core.lcm import assemble_context as lcm_assemble_context
+from app.core.lcm import ingest_message as lcm_ingest_message
 from app.core.observability._turn_view import (
     aggregator_stop_reason,
     build_llm_view_messages,
@@ -302,19 +304,35 @@ def _should_deliver_event(event: StreamEvent, verbose_level: int | None) -> bool
 async def _load_history_and_persist(
     turn_input: ChatTurnInput,
 ) -> tuple[list[dict[str, str]], uuid.UUID]:
-    """Read recent history, then persist the current user turn and placeholder."""
+    """Read recent history, then persist the current user turn and placeholder.
+
+    When ``settings.lcm_enabled`` is ``True``, the history slice is
+    assembled from the LCM context list (``lcm_context_items``) so that
+    compacted summaries are visible to the provider, and both the user
+    turn and assistant placeholder are ingested into the LCM context
+    list before the stream starts.  When LCM is off the behaviour is
+    unchanged — a raw ``LIMIT history_window`` query over
+    ``chat_messages``.
+    """
     async with _turn_session(turn_input) as session:
-        recent_rows = await get_messages_for_conversation(
-            session,
-            turn_input.conversation_id,
-            limit=turn_input.history_window,
-        )
-        history = [
-            {"role": row.role, "content": row.content or ""}
-            for row in recent_rows
-            if row.role in {"user", "assistant"}
-        ]
-        await append_user_message(
+        if settings.lcm_enabled:
+            history = await lcm_assemble_context(
+                session,
+                conversation_id=turn_input.conversation_id,
+                fresh_tail_count=settings.lcm_fresh_tail_count,
+            )
+        else:
+            recent_rows = await get_messages_for_conversation(
+                session,
+                turn_input.conversation_id,
+                limit=turn_input.history_window,
+            )
+            history = [
+                {"role": row.role, "content": row.content or ""}
+                for row in recent_rows
+                if row.role in {"user", "assistant"}
+            ]
+        user_msg = await append_user_message(
             session,
             conversation_id=turn_input.conversation_id,
             user_id=turn_input.user_id,
@@ -325,6 +343,17 @@ async def _load_history_and_persist(
             conversation_id=turn_input.conversation_id,
             user_id=turn_input.user_id,
         )
+        if settings.lcm_enabled:
+            await lcm_ingest_message(
+                session,
+                conversation_id=turn_input.conversation_id,
+                message_id=user_msg.id,
+            )
+            await lcm_ingest_message(
+                session,
+                conversation_id=turn_input.conversation_id,
+                message_id=assistant_row.id,
+            )
         await session.commit()
         return history, assistant_row.id
 

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 import uuid
@@ -15,28 +14,21 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.channels._turn_cost import record_turn_cost_if_enabled
 from app.core.chat_aggregator import ChatTurnAggregator, should_emit_event
 from app.core.config import settings
-from app.core.event_bus import TurnCompletedEvent
-from app.core.event_bus.global_bus import publish_if_available
-from app.core.governance.cost_tracker import (
-    PostgresCostLedger,
-    record_turn_cost,
-)
+from app.core.event_bus import TurnCompletedEvent, publish_if_available
 from app.core.governance.workspace_context import load_workspace_context
 from app.core.lcm import assemble_context as lcm_assemble_context
-from app.core.lcm import compact_leaf_if_needed as lcm_compact_leaf
 from app.core.lcm import ingest_message as lcm_ingest_message
-from app.core.observability._turn_view import (
+from app.core.lcm.background import schedule_lcm_compaction
+from app.core.observability import (
     aggregator_stop_reason,
     build_llm_view_messages,
-)
-from app.core.observability.workshop import (
     llm_span,
     turn_span,
     workshop_event_hook,
 )
-from app.core.providers.model_id import parse_model_id
 from app.core.tools.agents_md import assemble_workspace_prompt
 from app.crud.chat_message import (
     append_assistant_placeholder,
@@ -412,10 +404,17 @@ async def _finalize_turn(
             # persist so a failed commit leaves no orphaned ledger row.
             # Runs for every surface (web + Telegram) so the per-user
             # cap applies uniformly.
-            await _record_turn_cost(
+            channel_message = turn_input.channel_message
+            cost_model_id = (channel_message.get("model_id") or "") if channel_message else ""
+            cost_surface = (channel_message.get("surface") or "") if channel_message else ""
+            await record_turn_cost_if_enabled(
                 session=session,
-                turn_input=turn_input,
                 aggregator=aggregator,
+                user_id=turn_input.user_id,
+                conversation_id=turn_input.conversation_id,
+                model_id=cost_model_id,
+                surface=cost_surface,
+                log_tag=turn_input.log_tag,
             )
             await session.commit()
     except Exception:
@@ -462,97 +461,10 @@ async def _finalize_turn(
     )
     # Fire-and-forget LCM leaf compaction.  Runs after the assistant row is
     # finalized so the just-completed turn is eligible for compaction.
-    # Errors swallowed inside the bg helper — full history is always
-    # preserved in ``chat_messages``.
-    if settings.lcm_enabled:
-        asyncio.create_task(
-            _lcm_compact_bg(
-                conversation_id=turn_input.conversation_id,
-                user_id=turn_input.user_id,
-                model_id=model_id or "",
-            )
-        )
-
-
-async def _lcm_compact_bg(
-    *,
-    conversation_id: uuid.UUID,
-    user_id: uuid.UUID,
-    model_id: str,
-) -> None:
-    """Run one LCM leaf-compaction pass for ``conversation_id``.
-
-    Opens its own session so it runs independently of the request
-    lifecycle.  All exceptions are caught and logged — a failed
-    compaction must never surface to the user; the full message
-    history stays preserved in ``chat_messages``.
-    """
-    try:
-        async with async_session_maker() as compact_session:
-            await lcm_compact_leaf(
-                compact_session,
-                conversation_id=conversation_id,
-                user_id=user_id,
-                model_id=model_id,
-                fresh_tail_count=settings.lcm_fresh_tail_count,
-                max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
-            )
-            await compact_session.commit()
-    except Exception:
-        logger.exception(
-            "LCM_COMPACT_BG_ERR conversation_id=%s",
-            conversation_id,
-        )
-
-
-async def _record_turn_cost(
-    *,
-    session: AsyncSession,
-    turn_input: ChatTurnInput,
-    aggregator: ChatTurnAggregator,
-) -> None:
-    """Append the turn's spend to ``cost_ledger`` (PR 04).
-
-    No-op when cost tracking is disabled or the aggregator saw zero
-    usage events (early failures, errors before the terminal turn).
-    Catches and logs DB errors so a ledger write failure never leaves
-    the assistant row unpersisted — the caller commits in the same
-    transaction.
-    """
-    if not settings.cost_tracker_enabled:
-        return
-    if (
-        aggregator.total_input_tokens <= 0
-        and aggregator.total_output_tokens <= 0
-        and aggregator.total_cost_usd <= 0
-    ):
-        return
-    model_id = (
-        (turn_input.channel_message.get("model_id") or "") if turn_input.channel_message else ""
+    # The helper handles the ``settings.lcm_enabled`` gate, task-strong-ref
+    # bookkeeping, and exception suppression in one place.
+    schedule_lcm_compaction(
+        conversation_id=turn_input.conversation_id,
+        user_id=turn_input.user_id,
+        model_id=model_id or "",
     )
-    surface = (
-        (turn_input.channel_message.get("surface") or "") if turn_input.channel_message else ""
-    )
-    try:
-        provider_slug = parse_model_id(model_id).host.value if model_id else "unknown"
-    except Exception:
-        provider_slug = "unknown"
-    ledger = PostgresCostLedger(session=session)
-    try:
-        await record_turn_cost(
-            ledger,
-            user_id=turn_input.user_id,
-            conversation_id=turn_input.conversation_id,
-            provider=provider_slug,
-            model_id=model_id,
-            input_tokens=aggregator.total_input_tokens,
-            output_tokens=aggregator.total_output_tokens,
-            cost_usd=aggregator.total_cost_usd,
-            surface=surface,
-        )
-    except Exception:
-        logger.exception(
-            "%s_COST_LEDGER_ERR conversation_id=%s",
-            turn_input.log_tag,
-            turn_input.conversation_id,
-        )

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -24,6 +25,7 @@ from app.core.governance.cost_tracker import (
 )
 from app.core.governance.workspace_context import load_workspace_context
 from app.core.lcm import assemble_context as lcm_assemble_context
+from app.core.lcm import compact_leaf_if_needed as lcm_compact_leaf
 from app.core.lcm import ingest_message as lcm_ingest_message
 from app.core.observability._turn_view import (
     aggregator_stop_reason,
@@ -458,6 +460,49 @@ async def _finalize_turn(
             source=turn_input.log_tag.lower(),
         )
     )
+    # Fire-and-forget LCM leaf compaction.  Runs after the assistant row is
+    # finalized so the just-completed turn is eligible for compaction.
+    # Errors swallowed inside the bg helper — full history is always
+    # preserved in ``chat_messages``.
+    if settings.lcm_enabled:
+        asyncio.create_task(
+            _lcm_compact_bg(
+                conversation_id=turn_input.conversation_id,
+                user_id=turn_input.user_id,
+                model_id=model_id or "",
+            )
+        )
+
+
+async def _lcm_compact_bg(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> None:
+    """Run one LCM leaf-compaction pass for ``conversation_id``.
+
+    Opens its own session so it runs independently of the request
+    lifecycle.  All exceptions are caught and logged — a failed
+    compaction must never surface to the user; the full message
+    history stays preserved in ``chat_messages``.
+    """
+    try:
+        async with async_session_maker() as compact_session:
+            await lcm_compact_leaf(
+                compact_session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                fresh_tail_count=settings.lcm_fresh_tail_count,
+                max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
+            )
+            await compact_session.commit()
+    except Exception:
+        logger.exception(
+            "LCM_COMPACT_BG_ERR conversation_id=%s",
+            conversation_id,
+        )
 
 
 async def _record_turn_cost(

--- a/backend/app/core/agent_loop/loop.py
+++ b/backend/app/core/agent_loop/loop.py
@@ -277,9 +277,12 @@ async def _run_loop(
             content=stream_outcome.assistant_content,
             stop_reason=stream_outcome.stop_reason,
         )
-        # TODO(pawrrtal-55sw): Copy opaque provider_state from the terminal
-        # LLMDoneEvent into this AssistantMessage so the next provider call
-        # can replay native model content while the loop remains generic.
+        # Forward opaque provider replay state so the next provider call
+        # can replay native model content (e.g. Gemini ``thought_signature``)
+        # while the loop remains generic.  The slot is optional and the
+        # loop never inspects its contents.
+        if stream_outcome.provider_state is not None:
+            assistant_msg["provider_state"] = stream_outcome.provider_state
         messages.append(assistant_msg)
         new_messages.append(assistant_msg)
 
@@ -482,6 +485,7 @@ class _StreamOutcome:
         "assistant_content",
         "consecutive_llm_errors_after",
         "events",
+        "provider_state",
         "stop_reason",
         "terminated_event",
     )
@@ -493,12 +497,14 @@ class _StreamOutcome:
         stop_reason: str,
         consecutive_llm_errors_after: int,
         terminated_event: AgentTerminatedEvent | None,
+        provider_state: dict[str, Any] | None = None,
     ) -> None:
         self.events = events
         self.assistant_content = assistant_content
         self.stop_reason = stop_reason
         self.consecutive_llm_errors_after = consecutive_llm_errors_after
         self.terminated_event = terminated_event
+        self.provider_state = provider_state
 
 
 async def _stream_with_retry(
@@ -528,6 +534,7 @@ async def _stream_with_retry(
         events: list[AgentEvent] = []
         assistant_content: list[TextContent | ToolCallContent] = []
         stop_reason = "stop"
+        provider_state: dict[str, Any] | None = None
 
         try:
             async for llm_event in stream_fn(llm_messages, tools):
@@ -537,6 +544,7 @@ async def _stream_with_retry(
                 # the assignments here capture the final state.
                 assistant_content = done["content"] if done else assistant_content
                 stop_reason = done["stop_reason"] if done else stop_reason
+                provider_state = _carry_provider_state(done, provider_state)
         except Exception as exc:
             consecutive_llm_errors += 1
             _log.warning(
@@ -565,6 +573,7 @@ async def _stream_with_retry(
             stop_reason=stop_reason,
             consecutive_llm_errors_after=0,
             terminated_event=None,
+            provider_state=provider_state,
         )
 
 
@@ -642,13 +651,36 @@ def _consume_llm_event(
         )
         return None
     if llm_event["type"] == "done":
-        # TODO(pawrrtal-55sw): Return provider_state here once LLMDoneEvent
-        # supports it; _stream_with_retry should preserve it in _StreamOutcome.
-        return {
+        result: dict[str, Any] = {
             "content": llm_event["content"],
             "stop_reason": llm_event["stop_reason"],
         }
+        # Forward opaque provider replay state if the StreamFn populated
+        # it.  ``provider_state`` is a ``total=False`` field on
+        # ``LLMDoneEvent`` so we read it with ``.get`` and only copy it
+        # forward when the provider actually returned one.  See
+        # ``_stream_with_retry`` for the per-turn capture.
+        provider_state = llm_event.get("provider_state")
+        if provider_state is not None:
+            result["provider_state"] = provider_state
+        return result
     return None
+
+
+def _carry_provider_state(
+    done: dict[str, Any] | None,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the provider_state from ``done`` if present, else keep ``current``.
+
+    Extracted out of :func:`_stream_with_retry` so the streaming loop's
+    body stays under the project nesting-depth budget.  The loop never
+    inspects the contents — providers own the keyspace; we just forward
+    the slot.
+    """
+    if done is not None and "provider_state" in done:
+        return done["provider_state"]
+    return current
 
 
 def _terminated(

--- a/backend/app/core/agent_loop/types.py
+++ b/backend/app/core/agent_loop/types.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 # ---------------------------------------------------------------------------
 # Content blocks (inside messages)
@@ -55,7 +55,7 @@ class UserMessage(TypedDict):
     content: str
 
 
-class AssistantMessage(TypedDict, total=False):
+class AssistantMessage(TypedDict):
     """One assistant turn (text + optional tool calls) with its stop reason.
 
     ``provider_state`` is an opaque, optional slot for provider-native
@@ -64,12 +64,17 @@ class AssistantMessage(TypedDict, total=False):
     follow-up turns can replay ``thought_signature`` bytes that Vertex
     rejects without; see
     https://ai.google.dev/gemini-api/docs/thought-signatures.
+
+    Note: ``role``, ``content`` and ``stop_reason`` are mandatory; only
+    ``provider_state`` is marked ``NotRequired`` so the discriminant
+    fields keep TypeChecker-driven narrowing in ``_consume_llm_event``
+    and ``_build_gemini_contents``.
     """
 
     role: Literal["assistant"]
     content: list[TextContent | ToolCallContent]
     stop_reason: str  # "stop" | "tool_use" | "error" | "aborted"
-    provider_state: dict[str, Any]
+    provider_state: NotRequired[dict[str, Any]]
 
 
 class ToolResultMessage(TypedDict):
@@ -120,7 +125,7 @@ class LLMToolCallEvent(TypedDict):
     arguments: dict[str, Any]
 
 
-class LLMDoneEvent(TypedDict, total=False):
+class LLMDoneEvent(TypedDict):
     """Terminal event yielded by a provider to flush the assembled assistant turn.
 
     ``provider_state`` mirrors :class:`AssistantMessage.provider_state`:
@@ -128,12 +133,17 @@ class LLMDoneEvent(TypedDict, total=False):
     here without exposing it to ``StreamEvent`` / Telegram / persistence.
     The loop copies it onto the resulting :class:`AssistantMessage` so
     the next turn's StreamFn can replay native content.
+
+    The discriminant ``type`` and the loop-consumed ``stop_reason`` /
+    ``content`` are mandatory; only ``provider_state`` is
+    ``NotRequired`` so the union discriminant in ``LLMEvent`` keeps
+    exhaustive narrowing.
     """
 
     type: Literal["done"]
     stop_reason: str
     content: list[TextContent | ToolCallContent]
-    provider_state: dict[str, Any]
+    provider_state: NotRequired[dict[str, Any]]
 
 
 LLMEvent = LLMTextDeltaEvent | LLMThinkingDeltaEvent | LLMToolCallEvent | LLMDoneEvent

--- a/backend/app/core/agent_loop/types.py
+++ b/backend/app/core/agent_loop/types.py
@@ -55,15 +55,21 @@ class UserMessage(TypedDict):
     content: str
 
 
-class AssistantMessage(TypedDict):
-    """One assistant turn (text + optional tool calls) with its stop reason."""
+class AssistantMessage(TypedDict, total=False):
+    """One assistant turn (text + optional tool calls) with its stop reason.
+
+    ``provider_state`` is an opaque, optional slot for provider-native
+    replay metadata.  The loop never inspects its contents — providers
+    own the keyspace.  Gemini stores its ``ModelContent`` here so
+    follow-up turns can replay ``thought_signature`` bytes that Vertex
+    rejects without; see
+    https://ai.google.dev/gemini-api/docs/thought-signatures.
+    """
 
     role: Literal["assistant"]
     content: list[TextContent | ToolCallContent]
     stop_reason: str  # "stop" | "tool_use" | "error" | "aborted"
-    # TODO(pawrrtal-55sw): Add an optional provider_state field for
-    # opaque native replay data. Gemini needs this for thought signatures:
-    # https://ai.google.dev/gemini-api/docs/thought-signatures
+    provider_state: dict[str, Any]
 
 
 class ToolResultMessage(TypedDict):
@@ -114,15 +120,20 @@ class LLMToolCallEvent(TypedDict):
     arguments: dict[str, Any]
 
 
-class LLMDoneEvent(TypedDict):
-    """Terminal event yielded by a provider to flush the assembled assistant turn."""
+class LLMDoneEvent(TypedDict, total=False):
+    """Terminal event yielded by a provider to flush the assembled assistant turn.
+
+    ``provider_state`` mirrors :class:`AssistantMessage.provider_state`:
+    StreamFn implementations can return provider-native replay state
+    here without exposing it to ``StreamEvent`` / Telegram / persistence.
+    The loop copies it onto the resulting :class:`AssistantMessage` so
+    the next turn's StreamFn can replay native content.
+    """
 
     type: Literal["done"]
     stop_reason: str
     content: list[TextContent | ToolCallContent]
-    # TODO(pawrrtal-55sw): Mirror AssistantMessage.provider_state here so
-    # StreamFn implementations can return provider-native replay state
-    # without exposing it to StreamEvent/Telegram/persistence.
+    provider_state: dict[str, Any]
 
 
 LLMEvent = LLMTextDeltaEvent | LLMThinkingDeltaEvent | LLMToolCallEvent | LLMDoneEvent

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from app.core.agent_loop.types import AgentTool
 from app.core.config import settings
 from app.core.keys import resolve_api_key
+from app.core.providers.catalog import default_model
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
@@ -165,11 +166,17 @@ def build_agent_tools(
         tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
         tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
         if user_id is not None:
+            # When the caller didn't pin a model, fall back to the
+            # catalog's canonical default rather than a hardcoded
+            # preview ID — hardcoded preview IDs drift the moment the
+            # catalog moves (see commit 08318a1 for the analogous fix in
+            # ``app.cli.commit``).
+            expand_model_id = model_id or default_model().id
             tools.append(
                 make_lcm_expand_query_tool(
                     conversation_id=conversation_id,
                     user_id=user_id,
-                    model_id=model_id or "gemini-2.5-flash-preview-05-20",
+                    model_id=expand_model_id,
                 )
             )
 

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -35,6 +35,12 @@ from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
+from app.core.tools.lcm_describe_agent import (
+    make_lcm_describe_tool,
+    make_lcm_list_summaries_tool,
+)
+from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
+from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
@@ -46,6 +52,8 @@ def build_agent_tools(
     user_id: uuid.UUID | None = None,
     send_fn: SendFn | None = None,
     surface: str | None = None,
+    conversation_id: uuid.UUID | None = None,
+    model_id: str | None = None,
 ) -> list[AgentTool]:
     """Return the full ``AgentTool`` list for one chat turn.
 
@@ -74,6 +82,13 @@ def build_agent_tools(
             (``send_image_to_user`` / ``send_voice_to_user`` /
             ``send_document_to_user``) are appended so a workspace
             authored against CCT's MCP names runs unchanged here.
+        conversation_id: Active conversation UUID — required for the
+            LCM history tools (``lcm_grep`` / ``lcm_describe`` /
+            ``lcm_list_summaries`` / ``lcm_expand_query``) to scope
+            their queries.  Omitted in non-chat call sites.
+        model_id: Active model id — used by ``lcm_expand_query`` to
+            pick which provider to send the focused recall prompt to.
+            Falls back to a sane default when not supplied.
 
     Returns:
         A fresh list of :class:`AgentTool` ready to hand to a provider.
@@ -141,5 +156,21 @@ def build_agent_tools(
             )
 
             tools.extend(make_telegram_capability_tools(send_fn))
+
+    # LCM history tools — give the agent on-demand access to compacted
+    # conversation history.  All four are gated on the LCM master switch
+    # and a conversation_id being present.
+    if settings.lcm_enabled and conversation_id is not None:
+        tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
+        if user_id is not None:
+            tools.append(
+                make_lcm_expand_query_tool(
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                    model_id=model_id or "gemini-2.5-flash-preview-05-20",
+                )
+            )
 
     return tools

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -286,6 +286,30 @@ class Settings(BaseSettings):
     # Maximum voice file size accepted, in MB.
     voice_max_size_mb: int = 25
 
+    # ── Lossless Context Management (LCM) ────────────────────────────
+    # Master switch for the LCM compaction system (see app.core.lcm).
+    # Default OFF so the schema can land without changing runtime
+    # behaviour.  Later stack PRs activate ingest → assemble → compact.
+    lcm_enabled: bool = False
+    # Last N raw messages that are always kept verbatim, never compacted.
+    # 64 matches the upstream plugin's default; increase for chattier
+    # surfaces (Telegram) where short messages dominate.
+    lcm_fresh_tail_count: int = 64
+    # Approximate source-token ceiling per leaf summary.  Raise this on
+    # quota-limited summary providers; lower it for tighter context.
+    lcm_leaf_chunk_tokens: int = 20000
+    # Auto-trigger compaction when the conversation context is at or
+    # above this fraction of the model's window.  ``0.75`` is the
+    # upstream default.
+    lcm_context_threshold: float = 0.75
+    # How many condensation passes to run after each leaf compaction.
+    # 0 = leaf-only, -1 = unlimited cascade.
+    lcm_incremental_max_depth: int = 1
+    # Optional model override for compaction summarisation.  When unset,
+    # falls back to the same model the conversation is using — fine for
+    # cheap models, wasteful for premium ones.
+    lcm_summary_model: str = ""
+
     @property
     def claude_sandbox_excluded_commands_list(self) -> list[str]:
         """Parsed view of ``claude_sandbox_excluded_commands``."""

--- a/backend/app/core/event_bus/__init__.py
+++ b/backend/app/core/event_bus/__init__.py
@@ -25,6 +25,7 @@ the bus + agent handler split lives outside ``providers/``.
 """
 
 from app.core.event_bus.bus import Event, EventBus, EventHandler
+from app.core.event_bus.global_bus import publish_if_available
 from app.core.event_bus.handlers import AgentHandler, NotificationService
 from app.core.event_bus.types import (
     AgentResponseEvent,
@@ -45,4 +46,5 @@ __all__ = [
     "TurnCompletedEvent",
     "TurnStartedEvent",
     "WebhookEvent",
+    "publish_if_available",
 ]

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -1,0 +1,134 @@
+"""Lossless Context Management — ingest and assembly.
+
+Public API
+----------
+``ingest_message``   — record a new ChatMessage in lcm_context_items
+``assemble_context`` — build the [{role, content}] context list for a turn
+
+All functions are always importable; callers gate on ``settings.lcm_enabled``
+(default ``False``) before invoking them.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def ingest_message(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    message_id: uuid.UUID,
+) -> LCMContextItem:
+    """Append a ChatMessage to the conversation's ``lcm_context_items`` list.
+
+    Creates one :class:`~app.models.LCMContextItem` row with
+    ``item_kind="message"`` at the next free ordinal slot
+    (``max(ordinal) + 1`` for the conversation, or ``0`` for the very first
+    message).
+
+    The caller must commit the session after this call; the function calls
+    ``session.flush()`` so the new row's ``id`` is populated before returning.
+    """
+    result = await session.execute(
+        select(func.max(LCMContextItem.ordinal)).where(
+            LCMContextItem.conversation_id == conversation_id
+        )
+    )
+    current_max = result.scalar()
+    next_ordinal = 0 if current_max is None else current_max + 1
+
+    item = LCMContextItem(
+        conversation_id=conversation_id,
+        ordinal=next_ordinal,
+        item_kind="message",
+        item_id=message_id,
+    )
+    session.add(item)
+    await session.flush()
+    return item
+
+
+async def assemble_context(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int,
+) -> list[dict[str, Any]]:
+    """Return the assembled context window for a conversation turn.
+
+    Fetches the last ``fresh_tail_count`` entries from ``lcm_context_items``
+    (DESC + LIMIT, then reversed to chronological order), resolves each entry
+    to its backing row, and returns a list of ``{"role": ..., "content": ...}``
+    dicts ready to pass to a provider's ``history`` parameter.
+
+    Item-kind handling:
+
+    * ``"message"`` — resolved to its :class:`~app.models.ChatMessage`; only
+      ``user`` and ``assistant`` roles are included.
+    * ``"summary"`` — resolved to its :class:`~app.models.LCMSummary` and
+      injected as a synthetic ``user`` message with a
+      ``[Summary of earlier conversation]`` prefix so both the model and human
+      readers recognise it as compacted history rather than a real turn.
+
+    Returns an empty list if no items exist yet.
+    """
+    result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.desc())
+        .limit(fresh_tail_count)
+    )
+    items = list(result.scalars().all())
+    items.reverse()  # oldest first
+
+    if not items:
+        return []
+
+    message_ids = [item.item_id for item in items if item.item_kind == "message"]
+    summary_ids = [item.item_id for item in items if item.item_kind == "summary"]
+
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        msg_result = await session.execute(
+            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+        )
+        messages_by_id = {m.id: m for m in msg_result.scalars().all()}
+
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        sum_result = await session.execute(
+            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
+        )
+        summaries_by_id = {s.id: s for s in sum_result.scalars().all()}
+
+    context: list[dict[str, Any]] = []
+    for item in items:
+        if item.item_kind == "message":
+            msg = messages_by_id.get(item.item_id)
+            if msg is not None and msg.role in {"user", "assistant"}:
+                context.append({"role": msg.role, "content": msg.content or ""})
+        elif item.item_kind == "summary":
+            summary = summaries_by_id.get(item.item_id)
+            if summary is not None:
+                context.append(
+                    {
+                        "role": "user",
+                        "content": f"[Summary of earlier conversation]\n{summary.content}",
+                    }
+                )
+    return context

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -1,9 +1,11 @@
-"""Lossless Context Management — ingest and assembly.
+"""Lossless Context Management — ingest, assembly, and leaf compaction.
 
 Public API
 ----------
-``ingest_message``   — record a new ChatMessage in lcm_context_items
-``assemble_context`` — build the [{role, content}] context list for a turn
+``ingest_message``         — record a new ChatMessage in lcm_context_items
+``assemble_context``       — build the [{role, content}] context list for a turn
+``compact_leaf_if_needed`` — summarise the oldest non-fresh items into a leaf
+                             LCMSummary and rewrite lcm_context_items in place
 
 All functions are always importable; callers gate on ``settings.lcm_enabled``
 (default ``False``) before invoking them.
@@ -13,12 +15,15 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import ChatMessage, LCMContextItem, LCMSummary
+from app.core.config import settings as _settings
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
 
 _log = logging.getLogger(__name__)
 
@@ -132,3 +137,236 @@ async def assemble_context(
                     }
                 )
     return context
+
+
+# ---------------------------------------------------------------------------
+# Summarisation prompts — three-level escalation mirrors the upstream plugin.
+# ---------------------------------------------------------------------------
+
+_PROMPT_NORMAL = """\
+You are a memory compressor for an AI assistant.  Summarise the following
+conversation extract into a compact but lossless paragraph.  Preserve every
+decision, fact, file name, error message, and instruction so the assistant can
+reconstruct the full context from your summary alone.  Output the summary only
+— no preamble, no commentary.
+
+{turns}"""
+
+_PROMPT_AGGRESSIVE = """\
+Summarise the following conversation in one tight paragraph.  Keep only the
+most important decisions, facts, and instructions.  Output the summary only.
+
+{turns}"""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token count: 4 characters ≈ 1 token (good enough for budgeting)."""
+    return max(1, len(text) // 4)
+
+
+def _format_turns(messages: list[dict[str, str]]) -> str:
+    """Format [{role, content}] as a plain-text transcript for the summary prompt."""
+    parts: list[str] = []
+    for m in messages:
+        role = m.get("role", "").upper()
+        content = m.get("content", "")
+        if content:
+            parts.append(f"{role}: {content}")
+    return "\n\n".join(parts)
+
+
+async def _collect_stream(stream: AsyncIterator[Any]) -> str:
+    """Consume a provider stream and return all concatenated delta text."""
+    parts: list[str] = []
+    async for event in stream:
+        if event.get("type") == "delta":
+            chunk = event.get("content") or ""
+            if chunk:
+                parts.append(chunk)
+    return "".join(parts).strip()
+
+
+async def _summarize(
+    provider: Any,
+    turns_text: str,
+    user_id: uuid.UUID,
+) -> tuple[str, str]:
+    """Call the provider to summarise a turn block.
+
+    Three-level escalation:
+    1. Normal prompt — full fidelity.
+    2. Aggressive prompt — shorter, if normal fails or returns empty.
+    3. Deterministic fallback — first 1 500 chars of the raw transcript.
+
+    Returns:
+        ``(summary_text, summary_kind)`` where ``summary_kind`` is one of
+        ``"normal"``, ``"aggressive"``, or ``"fallback"``.
+    """
+    for prompt_template, kind in (
+        (_PROMPT_NORMAL, "normal"),
+        (_PROMPT_AGGRESSIVE, "aggressive"),
+    ):
+        try:
+            stream = provider.stream(
+                question=prompt_template.format(turns=turns_text),
+                conversation_id=uuid.uuid4(),
+                user_id=user_id,
+                history=None,
+                tools=None,
+                system_prompt=None,
+            )
+            text = await _collect_stream(stream)
+            if text:
+                return text, kind
+        except Exception:
+            _log.warning("LCM_SUMMARIZE_%s_FAILED", kind.upper(), exc_info=True)
+
+    # Deterministic truncation — always produces output.
+    return turns_text[:1500], "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Compaction
+# ---------------------------------------------------------------------------
+
+
+async def compact_leaf_if_needed(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    fresh_tail_count: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one leaf-compaction pass if items exist outside the fresh tail.
+
+    Algorithm
+    ---------
+    1.  Fetch the full ``lcm_context_items`` list for the conversation.
+    2.  If ``total_items <= fresh_tail_count`` there is nothing to compact.
+    3.  The *eligible* items are the oldest ones that fall outside the fresh
+        tail (``all_items[:total - fresh_tail_count]``).  Only
+        ``item_kind="message"`` rows are compacted; existing summaries inside
+        the eligible window are left in place (they are already compact).
+    4.  Batch the oldest eligible messages up to ``max_chunk_tokens`` source
+        tokens (approximate; 4 chars ≈ 1 token).
+    5.  Call the provider (three-level escalation) to produce a summary.
+    6.  Persist: :class:`~app.models.LCMSummary` + one
+        :class:`~app.models.LCMSummarySource` per source message.
+    7.  Rewrite ``lcm_context_items``: delete the compacted message rows,
+        insert one ``item_kind="summary"`` row at the lowest freed ordinal
+        slot.  Gaps are harmless — ``ingest_message`` uses max(ordinal)+1.
+
+    Returns:
+        ``True`` if a compaction pass ran, ``False`` if there was nothing to
+        compact or the eligible window contained no un-compacted messages.
+    """
+    # ------------------------------------------------------------------ 1+2
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+    total = len(all_items)
+
+    if total <= fresh_tail_count:
+        return False
+
+    # ------------------------------------------------------------------ 3
+    eligible = all_items[: total - fresh_tail_count]
+    eligible_message_ids = [
+        item.item_id for item in eligible if item.item_kind == "message"
+    ]
+
+    if not eligible_message_ids:
+        return False  # Only summaries outside the fresh tail — nothing to do.
+
+    # ------------------------------------------------------------------ 4
+    msg_result = await session.execute(
+        select(ChatMessage).where(ChatMessage.id.in_(eligible_message_ids))
+    )
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {
+        m.id: m for m in msg_result.scalars().all()
+    }
+
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item in eligible:
+        if item.item_kind != "message":
+            continue
+        msg = messages_by_id.get(item.item_id)
+        if msg is None:
+            continue
+        msg_tokens = _approx_tokens(msg.content or "")
+        if running_tokens + msg_tokens > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append({"role": msg.role, "content": msg.content or ""})
+        running_tokens += msg_tokens
+
+    if not selected_items:
+        return False
+
+    # ------------------------------------------------------------------ 5
+    summary_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(summary_model, user_id=user_id)
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(provider, turns_text, user_id)
+
+    _log.info(
+        "LCM_COMPACT conversation_id=%s kind=%s sources=%d tokens=%d→%d",
+        conversation_id,
+        summary_kind,
+        len(selected_items),
+        running_tokens,
+        _approx_tokens(summary_text),
+    )
+
+    # ------------------------------------------------------------------ 6
+    summary_row = LCMSummary(
+        conversation_id=conversation_id,
+        depth=0,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=summary_model,
+        summary_kind=summary_kind,
+    )
+    session.add(summary_row)
+    await session.flush()
+
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=summary_row.id,
+                source_kind="message",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    # ------------------------------------------------------------------ 7
+    slot_ordinal = selected_items[0].ordinal
+
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=summary_row.id,
+        )
+    )
+    await session.flush()
+    return True

--- a/backend/app/core/lcm.py
+++ b/backend/app/core/lcm.py
@@ -369,4 +369,157 @@ async def compact_leaf_if_needed(
         )
     )
     await session.flush()
+
+    # Condensation: fold accumulated leaf summaries into deeper parent nodes.
+    # Controlled by lcm_incremental_max_depth:
+    #   0  = leaf-only (no condensation)
+    #   1  = one pass (leaf → depth-1)  [default]
+    #  -1  = unlimited cascade
+    if _settings.lcm_incremental_max_depth != 0:
+        passes = (
+            _settings.lcm_incremental_max_depth
+            if _settings.lcm_incremental_max_depth > 0
+            else 999
+        )
+        for depth in range(passes):
+            ran = await _condense_at_depth(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                depth=depth,
+                max_chunk_tokens=max_chunk_tokens,
+            )
+            if not ran:
+                break
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Condensation
+# ---------------------------------------------------------------------------
+
+
+async def _condense_at_depth(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    depth: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one condensation pass: merge depth-*d* summaries into a depth-*(d+1)* parent.
+
+    Finds all ``LCMContextItem`` rows whose backing ``LCMSummary`` has the
+    given *depth*.  If at least two such items exist, takes the oldest batch
+    (up to *max_chunk_tokens* source tokens), calls the provider to produce a
+    parent summary, writes ``LCMSummary`` (depth+1) + ``LCMSummarySource``
+    edges, and replaces the compacted context items with a single
+    ``item_kind="summary"`` row pointing at the new parent.
+
+    Returns:
+        ``True`` if a condensation pass ran, ``False`` if fewer than 2
+        eligible items exist (nothing to condense at this depth).
+    """
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+
+    summary_item_ids = [i.item_id for i in all_items if i.item_kind == "summary"]
+    if len(summary_item_ids) < 2:
+        return False
+
+    s_result = await session.execute(
+        select(LCMSummary).where(LCMSummary.id.in_(summary_item_ids))
+    )
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {
+        s.id: s for s in s_result.scalars().all()
+    }
+
+    eligible: list[tuple[LCMContextItem, LCMSummary]] = [
+        (item, summaries_by_id[item.item_id])
+        for item in all_items
+        if item.item_kind == "summary"
+        and item.item_id in summaries_by_id
+        and summaries_by_id[item.item_id].depth == depth
+    ]
+
+    if len(eligible) < 2:
+        return False
+
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item, summ in eligible:
+        toks = _approx_tokens(summ.content)
+        if running_tokens + toks > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append(
+            {
+                "role": "user",
+                "content": f"[Summary depth={summ.depth}]\n{summ.content}",
+            }
+        )
+        running_tokens += toks
+
+    if len(selected_items) < 2:
+        return False
+
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(
+        resolve_llm(_settings.lcm_summary_model or model_id, user_id=user_id),
+        turns_text,
+        user_id,
+    )
+
+    _log.info(
+        "LCM_CONDENSE depth=%d→%d conversation_id=%s sources=%d",
+        depth,
+        depth + 1,
+        conversation_id,
+        len(selected_items),
+    )
+
+    parent = LCMSummary(
+        conversation_id=conversation_id,
+        depth=depth + 1,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=_settings.lcm_summary_model or model_id,
+        summary_kind=summary_kind,
+    )
+    session.add(parent)
+    await session.flush()
+
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    slot_ordinal = selected_items[0].ordinal
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=parent.id,
+        )
+    )
+    await session.flush()
     return True

--- a/backend/app/core/lcm/__init__.py
+++ b/backend/app/core/lcm/__init__.py
@@ -28,6 +28,13 @@ from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
 
 _log = logging.getLogger(__name__)
 
+# Character cap for the deterministic-truncation fallback when both the
+# normal and aggressive provider summarisations fail or return empty
+# text.  Tuned to roughly 375 tokens (4 chars ≈ 1 token), small enough
+# to keep the assembled context tight while still leaving the model
+# enough surface to recover continuity.
+_FALLBACK_TRUNCATE_CHARS = 1500
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -241,6 +248,13 @@ async def _summarize(
         ``(summary_text, summary_kind)`` where ``summary_kind`` is one of
         ``"normal"``, ``"aggressive"``, or ``"fallback"``.
     """
+    # Narrow exception classes to the failure modes we expect from the
+    # provider/streaming layer (network, timeout, transient provider
+    # errors).  Programmer errors (``TypeError``, ``AttributeError``,
+    # ``ImportError``) intentionally bubble up so they surface during
+    # development rather than being masked as a summarisation flake;
+    # the deterministic-truncation fallback below covers the legitimate
+    # transient-failure case.
     for prompt_template, kind in (
         (_PROMPT_NORMAL, "normal"),
         (_PROMPT_AGGRESSIVE, "aggressive"),
@@ -257,11 +271,11 @@ async def _summarize(
             text = await _collect_stream(stream)
             if text:
                 return text, kind
-        except Exception:
+        except (OSError, RuntimeError, ValueError, TimeoutError):
             _log.warning("LCM_SUMMARIZE_%s_FAILED", kind.upper(), exc_info=True)
 
     # Deterministic truncation — always produces output.
-    return turns_text[:1500], "fallback"
+    return turns_text[:_FALLBACK_TRUNCATE_CHARS], "fallback"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/core/lcm/__init__.py
+++ b/backend/app/core/lcm/__init__.py
@@ -22,6 +22,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings as _settings
+from app.core.lcm.condense import run_condensation_cascade
 from app.core.providers import resolve_llm
 from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
 
@@ -116,27 +117,43 @@ async def assemble_context(
 
     summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
     if summary_ids:
-        sum_result = await session.execute(
-            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
-        )
+        sum_result = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(summary_ids)))
         summaries_by_id = {s.id: s for s in sum_result.scalars().all()}
 
     context: list[dict[str, Any]] = []
     for item in items:
-        if item.item_kind == "message":
-            msg = messages_by_id.get(item.item_id)
-            if msg is not None and msg.role in {"user", "assistant"}:
-                context.append({"role": msg.role, "content": msg.content or ""})
-        elif item.item_kind == "summary":
-            summary = summaries_by_id.get(item.item_id)
-            if summary is not None:
-                context.append(
-                    {
-                        "role": "user",
-                        "content": f"[Summary of earlier conversation]\n{summary.content}",
-                    }
-                )
+        turn = _assemble_item_to_turn(item, messages_by_id, summaries_by_id)
+        if turn is not None:
+            context.append(turn)
     return context
+
+
+def _assemble_item_to_turn(
+    item: LCMContextItem,
+    messages_by_id: dict[uuid.UUID, ChatMessage],
+    summaries_by_id: dict[uuid.UUID, LCMSummary],
+) -> dict[str, Any] | None:
+    """Resolve one ``LCMContextItem`` to its ``{role, content}`` shape, or drop it.
+
+    Returns ``None`` when the backing row is missing, was a non-chat role
+    (``system``, ``tool``), or carries no content — keeps
+    :func:`assemble_context` flat enough to fit the project's nesting
+    budget.
+    """
+    if item.item_kind == "message":
+        msg = messages_by_id.get(item.item_id)
+        if msg is None or msg.role not in {"user", "assistant"}:
+            return None
+        return {"role": msg.role, "content": msg.content or ""}
+    if item.item_kind == "summary":
+        summary = summaries_by_id.get(item.item_id)
+        if summary is None:
+            return None
+        return {
+            "role": "user",
+            "content": f"[Summary of earlier conversation]\n{summary.content}",
+        }
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -281,9 +298,7 @@ async def compact_leaf_if_needed(
 
     # ------------------------------------------------------------------ 3
     eligible = all_items[: total - fresh_tail_count]
-    eligible_message_ids = [
-        item.item_id for item in eligible if item.item_kind == "message"
-    ]
+    eligible_message_ids = [item.item_id for item in eligible if item.item_kind == "message"]
 
     if not eligible_message_ids:
         return False  # Only summaries outside the fresh tail — nothing to do.
@@ -292,9 +307,7 @@ async def compact_leaf_if_needed(
     msg_result = await session.execute(
         select(ChatMessage).where(ChatMessage.id.in_(eligible_message_ids))
     )
-    messages_by_id: dict[uuid.UUID, ChatMessage] = {
-        m.id: m for m in msg_result.scalars().all()
-    }
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {m.id: m for m in msg_result.scalars().all()}
 
     selected_items: list[LCMContextItem] = []
     selected_messages: list[dict[str, str]] = []
@@ -370,156 +383,11 @@ async def compact_leaf_if_needed(
     )
     await session.flush()
 
-    # Condensation: fold accumulated leaf summaries into deeper parent nodes.
-    # Controlled by lcm_incremental_max_depth:
-    #   0  = leaf-only (no condensation)
-    #   1  = one pass (leaf → depth-1)  [default]
-    #  -1  = unlimited cascade
-    if _settings.lcm_incremental_max_depth != 0:
-        passes = (
-            _settings.lcm_incremental_max_depth
-            if _settings.lcm_incremental_max_depth > 0
-            else 999
-        )
-        for depth in range(passes):
-            ran = await _condense_at_depth(
-                session,
-                conversation_id=conversation_id,
-                user_id=user_id,
-                model_id=model_id,
-                depth=depth,
-                max_chunk_tokens=max_chunk_tokens,
-            )
-            if not ran:
-                break
-
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Condensation
-# ---------------------------------------------------------------------------
-
-
-async def _condense_at_depth(
-    session: AsyncSession,
-    *,
-    conversation_id: uuid.UUID,
-    user_id: uuid.UUID,
-    model_id: str,
-    depth: int,
-    max_chunk_tokens: int,
-) -> bool:
-    """Run one condensation pass: merge depth-*d* summaries into a depth-*(d+1)* parent.
-
-    Finds all ``LCMContextItem`` rows whose backing ``LCMSummary`` has the
-    given *depth*.  If at least two such items exist, takes the oldest batch
-    (up to *max_chunk_tokens* source tokens), calls the provider to produce a
-    parent summary, writes ``LCMSummary`` (depth+1) + ``LCMSummarySource``
-    edges, and replaces the compacted context items with a single
-    ``item_kind="summary"`` row pointing at the new parent.
-
-    Returns:
-        ``True`` if a condensation pass ran, ``False`` if fewer than 2
-        eligible items exist (nothing to condense at this depth).
-    """
-    all_items_result = await session.execute(
-        select(LCMContextItem)
-        .where(LCMContextItem.conversation_id == conversation_id)
-        .order_by(LCMContextItem.ordinal.asc())
-    )
-    all_items = list(all_items_result.scalars().all())
-
-    summary_item_ids = [i.item_id for i in all_items if i.item_kind == "summary"]
-    if len(summary_item_ids) < 2:
-        return False
-
-    s_result = await session.execute(
-        select(LCMSummary).where(LCMSummary.id.in_(summary_item_ids))
-    )
-    summaries_by_id: dict[uuid.UUID, LCMSummary] = {
-        s.id: s for s in s_result.scalars().all()
-    }
-
-    eligible: list[tuple[LCMContextItem, LCMSummary]] = [
-        (item, summaries_by_id[item.item_id])
-        for item in all_items
-        if item.item_kind == "summary"
-        and item.item_id in summaries_by_id
-        and summaries_by_id[item.item_id].depth == depth
-    ]
-
-    if len(eligible) < 2:
-        return False
-
-    selected_items: list[LCMContextItem] = []
-    selected_messages: list[dict[str, str]] = []
-    running_tokens = 0
-
-    for item, summ in eligible:
-        toks = _approx_tokens(summ.content)
-        if running_tokens + toks > max_chunk_tokens and selected_items:
-            break
-        selected_items.append(item)
-        selected_messages.append(
-            {
-                "role": "user",
-                "content": f"[Summary depth={summ.depth}]\n{summ.content}",
-            }
-        )
-        running_tokens += toks
-
-    if len(selected_items) < 2:
-        return False
-
-    turns_text = _format_turns(selected_messages)
-    summary_text, summary_kind = await _summarize(
-        resolve_llm(_settings.lcm_summary_model or model_id, user_id=user_id),
-        turns_text,
-        user_id,
-    )
-
-    _log.info(
-        "LCM_CONDENSE depth=%d→%d conversation_id=%s sources=%d",
-        depth,
-        depth + 1,
-        conversation_id,
-        len(selected_items),
-    )
-
-    parent = LCMSummary(
+    await run_condensation_cascade(
+        session,
         conversation_id=conversation_id,
-        depth=depth + 1,
-        content=summary_text,
-        token_count=_approx_tokens(summary_text),
-        model_id=_settings.lcm_summary_model or model_id,
-        summary_kind=summary_kind,
+        user_id=user_id,
+        model_id=model_id,
+        max_chunk_tokens=max_chunk_tokens,
     )
-    session.add(parent)
-    await session.flush()
-
-    for src_ordinal, item in enumerate(selected_items):
-        session.add(
-            LCMSummarySource(
-                summary_id=parent.id,
-                source_kind="summary",
-                source_id=item.item_id,
-                source_ordinal=src_ordinal,
-            )
-        )
-
-    slot_ordinal = selected_items[0].ordinal
-    for item in selected_items:
-        await session.delete(item)
-    await session.flush()
-
-    session.add(
-        LCMContextItem(
-            conversation_id=conversation_id,
-            ordinal=slot_ordinal,
-            item_kind="summary",
-            item_id=parent.id,
-        )
-    )
-    await session.flush()
     return True

--- a/backend/app/core/lcm/__init__.py
+++ b/backend/app/core/lcm/__init__.py
@@ -77,36 +77,53 @@ async def assemble_context(
 ) -> list[dict[str, Any]]:
     """Return the assembled context window for a conversation turn.
 
-    Fetches the last ``fresh_tail_count`` entries from ``lcm_context_items``
-    (DESC + LIMIT, then reversed to chronological order), resolves each entry
-    to its backing row, and returns a list of ``{"role": ..., "content": ...}``
-    dicts ready to pass to a provider's ``history`` parameter.
+    Implements the per-turn assembly contract from ``docs/design/lcm.md``:
+    the **protected fresh tail** of the most recent raw messages (up to
+    ``fresh_tail_count``) plus **every summary item** that precedes /
+    interleaves them.  Summaries are *always* delivered — they are the
+    only handle the model has on compacted history — and a naive
+    ``ORDER BY ordinal DESC LIMIT fresh_tail_count`` over all items
+    would silently drop the (older, lower-ordinal) summary rows once
+    compaction has run.
 
     Item-kind handling:
 
-    * ``"message"`` — resolved to its :class:`~app.models.ChatMessage`; only
-      ``user`` and ``assistant`` roles are included.
-    * ``"summary"`` — resolved to its :class:`~app.models.LCMSummary` and
-      injected as a synthetic ``user`` message with a
-      ``[Summary of earlier conversation]`` prefix so both the model and human
-      readers recognise it as compacted history rather than a real turn.
+    * ``"message"`` — resolved to its :class:`~app.models.ChatMessage`;
+      only ``user`` and ``assistant`` roles are included.  Capped to
+      the most-recent ``fresh_tail_count`` messages.
+    * ``"summary"`` — resolved to its :class:`~app.models.LCMSummary`
+      and injected as a synthetic ``user`` message with a
+      ``[Summary of earlier conversation]`` prefix so both the model
+      and human readers recognise it as compacted history rather than
+      a real turn.  All summaries for the conversation are kept.
 
     Returns an empty list if no items exist yet.
     """
     result = await session.execute(
         select(LCMContextItem)
         .where(LCMContextItem.conversation_id == conversation_id)
-        .order_by(LCMContextItem.ordinal.desc())
-        .limit(fresh_tail_count)
+        .order_by(LCMContextItem.ordinal.asc())
     )
-    items = list(result.scalars().all())
-    items.reverse()  # oldest first
-
-    if not items:
+    all_items = list(result.scalars().all())
+    if not all_items:
         return []
 
-    message_ids = [item.item_id for item in items if item.item_kind == "message"]
-    summary_ids = [item.item_id for item in items if item.item_kind == "summary"]
+    # Cap message items to the most-recent ``fresh_tail_count`` while
+    # preserving every summary item.  Walking the ordinal-ordered list
+    # in reverse lets us tag the eligible message tail without
+    # disturbing summary ordering.
+    message_tail_quota = fresh_tail_count
+    keep: list[LCMContextItem] = []
+    for item in reversed(all_items):
+        if item.item_kind == "message":
+            if message_tail_quota <= 0:
+                continue
+            message_tail_quota -= 1
+        keep.append(item)
+    keep.reverse()  # restore chronological order
+
+    message_ids = [item.item_id for item in keep if item.item_kind == "message"]
+    summary_ids = [item.item_id for item in keep if item.item_kind == "summary"]
 
     messages_by_id: dict[uuid.UUID, ChatMessage] = {}
     if message_ids:
@@ -121,7 +138,7 @@ async def assemble_context(
         summaries_by_id = {s.id: s for s in sum_result.scalars().all()}
 
     context: list[dict[str, Any]] = []
-    for item in items:
+    for item in keep:
         turn = _assemble_item_to_turn(item, messages_by_id, summaries_by_id)
         if turn is not None:
             context.append(turn)

--- a/backend/app/core/lcm/background.py
+++ b/backend/app/core/lcm/background.py
@@ -9,6 +9,23 @@ calls when ``settings.lcm_enabled`` is on.
 All errors are swallowed inside the bg helper — a failed compaction
 is invisible to the user; the full message history stays preserved
 in ``chat_messages``.
+
+Concurrency model
+-----------------
+Compactions for the same conversation are serialized through a
+per-conversation :class:`asyncio.Lock`.  Two consecutive turns (web +
+Telegram, or rapid back-to-back user turns) would otherwise race each
+other on:
+
+* The shared ``(conversation_id, ordinal)`` unique constraint in
+  ``lcm_context_items`` — both runs select the same eligible rows
+  and try to insert a summary at the same freed ordinal slot.
+* The DB connection pool — without a lock every concurrent turn
+  pins a connection across the full LLM round-trip.
+
+Different conversations stay parallel; only same-conversation runs
+queue.  When a lock has no waiters and is not held it is dropped
+from the registry so the dict doesn't grow unbounded.
 """
 
 from __future__ import annotations
@@ -29,6 +46,11 @@ logger = logging.getLogger(__name__)
 # value; the task drops itself from this set on completion so the set
 # doesn't grow unbounded.
 _LCM_COMPACT_TASKS: set[asyncio.Task[None]] = set()
+
+# Per-conversation lock registry — serializes compaction passes for the
+# same conversation across concurrent turns.  See module docstring for
+# the concurrency model.
+_LCM_COMPACT_LOCKS: dict[uuid.UUID, asyncio.Lock] = {}
 
 
 def schedule_lcm_compaction(
@@ -66,10 +88,13 @@ async def _lcm_compact_bg(
     """Run one LCM leaf-compaction pass for ``conversation_id``.
 
     Opens its own session so it runs independently of the request
-    lifecycle.  All exceptions are caught and logged.
+    lifecycle and acquires the per-conversation lock so concurrent
+    runs queue instead of racing.  All exceptions are caught and
+    logged.
     """
+    lock = _LCM_COMPACT_LOCKS.setdefault(conversation_id, asyncio.Lock())
     try:
-        async with async_session_maker() as compact_session:
+        async with lock, async_session_maker() as compact_session:
             await compact_leaf_if_needed(
                 compact_session,
                 conversation_id=conversation_id,
@@ -84,3 +109,10 @@ async def _lcm_compact_bg(
             "LCM_COMPACT_BG_ERR conversation_id=%s",
             conversation_id,
         )
+    finally:
+        # Drop the lock entry when nothing else is waiting; this keeps
+        # the registry from growing unbounded for one-shot conversations
+        # while leaving busy conversations' locks pinned until their
+        # queue drains.
+        if not lock.locked() and conversation_id in _LCM_COMPACT_LOCKS:
+            _LCM_COMPACT_LOCKS.pop(conversation_id, None)

--- a/backend/app/core/lcm/background.py
+++ b/backend/app/core/lcm/background.py
@@ -24,8 +24,11 @@ other on:
   pins a connection across the full LLM round-trip.
 
 Different conversations stay parallel; only same-conversation runs
-queue.  When a lock has no waiters and is not held it is dropped
-from the registry so the dict doesn't grow unbounded.
+queue.  A reference count next to the lock tracks how many pending
++ in-flight tasks exist for the conversation; the lock entry drops
+out of the registry only when the count reaches 0, so a waiter
+suspended mid-``acquire`` is never separated from the live lock the
+running holder is about to release.
 """
 
 from __future__ import annotations
@@ -33,6 +36,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from dataclasses import dataclass
+
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.core.config import settings
 from app.core.lcm import compact_leaf_if_needed
@@ -47,10 +53,28 @@ logger = logging.getLogger(__name__)
 # doesn't grow unbounded.
 _LCM_COMPACT_TASKS: set[asyncio.Task[None]] = set()
 
+
+@dataclass
+class _LockSlot:
+    """One conversation's lock plus a refcount of pending + in-flight tasks.
+
+    ``refcount`` is incremented in ``schedule_lcm_compaction`` (the
+    synchronous half) and decremented in the task's ``finally``.  The
+    slot is dropped from the registry only when the count returns to
+    0 — i.e. when nothing is waiting on, holding, or about to acquire
+    the lock.  This is the simplest correct way to avoid the
+    "``Lock.release`` does not yield, so ``lock.locked()`` is always
+    ``False`` in ``finally``" race that a naïve check has.
+    """
+
+    lock: asyncio.Lock
+    refcount: int
+
+
 # Per-conversation lock registry — serializes compaction passes for the
 # same conversation across concurrent turns.  See module docstring for
 # the concurrency model.
-_LCM_COMPACT_LOCKS: dict[uuid.UUID, asyncio.Lock] = {}
+_LCM_COMPACT_LOCKS: dict[uuid.UUID, _LockSlot] = {}
 
 
 def schedule_lcm_compaction(
@@ -65,9 +89,19 @@ def schedule_lcm_compaction(
     the gate.  The task keeps a strong reference in
     :data:`_LCM_COMPACT_TASKS` to survive GC and self-cleans on
     completion.
+
+    The lock-slot refcount is bumped here — synchronously, before the
+    task is created — so a waiter scheduled on top of an already-held
+    lock cannot be orphaned by an in-flight ``finally`` block from a
+    previous task that's already releasing the lock.
     """
     if not settings.lcm_enabled:
         return
+    slot = _LCM_COMPACT_LOCKS.get(conversation_id)
+    if slot is None:
+        slot = _LockSlot(lock=asyncio.Lock(), refcount=0)
+        _LCM_COMPACT_LOCKS[conversation_id] = slot
+    slot.refcount += 1
     task = asyncio.create_task(
         _lcm_compact_bg(
             conversation_id=conversation_id,
@@ -89,12 +123,17 @@ async def _lcm_compact_bg(
 
     Opens its own session so it runs independently of the request
     lifecycle and acquires the per-conversation lock so concurrent
-    runs queue instead of racing.  All exceptions are caught and
-    logged.
+    runs queue instead of racing.
+
+    Caught errors are limited to provider/network/DB classes so that
+    real programmer errors (``TypeError``, ``AttributeError``,
+    ``ImportError`` …) surface to asyncio's default exception handler
+    instead of being silently swallowed under a generic
+    ``LCM_COMPACT_BG_ERR`` log line.
     """
-    lock = _LCM_COMPACT_LOCKS.setdefault(conversation_id, asyncio.Lock())
+    slot = _LCM_COMPACT_LOCKS[conversation_id]
     try:
-        async with lock, async_session_maker() as compact_session:
+        async with slot.lock, async_session_maker() as compact_session:
             await compact_leaf_if_needed(
                 compact_session,
                 conversation_id=conversation_id,
@@ -104,15 +143,12 @@ async def _lcm_compact_bg(
                 max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
             )
             await compact_session.commit()
-    except Exception:
+    except (OSError, RuntimeError, ValueError, TimeoutError, SQLAlchemyError):
         logger.exception(
             "LCM_COMPACT_BG_ERR conversation_id=%s",
             conversation_id,
         )
     finally:
-        # Drop the lock entry when nothing else is waiting; this keeps
-        # the registry from growing unbounded for one-shot conversations
-        # while leaving busy conversations' locks pinned until their
-        # queue drains.
-        if not lock.locked() and conversation_id in _LCM_COMPACT_LOCKS:
+        slot.refcount -= 1
+        if slot.refcount <= 0:
             _LCM_COMPACT_LOCKS.pop(conversation_id, None)

--- a/backend/app/core/lcm/background.py
+++ b/backend/app/core/lcm/background.py
@@ -1,0 +1,86 @@
+"""Fire-and-forget LCM compaction trigger.
+
+Splits the background-task plumbing out of
+``app.channels.turn_runner`` to keep that module under the project's
+500-line file budget while keeping the public surface tiny:
+``schedule_lcm_compaction`` is the single seam ``_finalize_turn``
+calls when ``settings.lcm_enabled`` is on.
+
+All errors are swallowed inside the bg helper — a failed compaction
+is invisible to the user; the full message history stays preserved
+in ``chat_messages``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from app.core.config import settings
+from app.core.lcm import compact_leaf_if_needed
+from app.db import async_session_maker
+
+logger = logging.getLogger(__name__)
+
+# Holds strong refs to fire-and-forget background tasks (LCM compaction).
+# Without this set, the GC can collect the task mid-flight because
+# ``asyncio.create_task`` only stores a weak reference to its return
+# value; the task drops itself from this set on completion so the set
+# doesn't grow unbounded.
+_LCM_COMPACT_TASKS: set[asyncio.Task[None]] = set()
+
+
+def schedule_lcm_compaction(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> None:
+    """Fire one LCM leaf-compaction pass for ``conversation_id`` in the background.
+
+    No-op when ``settings.lcm_enabled`` is ``False`` so callers can drop
+    the gate.  The task keeps a strong reference in
+    :data:`_LCM_COMPACT_TASKS` to survive GC and self-cleans on
+    completion.
+    """
+    if not settings.lcm_enabled:
+        return
+    task = asyncio.create_task(
+        _lcm_compact_bg(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            model_id=model_id,
+        )
+    )
+    _LCM_COMPACT_TASKS.add(task)
+    task.add_done_callback(_LCM_COMPACT_TASKS.discard)
+
+
+async def _lcm_compact_bg(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> None:
+    """Run one LCM leaf-compaction pass for ``conversation_id``.
+
+    Opens its own session so it runs independently of the request
+    lifecycle.  All exceptions are caught and logged.
+    """
+    try:
+        async with async_session_maker() as compact_session:
+            await compact_leaf_if_needed(
+                compact_session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                fresh_tail_count=settings.lcm_fresh_tail_count,
+                max_chunk_tokens=settings.lcm_leaf_chunk_tokens,
+            )
+            await compact_session.commit()
+    except Exception:
+        logger.exception(
+            "LCM_COMPACT_BG_ERR conversation_id=%s",
+            conversation_id,
+        )

--- a/backend/app/core/lcm/condense.py
+++ b/backend/app/core/lcm/condense.py
@@ -1,0 +1,197 @@
+"""LCM condensation — fold same-depth summaries into deeper parent nodes.
+
+Split out of ``app.core.lcm`` to keep that module under the 500-line
+file budget while keeping the call surface tiny:
+:func:`run_condensation_cascade` is the single seam
+``compact_leaf_if_needed`` calls after a successful leaf compaction.
+
+The condensation pass is what prevents unbounded growth of leaf
+summaries: once two depth-0 summaries exist, the next compaction
+folds them into a depth-1 parent, and so on.  Controlled by
+``settings.lcm_incremental_max_depth`` (0 = leaf-only, 1 = one pass,
+-1 = unlimited cascade capped at :data:`_CONDENSATION_HARD_CAP`).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings as _settings
+from app.core.providers import resolve_llm
+from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+_log = logging.getLogger(__name__)
+
+# Minimum number of same-depth summaries required before condensation
+# kicks in.  Two is the natural floor: condensation folds N summaries
+# into one parent, so a single summary cannot meaningfully condense.
+_MIN_CONDENSE_SOURCES = 2
+
+# Practical safety cap on the unlimited-cascade option
+# (``lcm_incremental_max_depth == -1``).  No reasonable conversation
+# produces 999 condensation depths; the cap exists purely to keep a
+# runaway feedback loop from blocking the event loop.
+_CONDENSATION_HARD_CAP = 999
+
+
+async def run_condensation_cascade(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    max_chunk_tokens: int,
+) -> None:
+    """Fold accumulated leaf summaries into deeper parent nodes.
+
+    Controlled by ``settings.lcm_incremental_max_depth``:
+
+    * ``0``  — leaf-only (no condensation)
+    * ``1``  — one pass (leaf → depth-1) [default]
+    * ``-1`` — unlimited cascade, capped at :data:`_CONDENSATION_HARD_CAP`
+    """
+    if _settings.lcm_incremental_max_depth == 0:
+        return
+    passes = (
+        _settings.lcm_incremental_max_depth
+        if _settings.lcm_incremental_max_depth > 0
+        else _CONDENSATION_HARD_CAP
+    )
+    for depth in range(passes):
+        ran = await _condense_at_depth(
+            session,
+            conversation_id=conversation_id,
+            user_id=user_id,
+            model_id=model_id,
+            depth=depth,
+            max_chunk_tokens=max_chunk_tokens,
+        )
+        if not ran:
+            return
+
+
+async def _condense_at_depth(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    depth: int,
+    max_chunk_tokens: int,
+) -> bool:
+    """Run one condensation pass: merge depth-*d* summaries into a depth-*(d+1)* parent.
+
+    Finds all ``LCMContextItem`` rows whose backing ``LCMSummary`` has the
+    given *depth*.  If at least two such items exist, takes the oldest batch
+    (up to *max_chunk_tokens* source tokens), calls the provider to produce a
+    parent summary, writes ``LCMSummary`` (depth+1) + ``LCMSummarySource``
+    edges, and replaces the compacted context items with a single
+    ``item_kind="summary"`` row pointing at the new parent.
+
+    Returns:
+        ``True`` if a condensation pass ran, ``False`` if fewer than 2
+        eligible items exist (nothing to condense at this depth).
+    """
+    # Lazy import: keeps the ``lcm`` ↔ ``lcm_condense`` cycle one-way.
+    from app.core.lcm import _approx_tokens, _format_turns, _summarize  # noqa: PLC0415
+
+    all_items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(all_items_result.scalars().all())
+
+    summary_item_ids = [i.item_id for i in all_items if i.item_kind == "summary"]
+    if len(summary_item_ids) < _MIN_CONDENSE_SOURCES:
+        return False
+
+    s_result = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(summary_item_ids)))
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {s.id: s for s in s_result.scalars().all()}
+
+    eligible: list[tuple[LCMContextItem, LCMSummary]] = [
+        (item, summaries_by_id[item.item_id])
+        for item in all_items
+        if item.item_kind == "summary"
+        and item.item_id in summaries_by_id
+        and summaries_by_id[item.item_id].depth == depth
+    ]
+
+    if len(eligible) < _MIN_CONDENSE_SOURCES:
+        return False
+
+    selected_items: list[LCMContextItem] = []
+    selected_messages: list[dict[str, str]] = []
+    running_tokens = 0
+
+    for item, summ in eligible:
+        toks = _approx_tokens(summ.content)
+        if running_tokens + toks > max_chunk_tokens and selected_items:
+            break
+        selected_items.append(item)
+        selected_messages.append(
+            {
+                "role": "user",
+                "content": f"[Summary depth={summ.depth}]\n{summ.content}",
+            }
+        )
+        running_tokens += toks
+
+    if len(selected_items) < _MIN_CONDENSE_SOURCES:
+        return False
+
+    turns_text = _format_turns(selected_messages)
+    summary_text, summary_kind = await _summarize(
+        resolve_llm(_settings.lcm_summary_model or model_id, user_id=user_id),
+        turns_text,
+        user_id,
+    )
+
+    _log.info(
+        "LCM_CONDENSE depth=%d→%d conversation_id=%s sources=%d",
+        depth,
+        depth + 1,
+        conversation_id,
+        len(selected_items),
+    )
+
+    parent = LCMSummary(
+        conversation_id=conversation_id,
+        depth=depth + 1,
+        content=summary_text,
+        token_count=_approx_tokens(summary_text),
+        model_id=_settings.lcm_summary_model or model_id,
+        summary_kind=summary_kind,
+    )
+    session.add(parent)
+    await session.flush()
+
+    for src_ordinal, item in enumerate(selected_items):
+        session.add(
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=item.item_id,
+                source_ordinal=src_ordinal,
+            )
+        )
+
+    slot_ordinal = selected_items[0].ordinal
+    for item in selected_items:
+        await session.delete(item)
+    await session.flush()
+
+    session.add(
+        LCMContextItem(
+            conversation_id=conversation_id,
+            ordinal=slot_ordinal,
+            item_kind="summary",
+            item_id=parent.id,
+        )
+    )
+    await session.flush()
+    return True

--- a/backend/app/core/lcm/condense.py
+++ b/backend/app/core/lcm/condense.py
@@ -107,22 +107,31 @@ async def _condense_at_depth(
     all_items = list(all_items_result.scalars().all())
 
     summary_item_ids = [i.item_id for i in all_items if i.item_kind == "summary"]
-    if len(summary_item_ids) < _MIN_CONDENSE_SOURCES:
+    if not summary_item_ids:
         return False
 
-    s_result = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(summary_item_ids)))
+    # Filter by ``depth`` at the DB layer so a context list that holds
+    # summaries at multiple depths (one depth-0, one depth-1, ...) only
+    # round-trips the rows that this pass could actually fold.  The
+    # previous shape counted summaries-at-any-depth in a Python-side
+    # guard and then issued the IN-query anyway when the count was ≥ 2,
+    # which wasted a query whenever the depth-specific subset was < 2.
+    s_result = await session.execute(
+        select(LCMSummary).where(
+            LCMSummary.id.in_(summary_item_ids),
+            LCMSummary.depth == depth,
+        )
+    )
     summaries_by_id: dict[uuid.UUID, LCMSummary] = {s.id: s for s in s_result.scalars().all()}
+
+    if len(summaries_by_id) < _MIN_CONDENSE_SOURCES:
+        return False
 
     eligible: list[tuple[LCMContextItem, LCMSummary]] = [
         (item, summaries_by_id[item.item_id])
         for item in all_items
-        if item.item_kind == "summary"
-        and item.item_id in summaries_by_id
-        and summaries_by_id[item.item_id].depth == depth
+        if item.item_kind == "summary" and item.item_id in summaries_by_id
     ]
-
-    if len(eligible) < _MIN_CONDENSE_SOURCES:
-        return False
 
     selected_items: list[LCMContextItem] = []
     selected_messages: list[dict[str, str]] = []

--- a/backend/app/core/observability/__init__.py
+++ b/backend/app/core/observability/__init__.py
@@ -9,6 +9,10 @@ SigNoz, Tempo, etc.) — Workshop is just the local renderer.
 .. _Raindrop Workshop: https://github.com/raindrop-ai/workshop
 """
 
+from app.core.observability._turn_view import (
+    aggregator_stop_reason,
+    build_llm_view_messages,
+)
 from app.core.observability.workshop import (
     LLMSpanRecorder,
     ToolSpanRecorder,
@@ -21,6 +25,8 @@ from app.core.observability.workshop import (
 __all__ = [
     "LLMSpanRecorder",
     "ToolSpanRecorder",
+    "aggregator_stop_reason",
+    "build_llm_view_messages",
     "llm_span",
     "tool_span",
     "turn_span",

--- a/backend/app/core/providers/_gemini_events.py
+++ b/backend/app/core/providers/_gemini_events.py
@@ -1,0 +1,61 @@
+"""Gemini AgentEvent → StreamEvent translation helper.
+
+Split out of ``gemini_provider`` to keep that module under the 500-line
+file budget.  Pure translation — no I/O, no Gemini SDK references.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.agent_loop.types import AgentMessage
+
+from .base import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Pass through messages the LLM understands; filter UI-only types."""
+    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
+
+
+def agent_event_to_stream_event(event: Any) -> StreamEvent | None:
+    """Translate one ``AgentEvent`` from the loop into a frontend ``StreamEvent``.
+
+    Returns ``None`` for events that don't carry user-facing payload
+    (``agent_start`` / ``agent_end`` / ``message_*`` / ``turn_*`` /
+    ``tool_call_end``) — the chat router emits the ``[DONE]`` sentinel
+    itself when the loop completes.
+    """
+    event_type = event["type"]
+    if event_type == "text_delta":
+        return StreamEvent(type="delta", content=event["text"])
+    if event_type == "thinking_delta":
+        return StreamEvent(type="thinking", content=event["text"])
+    if event_type == "tool_call_start":
+        return StreamEvent(
+            type="tool_use",
+            name=event["name"],
+            input={},
+            tool_use_id=event["tool_call_id"],
+        )
+    if event_type == "tool_result":
+        return StreamEvent(
+            type="tool_result",
+            content=event["content"],
+            tool_use_id=event["tool_call_id"],
+        )
+    if event_type == "agent_terminated":
+        # Safety layer tripped — forward the structured event so the
+        # frontend can render a distinct termination notice instead of a
+        # generic error banner. ``reason`` is the machine-readable label;
+        # ``message`` is the human copy.
+        logger.warning(
+            "AGENT_TERMINATED reason=%s details=%s",
+            event["reason"],
+            event["details"],
+        )
+        return StreamEvent(type="agent_terminated", content=event["message"])
+    return None

--- a/backend/app/core/providers/_gemini_replay.py
+++ b/backend/app/core/providers/_gemini_replay.py
@@ -1,0 +1,64 @@
+"""Gemini provider-native replay helpers.
+
+Split out of ``gemini_provider`` to keep that module under the 500-line
+file budget.  All helpers are private — the public surface lives on
+``gemini_provider`` (``_build_gemini_contents`` consumes
+:func:`replay_content_for`; ``make_gemini_stream_fn`` consumes
+:func:`function_call_content_for`).
+
+Background
+----------
+Gemini-3 / Vertex requires that ``thought_signature`` bytes from a
+prior turn be replayed verbatim on the follow-up tool turn — see
+https://ai.google.dev/gemini-api/docs/thought-signatures.  Pawrrtal's
+agent loop is provider-neutral, so the bytes ride in an opaque
+``provider_state["gemini"]["model_content"]`` slot on the
+``AssistantMessage`` and the StreamFn captures them on the producing
+turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.genai import types as gtypes
+
+from app.core.agent_loop.types import AgentMessage
+
+
+def replay_content_for(msg: AgentMessage) -> gtypes.Content | None:
+    """Return the saved native ``ModelContent`` from ``msg`` if present.
+
+    Pawrrtal stores Gemini's original ``ModelContent`` on the assistant
+    message under ``provider_state["gemini"]["model_content"]`` (set by
+    :func:`make_gemini_stream_fn`).  Replaying it verbatim keeps the
+    ``thought_signature`` bytes intact, which Gemini-3 / Vertex require
+    on follow-up tool turns or the request 4xx's.
+    """
+    if msg.get("role") != "assistant":
+        return None
+    state = msg.get("provider_state") or {}
+    gemini_state = state.get("gemini") if isinstance(state, dict) else None
+    if not isinstance(gemini_state, dict):
+        return None
+    content = gemini_state.get("model_content")
+    if isinstance(content, gtypes.Content):
+        return content
+    return None
+
+
+def function_call_content_for(chunk: Any) -> gtypes.Content | None:
+    """Return the first candidate's ``ModelContent`` when it contains a function call.
+
+    The native ``ModelContent`` carries ``thought_signature`` bytes that
+    Gemini-3 / Vertex demand on follow-up tool turns; saving it lets us
+    replay the exact part instead of reconstructing a lossy
+    ``function_call`` from name + args.
+    """
+    for candidate in chunk.candidates or []:
+        content = getattr(candidate, "content", None)
+        if content is None or not getattr(content, "parts", None):
+            continue
+        if any(part.function_call for part in content.parts):
+            return content
+    return None

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -38,6 +38,8 @@ from app.core.agent_system_prompt import (
 from app.core.config import settings
 from app.core.keys import resolve_api_key
 
+from ._gemini_events import agent_event_to_stream_event, identity_convert
+from ._gemini_replay import function_call_content_for, replay_content_for
 from .base import ReasoningEffort, StreamEvent
 
 logger = logging.getLogger(__name__)
@@ -130,11 +132,15 @@ def _build_gemini_contents(messages: list[AgentMessage]) -> list[gtypes.Content]
                 contents.append(gtypes.UserContent(parts=[gtypes.Part.from_text(text=text)]))
             continue
         if msg["role"] == "assistant":
-            # TODO(pawrrtal-55sw): If the assistant message carries
-            # provider_state["gemini"]["model_content"], replay that native
-            # content instead of reconstructing function_call parts. This
-            # preserves Gemini thought signatures per the official docs:
+            # When the assistant message carries the original Gemini
+            # ``ModelContent`` (saved on the producing turn), replay it
+            # verbatim.  This preserves ``thought_signature`` bytes that
+            # Vertex / Gemini-3 require for follow-up tool turns:
             # https://ai.google.dev/gemini-api/docs/thought-signatures
+            replay = replay_content_for(msg)
+            if replay is not None:
+                contents.append(replay)
+                continue
             parts = _assistant_parts(msg["content"])
             if parts:
                 contents.append(gtypes.ModelContent(parts=parts))
@@ -182,7 +188,13 @@ def _split_chunk_text(chunk: Any) -> tuple[str, str]:
 
 
 def _tool_calls_from_chunk(chunk: Any, start_index: int) -> list[dict[str, Any]]:
-    """Extract Gemini function-call parts from a streaming chunk."""
+    """Extract Gemini function-call parts from a streaming chunk.
+
+    Only the name + args are surfaced to the agent loop; the enclosing
+    ``ModelContent`` (with its ``thought_signature`` bytes) is captured
+    separately by :func:`function_call_content_for` and forwarded as opaque
+    ``provider_state`` on the terminal ``LLMDoneEvent``.
+    """
     calls: list[dict[str, Any]] = []
     for candidate in chunk.candidates or []:
         if not candidate.content or not candidate.content.parts:
@@ -193,9 +205,6 @@ def _tool_calls_from_chunk(chunk: Any, start_index: int) -> list[dict[str, Any]]
             fc = part.function_call
             fn_name = fc.name or ""
             tool_call_id = f"call-{fn_name}-{start_index + len(calls)}"
-            # TODO(pawrrtal-55sw): Also preserve the original Gemini Part or
-            # enclosing ModelContent for provider_state; name/args alone are
-            # insufficient for Gemini 3 function calls with thought_signature.
             calls.append(
                 {
                     "tool_call_id": tool_call_id,
@@ -253,6 +262,12 @@ def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> St
 
         full_text = ""
         tool_calls: list[dict[str, Any]] = []
+        # Holds the native ``ModelContent`` from whichever chunk produced
+        # the function_call parts (Gemini delivers function calls in a
+        # single chunk).  When set, the loop forwards it as
+        # ``LLMDoneEvent.provider_state["gemini"]["model_content"]`` so
+        # the next turn's request can replay ``thought_signature`` bytes.
+        function_call_content: gtypes.Content | None = None
 
         try:
             # google-genai's async ``generate_content_stream`` returns
@@ -277,14 +292,23 @@ def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> St
                     yield LLMTextDeltaEvent(type="text_delta", text=response_text)
                     full_text += response_text
 
-                for tool_call in _tool_calls_from_chunk(chunk, len(tool_calls)):
-                    yield LLMToolCallEvent(
-                        type="tool_call",
-                        tool_call_id=tool_call["tool_call_id"],
-                        name=tool_call["name"],
-                        arguments=tool_call["arguments"],
-                    )
-                    tool_calls.append(tool_call)
+                chunk_tool_calls = _tool_calls_from_chunk(chunk, len(tool_calls))
+                if chunk_tool_calls:
+                    # Capture the original Gemini ``ModelContent`` so
+                    # follow-up turns can replay ``thought_signature``
+                    # bytes verbatim.  Only the first function-call chunk
+                    # is preserved — Gemini emits function calls in a
+                    # single chunk so this is sufficient.
+                    if function_call_content is None:
+                        function_call_content = function_call_content_for(chunk)
+                    for tool_call in chunk_tool_calls:
+                        yield LLMToolCallEvent(
+                            type="tool_call",
+                            tool_call_id=tool_call["tool_call_id"],
+                            name=tool_call["name"],
+                            arguments=tool_call["arguments"],
+                        )
+                        tool_calls.append(tool_call)
 
         except Exception as exc:
             # Log so the error is visible in app.log — previously swallowed silently.
@@ -315,60 +339,22 @@ def make_gemini_stream_fn(model_id: str, user_id: uuid.UUID | None = None) -> St
             for tc in tool_calls
         )
 
-        # TODO(pawrrtal-55sw): Include Gemini native model content in
-        # LLMDoneEvent.provider_state so the next iteration can replay the
-        # model's exact function_call parts, not lossy reconstructed ones.
-        yield LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+        # When the turn made any tool calls, forward the original Gemini
+        # ``ModelContent`` as opaque ``provider_state`` so the next
+        # iteration's request body replays the exact function_call parts
+        # (preserving ``thought_signature`` bytes that Gemini-3 / Vertex
+        # require).  Pure-text turns omit the field — there is nothing
+        # for the next turn to replay.
+        done_event: LLMDoneEvent = LLMDoneEvent(
+            type="done",
+            stop_reason=stop_reason,
+            content=content,
+        )
+        if function_call_content is not None:
+            done_event["provider_state"] = {"gemini": {"model_content": function_call_content}}
+        yield done_event
 
     return stream_fn
-
-
-def _identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
-    """Pass through messages the LLM understands; filter UI-only types."""
-    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
-
-
-def _agent_event_to_stream_event(event: Any) -> StreamEvent | None:
-    """Translate one ``AgentEvent`` from the loop into a frontend ``StreamEvent``.
-
-    Returns ``None`` for events that don't carry user-facing payload
-    (``agent_start`` / ``agent_end`` / ``message_*`` / ``turn_*`` /
-    ``tool_call_end``) — the chat router emits the ``[DONE]`` sentinel
-    itself when the loop completes. Splitting this out of
-    ``GeminiLLM.stream`` keeps that method under the project complexity
-    cap (``C901`` ≤ 12) now that ``thinking_delta`` lives alongside the
-    other branches.
-    """
-    event_type = event["type"]
-    if event_type == "text_delta":
-        return StreamEvent(type="delta", content=event["text"])
-    if event_type == "thinking_delta":
-        return StreamEvent(type="thinking", content=event["text"])
-    if event_type == "tool_call_start":
-        return StreamEvent(
-            type="tool_use",
-            name=event["name"],
-            input={},
-            tool_use_id=event["tool_call_id"],
-        )
-    if event_type == "tool_result":
-        return StreamEvent(
-            type="tool_result",
-            content=event["content"],
-            tool_use_id=event["tool_call_id"],
-        )
-    if event_type == "agent_terminated":
-        # Safety layer tripped — forward the structured event so the
-        # frontend can render a distinct termination notice instead of a
-        # generic error banner. ``reason`` is the machine-readable label;
-        # ``message`` is the human copy.
-        logger.warning(
-            "AGENT_TERMINATED reason=%s details=%s",
-            event["reason"],
-            event["details"],
-        )
-        return StreamEvent(type="agent_terminated", content=event["message"])
-    return None
 
 
 class GeminiLLM:
@@ -468,14 +454,14 @@ class GeminiLLM:
         # etc.) without a code deploy.  Defaults are conservative and appropriate
         # for the interactive chat path; raise them for long-running automations.
         config = AgentLoopConfig(
-            convert_to_llm=_identity_convert,
+            convert_to_llm=identity_convert,
             safety=safety_from_settings(settings),
             permission_check=permission_check,
         )
 
         try:
             async for event in agent_loop([prompt], context, config, self._stream_fn):
-                stream_event = _agent_event_to_stream_event(event)
+                stream_event = agent_event_to_stream_event(event)
                 if stream_event is not None:
                     yield stream_event
 

--- a/backend/app/core/tools/lcm_describe.py
+++ b/backend/app/core/tools/lcm_describe.py
@@ -20,7 +20,12 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+from app.models import LCMSummary, LCMSummarySource
+
+# Number of characters from a summary's content shown as the per-node
+# excerpt in ``lcm_list_summaries``.  Wide enough to pick up the first
+# sentence; narrow enough to keep the list compact in agent context.
+_LIST_EXCERPT_CHARS = 120
 
 
 def _format_summary(
@@ -40,8 +45,7 @@ def _format_summary(
         f"Sources:      {len(sources)} item(s)",
     ]
     if sources:
-        for s in sources:
-            lines.append(f"  [{s.source_ordinal}] {s.source_kind} id={s.source_id}")
+        lines.extend(f"  [{s.source_ordinal}] {s.source_kind} id={s.source_id}" for s in sources)
     if include_full_content:
         lines.append("")
         lines.append("Content:")
@@ -116,8 +120,8 @@ async def lcm_list_summaries(
     header = f"lcm_list_summaries: {len(summaries)} node(s)\n"
     rows: list[str] = []
     for s in summaries:
-        excerpt = s.content[:120].replace("\n", " ")
-        if len(s.content) > 120:
+        excerpt = s.content[:_LIST_EXCERPT_CHARS].replace("\n", " ")
+        if len(s.content) > _LIST_EXCERPT_CHARS:
             excerpt += "…"
         rows.append(
             f"  id={s.id}  depth={s.depth}  kind={s.summary_kind}  "

--- a/backend/app/core/tools/lcm_describe.py
+++ b/backend/app/core/tools/lcm_describe.py
@@ -1,0 +1,126 @@
+"""LCM describe — cheap inspection of a single LCMSummary node.
+
+This is the backing implementation for the ``lcm_describe`` agent tool
+introduced in PR #5 of the LCM stack.
+
+Use case
+--------
+After ``lcm_grep`` returns a match inside a summary node, the agent may want
+to read the *full* summary text (not just the excerpt).  ``lcm_describe``
+fetches the complete node and its metadata in one cheap DB round-trip.
+
+It also exposes ``lcm_list_summaries`` so the agent can enumerate all summary
+nodes for the current conversation and pick the right one to inspect.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+
+def _format_summary(
+    summary: LCMSummary,
+    sources: list[LCMSummarySource],
+    *,
+    include_full_content: bool = True,
+) -> str:
+    """Format a summary node and its source edges as a readable string."""
+    lines: list[str] = [
+        f"Summary ID:   {summary.id}",
+        f"Depth:        {summary.depth}",
+        f"Kind:         {summary.summary_kind}",
+        f"Model:        {summary.model_id or '(unknown)'}",
+        f"Tokens:       ~{summary.token_count}",
+        f"Created:      {summary.created_at.isoformat()}",
+        f"Sources:      {len(sources)} item(s)",
+    ]
+    if sources:
+        for s in sources:
+            lines.append(f"  [{s.source_ordinal}] {s.source_kind} id={s.source_id}")
+    if include_full_content:
+        lines.append("")
+        lines.append("Content:")
+        lines.append(summary.content)
+    return "\n".join(lines)
+
+
+async def lcm_describe(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    summary_id: uuid.UUID,
+) -> str:
+    """Return the full content and metadata of a single LCMSummary node.
+
+    The lookup is scoped to *conversation_id* so the agent cannot inspect
+    summaries from other conversations even if it somehow obtains a foreign ID.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation the summary must belong to.
+        summary_id: UUID of the target :class:`~app.models.LCMSummary`.
+
+    Returns:
+        A formatted multi-line string with the summary's metadata and full
+        content, or an error string if not found.
+    """
+    result = await session.execute(
+        select(LCMSummary).where(
+            LCMSummary.id == summary_id,
+            LCMSummary.conversation_id == conversation_id,
+        )
+    )
+    summary = result.scalar_one_or_none()
+
+    if summary is None:
+        return (
+            f"lcm_describe: summary {summary_id} not found "
+            f"(may belong to a different conversation, or may not exist)."
+        )
+
+    sources_result = await session.execute(
+        select(LCMSummarySource)
+        .where(LCMSummarySource.summary_id == summary.id)
+        .order_by(LCMSummarySource.source_ordinal)
+    )
+    sources = list(sources_result.scalars().all())
+
+    return _format_summary(summary, sources, include_full_content=True)
+
+
+async def lcm_list_summaries(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+) -> str:
+    """List all LCMSummary nodes for a conversation, most-recent-first.
+
+    Returns a compact table showing each node's ID, depth, kind, and a
+    brief excerpt so the agent can decide which one to inspect further.
+    """
+    result = await session.execute(
+        select(LCMSummary)
+        .where(LCMSummary.conversation_id == conversation_id)
+        .order_by(LCMSummary.created_at.desc())
+    )
+    summaries = list(result.scalars().all())
+
+    if not summaries:
+        return "lcm_list_summaries: no summaries exist for this conversation yet."
+
+    header = f"lcm_list_summaries: {len(summaries)} node(s)\n"
+    rows: list[str] = []
+    for s in summaries:
+        excerpt = s.content[:120].replace("\n", " ")
+        if len(s.content) > 120:
+            excerpt += "…"
+        rows.append(
+            f"  id={s.id}  depth={s.depth}  kind={s.summary_kind}  "
+            f"tokens=~{s.token_count}\n    {excerpt}"
+        )
+    return header + "\n".join(rows)

--- a/backend/app/core/tools/lcm_describe_agent.py
+++ b/backend/app/core/tools/lcm_describe_agent.py
@@ -1,0 +1,130 @@
+"""Agent-loop adapter for the LCM describe tool (PR #5).
+
+Exposes two :class:`AgentTool` factories:
+
+* :func:`make_lcm_describe_tool` — inspect a specific summary by ID.
+* :func:`make_lcm_list_summaries_tool` — enumerate all summaries for
+  the current conversation (so the agent can find the right ID to pass
+  to ``lcm_describe``).
+
+Usage::
+
+    from app.core.tools.lcm_describe_agent import (
+        make_lcm_describe_tool,
+        make_lcm_list_summaries_tool,
+    )
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_list_summaries_tool(conversation_id=conv.id))
+        tools.append(make_lcm_describe_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import async_session_maker
+
+# ---------------------------------------------------------------------------
+# lcm_list_summaries
+# ---------------------------------------------------------------------------
+
+_LIST_TOOL_NAME = "lcm_list_summaries"
+
+_LIST_TOOL_DESCRIPTION = (
+    "List all compacted summary nodes for the current conversation, most-recent-first."
+    "  Each entry shows the summary ID, depth, kind, token count, and a brief excerpt."
+    "  Use this to discover which summary IDs are available before calling"
+    " ``lcm_describe`` to read one in full."
+)
+
+_LIST_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+
+def make_lcm_list_summaries_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that lists LCM summary nodes for a conversation.
+
+    Args:
+        conversation_id: Baked into the closure — the agent cannot list
+            summaries from other conversations.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        async with async_session_maker() as session:
+            return await lcm_list_summaries(
+                session, conversation_id=conversation_id
+            )
+
+    return AgentTool(
+        name=_LIST_TOOL_NAME,
+        description=_LIST_TOOL_DESCRIPTION,
+        parameters=_LIST_PARAMETERS,
+        execute=_execute,
+    )
+
+
+# ---------------------------------------------------------------------------
+# lcm_describe
+# ---------------------------------------------------------------------------
+
+_DESCRIBE_TOOL_NAME = "lcm_describe"
+
+_DESCRIBE_TOOL_DESCRIPTION = (
+    "Read the full content and metadata of a single compacted summary node."
+    "  Supply the summary ID (obtained via ``lcm_list_summaries`` or from a"
+    " ``[SUMMARY`` annotation in ``lcm_grep`` output)."
+    "  Returns the complete summary text and its source-edge list."
+    "  This is a cheap single-row lookup — use it freely to recover compacted"
+    " context without the overhead of a full expand_query sub-agent."
+)
+
+_DESCRIBE_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "summary_id": {
+            "type": "string",
+            "description": (
+                "UUID of the LCMSummary node to inspect."
+                " Obtain this from lcm_list_summaries or from a [SUMMARY ..."
+                " annotation in lcm_grep output."
+            ),
+        },
+    },
+    "required": ["summary_id"],
+}
+
+
+def make_lcm_describe_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` that reads a specific LCMSummary in full.
+
+    Args:
+        conversation_id: Baked into the closure — prevents cross-conversation
+            inspection even if the agent passes a foreign UUID.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        raw_id = str(kwargs.get("summary_id") or "")
+        try:
+            sid = uuid.UUID(raw_id)
+        except ValueError:
+            return f"lcm_describe: invalid UUID {raw_id!r}"
+
+        async with async_session_maker() as session:
+            return await lcm_describe(
+                session,
+                conversation_id=conversation_id,
+                summary_id=sid,
+            )
+
+    return AgentTool(
+        name=_DESCRIBE_TOOL_NAME,
+        description=_DESCRIBE_TOOL_DESCRIPTION,
+        parameters=_DESCRIBE_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/core/tools/lcm_describe_agent.py
+++ b/backend/app/core/tools/lcm_describe_agent.py
@@ -57,9 +57,7 @@ def make_lcm_list_summaries_tool(*, conversation_id: uuid.UUID) -> AgentTool:
 
     async def _execute(tool_call_id: str, **kwargs: object) -> str:
         async with async_session_maker() as session:
-            return await lcm_list_summaries(
-                session, conversation_id=conversation_id
-            )
+            return await lcm_list_summaries(session, conversation_id=conversation_id)
 
     return AgentTool(
         name=_LIST_TOOL_NAME,

--- a/backend/app/core/tools/lcm_expand_query.py
+++ b/backend/app/core/tools/lcm_expand_query.py
@@ -32,7 +32,6 @@ When to use it vs. lcm_grep
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -83,70 +82,16 @@ async def lcm_expand_query(
     if not prompt.strip():
         return "lcm_expand_query: empty prompt — nothing to answer."
 
-    # ------------------------------------------------------------------ 1
-    # Fetch the full context list (bounded).
-    items_result = await session.execute(
-        select(LCMContextItem)
-        .where(LCMContextItem.conversation_id == conversation_id)
-        .order_by(LCMContextItem.ordinal.asc())
-        .limit(_MAX_EXPAND_ITEMS)
-    )
-    items = list(items_result.scalars().all())
-
-    if not items:
+    turns = await _collect_full_history_turns(session, conversation_id=conversation_id)
+    if turns is None:
         return (
             "lcm_expand_query: no conversation history found.  "
             "The conversation may be empty or LCM ingest has not run yet."
         )
-
-    # ------------------------------------------------------------------ 2
-    # Batch-resolve all backing rows.
-    message_ids = [i.item_id for i in items if i.item_kind == "message"]
-    summary_ids = [i.item_id for i in items if i.item_kind == "summary"]
-
-    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
-    if message_ids:
-        m_res = await session.execute(
-            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
-        )
-        messages_by_id = {m.id: m for m in m_res.scalars().all()}
-
-    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
-    if summary_ids:
-        s_res = await session.execute(
-            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
-        )
-        summaries_by_id = {s.id: s for s in s_res.scalars().all()}
-
-    # ------------------------------------------------------------------ 3
-    # Build the full-history transcript.
-    turns: list[dict[str, str]] = []
-    for item in items:
-        if item.item_kind == "message":
-            msg = messages_by_id.get(item.item_id)
-            if msg and msg.role in {"user", "assistant"} and msg.content:
-                turns.append({"role": msg.role, "content": msg.content})
-        elif item.item_kind == "summary":
-            summ = summaries_by_id.get(item.item_id)
-            if summ and summ.content:
-                turns.append(
-                    {
-                        "role": "user",
-                        "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
-                    }
-                )
-
     if not turns:
         return "lcm_expand_query: resolved to an empty history — nothing to answer."
 
-    history_text = _format_turns(turns)
-    expansion_prompt = (
-        f"CONVERSATION HISTORY:\n{history_text}\n\n"
-        f"QUESTION:\n{prompt}"
-    )
-
-    # ------------------------------------------------------------------ 4
-    # Single focused LLM call.
+    expansion_prompt = f"CONVERSATION HISTORY:\n{_format_turns(turns)}\n\nQUESTION:\n{prompt}"
     expand_model = _settings.lcm_summary_model or model_id
     provider = resolve_llm(expand_model, user_id=user_id)
 
@@ -165,3 +110,68 @@ async def lcm_expand_query(
         return "lcm_expand_query: the model returned an empty response."
     except Exception as exc:
         return f"lcm_expand_query: expansion call failed — {exc}"
+
+
+async def _collect_full_history_turns(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+) -> list[dict[str, str]] | None:
+    """Resolve every LCM context item into a ``{role, content}`` turn list.
+
+    Returns ``None`` when there are no context items at all (caller renders
+    the explicit "no history" message), or an empty list when items exist
+    but none resolve to non-empty content.  Bounded by
+    ``_MAX_EXPAND_ITEMS`` so a runaway conversation can't blow the model's
+    context window.
+    """
+    items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+        .limit(_MAX_EXPAND_ITEMS)
+    )
+    items = list(items_result.scalars().all())
+    if not items:
+        return None
+
+    message_ids = [i.item_id for i in items if i.item_kind == "message"]
+    summary_ids = [i.item_id for i in items if i.item_kind == "summary"]
+
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        m_res = await session.execute(select(ChatMessage).where(ChatMessage.id.in_(message_ids)))
+        messages_by_id = {m.id: m for m in m_res.scalars().all()}
+
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        s_res = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(summary_ids)))
+        summaries_by_id = {s.id: s for s in s_res.scalars().all()}
+
+    turns: list[dict[str, str]] = []
+    for item in items:
+        turn = _resolve_item_to_turn(item, messages_by_id, summaries_by_id)
+        if turn is not None:
+            turns.append(turn)
+    return turns
+
+
+def _resolve_item_to_turn(
+    item: LCMContextItem,
+    messages_by_id: dict[uuid.UUID, ChatMessage],
+    summaries_by_id: dict[uuid.UUID, LCMSummary],
+) -> dict[str, str] | None:
+    """Map one ``LCMContextItem`` to its ``{role, content}`` shape, or ``None`` to drop."""
+    if item.item_kind == "message":
+        msg = messages_by_id.get(item.item_id)
+        if msg and msg.role in {"user", "assistant"} and msg.content:
+            return {"role": msg.role, "content": msg.content}
+        return None
+    if item.item_kind == "summary":
+        summ = summaries_by_id.get(item.item_id)
+        if summ and summ.content:
+            return {
+                "role": "user",
+                "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
+            }
+    return None

--- a/backend/app/core/tools/lcm_expand_query.py
+++ b/backend/app/core/tools/lcm_expand_query.py
@@ -1,0 +1,167 @@
+"""LCM expand_query — bounded deep-recall via a single focused LLM call.
+
+This is the backing implementation for the ``lcm_expand_query`` agent tool
+introduced in PR #6 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin spawns an OpenClaw sub-agent that walks
+the full summary DAG.  We use our own infrastructure: instead of a real
+sub-agent, we make one focused LLM call with the *complete* conversation
+history — all LCMContextItems resolved in ordinal order, not just the
+fresh tail — and return its answer.
+
+This is "bounded" in the sense that:
+- It is a single-turn call, not a multi-turn loop.
+- Input is capped at MAX_EXPAND_ITEMS items so we don't exceed a model
+  context window even for very long conversations.
+- Errors are surfaced as descriptive strings, not exceptions, so the
+  calling agent can self-correct.
+
+When to use it vs. lcm_grep
+-----------------------------
+* ``lcm_grep``         — keyword/phrase search; cheap; returns excerpts.
+* ``lcm_describe``     — read one summary node in full; very cheap.
+* ``lcm_expand_query`` — "answer a question about the full history"; slower
+                         (one extra LLM call) but gives a synthesised answer.
+                         Use when grep returns an excerpt and you need the
+                         full story, or when the answer spans multiple
+                         compacted nodes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings as _settings
+from app.core.lcm import _collect_stream, _format_turns
+from app.core.providers import resolve_llm
+from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+# Hard cap so we never build a prompt larger than the model can handle.
+_MAX_EXPAND_ITEMS = 500
+
+_EXPAND_SYSTEM_PROMPT = """\
+You are a recall assistant.  You have access to the full history of a
+conversation (raw messages and compacted summaries, in chronological order).
+Answer the user's question based ONLY on what is present in this history.
+If the answer is not in the history, say so explicitly.
+Be concise and cite specific turns or summary nodes when relevant."""
+
+
+async def lcm_expand_query(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+    prompt: str,
+) -> str:
+    """Answer *prompt* by running a focused LLM call over the full history.
+
+    Fetches ALL ``lcm_context_items`` for *conversation_id* (up to
+    ``_MAX_EXPAND_ITEMS``), resolves each one to its backing content,
+    assembles a transcript, and calls the model with *prompt* as the
+    user turn.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to expand.
+        user_id: Used to resolve provider API keys.
+        model_id: The model to use for the expansion call.  Falls back to
+            ``settings.lcm_summary_model`` if non-empty, then to model_id.
+        prompt: The question / retrieval task for the sub-call.
+
+    Returns:
+        The model's synthesised answer, or an error string if the call
+        fails or no history exists.
+    """
+    if not prompt.strip():
+        return "lcm_expand_query: empty prompt — nothing to answer."
+
+    # ------------------------------------------------------------------ 1
+    # Fetch the full context list (bounded).
+    items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+        .limit(_MAX_EXPAND_ITEMS)
+    )
+    items = list(items_result.scalars().all())
+
+    if not items:
+        return (
+            "lcm_expand_query: no conversation history found.  "
+            "The conversation may be empty or LCM ingest has not run yet."
+        )
+
+    # ------------------------------------------------------------------ 2
+    # Batch-resolve all backing rows.
+    message_ids = [i.item_id for i in items if i.item_kind == "message"]
+    summary_ids = [i.item_id for i in items if i.item_kind == "summary"]
+
+    messages_by_id: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        m_res = await session.execute(
+            select(ChatMessage).where(ChatMessage.id.in_(message_ids))
+        )
+        messages_by_id = {m.id: m for m in m_res.scalars().all()}
+
+    summaries_by_id: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        s_res = await session.execute(
+            select(LCMSummary).where(LCMSummary.id.in_(summary_ids))
+        )
+        summaries_by_id = {s.id: s for s in s_res.scalars().all()}
+
+    # ------------------------------------------------------------------ 3
+    # Build the full-history transcript.
+    turns: list[dict[str, str]] = []
+    for item in items:
+        if item.item_kind == "message":
+            msg = messages_by_id.get(item.item_id)
+            if msg and msg.role in {"user", "assistant"} and msg.content:
+                turns.append({"role": msg.role, "content": msg.content})
+        elif item.item_kind == "summary":
+            summ = summaries_by_id.get(item.item_id)
+            if summ and summ.content:
+                turns.append(
+                    {
+                        "role": "user",
+                        "content": f"[Compacted summary, depth={summ.depth}]\n{summ.content}",
+                    }
+                )
+
+    if not turns:
+        return "lcm_expand_query: resolved to an empty history — nothing to answer."
+
+    history_text = _format_turns(turns)
+    expansion_prompt = (
+        f"CONVERSATION HISTORY:\n{history_text}\n\n"
+        f"QUESTION:\n{prompt}"
+    )
+
+    # ------------------------------------------------------------------ 4
+    # Single focused LLM call.
+    expand_model = _settings.lcm_summary_model or model_id
+    provider = resolve_llm(expand_model, user_id=user_id)
+
+    try:
+        stream = provider.stream(
+            question=expansion_prompt,
+            conversation_id=uuid.uuid4(),  # isolated; not a real turn
+            user_id=user_id,
+            history=None,
+            tools=None,
+            system_prompt=_EXPAND_SYSTEM_PROMPT,
+        )
+        answer = await _collect_stream(stream)
+        if answer:
+            return answer
+        return "lcm_expand_query: the model returned an empty response."
+    except Exception as exc:
+        return f"lcm_expand_query: expansion call failed — {exc}"

--- a/backend/app/core/tools/lcm_expand_query_agent.py
+++ b/backend/app/core/tools/lcm_expand_query_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM expand_query tool (PR #6).
+
+Exposes :func:`make_lcm_expand_query_tool` which returns an
+:class:`AgentTool` for deep recall over the full conversation history.
+
+Usage::
+
+    from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
+
+    if settings.lcm_enabled:
+        tools.append(
+            make_lcm_expand_query_tool(
+                conversation_id=conv.id,
+                user_id=user.id,
+                model_id=model_id,
+            )
+        )
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_expand_query"
+
+_TOOL_DESCRIPTION = (
+    "Answer a question by reading the FULL conversation history — including"
+    " all compacted summary nodes AND raw messages — with a dedicated LLM call."
+    "  Use this when lcm_grep found a relevant excerpt but you need the complete"
+    " story, or when the answer likely spans multiple compacted nodes and a"
+    " summary cannot give you enough detail."
+    "  This tool makes an extra LLM call, so prefer lcm_grep or lcm_describe"
+    " for simple lookups."
+    "  Tip: be specific in your prompt — the better the question, the better"
+    " the answer."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": (
+                "The question or retrieval task to answer from the full"
+                " conversation history.  Be specific: include key terms,"
+                " names, or topics relevant to what you're looking for."
+            ),
+        },
+    },
+    "required": ["prompt"],
+}
+
+
+def make_lcm_expand_query_tool(
+    *,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    model_id: str,
+) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM deep-recall expansion.
+
+    Args:
+        conversation_id: The conversation to expand.  Baked in so the
+            agent cannot query other conversations.
+        user_id: Used to resolve provider API keys for the expansion call.
+        model_id: Default model for the expansion call.  May be overridden
+            by ``settings.lcm_summary_model`` if set.
+
+    Returns:
+        A configured :class:`AgentTool` ready for the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        prompt = str(kwargs.get("prompt") or "")
+        async with async_session_maker() as session:
+            return await lcm_expand_query(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                model_id=model_id,
+                prompt=prompt,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/core/tools/lcm_grep.py
+++ b/backend/app/core/tools/lcm_grep.py
@@ -29,7 +29,6 @@ token-efficient.
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/backend/app/core/tools/lcm_grep.py
+++ b/backend/app/core/tools/lcm_grep.py
@@ -1,0 +1,158 @@
+"""LCM grep — search conversation history across messages and summaries.
+
+This is the backing implementation for the ``lcm_grep`` agent tool introduced
+in PR #4 of the LCM stack.
+
+Design
+------
+The upstream lossless-claw plugin uses SQLite FTS5 for full-text search.
+We run Postgres in production, where a dedicated ``tsvector`` index is the
+right long-term solution (tracked in ``.beans/lcm-followups.md``).  For this
+tracer-bullet PR we use ``ILIKE '%query%'`` which works on both SQLite (tests)
+and Postgres (production) without a schema migration.  The FTS upgrade can
+land in a follow-up once we have real production workloads to benchmark.
+
+Returned result format
+----------------------
+Each match is a compact block::
+
+    [MESSAGE role=user ordinal=12]
+    ...matching content excerpt...
+
+    [SUMMARY depth=0]
+    ...matching summary excerpt...
+
+Matches are capped at ``max_excerpt_chars`` per entry to keep the response
+token-efficient.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMSummary
+
+_MAX_RESULTS_DEFAULT = 10
+_MAX_EXCERPT_CHARS = 500
+
+
+def _excerpt(text: str, *, query: str, max_chars: int = _MAX_EXCERPT_CHARS) -> str:
+    """Return a snippet around the first occurrence of *query* in *text*.
+
+    The snippet is at most *max_chars* characters.  If the match is near
+    the start or end, the window shifts to fit; the edge is marked with ``…``
+    when content is elided.
+    """
+    text = text or ""
+    query_lower = query.lower()
+    pos = text.lower().find(query_lower)
+    if pos == -1:
+        # Shouldn't happen (we searched for the query), but handle gracefully.
+        return text[:max_chars] + ("…" if len(text) > max_chars else "")
+
+    half = max_chars // 2
+    start = max(0, pos - half)
+    end = min(len(text), pos + len(query) + half)
+
+    # Expand the window to *max_chars* if we hit an edge.
+    if start == 0:
+        end = min(len(text), max_chars)
+    if end == len(text):
+        start = max(0, len(text) - max_chars)
+
+    snippet = text[start:end]
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet = snippet + "…"
+    return snippet
+
+
+def _format_results(
+    message_hits: list[ChatMessage],
+    summary_hits: list[LCMSummary],
+    query: str,
+) -> str:
+    """Format matched rows as a compact markdown-ish string for the agent."""
+    if not message_hits and not summary_hits:
+        return f"No matches found for query: {query!r}"
+
+    parts: list[str] = []
+
+    for msg in message_hits:
+        exc = _excerpt(msg.content or "", query=query)
+        parts.append(f"[MESSAGE role={msg.role} ordinal={msg.ordinal}]\n{exc}")
+
+    for summ in summary_hits:
+        exc = _excerpt(summ.content or "", query=query)
+        parts.append(f"[SUMMARY depth={summ.depth} kind={summ.summary_kind}]\n{exc}")
+
+    header = (
+        f"lcm_grep: {len(message_hits)} message match(es), "
+        f"{len(summary_hits)} summary match(es) for {query!r}\n"
+    )
+    return header + "\n\n".join(parts)
+
+
+async def lcm_grep(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int = _MAX_RESULTS_DEFAULT,
+) -> str:
+    """Search a conversation's messages and summaries for *query*.
+
+    Performs case-insensitive substring matching across:
+
+    * ``chat_messages.content`` — raw user/assistant turns
+    * ``lcm_summaries.content`` — compacted history nodes
+
+    Both searches are scoped to *conversation_id*.  Results are ordered
+    most-recent-first and capped at *limit* per source.  The combined output
+    is formatted as a compact annotated text block suitable for direct
+    inclusion in an agent's tool result.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to search.
+        query: The search string.  Matched case-insensitively as a substring.
+        limit: Maximum number of results per source (messages + summaries each).
+
+    Returns:
+        A formatted string with matches and excerpts, or a "no matches"
+        message if nothing matched.
+    """
+    if not query.strip():
+        return "lcm_grep: empty query — nothing to search."
+
+    # SQLAlchemy's ``.ilike()`` emits ``ILIKE`` on Postgres and
+    # ``LIKE LOWER(...)`` on SQLite — both work for our needs.
+    msg_result = await session.execute(
+        select(ChatMessage)
+        .where(
+            ChatMessage.conversation_id == conversation_id,
+            ChatMessage.role.in_(["user", "assistant"]),
+            ChatMessage.content.ilike(f"%{query}%"),
+        )
+        .order_by(ChatMessage.ordinal.desc())
+        .limit(limit)
+    )
+    message_hits = list(msg_result.scalars().all())
+
+    sum_result = await session.execute(
+        select(LCMSummary)
+        .where(
+            LCMSummary.conversation_id == conversation_id,
+            LCMSummary.content.ilike(f"%{query}%"),
+        )
+        .order_by(LCMSummary.created_at.desc())
+        .limit(limit)
+    )
+    summary_hits = list(sum_result.scalars().all())
+
+    return _format_results(message_hits, summary_hits, query)

--- a/backend/app/core/tools/lcm_grep_agent.py
+++ b/backend/app/core/tools/lcm_grep_agent.py
@@ -1,0 +1,93 @@
+"""Agent-loop adapter for the LCM grep tool (PR #4).
+
+Exposes :func:`make_lcm_grep_tool` which returns an :class:`AgentTool`
+that the provider can append to ``AgentContext.tools``.  The actual DB
+search lives in :mod:`app.core.tools.lcm_grep`; this module only handles
+the JSON schema and the thin async wrapper the loop calls.
+
+Usage::
+
+    from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
+
+    if settings.lcm_enabled:
+        tools.append(make_lcm_grep_tool(conversation_id=conv.id))
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_grep import _MAX_RESULTS_DEFAULT, lcm_grep
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_grep"
+
+_TOOL_DESCRIPTION = (
+    "Search the full history of this conversation — including any compacted"
+    " summaries — for a keyword or phrase.  Use this when you need to recall"
+    " something that may have been mentioned earlier but is no longer in your"
+    " current context window.  Returns matching excerpts from both raw messages"
+    " and summary nodes, annotated with their position in the conversation."
+    " Results are ordered most-recent-first.  Prefer short, distinctive search"
+    " terms (1-3 words) for best recall."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Keyword or phrase to search for.  Case-insensitive substring"
+                " match.  Use a short, distinctive term for best results."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"Maximum number of matches per source (messages + summaries"
+                f" searched independently).  Default {_MAX_RESULTS_DEFAULT}."
+            ),
+            "default": _MAX_RESULTS_DEFAULT,
+            "minimum": 1,
+            "maximum": 50,
+        },
+    },
+    "required": ["query"],
+}
+
+
+def make_lcm_grep_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the LCM history search.
+
+    The tool opens its own database session per call so it is independent
+    of the request-scoped session.
+
+    Args:
+        conversation_id: The conversation to search.  Baked into the closure
+            at tool construction time so the agent cannot search other
+            conversations.
+
+    Returns:
+        A configured :class:`AgentTool` ready to be appended to the tools list.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        query = str(kwargs.get("query") or "")
+        limit = int(kwargs.get("limit") or _MAX_RESULTS_DEFAULT)
+        limit = max(1, min(50, limit))
+        async with async_session_maker() as session:
+            return await lcm_grep(
+                session,
+                conversation_id=conversation_id,
+                query=query,
+                limit=limit,
+            )
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Text
 
@@ -307,6 +307,104 @@ class Workspace(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
 
 
+class LCMSummary(Base):
+    """A single LCM summary node — either a leaf or a condensed parent."""
+
+    __tablename__ = "lcm_summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 0 = leaf (summarises raw messages); 1+ = condensed (summarises other
+    # summaries at depth-1).  Used by the condensation pass to decide which
+    # nodes are eligible for the next level up.
+    depth: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # The actual summary prose the model produced.
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Approximate token count of ``content`` — cached so the assembly + budget
+    # math doesn't have to re-tokenise on every turn.
+    token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Which model produced this summary (e.g. ``gemini-2.5-flash-preview-05-20``).
+    # Stored so future re-compaction can pick a stronger model if needed.
+    model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # "normal" | "aggressive" | "fallback" — mirrors the three-level escalation
+    # used by the upstream plugin: normal prompt first, aggressive if the
+    # output is too large, deterministic truncation if both LLM passes fail.
+    summary_kind: Mapped[str] = mapped_column(String(16), nullable=False, default="normal")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
+class LCMSummarySource(Base):
+    """Edge from an :class:`LCMSummary` to one of its source items.
+
+    A source is either a :class:`ChatMessage` (when the parent is a leaf
+    summary) or another :class:`LCMSummary` (when the parent is a condensed
+    summary).  ``source_kind`` discriminates between the two so a single
+    join + filter recovers either flavour.
+    """
+
+    __tablename__ = "lcm_summary_sources"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    summary_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("lcm_summaries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # "message" | "summary" — string discriminator so the FK can target either.
+    source_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    source_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    # Position in the original ordering so re-assembly is deterministic.
+    source_ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class LCMContextItem(Base):
+    """One entry in the assembled context list for a conversation.
+
+    Walking this table in ``ordinal`` order produces the sequence of items
+    fed to the provider every turn.  Each row points at either a raw
+    :class:`ChatMessage` or a compacted :class:`LCMSummary`; the chat
+    router resolves the actual content at assembly time.
+
+    Compaction rewrites this list in place: a contiguous range of
+    ``item_kind="message"`` rows is replaced by a single
+    ``item_kind="summary"`` row, and the ordinals are renumbered so the
+    list stays dense.
+    """
+
+    __tablename__ = "lcm_context_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "conversation_id",
+            "ordinal",
+            name="uq_lcm_context_items_conv_ordinal",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Position in the assembled list.  Gaps are harmless; ingest_message
+    # uses max(ordinal)+1 so no dense renumbering after compaction.
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    # "message" | "summary" — the discriminator the assembly step uses to
+    # decide which lookup to perform.
+    item_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # FK target into either chat_messages or lcm_summaries depending on
+    # ``item_kind``.  Cascades happen via the parent conversation_id FK.
+    item_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
 # ---------------------------------------------------------------------------
 # Governance + ops platform (PRs 01-12)
 #
@@ -329,6 +427,9 @@ __all__ = [
     "ChatMessage",
     "Conversation",
     "CostLedger",
+    "LCMContextItem",
+    "LCMSummary",
+    "LCMSummarySource",
     "Project",
     "ScheduledJob",
     "SenderType",

--- a/backend/tests/test_lcm_agent_tools.py
+++ b/backend/tests/test_lcm_agent_tools.py
@@ -1,0 +1,142 @@
+"""build_agent_tools wiring tests for all LCM tools.
+
+These tests were deferred from PRs 7–9 because they require
+build_agent_tools to accept conversation_id and model_id (this PR).
+
+Covers:
+- lcm_grep is present when lcm_enabled=True and conversation_id is set
+- lcm_grep is absent when lcm_enabled=False
+- lcm_grep is absent when conversation_id is None
+- lcm_describe and lcm_list_summaries are present/absent under the same gates
+- lcm_expand_query is present only when user_id is also provided
+- lcm_expand_query is absent when user_id is None
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def test_lcm_grep_tool_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    assert "lcm_grep" in [t.name for t in tools]
+
+
+def test_lcm_grep_tool_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    assert "lcm_grep" not in [t.name for t in tools]
+
+
+def test_lcm_grep_tool_absent_when_no_conversation_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=None)
+    assert "lcm_grep" not in [t.name for t in tools]
+
+
+def test_describe_tools_present_when_lcm_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_list_summaries" in names
+    assert "lcm_describe" in names
+
+
+def test_describe_tools_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(workspace_root=tmp_path, conversation_id=uuid.uuid4())
+    names = [t.name for t in tools]
+    assert "lcm_list_summaries" not in names
+    assert "lcm_describe" not in names
+
+
+def test_expand_query_tool_present_when_user_id_provided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    assert "lcm_expand_query" in [t.name for t in tools]
+
+
+def test_expand_query_tool_absent_without_user_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    # user_id=None → expand_query should NOT be present (it needs user_id for
+    # the LLM sub-call).
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=None,
+    )
+    assert "lcm_expand_query" not in [t.name for t in tools]
+
+
+def test_expand_query_tool_absent_when_lcm_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.core.agent_tools import build_agent_tools
+    from app.core import config as _cfg
+
+    monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
+    monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
+
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    assert "lcm_expand_query" not in [t.name for t in tools]

--- a/backend/tests/test_lcm_agent_tools.py
+++ b/backend/tests/test_lcm_agent_tools.py
@@ -1,6 +1,6 @@
 """build_agent_tools wiring tests for all LCM tools.
 
-These tests were deferred from PRs 7–9 because they require
+These tests were deferred from PRs 7-9 because they require
 build_agent_tools to accept conversation_id and model_id (this PR).
 
 Covers:
@@ -23,8 +23,8 @@ import pytest
 def test_lcm_grep_tool_present_when_lcm_enabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -36,8 +36,8 @@ def test_lcm_grep_tool_present_when_lcm_enabled(
 def test_lcm_grep_tool_absent_when_lcm_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -49,8 +49,8 @@ def test_lcm_grep_tool_absent_when_lcm_disabled(
 def test_lcm_grep_tool_absent_when_no_conversation_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -62,8 +62,8 @@ def test_lcm_grep_tool_absent_when_no_conversation_id(
 def test_describe_tools_present_when_lcm_enabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -77,8 +77,8 @@ def test_describe_tools_present_when_lcm_enabled(
 def test_describe_tools_absent_when_lcm_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -92,8 +92,8 @@ def test_describe_tools_absent_when_lcm_disabled(
 def test_expand_query_tool_present_when_user_id_provided(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -109,8 +109,8 @@ def test_expand_query_tool_present_when_user_id_provided(
 def test_expand_query_tool_absent_without_user_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", True)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)
@@ -128,8 +128,8 @@ def test_expand_query_tool_absent_without_user_id(
 def test_expand_query_tool_absent_when_lcm_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from app.core.agent_tools import build_agent_tools
     from app.core import config as _cfg
+    from app.core.agent_tools import build_agent_tools
 
     monkeypatch.setattr(_cfg.settings, "lcm_enabled", False)
     monkeypatch.setattr(_cfg.settings, "exa_api_key", None)

--- a/backend/tests/test_lcm_compaction.py
+++ b/backend/tests/test_lcm_compaction.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
@@ -39,7 +39,6 @@ from app.models import (
     LCMSummarySource,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -50,8 +49,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="LCM compaction test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -74,8 +73,8 @@ async def _make_message(
         ordinal=ordinal,
         role=role,
         content=content,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(msg)
     await session.flush()
@@ -130,7 +129,7 @@ def _make_failing_provider() -> Any:
 
 # Patch the provider resolution so compaction uses our mock.
 def _patch_resolve_llm(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
-    import app.core.lcm as _lcm  # noqa: PLC0415
+    import app.core.lcm as _lcm
 
     monkeypatch.setattr(_lcm, "resolve_llm", lambda *args, **kwargs: provider)
 
@@ -240,22 +239,24 @@ async def test_compact_creates_summary_and_sources(
     await db_session.commit()
 
     summaries = (
-        await db_session.execute(
-            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
-        )
-    ).scalars().all()
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
     assert len(summaries) == 1
     assert summaries[0].content == "hello world summary"
     assert summaries[0].depth == 0
     assert summaries[0].summary_kind == "normal"
 
     sources = (
-        await db_session.execute(
-            select(LCMSummarySource).where(
-                LCMSummarySource.summary_id == summaries[0].id
+        (
+            await db_session.execute(
+                select(LCMSummarySource).where(LCMSummarySource.summary_id == summaries[0].id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     # Only msg0 ("hello") is outside the fresh tail of 2 and should be compacted.
     assert len(sources) == 1
     assert sources[0].source_kind == "message"
@@ -287,12 +288,16 @@ async def test_compact_replaces_message_items_with_summary_item(
     await db_session.commit()
 
     items = (
-        await db_session.execute(
-            select(LCMContextItem)
-            .where(LCMContextItem.conversation_id == conv.id)
-            .order_by(LCMContextItem.ordinal)
+        (
+            await db_session.execute(
+                select(LCMContextItem)
+                .where(LCMContextItem.conversation_id == conv.id)
+                .order_by(LCMContextItem.ordinal)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     # 3 items before → 3 items after (summary + 2 message items in fresh tail).
     assert len(items) == 3
@@ -321,7 +326,7 @@ async def test_compact_multiple_eligible_messages(
             ("assistant", "b"),
             ("user", "c"),
             ("assistant", "d"),  # fresh tail starts here
-            ("user", "e"),       # fresh tail end
+            ("user", "e"),  # fresh tail end
         ],
     )
     _patch_resolve_llm(monkeypatch, _make_fake_provider("summary abc"))
@@ -337,20 +342,22 @@ async def test_compact_multiple_eligible_messages(
     await db_session.commit()
 
     items = (
-        await db_session.execute(
-            select(LCMContextItem)
-            .where(LCMContextItem.conversation_id == conv.id)
-            .order_by(LCMContextItem.ordinal)
+        (
+            await db_session.execute(
+                select(LCMContextItem)
+                .where(LCMContextItem.conversation_id == conv.id)
+                .order_by(LCMContextItem.ordinal)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     # 5 items → 1 summary + 2 fresh = 3 items total.
     assert len(items) == 3
     assert items[0].item_kind == "summary"
 
-    sources = (
-        await db_session.execute(select(LCMSummarySource))
-    ).scalars().all()
+    sources = (await db_session.execute(select(LCMSummarySource))).scalars().all()
     # msgs 0, 1, 2 should all be sources of the summary.
     source_ids = {s.source_id for s in sources}
     assert msgs[0].id in source_ids
@@ -377,9 +384,9 @@ async def test_compact_respects_token_budget(
         test_user,
         conv,
         [
-            ("user", "first message here"),   # ~5 tokens
-            ("assistant", "second one here"), # ~5 tokens
-            ("user", "fresh tail msg"),       # fresh tail
+            ("user", "first message here"),  # ~5 tokens
+            ("assistant", "second one here"),  # ~5 tokens
+            ("user", "fresh tail msg"),  # fresh tail
         ],
     )
     _patch_resolve_llm(monkeypatch, _make_fake_provider("first only"))
@@ -394,9 +401,7 @@ async def test_compact_respects_token_budget(
     )
     await db_session.commit()
 
-    sources = (
-        await db_session.execute(select(LCMSummarySource))
-    ).scalars().all()
+    sources = (await db_session.execute(select(LCMSummarySource))).scalars().all()
     # Only the first message should be in sources.
     assert len(sources) == 1
     assert sources[0].source_id == msgs[0].id
@@ -404,16 +409,20 @@ async def test_compact_respects_token_budget(
     # Second message (budget overflow) and third (fresh tail) should still be
     # message items in lcm_context_items.
     items = (
-        await db_session.execute(
-            select(LCMContextItem)
-            .where(LCMContextItem.conversation_id == conv.id)
-            .order_by(LCMContextItem.ordinal)
+        (
+            await db_session.execute(
+                select(LCMContextItem)
+                .where(LCMContextItem.conversation_id == conv.id)
+                .order_by(LCMContextItem.ordinal)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     kinds = [i.item_kind for i in items]
     assert kinds[0] == "summary"
-    assert kinds[1] == "message"   # second message still in place
-    assert kinds[2] == "message"   # fresh tail
+    assert kinds[1] == "message"  # second message still in place
+    assert kinds[2] == "message"  # fresh tail
 
 
 # ---------------------------------------------------------------------------
@@ -447,10 +456,10 @@ async def test_compact_uses_fallback_when_provider_fails(
 
     assert ran is True
     summaries = (
-        await db_session.execute(
-            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
-        )
-    ).scalars().all()
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
     assert len(summaries) == 1
     assert summaries[0].summary_kind == "fallback"
     # Deterministic fallback contains the raw transcript text.
@@ -486,9 +495,7 @@ async def test_assemble_after_compaction_returns_summary_plus_fresh(
     )
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
 
     assert len(context) == 3
     # First entry is the injected summary.

--- a/backend/tests/test_lcm_compaction.py
+++ b/backend/tests/test_lcm_compaction.py
@@ -1,0 +1,500 @@
+"""LCM PR #3 — leaf compaction tests.
+
+Covers:
+- compact_leaf_if_needed returns False when items ≤ fresh_tail_count.
+- compact_leaf_if_needed runs and returns True when there are items outside
+  the fresh tail.
+- After compaction: the source message items are replaced by a single
+  summary item; LCMSummary + LCMSummarySource rows are created.
+- The ordinal slot of the first compacted item is reused for the summary item.
+- Items inside the fresh tail are untouched.
+- max_chunk_tokens limits the compaction batch: messages beyond the token
+  budget are left in place.
+- Summary items already in the eligible window are left in place (not
+  re-compacted).
+- assemble_context after compaction returns the summary content + fresh tail.
+- Deterministic fallback is used when the provider raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context, compact_leaf_if_needed
+from app.core.providers.base import StreamEvent
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM compaction test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _seed_context(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    turns: list[tuple[str, str]],  # [(role, content), ...]
+) -> list[ChatMessage]:
+    """Insert N messages and their corresponding LCMContextItems."""
+    messages: list[ChatMessage] = []
+    for i, (role, content) in enumerate(turns):
+        msg = await _make_message(session, user, conv, role, content, i)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=i,
+                item_kind="message",
+                item_id=msg.id,
+            )
+        )
+        messages.append(msg)
+    await session.commit()
+    return messages
+
+
+def _make_fake_provider(summary_text: str = "SUMMARY") -> Any:
+    """Return a provider mock whose stream() yields a single delta."""
+
+    async def _fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type="delta", content=summary_text)
+
+    provider = MagicMock()
+    provider.stream = _fake_stream
+    return provider
+
+
+def _make_failing_provider() -> Any:
+    """Return a provider mock whose stream() raises immediately."""
+
+    async def _failing_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        raise RuntimeError("LLM unavailable")
+        yield  # make it an async generator
+
+    provider = MagicMock()
+    provider.stream = _failing_stream
+    return provider
+
+
+# Patch the provider resolution so compaction uses our mock.
+def _patch_resolve_llm(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    monkeypatch.setattr(_lcm, "resolve_llm", lambda *args, **kwargs: provider)
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_noop_when_within_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False when total items ≤ fresh_tail_count."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(db_session, test_user, conv, [("user", "hi"), ("assistant", "hello")])
+
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=5,  # larger than total items
+        max_chunk_tokens=100_000,
+    )
+
+    assert ran is False
+    # Provider should not have been called.
+    assert not provider.stream.called if hasattr(provider.stream, "called") else True
+
+
+@pytest.mark.anyio
+async def test_compact_noop_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False for an empty conversation."""
+    conv = await _make_conversation(db_session, test_user)
+    provider = _make_fake_provider()
+    _patch_resolve_llm(monkeypatch, provider)
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# compact_leaf_if_needed — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_runs_when_items_exceed_fresh_tail(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns True when compaction runs successfully."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "msg0"), ("assistant", "msg1"), ("user", "msg2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("compacted"))
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,  # last 2 kept; msg0 is eligible
+        max_chunk_tokens=100_000,
+    )
+    assert ran is True
+
+
+@pytest.mark.anyio
+async def test_compact_creates_summary_and_sources(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, LCMSummary and LCMSummarySource rows exist."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "hello"), ("assistant", "world"), ("user", "question")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("hello world summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].content == "hello world summary"
+    assert summaries[0].depth == 0
+    assert summaries[0].summary_kind == "normal"
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource).where(
+                LCMSummarySource.summary_id == summaries[0].id
+            )
+        )
+    ).scalars().all()
+    # Only msg0 ("hello") is outside the fresh tail of 2 and should be compacted.
+    assert len(sources) == 1
+    assert sources[0].source_kind == "message"
+    assert sources[0].source_id == msgs[0].id
+
+
+@pytest.mark.anyio
+async def test_compact_replaces_message_items_with_summary_item(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, the source message item is gone; a summary item takes its slot."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "reply"), ("user", "new")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary text"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 3 items before → 3 items after (summary + 2 message items in fresh tail).
+    assert len(items) == 3
+    # First item must now be the summary at the original slot 0.
+    assert items[0].item_kind == "summary"
+    assert items[0].ordinal == 0
+    # Fresh-tail items are still message items.
+    assert items[1].item_kind == "message"
+    assert items[2].item_kind == "message"
+    assert items[1].item_id == msgs[1].id
+    assert items[2].item_id == msgs[2].id
+
+
+@pytest.mark.anyio
+async def test_compact_multiple_eligible_messages(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When several messages are eligible, all are folded into one summary."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "a"),
+            ("assistant", "b"),
+            ("user", "c"),
+            ("assistant", "d"),  # fresh tail starts here
+            ("user", "e"),       # fresh tail end
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("summary abc"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 5 items → 1 summary + 2 fresh = 3 items total.
+    assert len(items) == 3
+    assert items[0].item_kind == "summary"
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # msgs 0, 1, 2 should all be sources of the summary.
+    source_ids = {s.source_id for s in sources}
+    assert msgs[0].id in source_ids
+    assert msgs[1].id in source_ids
+    assert msgs[2].id in source_ids
+    assert msgs[3].id not in source_ids  # fresh tail
+    assert msgs[4].id not in source_ids  # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# max_chunk_tokens budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_respects_token_budget(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the oldest messages that fit in max_chunk_tokens are compacted."""
+    conv = await _make_conversation(db_session, test_user)
+    # Each message is ~20 chars ≈ 5 tokens.  Budget of 6 tokens should fit only 1.
+    msgs = await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [
+            ("user", "first message here"),   # ~5 tokens
+            ("assistant", "second one here"), # ~5 tokens
+            ("user", "fresh tail msg"),       # fresh tail
+        ],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("first only"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=1,  # only last 1 in fresh tail → 2 eligible
+        max_chunk_tokens=6,  # fits only the first message
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(select(LCMSummarySource))
+    ).scalars().all()
+    # Only the first message should be in sources.
+    assert len(sources) == 1
+    assert sources[0].source_id == msgs[0].id
+
+    # Second message (budget overflow) and third (fresh tail) should still be
+    # message items in lcm_context_items.
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+    kinds = [i.item_kind for i in items]
+    assert kinds[0] == "summary"
+    assert kinds[1] == "message"   # second message still in place
+    assert kinds[2] == "message"   # fresh tail
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_uses_fallback_when_provider_fails(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Uses deterministic truncation when the LLM provider raises."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old message"), ("assistant", "reply"), ("user", "fresh")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_failing_provider())
+
+    ran = await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    assert ran is True
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    assert len(summaries) == 1
+    assert summaries[0].summary_kind == "fallback"
+    # Deterministic fallback contains the raw transcript text.
+    assert "USER:" in summaries[0].content or "old message" in summaries[0].content
+
+
+# ---------------------------------------------------------------------------
+# assemble_context after compaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_after_compaction_returns_summary_plus_fresh(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After compaction, assemble_context returns [summary, *fresh_tail]."""
+    conv = await _make_conversation(db_session, test_user)
+    await _seed_context(
+        db_session,
+        test_user,
+        conv,
+        [("user", "old"), ("assistant", "tail1"), ("user", "tail2")],
+    )
+    _patch_resolve_llm(monkeypatch, _make_fake_provider("the summary"))
+
+    await compact_leaf_if_needed(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        fresh_tail_count=2,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert len(context) == 3
+    # First entry is the injected summary.
+    assert context[0]["role"] == "user"
+    assert "[Summary of earlier conversation]" in context[0]["content"]
+    assert "the summary" in context[0]["content"]
+    # Then the fresh-tail messages.
+    assert context[1] == {"role": "assistant", "content": "tail1"}
+    assert context[2] == {"role": "user", "content": "tail2"}

--- a/backend/tests/test_lcm_condensation.py
+++ b/backend/tests/test_lcm_condensation.py
@@ -339,7 +339,13 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
     _patch(monkeypatch, _make_provider("compacted+condensed"))
 
     # Patch settings so incremental_max_depth=1 and fresh_tail=2.
+    # Both ``app.core.lcm`` and ``app.core.lcm.condense`` hold their own
+    # ``settings`` binding (each imported the symbol at module load),
+    # so the patch has to land on both — otherwise the cascade reads
+    # the real settings object and the test passes only by accident
+    # when the real defaults happen to align with ``_S``.
     import app.core.lcm as _lcm
+    import app.core.lcm.condense as _lcm_condense
 
     class _S:
         lcm_summary_model = ""
@@ -347,8 +353,11 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
         lcm_leaf_chunk_tokens = 100_000
         lcm_incremental_max_depth = 1
 
-    original = _lcm._settings
-    _lcm._settings = _S()  # type: ignore[assignment]
+    fake_settings = _S()
+    original_lcm = _lcm._settings
+    original_condense = _lcm_condense._settings
+    _lcm._settings = fake_settings  # type: ignore[assignment]
+    _lcm_condense._settings = fake_settings  # type: ignore[assignment]
     try:
         # First compaction — compacts msgs 0-3 (4 items outside fresh tail of 2).
         await compact_leaf_if_needed(
@@ -410,7 +419,8 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
         )
         await db_session.commit()
     finally:
-        _lcm._settings = original  # type: ignore[assignment]
+        _lcm._settings = original_lcm  # type: ignore[assignment]
+        _lcm_condense._settings = original_condense  # type: ignore[assignment]
 
     # After the second compaction + condensation pass, there should be a depth-1 summary.
     all_summaries = (
@@ -443,6 +453,7 @@ async def test_compact_skips_condensation_when_depth_is_0(
     _patch(monkeypatch, _make_provider("leaf"))
 
     import app.core.lcm as _lcm
+    import app.core.lcm.condense as _lcm_condense
 
     class _S:
         lcm_summary_model = ""
@@ -450,8 +461,11 @@ async def test_compact_skips_condensation_when_depth_is_0(
         lcm_leaf_chunk_tokens = 100_000
         lcm_incremental_max_depth = 0  # <-- condensation disabled
 
-    original = _lcm._settings
-    _lcm._settings = _S()  # type: ignore[assignment]
+    fake_settings = _S()
+    original_lcm = _lcm._settings
+    original_condense = _lcm_condense._settings
+    _lcm._settings = fake_settings  # type: ignore[assignment]
+    _lcm_condense._settings = fake_settings  # type: ignore[assignment]
     try:
         # compact_leaf_if_needed won't compact because the eligible items are
         # summaries (item_kind="summary"), not messages.  So it returns False
@@ -466,7 +480,8 @@ async def test_compact_skips_condensation_when_depth_is_0(
         )
         await db_session.commit()
     finally:
-        _lcm._settings = original  # type: ignore[assignment]
+        _lcm._settings = original_lcm  # type: ignore[assignment]
+        _lcm_condense._settings = original_condense  # type: ignore[assignment]
 
     # ran=False because compact_leaf sees no message items to compact;
     # condensation also did not run.

--- a/backend/tests/test_lcm_condensation.py
+++ b/backend/tests/test_lcm_condensation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -24,7 +24,8 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.lcm import _condense_at_depth, assemble_context, compact_leaf_if_needed
+from app.core.lcm import assemble_context, compact_leaf_if_needed
+from app.core.lcm.condense import _condense_at_depth
 from app.db import User
 from app.models import (
     ChatMessage,
@@ -33,7 +34,6 @@ from app.models import (
     LCMSummary,
     LCMSummarySource,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -45,8 +45,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="condensation test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -69,8 +69,8 @@ async def _make_message(
         ordinal=ordinal,
         role=role,
         content=content,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(msg)
     await session.flush()
@@ -116,9 +116,7 @@ async def _seed_context(
     for i, (role, content) in enumerate(turns):
         msg = await _make_message(session, user, conv, role, content, i)
         session.add(
-            LCMContextItem(
-                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
-            )
+            LCMContextItem(conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id)
         )
         messages.append(msg)
     await session.commit()
@@ -135,9 +133,14 @@ def _make_provider(answer: str = "CONDENSED") -> Any:
 
 
 def _patch(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
-    import app.core.lcm as _lcm  # noqa: PLC0415
+    import app.core.lcm as _lcm
+    import app.core.lcm.condense as _lcm_condense
 
     monkeypatch.setattr(_lcm, "resolve_llm", lambda *a, **kw: provider)
+    # Condensation lives in app.core.lcm.condense (split out for the
+    # file-line budget) — patch its resolve_llm import too so
+    # monkeypatched providers reach _condense_at_depth.
+    monkeypatch.setattr(_lcm_condense, "resolve_llm", lambda *a, **kw: provider)
 
 
 # ---------------------------------------------------------------------------
@@ -210,10 +213,10 @@ async def test_condense_creates_depth1_parent(
 
     assert ran is True
     summaries = (
-        await db_session.execute(
-            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
-        )
-    ).scalars().all()
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
     depths = [s.depth for s in summaries]
     # Two depth-0 + one depth-1.
     assert depths.count(0) == 2
@@ -251,12 +254,14 @@ async def test_condense_source_edges_point_at_leaves(
         )
     ).scalar_one()
     sources = (
-        await db_session.execute(
-            select(LCMSummarySource).where(
-                LCMSummarySource.summary_id == parent.id
+        (
+            await db_session.execute(
+                select(LCMSummarySource).where(LCMSummarySource.summary_id == parent.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     source_ids = {s.source_id for s in sources}
     assert leaf_a.id in source_ids
@@ -276,9 +281,7 @@ async def test_condense_replaces_leaf_items_with_parent_item(
     msg = await _make_message(db_session, test_user, conv, "user", "tail", 2)
     session = db_session
     session.add(
-        LCMContextItem(
-            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
-        )
+        LCMContextItem(conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id)
     )
     await db_session.commit()
 
@@ -294,12 +297,16 @@ async def test_condense_replaces_leaf_items_with_parent_item(
     await db_session.commit()
 
     items = (
-        await db_session.execute(
-            select(LCMContextItem)
-            .where(LCMContextItem.conversation_id == conv.id)
-            .order_by(LCMContextItem.ordinal)
+        (
+            await db_session.execute(
+                select(LCMContextItem)
+                .where(LCMContextItem.conversation_id == conv.id)
+                .order_by(LCMContextItem.ordinal)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     # 3 items before (2 leaf summaries + 1 message) →
     # 2 items after (1 depth-1 summary + 1 message).
@@ -325,16 +332,14 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
         role = "user" if i % 2 == 0 else "assistant"
         msg = await _make_message(db_session, test_user, conv, role, f"msg{i}", i)
         db_session.add(
-            LCMContextItem(
-                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
-            )
+            LCMContextItem(conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id)
         )
     await db_session.commit()
 
     _patch(monkeypatch, _make_provider("compacted+condensed"))
 
     # Patch settings so incremental_max_depth=1 and fresh_tail=2.
-    import app.core.lcm as _lcm  # noqa: PLC0415
+    import app.core.lcm as _lcm
 
     class _S:
         lcm_summary_model = ""
@@ -359,13 +364,17 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
         # Now the context has: [summary(depth=0)] + [msg4, msg5].
         # There's only one depth-0 summary, so condensation is a no-op.
         depth1_after_first = (
-            await db_session.execute(
-                select(LCMSummary).where(
-                    LCMSummary.conversation_id == conv.id,
-                    LCMSummary.depth == 1,
+            (
+                await db_session.execute(
+                    select(LCMSummary).where(
+                        LCMSummary.conversation_id == conv.id,
+                        LCMSummary.depth == 1,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(depth1_after_first) == 0  # not enough leaves yet
 
         # Add two more messages so there's something outside the fresh tail again.
@@ -405,10 +414,10 @@ async def test_compact_triggers_condensation_when_depth_ge_1(
 
     # After the second compaction + condensation pass, there should be a depth-1 summary.
     all_summaries = (
-        await db_session.execute(
-            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
-        )
-    ).scalars().all()
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
     depths = [s.depth for s in all_summaries]
     assert 1 in depths, f"Expected a depth-1 summary, got depths: {depths}"
 
@@ -427,15 +436,13 @@ async def test_compact_skips_condensation_when_depth_is_0(
     for i in range(2, 4):
         msg = await _make_message(db_session, test_user, conv, "user", f"m{i}", i)
         db_session.add(
-            LCMContextItem(
-                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
-            )
+            LCMContextItem(conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id)
         )
     await db_session.commit()
 
     _patch(monkeypatch, _make_provider("leaf"))
 
-    import app.core.lcm as _lcm  # noqa: PLC0415
+    import app.core.lcm as _lcm
 
     class _S:
         lcm_summary_model = ""
@@ -465,13 +472,17 @@ async def test_compact_skips_condensation_when_depth_is_0(
     # condensation also did not run.
     assert ran is False
     depth1 = (
-        await db_session.execute(
-            select(LCMSummary).where(
-                LCMSummary.conversation_id == conv.id,
-                LCMSummary.depth == 1,
+        (
+            await db_session.execute(
+                select(LCMSummary).where(
+                    LCMSummary.conversation_id == conv.id,
+                    LCMSummary.depth == 1,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(depth1) == 0
 
 
@@ -490,9 +501,7 @@ async def test_assemble_after_condensation(
     await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
     msg = await _make_message(db_session, test_user, conv, "user", "fresh tail", 2)
     db_session.add(
-        LCMContextItem(
-            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
-        )
+        LCMContextItem(conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id)
     )
     await db_session.commit()
 
@@ -507,9 +516,7 @@ async def test_assemble_after_condensation(
     )
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
 
     assert len(context) == 2
     assert "[Summary of earlier conversation]" in context[0]["content"]

--- a/backend/tests/test_lcm_condensation.py
+++ b/backend/tests/test_lcm_condensation.py
@@ -1,0 +1,517 @@
+"""LCM PR #7 — condensation pass tests.
+
+Covers:
+- _condense_at_depth returns False when < 2 depth-0 summaries exist.
+- _condense_at_depth returns True and creates a depth-1 parent summary.
+- Source edges on the parent summary point at the depth-0 child summaries.
+- The depth-0 context items are replaced by a single depth-1 item.
+- Token budget limits the condensation batch.
+- compact_leaf_if_needed triggers condensation when lcm_incremental_max_depth >= 1.
+- lcm_incremental_max_depth=0 skips condensation.
+- Two sequential compactions produce a depth-1 condensed summary.
+- assemble_context after condensation returns depth-1 summary + fresh tail.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import _condense_at_depth, assemble_context, compact_leaf_if_needed
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="condensation test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _insert_summary_item(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    ordinal: int,
+    depth: int = 0,
+) -> LCMSummary:
+    """Insert a depth-d LCMSummary + its LCMContextItem at the given ordinal."""
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+        summary_kind="normal",
+    )
+    session.add(s)
+    await session.flush()
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="summary",
+            item_id=s.id,
+        )
+    )
+    await session.flush()
+    return s
+
+
+async def _seed_context(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    turns: list[tuple[str, str]],
+) -> list[ChatMessage]:
+    messages: list[ChatMessage] = []
+    for i, (role, content) in enumerate(turns):
+        msg = await _make_message(session, user, conv, role, content, i)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+        messages.append(msg)
+    await session.commit()
+    return messages
+
+
+def _make_provider(answer: str = "CONDENSED") -> Any:
+    async def _stream(*a: Any, **kw: Any) -> AsyncIterator:
+        yield {"type": "delta", "content": answer}
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    monkeypatch.setattr(_lcm, "resolve_llm", lambda *a, **kw: provider)
+
+
+# ---------------------------------------------------------------------------
+# _condense_at_depth — gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_condense_noop_with_single_summary(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns False when only 1 depth-0 summary exists."""
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "just one summary", ordinal=0, depth=0)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider())
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+@pytest.mark.anyio
+async def test_condense_noop_no_summaries(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    _patch(monkeypatch, _make_provider())
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# _condense_at_depth — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_condense_creates_depth1_parent(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("condensed AB"))
+    ran = await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    assert ran is True
+    summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    depths = [s.depth for s in summaries]
+    # Two depth-0 + one depth-1.
+    assert depths.count(0) == 2
+    assert depths.count(1) == 1
+    parent = next(s for s in summaries if s.depth == 1)
+    assert parent.content == "condensed AB"
+
+
+@pytest.mark.anyio
+async def test_condense_source_edges_point_at_leaves(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    leaf_a = await _insert_summary_item(db_session, conv, "leaf A", ordinal=0)
+    leaf_b = await _insert_summary_item(db_session, conv, "leaf B", ordinal=1)
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("parent"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    parent = (
+        await db_session.execute(
+            select(LCMSummary).where(
+                LCMSummary.conversation_id == conv.id,
+                LCMSummary.depth == 1,
+            )
+        )
+    ).scalar_one()
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource).where(
+                LCMSummarySource.summary_id == parent.id
+            )
+        )
+    ).scalars().all()
+
+    source_ids = {s.source_id for s in sources}
+    assert leaf_a.id in source_ids
+    assert leaf_b.id in source_ids
+    for s in sources:
+        assert s.source_kind == "summary"
+
+
+@pytest.mark.anyio
+async def test_condense_replaces_leaf_items_with_parent_item(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1)
+    # A raw message at ordinal 2 (shouldn't be touched).
+    msg = await _make_message(db_session, test_user, conv, "user", "tail", 2)
+    session = db_session
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
+        )
+    )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("parent"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    items = (
+        await db_session.execute(
+            select(LCMContextItem)
+            .where(LCMContextItem.conversation_id == conv.id)
+            .order_by(LCMContextItem.ordinal)
+        )
+    ).scalars().all()
+
+    # 3 items before (2 leaf summaries + 1 message) →
+    # 2 items after (1 depth-1 summary + 1 message).
+    assert len(items) == 2
+    assert items[0].item_kind == "summary"
+    assert items[1].item_kind == "message"
+
+
+# ---------------------------------------------------------------------------
+# Integration with compact_leaf_if_needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compact_triggers_condensation_when_depth_ge_1(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After two leaf compactions, condensation should produce a depth-1 summary."""
+    conv = await _make_conversation(db_session, test_user)
+
+    # Seed enough messages so two separate compactions each produce one leaf summary.
+    for i in range(6):
+        role = "user" if i % 2 == 0 else "assistant"
+        msg = await _make_message(db_session, test_user, conv, role, f"msg{i}", i)
+        db_session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("compacted+condensed"))
+
+    # Patch settings so incremental_max_depth=1 and fresh_tail=2.
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    class _S:
+        lcm_summary_model = ""
+        lcm_fresh_tail_count = 2
+        lcm_leaf_chunk_tokens = 100_000
+        lcm_incremental_max_depth = 1
+
+    original = _lcm._settings
+    _lcm._settings = _S()  # type: ignore[assignment]
+    try:
+        # First compaction — compacts msgs 0-3 (4 items outside fresh tail of 2).
+        await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+
+        # Now the context has: [summary(depth=0)] + [msg4, msg5].
+        # There's only one depth-0 summary, so condensation is a no-op.
+        depth1_after_first = (
+            await db_session.execute(
+                select(LCMSummary).where(
+                    LCMSummary.conversation_id == conv.id,
+                    LCMSummary.depth == 1,
+                )
+            )
+        ).scalars().all()
+        assert len(depth1_after_first) == 0  # not enough leaves yet
+
+        # Add two more messages so there's something outside the fresh tail again.
+        for i in range(6, 8):
+            role = "user" if i % 2 == 0 else "assistant"
+            msg = await _make_message(db_session, test_user, conv, role, f"extra{i}", i)
+            db_session.add(
+                LCMContextItem(
+                    conversation_id=conv.id,
+                    ordinal=i,
+                    item_kind="message",
+                    item_id=msg.id,
+                )
+            )
+        await db_session.commit()
+
+        # Second compaction — the summary item (ordinal 0) is outside the fresh tail of 2.
+        # But wait — the eligible window is items OUTSIDE the fresh tail.
+        # We now have: [summary(0)][msg4(4-ish)][msg6(6)][msg7(7)].
+        # Fresh tail = 2 → tail is msg6+msg7.
+        # Eligible = summary(0) + msg4.
+        # The summary item_kind is "summary" so it won't be leaf-compacted...
+        # But msg4 is a message and IS eligible.
+        # After compaction of msg4: [summary(0), new_leaf_summary(4), msg6, msg7].
+        # Now there are 2 depth-0 summaries → condensation fires.
+        await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+    finally:
+        _lcm._settings = original  # type: ignore[assignment]
+
+    # After the second compaction + condensation pass, there should be a depth-1 summary.
+    all_summaries = (
+        await db_session.execute(
+            select(LCMSummary).where(LCMSummary.conversation_id == conv.id)
+        )
+    ).scalars().all()
+    depths = [s.depth for s in all_summaries]
+    assert 1 in depths, f"Expected a depth-1 summary, got depths: {depths}"
+
+
+@pytest.mark.anyio
+async def test_compact_skips_condensation_when_depth_is_0(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """lcm_incremental_max_depth=0 means leaf-only, no condensation."""
+    conv = await _make_conversation(db_session, test_user)
+
+    # Pre-populate two depth-0 leaf summary context items.
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    # Add fresh messages.
+    for i in range(2, 4):
+        msg = await _make_message(db_session, test_user, conv, "user", f"m{i}", i)
+        db_session.add(
+            LCMContextItem(
+                conversation_id=conv.id, ordinal=i, item_kind="message", item_id=msg.id
+            )
+        )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("leaf"))
+
+    import app.core.lcm as _lcm  # noqa: PLC0415
+
+    class _S:
+        lcm_summary_model = ""
+        lcm_fresh_tail_count = 2
+        lcm_leaf_chunk_tokens = 100_000
+        lcm_incremental_max_depth = 0  # <-- condensation disabled
+
+    original = _lcm._settings
+    _lcm._settings = _S()  # type: ignore[assignment]
+    try:
+        # compact_leaf_if_needed won't compact because the eligible items are
+        # summaries (item_kind="summary"), not messages.  So it returns False
+        # and no condensation runs.
+        ran = await compact_leaf_if_needed(
+            db_session,
+            conversation_id=conv.id,
+            user_id=test_user.id,
+            model_id="gemini-2.5-flash",
+            fresh_tail_count=2,
+            max_chunk_tokens=100_000,
+        )
+        await db_session.commit()
+    finally:
+        _lcm._settings = original  # type: ignore[assignment]
+
+    # ran=False because compact_leaf sees no message items to compact;
+    # condensation also did not run.
+    assert ran is False
+    depth1 = (
+        await db_session.execute(
+            select(LCMSummary).where(
+                LCMSummary.conversation_id == conv.id,
+                LCMSummary.depth == 1,
+            )
+        )
+    ).scalars().all()
+    assert len(depth1) == 0
+
+
+# ---------------------------------------------------------------------------
+# assemble_context after condensation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_after_condensation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After condensation, assemble_context returns depth-1 summary + fresh tail."""
+    conv = await _make_conversation(db_session, test_user)
+    await _insert_summary_item(db_session, conv, "leaf A", ordinal=0, depth=0)
+    await _insert_summary_item(db_session, conv, "leaf B", ordinal=1, depth=0)
+    msg = await _make_message(db_session, test_user, conv, "user", "fresh tail", 2)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id, ordinal=2, item_kind="message", item_id=msg.id
+        )
+    )
+    await db_session.commit()
+
+    _patch(monkeypatch, _make_provider("depth-1 condensed"))
+    await _condense_at_depth(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        depth=0,
+        max_chunk_tokens=100_000,
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert len(context) == 2
+    assert "[Summary of earlier conversation]" in context[0]["content"]
+    assert "depth-1 condensed" in context[0]["content"]
+    assert context[1] == {"role": "user", "content": "fresh tail"}

--- a/backend/tests/test_lcm_describe.py
+++ b/backend/tests/test_lcm_describe.py
@@ -13,8 +13,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
-from pathlib import Path
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,10 +22,7 @@ from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
 from app.db import User
 from app.models import Conversation, LCMSummary, LCMSummarySource
 
-
-
 # Helpers
-
 
 
 async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
@@ -34,8 +30,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="describe test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -63,9 +59,7 @@ async def _make_summary(
     return s
 
 
-
 # lcm_describe
-
 
 
 @pytest.mark.anyio
@@ -76,9 +70,7 @@ async def test_describe_returns_metadata_and_content(
     summary = await _make_summary(db_session, conv, "User asked about deploying to Hetzner.")
     await db_session.commit()
 
-    result = await lcm_describe(
-        db_session, conversation_id=conv.id, summary_id=summary.id
-    )
+    result = await lcm_describe(db_session, conversation_id=conv.id, summary_id=summary.id)
 
     assert str(summary.id) in result
     assert "depth" in result.lower()
@@ -86,9 +78,7 @@ async def test_describe_returns_metadata_and_content(
 
 
 @pytest.mark.anyio
-async def test_describe_includes_source_edges(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_describe_includes_source_edges(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     summary = await _make_summary(db_session, conv, "Summary with sources")
     source_id = uuid.uuid4()
@@ -102,59 +92,43 @@ async def test_describe_includes_source_edges(
     )
     await db_session.commit()
 
-    result = await lcm_describe(
-        db_session, conversation_id=conv.id, summary_id=summary.id
-    )
+    result = await lcm_describe(db_session, conversation_id=conv.id, summary_id=summary.id)
 
     assert "message" in result
     assert str(source_id) in result
 
 
 @pytest.mark.anyio
-async def test_describe_unknown_id_returns_error(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_describe_unknown_id_returns_error(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
-    result = await lcm_describe(
-        db_session, conversation_id=conv.id, summary_id=uuid.uuid4()
-    )
+    result = await lcm_describe(db_session, conversation_id=conv.id, summary_id=uuid.uuid4())
     assert "not found" in result.lower()
 
 
 @pytest.mark.anyio
-async def test_describe_scoped_to_conversation(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_describe_scoped_to_conversation(db_session: AsyncSession, test_user: User) -> None:
     """A summary from another conversation should not be visible."""
     conv_a = await _make_conversation(db_session, test_user)
     conv_b = await _make_conversation(db_session, test_user)
     summary_b = await _make_summary(db_session, conv_b, "Private summary in conv B")
     await db_session.commit()
 
-    result = await lcm_describe(
-        db_session, conversation_id=conv_a.id, summary_id=summary_b.id
-    )
+    result = await lcm_describe(db_session, conversation_id=conv_a.id, summary_id=summary_b.id)
     assert "not found" in result.lower()
-
 
 
 # lcm_list_summaries
 
 
-
 @pytest.mark.anyio
-async def test_list_summaries_empty_conversation(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_list_summaries_empty_conversation(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     result = await lcm_list_summaries(db_session, conversation_id=conv.id)
     assert "no summaries" in result.lower()
 
 
 @pytest.mark.anyio
-async def test_list_summaries_returns_all_nodes(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_list_summaries_returns_all_nodes(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     for i in range(3):
         await _make_summary(db_session, conv, f"Summary {i} content")
@@ -175,6 +149,3 @@ async def test_list_summaries_shows_id_and_excerpt(
     result = await lcm_list_summaries(db_session, conversation_id=conv.id)
     assert str(s.id) in result
     assert "Unique content" in result
-
-
-

--- a/backend/tests/test_lcm_describe.py
+++ b/backend/tests/test_lcm_describe.py
@@ -1,0 +1,180 @@
+"""LCM PR #5 — lcm_describe tool tests.
+
+Covers:
+- lcm_describe returns metadata + full content for an existing summary.
+- lcm_describe returns an error string for an unknown summary_id.
+- lcm_describe is scoped to conversation_id (foreign ID returns error).
+- lcm_list_summaries returns a compact table for a conversation with summaries.
+- lcm_list_summaries returns "no summaries" for an empty conversation.
+- make_lcm_describe_tool and make_lcm_list_summaries_tool are present in
+  build_agent_tools when lcm_enabled=True.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_describe import lcm_describe, lcm_list_summaries
+from app.db import User
+from app.models import Conversation, LCMSummary, LCMSummarySource
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="describe test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+    summary_kind: str = "normal",
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+        summary_kind=summary_kind,
+        model_id="gemini-2.5-flash",
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+
+# lcm_describe
+
+
+
+@pytest.mark.anyio
+async def test_describe_returns_metadata_and_content(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "User asked about deploying to Hetzner.")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert str(summary.id) in result
+    assert "depth" in result.lower()
+    assert "User asked about deploying" in result
+
+
+@pytest.mark.anyio
+async def test_describe_includes_source_edges(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, "Summary with sources")
+    source_id = uuid.uuid4()
+    db_session.add(
+        LCMSummarySource(
+            summary_id=summary.id,
+            source_kind="message",
+            source_id=source_id,
+            source_ordinal=0,
+        )
+    )
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=summary.id
+    )
+
+    assert "message" in result
+    assert str(source_id) in result
+
+
+@pytest.mark.anyio
+async def test_describe_unknown_id_returns_error(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_describe(
+        db_session, conversation_id=conv.id, summary_id=uuid.uuid4()
+    )
+    assert "not found" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_describe_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A summary from another conversation should not be visible."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    summary_b = await _make_summary(db_session, conv_b, "Private summary in conv B")
+    await db_session.commit()
+
+    result = await lcm_describe(
+        db_session, conversation_id=conv_a.id, summary_id=summary_b.id
+    )
+    assert "not found" in result.lower()
+
+
+
+# lcm_list_summaries
+
+
+
+@pytest.mark.anyio
+async def test_list_summaries_empty_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "no summaries" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_list_summaries_returns_all_nodes(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(3):
+        await _make_summary(db_session, conv, f"Summary {i} content")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert "3 node" in result
+
+
+@pytest.mark.anyio
+async def test_list_summaries_shows_id_and_excerpt(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    s = await _make_summary(db_session, conv, "Unique content for listing test")
+    await db_session.commit()
+
+    result = await lcm_list_summaries(db_session, conversation_id=conv.id)
+    assert str(s.id) in result
+    assert "Unique content" in result
+
+
+

--- a/backend/tests/test_lcm_expand_query.py
+++ b/backend/tests/test_lcm_expand_query.py
@@ -1,0 +1,258 @@
+"""LCM PR #6 — lcm_expand_query tool tests.
+
+Covers:
+- Empty prompt returns an informative error string.
+- Empty conversation (no context items) returns an error string.
+- expand_query calls the provider with a prompt that contains the full history.
+- Provider response is returned as the answer.
+- Provider failure returns an error string (no exception propagation).
+- Both message and summary items are included in the expansion context.
+- make_lcm_expand_query_tool is in build_agent_tools when lcm_enabled
+  and user_id is provided.
+- make_lcm_expand_query_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_expand_query import lcm_expand_query
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+)
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="expand test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="message",
+            item_id=msg.id,
+        )
+    )
+    await session.flush()
+    return msg
+
+
+async def _make_summary_item(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    ordinal: int,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=ordinal,
+            item_kind="summary",
+            item_id=s.id,
+        )
+    )
+    await session.flush()
+    return s
+
+
+def _make_provider(answer: str) -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        yield {"type": "delta", "content": answer}
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _make_failing_provider() -> Any:
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        raise RuntimeError("provider down")
+        yield
+
+    p = MagicMock()
+    p.stream = _stream
+    return p
+
+
+def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    monkeypatch.setattr(_mod, "resolve_llm", lambda *a, **kw: provider)
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+
+    class _Fake:
+        lcm_summary_model = ""
+
+    monkeypatch.setattr(_mod, "_settings", _Fake())
+
+
+
+# Tests
+
+
+
+@pytest.mark.anyio
+async def test_expand_empty_prompt(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="",
+    )
+    assert "empty prompt" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_empty_conversation(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    _patch_provider(monkeypatch, _make_provider("unused"))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was discussed?",
+    )
+    assert "no conversation history" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_returns_provider_answer(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello there", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_provider("The user greeted the assistant."))
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What did the user say?",
+    )
+    assert "The user greeted" in result
+
+
+@pytest.mark.anyio
+async def test_expand_prompt_contains_full_history(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The expansion prompt sent to the provider should contain the full history."""
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "unique_marker_abc", 0)
+    await _make_summary_item(db_session, conv, "Earlier summary_marker_xyz", 1)
+    await db_session.commit()
+
+    captured_questions: list[str] = []
+
+    async def _capturing_stream(*args: Any, **kwargs: Any) -> AsyncIterator:
+        captured_questions.append(kwargs.get("question", ""))
+        yield {"type": "delta", "content": "captured"}
+
+    p = MagicMock()
+    p.stream = _capturing_stream
+    _patch_provider(monkeypatch, p)
+    _patch_settings(monkeypatch)
+
+    await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What was in the history?",
+    )
+
+    assert captured_questions, "Provider was not called"
+    question_sent = captured_questions[0]
+    assert "unique_marker_abc" in question_sent
+    assert "summary_marker_xyz" in question_sent
+
+
+@pytest.mark.anyio
+async def test_expand_provider_failure_returns_error_string(
+    db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hi", 0)
+    await db_session.commit()
+
+    _patch_provider(monkeypatch, _make_failing_provider())
+    _patch_settings(monkeypatch)
+
+    result = await lcm_expand_query(
+        db_session,
+        conversation_id=conv.id,
+        user_id=test_user.id,
+        model_id="gemini-2.5-flash",
+        prompt="What happened?",
+    )
+    assert "failed" in result.lower() or "error" in result.lower()
+
+

--- a/backend/tests/test_lcm_expand_query.py
+++ b/backend/tests/test_lcm_expand_query.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -32,10 +32,7 @@ from app.models import (
     LCMSummary,
 )
 
-
-
 # Helpers
-
 
 
 async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
@@ -43,8 +40,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="expand test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -67,8 +64,8 @@ async def _make_message(
         ordinal=ordinal,
         role=role,
         content=content,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(msg)
     session.add(
@@ -129,13 +126,13 @@ def _make_failing_provider() -> Any:
 
 
 def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
-    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+    import app.core.tools.lcm_expand_query as _mod
 
     monkeypatch.setattr(_mod, "resolve_llm", lambda *a, **kw: provider)
 
 
 def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
-    import app.core.tools.lcm_expand_query as _mod  # noqa: PLC0415
+    import app.core.tools.lcm_expand_query as _mod
 
     class _Fake:
         lcm_summary_model = ""
@@ -143,9 +140,7 @@ def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_mod, "_settings", _Fake())
 
 
-
 # Tests
-
 
 
 @pytest.mark.anyio
@@ -254,5 +249,3 @@ async def test_expand_provider_failure_returns_error_string(
         prompt="What happened?",
     )
     assert "failed" in result.lower() or "error" in result.lower()
-
-

--- a/backend/tests/test_lcm_grep.py
+++ b/backend/tests/test_lcm_grep.py
@@ -17,8 +17,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
-from pathlib import Path
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,10 +30,7 @@ from app.models import (
     LCMSummary,
 )
 
-
-
 # Helpers
-
 
 
 async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
@@ -42,8 +38,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="grep test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -66,8 +62,8 @@ async def _make_message(
         ordinal=ordinal,
         role=role,
         content=content,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(msg)
     await session.flush()
@@ -91,9 +87,7 @@ async def _make_summary(
     return s
 
 
-
 # _excerpt unit tests
-
 
 
 def test_excerpt_short_text_not_truncated() -> None:
@@ -124,9 +118,7 @@ def test_excerpt_no_match_returns_prefix() -> None:
     assert "nothing" in result
 
 
-
 # lcm_grep — query handling
-
 
 
 @pytest.mark.anyio
@@ -142,16 +134,12 @@ async def test_grep_no_matches(db_session: AsyncSession, test_user: User) -> Non
     await _make_message(db_session, test_user, conv, "user", "hello world", 0)
     await db_session.commit()
 
-    result = await lcm_grep(
-        db_session, conversation_id=conv.id, query="NONEXISTENT_XYZZY"
-    )
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="NONEXISTENT_XYZZY")
     assert "no matches" in result.lower()
 
 
 @pytest.mark.anyio
-async def test_grep_finds_message_hit(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_finds_message_hit(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     await _make_message(db_session, test_user, conv, "user", "deploy to Hetzner VPS", 0)
     await db_session.commit()
@@ -162,9 +150,7 @@ async def test_grep_finds_message_hit(
 
 
 @pytest.mark.anyio
-async def test_grep_finds_summary_hit(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_finds_summary_hit(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     await _make_summary(db_session, conv, "User discussed deploying the Hetzner VPS")
     await db_session.commit()
@@ -191,9 +177,7 @@ async def test_grep_returns_both_message_and_summary_hits(
 
 
 @pytest.mark.anyio
-async def test_grep_case_insensitive(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_case_insensitive(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     await _make_message(db_session, test_user, conv, "user", "Deploy to HETZNER vps", 0)
     await db_session.commit()
@@ -203,14 +187,10 @@ async def test_grep_case_insensitive(
 
 
 @pytest.mark.anyio
-async def test_grep_limit_caps_results(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_limit_caps_results(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     for i in range(5):
-        await _make_message(
-            db_session, test_user, conv, "user", f"mention target {i}", i
-        )
+        await _make_message(db_session, test_user, conv, "user", f"mention target {i}", i)
     await db_session.commit()
 
     result = await lcm_grep(db_session, conversation_id=conv.id, query="target", limit=2)
@@ -219,9 +199,7 @@ async def test_grep_limit_caps_results(
 
 
 @pytest.mark.anyio
-async def test_grep_scoped_to_conversation(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_scoped_to_conversation(db_session: AsyncSession, test_user: User) -> None:
     """Messages in other conversations must not appear in results."""
     conv_a = await _make_conversation(db_session, test_user)
     conv_b = await _make_conversation(db_session, test_user)
@@ -233,9 +211,7 @@ async def test_grep_scoped_to_conversation(
 
 
 @pytest.mark.anyio
-async def test_grep_excludes_system_role(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_grep_excludes_system_role(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     await _make_message(db_session, test_user, conv, "system", "system needle here", 0)
     await db_session.commit()
@@ -244,8 +220,4 @@ async def test_grep_excludes_system_role(
     assert "no matches" in result.lower()
 
 
-
 # build_agent_tools integration
-
-
-

--- a/backend/tests/test_lcm_grep.py
+++ b/backend/tests/test_lcm_grep.py
@@ -1,0 +1,251 @@
+"""LCM PR #4 — lcm_grep tool tests.
+
+Covers:
+- Empty query returns a "nothing to search" message.
+- No matches returns a "no matches" message.
+- Message hits are returned with role + ordinal annotations.
+- Summary hits are returned with depth annotation.
+- Both message and summary hits are returned in the same call.
+- Search is case-insensitive.
+- Limit caps the result count per source.
+- Results are most-recent-first (by ordinal for messages, by created_at for summaries).
+- _excerpt trims long content around the match.
+- make_lcm_grep_tool is present in build_agent_tools when lcm_enabled.
+- make_lcm_grep_tool is absent when lcm_enabled=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_grep import _excerpt, lcm_grep
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMSummary,
+)
+
+
+
+# Helpers
+
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="grep test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    content: str,
+    depth: int = 0,
+) -> LCMSummary:
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=len(content) // 4,
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+
+# _excerpt unit tests
+
+
+
+def test_excerpt_short_text_not_truncated() -> None:
+    result = _excerpt("hello world", query="world")
+    assert "hello world" in result
+    assert "…" not in result
+
+
+def test_excerpt_long_text_truncated_around_match() -> None:
+    padding = "x" * 300
+    text = padding + "TARGET" + padding
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert len(result) <= 110  # a bit of slack for ellipsis
+
+
+def test_excerpt_match_near_start() -> None:
+    text = "TARGET" + "y" * 600
+    result = _excerpt(text, query="TARGET", max_chars=100)
+    assert "TARGET" in result
+    assert result.startswith("TARGET") or result.startswith("…")
+
+
+def test_excerpt_no_match_returns_prefix() -> None:
+    text = "nothing here at all"
+    result = _excerpt(text, query="MISSING", max_chars=50)
+    # Should return the beginning of the text when there's no match.
+    assert "nothing" in result
+
+
+
+# lcm_grep — query handling
+
+
+
+@pytest.mark.anyio
+async def test_grep_empty_query(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="")
+    assert "empty query" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_no_matches(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "hello world", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(
+        db_session, conversation_id=conv.id, query="NONEXISTENT_XYZZY"
+    )
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_finds_message_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "deploy to Hetzner VPS", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_finds_summary_hit(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_summary(db_session, conv, "User discussed deploying the Hetzner VPS")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[SUMMARY" in result
+    assert "Hetzner" in result
+
+
+@pytest.mark.anyio
+async def test_grep_returns_both_message_and_summary_hits(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Hetzner config", 0)
+    await _make_summary(db_session, conv, "Earlier: set up Hetzner server")
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="Hetzner")
+    assert "[MESSAGE" in result
+    assert "[SUMMARY" in result
+    assert "1 message match" in result
+    assert "1 summary match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_case_insensitive(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "user", "Deploy to HETZNER vps", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="hetzner")
+    assert "[MESSAGE" in result
+
+
+@pytest.mark.anyio
+async def test_grep_limit_caps_results(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(5):
+        await _make_message(
+            db_session, test_user, conv, "user", f"mention target {i}", i
+        )
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="target", limit=2)
+    # Should report 2 matches despite 5 messages matching.
+    assert "2 message match" in result
+
+
+@pytest.mark.anyio
+async def test_grep_scoped_to_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Messages in other conversations must not appear in results."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv_b, "user", "secret banana", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv_a.id, query="banana")
+    assert "no matches" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_grep_excludes_system_role(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(db_session, test_user, conv, "system", "system needle here", 0)
+    await db_session.commit()
+
+    result = await lcm_grep(db_session, conversation_id=conv.id, query="needle")
+    assert "no matches" in result.lower()
+
+
+
+# build_agent_tools integration
+
+
+

--- a/backend/tests/test_lcm_ingest.py
+++ b/backend/tests/test_lcm_ingest.py
@@ -19,7 +19,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import select
@@ -34,7 +34,6 @@ from app.models import (
     LCMSummary,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -45,8 +44,8 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
         id=uuid.uuid4(),
         user_id=user.id,
         title="LCM ingest test",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(conv)
     await session.commit()
@@ -69,8 +68,8 @@ async def _make_message(
         ordinal=ordinal,
         role=role,
         content=content,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
     session.add(msg)
     await session.flush()
@@ -83,22 +82,16 @@ async def _make_message(
 
 
 @pytest.mark.anyio
-async def test_ingest_creates_context_item(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_ingest_creates_context_item(db_session: AsyncSession, test_user: User) -> None:
     """``ingest_message`` inserts exactly one LCMContextItem."""
     conv = await _make_conversation(db_session, test_user)
     msg = await _make_message(db_session, test_user, conv, "user", "hello", 0)
 
-    item = await ingest_message(
-        db_session, conversation_id=conv.id, message_id=msg.id
-    )
+    item = await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
     await db_session.commit()
 
     fetched = (
-        await db_session.execute(
-            select(LCMContextItem).where(LCMContextItem.id == item.id)
-        )
+        await db_session.execute(select(LCMContextItem).where(LCMContextItem.id == item.id))
     ).scalar_one()
 
     assert fetched.item_kind == "message"
@@ -108,9 +101,7 @@ async def test_ingest_creates_context_item(
 
 
 @pytest.mark.anyio
-async def test_ingest_ordinals_increment(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_ingest_ordinals_increment(db_session: AsyncSession, test_user: User) -> None:
     """Consecutive ingests get monotonically increasing ordinals."""
     conv = await _make_conversation(db_session, test_user)
     msgs = [
@@ -172,21 +163,15 @@ async def test_ingest_ordinals_are_independent_per_conversation(
 
 
 @pytest.mark.anyio
-async def test_assemble_empty_conversation(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_assemble_empty_conversation(db_session: AsyncSession, test_user: User) -> None:
     """An empty conversation returns an empty context list."""
     conv = await _make_conversation(db_session, test_user)
-    result = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    result = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
     assert result == []
 
 
 @pytest.mark.anyio
-async def test_assemble_returns_oldest_first(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_assemble_returns_oldest_first(db_session: AsyncSession, test_user: User) -> None:
     """assemble_context returns messages in ascending ordinal order."""
     conv = await _make_conversation(db_session, test_user)
     turns = [
@@ -199,9 +184,7 @@ async def test_assemble_returns_oldest_first(
         await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
 
     assert context == [
         {"role": "user", "content": "hi"},
@@ -222,9 +205,7 @@ async def test_assemble_respects_fresh_tail_count(
         await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=3
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=3)
 
     # Last 3 ordinals are 2, 3, 4 → contents "msg2", "msg3", "msg4".
     assert len(context) == 3
@@ -233,23 +214,17 @@ async def test_assemble_respects_fresh_tail_count(
 
 
 @pytest.mark.anyio
-async def test_assemble_filters_non_chat_roles(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_assemble_filters_non_chat_roles(db_session: AsyncSession, test_user: User) -> None:
     """Messages with roles other than user/assistant are excluded."""
     conv = await _make_conversation(db_session, test_user)
     user_msg = await _make_message(db_session, test_user, conv, "user", "hi", 0)
     system_msg = await _make_message(db_session, test_user, conv, "system", "sys", 1)
-    asst_msg = await _make_message(
-        db_session, test_user, conv, "assistant", "hello", 2
-    )
+    asst_msg = await _make_message(db_session, test_user, conv, "assistant", "hello", 2)
     for msg in (user_msg, system_msg, asst_msg):
         await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
 
     assert context == [
         {"role": "user", "content": "hi"},
@@ -258,9 +233,7 @@ async def test_assemble_filters_non_chat_roles(
 
 
 @pytest.mark.anyio
-async def test_assemble_includes_summary_items(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_assemble_includes_summary_items(db_session: AsyncSession, test_user: User) -> None:
     """item_kind='summary' rows are resolved and returned as synthetic user messages.
 
     PR #3 added real summary support to assemble_context.  Summaries are
@@ -298,9 +271,7 @@ async def test_assemble_includes_summary_items(
     )
     await db_session.commit()
 
-    context = await assemble_context(
-        db_session, conversation_id=conv.id, fresh_tail_count=64
-    )
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=64)
 
     # Summary comes first (ordinal 0), then the real message.
     assert len(context) == 2

--- a/backend/tests/test_lcm_ingest.py
+++ b/backend/tests/test_lcm_ingest.py
@@ -1,0 +1,310 @@
+"""LCM PR #2 — ingest + assembly tests.
+
+Covers:
+- ``ingest_message`` creates an ``LCMContextItem`` with the correct ordinal
+  and ``item_kind="message"``.
+- Ordinals increment monotonically across consecutive ingests.
+- ``assemble_context`` with fresh-tail-only returns rows in ascending ordinal
+  order (oldest first), filtered to user/assistant roles.
+- ``assemble_context`` respects ``fresh_tail_count`` — only the last N items
+  are returned when the conversation is longer.
+- ``assemble_context`` returns an empty list for a brand-new conversation.
+- ``assemble_context`` silently skips ``item_kind="summary"`` rows (no
+  summaries exist in PR #2, but the guard must not crash — PR #3 will add
+  real coverage).
+- A ``ChatMessage`` with a role other than user/assistant (e.g. ``system``)
+  is filtered out.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context, ingest_message
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM ingest test",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# ingest_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ingest_creates_context_item(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """``ingest_message`` inserts exactly one LCMContextItem."""
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(db_session, test_user, conv, "user", "hello", 0)
+
+    item = await ingest_message(
+        db_session, conversation_id=conv.id, message_id=msg.id
+    )
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(
+            select(LCMContextItem).where(LCMContextItem.id == item.id)
+        )
+    ).scalar_one()
+
+    assert fetched.item_kind == "message"
+    assert fetched.item_id == msg.id
+    assert fetched.conversation_id == conv.id
+    assert fetched.ordinal == 0
+
+
+@pytest.mark.anyio
+async def test_ingest_ordinals_increment(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Consecutive ingests get monotonically increasing ordinals."""
+    conv = await _make_conversation(db_session, test_user)
+    msgs = [
+        await _make_message(db_session, test_user, conv, role, f"msg {i}", i)
+        for i, role in enumerate(["user", "assistant", "user"])
+    ]
+
+    for msg in msgs:
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conv.id)
+        .order_by(LCMContextItem.ordinal)
+    )
+    items = result.scalars().all()
+    assert [item.ordinal for item in items] == [0, 1, 2]
+
+
+@pytest.mark.anyio
+async def test_ingest_ordinals_are_independent_per_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Each conversation has its own ordinal sequence starting at 0."""
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+
+    msg_a = await _make_message(db_session, test_user, conv_a, "user", "a0", 0)
+    msg_b0 = await _make_message(db_session, test_user, conv_b, "user", "b0", 0)
+    msg_b1 = await _make_message(db_session, test_user, conv_b, "assistant", "b1", 1)
+
+    await ingest_message(db_session, conversation_id=conv_a.id, message_id=msg_a.id)
+    await ingest_message(db_session, conversation_id=conv_b.id, message_id=msg_b0.id)
+    await ingest_message(db_session, conversation_id=conv_b.id, message_id=msg_b1.id)
+    await db_session.commit()
+
+    result_a = await db_session.execute(
+        select(LCMContextItem).where(LCMContextItem.conversation_id == conv_a.id)
+    )
+    result_b = await db_session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conv_b.id)
+        .order_by(LCMContextItem.ordinal)
+    )
+
+    items_a = result_a.scalars().all()
+    items_b = result_b.scalars().all()
+
+    assert len(items_a) == 1
+    assert items_a[0].ordinal == 0
+    assert len(items_b) == 2
+    assert [i.ordinal for i in items_b] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# assemble_context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_empty_conversation(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """An empty conversation returns an empty context list."""
+    conv = await _make_conversation(db_session, test_user)
+    result = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_assemble_returns_oldest_first(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """assemble_context returns messages in ascending ordinal order."""
+    conv = await _make_conversation(db_session, test_user)
+    turns = [
+        ("user", "hi"),
+        ("assistant", "hello"),
+        ("user", "how are you?"),
+    ]
+    for i, (role, text) in enumerate(turns):
+        msg = await _make_message(db_session, test_user, conv, role, text, i)
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert context == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "how are you?"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_assemble_respects_fresh_tail_count(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """fresh_tail_count caps the returned window to the most recent N items."""
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(5):
+        role = "user" if i % 2 == 0 else "assistant"
+        msg = await _make_message(db_session, test_user, conv, role, f"msg{i}", i)
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=3
+    )
+
+    # Last 3 ordinals are 2, 3, 4 → contents "msg2", "msg3", "msg4".
+    assert len(context) == 3
+    assert context[0]["content"] == "msg2"
+    assert context[-1]["content"] == "msg4"
+
+
+@pytest.mark.anyio
+async def test_assemble_filters_non_chat_roles(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Messages with roles other than user/assistant are excluded."""
+    conv = await _make_conversation(db_session, test_user)
+    user_msg = await _make_message(db_session, test_user, conv, "user", "hi", 0)
+    system_msg = await _make_message(db_session, test_user, conv, "system", "sys", 1)
+    asst_msg = await _make_message(
+        db_session, test_user, conv, "assistant", "hello", 2
+    )
+    for msg in (user_msg, system_msg, asst_msg):
+        await ingest_message(db_session, conversation_id=conv.id, message_id=msg.id)
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    assert context == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_assemble_includes_summary_items(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """item_kind='summary' rows are resolved and returned as synthetic user messages.
+
+    PR #3 added real summary support to assemble_context.  Summaries are
+    injected as {"role": "user", "content": "[Summary of earlier conversation]\\n..."}.
+    """
+    conv = await _make_conversation(db_session, test_user)
+
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="some older context",
+        token_count=5,
+    )
+    db_session.add(summary)
+    await db_session.flush()
+
+    # Summary at ordinal 0, message at ordinal 1.
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=summary.id,
+        )
+    )
+
+    msg = await _make_message(db_session, test_user, conv, "user", "visible", 0)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=1,
+            item_kind="message",
+            item_id=msg.id,
+        )
+    )
+    await db_session.commit()
+
+    context = await assemble_context(
+        db_session, conversation_id=conv.id, fresh_tail_count=64
+    )
+
+    # Summary comes first (ordinal 0), then the real message.
+    assert len(context) == 2
+    assert context[0]["role"] == "user"
+    assert context[0]["content"].startswith("[Summary of earlier conversation]")
+    assert "some older context" in context[0]["content"]
+    assert context[1] == {"role": "user", "content": "visible"}

--- a/backend/tests/test_lcm_ingest.py
+++ b/backend/tests/test_lcm_ingest.py
@@ -214,6 +214,60 @@ async def test_assemble_respects_fresh_tail_count(
 
 
 @pytest.mark.anyio
+async def test_assemble_keeps_summaries_when_messages_exceed_fresh_tail(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Regression: summaries at low ordinals must be delivered to the provider.
+
+    After the first leaf compaction the context list looks like
+    ``[summary@0, msg@1, ..., msg@N]`` with N > ``fresh_tail_count``.  A
+    naive ``ORDER BY ordinal DESC LIMIT fresh_tail_count`` clips off the
+    summary at ordinal 0, silently dropping the only handle the model has
+    on the compacted history.  ``assemble_context`` must keep every
+    summary while only capping the message tail.
+    """
+    conv = await _make_conversation(db_session, test_user)
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="ancient history",
+        token_count=5,
+    )
+    db_session.add(summary)
+    await db_session.flush()
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=summary.id,
+        )
+    )
+    # 5 messages at ordinals 1-5; fresh_tail_count=3 → keep only msg2-4
+    # (the last three messages) but ALSO keep the summary at ordinal 0.
+    for i in range(5):
+        msg = await _make_message(db_session, test_user, conv, "user", f"msg{i}", i)
+        db_session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=i + 1,
+                item_kind="message",
+                item_id=msg.id,
+            )
+        )
+    await db_session.commit()
+
+    context = await assemble_context(db_session, conversation_id=conv.id, fresh_tail_count=3)
+
+    # First entry must be the summary (NOT clipped), followed by the
+    # most-recent three messages.
+    assert len(context) == 4
+    assert context[0]["content"].startswith("[Summary of earlier conversation]")
+    assert "ancient history" in context[0]["content"]
+    assert [c["content"] for c in context[1:]] == ["msg2", "msg3", "msg4"]
+
+
+@pytest.mark.anyio
 async def test_assemble_filters_non_chat_roles(db_session: AsyncSession, test_user: User) -> None:
     """Messages with roles other than user/assistant are excluded."""
     conv = await _make_conversation(db_session, test_user)

--- a/backend/tests/test_lcm_schema.py
+++ b/backend/tests/test_lcm_schema.py
@@ -1,0 +1,172 @@
+"""Schema smoke tests for the LCM tables.
+
+This is the first PR in the LCM stack — only the storage layer exists,
+no application code reads or writes these tables yet.  The tests
+confirm:
+
+- The three tables exist with the expected columns.
+- Their cascade FK against ``conversations`` works (deleting a
+  conversation tears down all LCM rows).
+- A summary can hold zero or more sources, mixing ``message`` + ``summary``
+  source kinds in one parent.
+- The ``(conversation_id, ordinal)`` unique constraint on
+  ``lcm_context_items`` actually fires so compaction's dense renumber
+  is safe.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import User
+from app.models import (
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="LCM schema test",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+@pytest.mark.anyio
+async def test_summary_insert_round_trips(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    summary = LCMSummary(
+        conversation_id=conv.id,
+        depth=0,
+        content="The user asked about deploying Pawrrtal on a VPS.",
+        token_count=12,
+        model_id="gemini-2.5-flash-preview-05-20",
+        summary_kind="normal",
+    )
+    db_session.add(summary)
+    await db_session.commit()
+    await db_session.refresh(summary)
+
+    fetched = (
+        await db_session.execute(select(LCMSummary).where(LCMSummary.id == summary.id))
+    ).scalar_one()
+    assert fetched.content.startswith("The user asked about deploying")
+    assert fetched.depth == 0
+    assert fetched.summary_kind == "normal"
+
+
+@pytest.mark.anyio
+async def test_summary_sources_support_mixed_kinds(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A condensed parent can point at a mix of message + summary sources."""
+    conv = await _make_conversation(db_session, test_user)
+    parent = LCMSummary(conversation_id=conv.id, depth=1, content="parent")
+    db_session.add(parent)
+    await db_session.commit()
+    await db_session.refresh(parent)
+
+    db_session.add_all(
+        [
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="message",
+                source_id=uuid.uuid4(),
+                source_ordinal=0,
+            ),
+            LCMSummarySource(
+                summary_id=parent.id,
+                source_kind="summary",
+                source_id=uuid.uuid4(),
+                source_ordinal=1,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    sources = (
+        await db_session.execute(
+            select(LCMSummarySource)
+            .where(LCMSummarySource.summary_id == parent.id)
+            .order_by(LCMSummarySource.source_ordinal)
+        )
+    ).scalars().all()
+    assert [s.source_kind for s in sources] == ["message", "summary"]
+
+
+@pytest.mark.anyio
+async def test_context_items_have_unique_conversation_ordinal(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Two items can't share the same (conversation_id, ordinal)."""
+    conv = await _make_conversation(db_session, test_user)
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="message",
+            item_id=uuid.uuid4(),
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        LCMContextItem(
+            conversation_id=conv.id,
+            ordinal=0,
+            item_kind="summary",
+            item_id=uuid.uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+def test_cascade_metadata_is_declared() -> None:
+    """Pin the ``ON DELETE CASCADE`` metadata on every LCM FK.
+
+    Runtime cascade behaviour is not exercised here — the SQLite test
+    harness uses ``Base.metadata.create_all`` without enabling
+    ``PRAGMA foreign_keys=ON``, so cascades are inert in tests.  Postgres
+    (where the migration runs in production) enforces them; this test
+    just makes sure the *declaration* is correct so a future model edit
+    can't silently drop the cascade.
+    """
+    from app.models import LCMContextItem, LCMSummary, LCMSummarySource
+
+    expected_cascades = {
+        (LCMSummary.__table__, "conversation_id"): "CASCADE",
+        (LCMSummarySource.__table__, "summary_id"): "CASCADE",
+        (LCMContextItem.__table__, "conversation_id"): "CASCADE",
+    }
+    for (table, column_name), expected in expected_cascades.items():
+        matching_fks = [
+            fk
+            for fk in table.foreign_keys
+            if fk.parent.name == column_name
+        ]
+        assert matching_fks, f"missing FK on {table.name}.{column_name}"
+        assert matching_fks[0].ondelete == expected, (
+            f"{table.name}.{column_name} expected ondelete={expected!r} "
+            f"got {matching_fks[0].ondelete!r}"
+        )
+
+

--- a/backend/tests/test_lcm_schema.py
+++ b/backend/tests/test_lcm_schema.py
@@ -48,9 +48,7 @@ async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
 
 
 @pytest.mark.anyio
-async def test_summary_insert_round_trips(
-    db_session: AsyncSession, test_user: User
-) -> None:
+async def test_summary_insert_round_trips(db_session: AsyncSession, test_user: User) -> None:
     conv = await _make_conversation(db_session, test_user)
     summary = LCMSummary(
         conversation_id=conv.id,
@@ -102,12 +100,16 @@ async def test_summary_sources_support_mixed_kinds(
     await db_session.commit()
 
     sources = (
-        await db_session.execute(
-            select(LCMSummarySource)
-            .where(LCMSummarySource.summary_id == parent.id)
-            .order_by(LCMSummarySource.source_ordinal)
+        (
+            await db_session.execute(
+                select(LCMSummarySource)
+                .where(LCMSummarySource.summary_id == parent.id)
+                .order_by(LCMSummarySource.source_ordinal)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert [s.source_kind for s in sources] == ["message", "summary"]
 
 
@@ -158,15 +160,9 @@ def test_cascade_metadata_is_declared() -> None:
         (LCMContextItem.__table__, "conversation_id"): "CASCADE",
     }
     for (table, column_name), expected in expected_cascades.items():
-        matching_fks = [
-            fk
-            for fk in table.foreign_keys
-            if fk.parent.name == column_name
-        ]
+        matching_fks = [fk for fk in table.foreign_keys if fk.parent.name == column_name]
         assert matching_fks, f"missing FK on {table.name}.{column_name}"
         assert matching_fks[0].ondelete == expected, (
             f"{table.name}.{column_name} expected ondelete={expected!r} "
             f"got {matching_fks[0].ondelete!r}"
         )
-
-

--- a/backend/tests/test_lcm_settings.py
+++ b/backend/tests/test_lcm_settings.py
@@ -1,0 +1,24 @@
+"""Settings smoke test for the LCM configuration knobs.
+
+Part of the LCM stack — PR #1 (design doc + settings).
+Confirms the five new config keys have safe off-by-default values so
+this PR cannot change runtime behaviour for any existing deployment.
+"""
+
+from __future__ import annotations
+
+
+def test_lcm_settings_have_safe_defaults() -> None:
+    """All LCM knobs must have sane off-by-default values."""
+    from app.core.config import settings
+
+    # Master switch off — no chat-router code path is altered.
+    assert settings.lcm_enabled is False
+    # Numeric defaults match the upstream plugin.
+    assert settings.lcm_fresh_tail_count == 64
+    assert settings.lcm_leaf_chunk_tokens == 20000
+    assert 0.0 < settings.lcm_context_threshold <= 1.0
+    # Leaf-only condensation by default.
+    assert settings.lcm_incremental_max_depth == 1
+    # No summary-model override — falls back to the conversation model.
+    assert settings.lcm_summary_model == ""

--- a/docs/design/lcm.md
+++ b/docs/design/lcm.md
@@ -1,0 +1,70 @@
+# Lossless Context Management (LCM) for Pawrrtal
+
+**Status:** in progress — schema landed, runtime activation in stacked PRs
+**Inspiration:** [Martian-Engineering/lossless-claw](https://github.com/Martian-Engineering/lossless-claw) (TypeScript, OpenClaw plugin)
+**Why a port instead of vendoring:** lossless-claw plugs into the OpenClaw `ContextEngine` lifecycle that doesn't exist in our FastAPI + Postgres stack.  Re-implementing the algorithm natively beats stitching a Node.js sidecar into every chat turn.
+
+## Problem
+
+Today the chat router does `chat_messages` `ORDER BY ordinal LIMIT 20`.  Anything older than the last 20 messages is invisible to the model.  Long conversations silently lose continuity.
+
+## Approach
+
+A DAG of summaries that grows as a conversation grows:
+
+1. **Persist every message** (we already do this in `chat_messages`).
+2. **Periodically summarise** the oldest non-protected messages into a **leaf summary**.
+3. **Condense** accumulated leaf summaries into deeper parent summaries to keep the assembled list short.
+4. **Assemble** each turn's prompt from: (a) the protected **fresh tail** of recent raw messages + (b) as many of the most recent summary/message items as fit in the model's window.
+
+## Data model (this PR — #1 of the stack)
+
+Three tables in `app/models.py`:
+
+| Table | Role |
+| --- | --- |
+| `lcm_summaries` | A summary node.  `depth=0` is a leaf (summarises raw messages); `depth>=1` is a condensed parent. |
+| `lcm_summary_sources` | Link table from a summary to its source items.  `source_kind` discriminates `message` vs `summary`. |
+| `lcm_context_items` | The ordered "replacement list" assembled per turn.  Each row points at a `ChatMessage` (raw) or an `LCMSummary` (compacted).  Compaction rewrites rows in place. |
+
+See `app/models.py` for the SQLAlchemy definitions and inline comments.
+
+## Config
+
+All settings default OFF / safe — adding the schema doesn't change behaviour for any existing deployment.
+
+| Env / setting | Default | Meaning |
+| --- | --- | --- |
+| `LCM_ENABLED` | `false` | Master switch.  Later stack PRs gate every code path on this. |
+| `LCM_FRESH_TAIL_COUNT` | `64` | Recent messages always kept verbatim. |
+| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Source-token ceiling per leaf summary. |
+| `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of model window that triggers auto-compaction. |
+| `LCM_INCREMENTAL_MAX_DEPTH` | `1` | Condensation passes per leaf compaction.  `-1` = unlimited. |
+| `LCM_SUMMARY_MODEL` | (unset → same as conversation) | Model used for summarisation calls. |
+
+## Stack roadmap
+
+This PR ships **schema only**.  Subsequent PRs in the stack:
+
+1. ✅ **Schema + models** (this PR)
+2. ⏭ **Ingest + assembly** — wire every ChatMessage into an `LCMContextItem`; replace `LIMIT 20` with `assemble_context()` (fresh tail only at first)
+3. ⏭ **Leaf compaction** — first real summarisation pass
+4. ⏭ **`lcm_grep` tool** — agent-callable history search
+5. ⏭ **`lcm_describe` tool** — cheap summary inspection
+6. ⏭ **`lcm_expand_query` tool** — bounded sub-agent for deep recall
+7. ⏭ **Condensation pass** — depth-1+ summaries
+
+Each is a tracer-bullet PR — one main feature, end-to-end, minimal scope.  Things deferred from each PR are captured in `.beans/lcm-followups.md`.
+
+## Why this design and not theirs verbatim
+
+The upstream plugin makes excellent choices that we adopt:
+- DAG of summaries, not a flat rolling buffer.
+- Fresh-tail protection so recent context is never compressed.
+- Three-level escalation (normal prompt → aggressive → deterministic truncation).
+- Tool surface (`grep`, `describe`, `expand_query`) so the agent can drill into compacted history on demand.
+
+Where we diverge:
+- **Postgres, not SQLite.**  We already run Postgres; adding SQLite for one feature would mean two DB volumes and two migration stories.
+- **In-process, not subagent-spawning via plugin SDK.**  Their `lcm_expand_query` spawns an OpenClaw sub-agent through the plugin runtime.  We'll use our existing agent_loop infrastructure when we get to that PR.
+- **No `/lcm doctor` command yet.**  Operational tooling can come later — health probes already cover the obvious failure modes.


### PR DESCRIPTION
## What lands here

The final piece: prevents unbounded growth of leaf summaries by folding same-depth summaries into deeper parent nodes.

### `_condense_at_depth(session, *, conversation_id, user_id, model_id, depth, max_chunk_tokens) -> bool`
1. Fetches all `LCMContextItem` rows for the conversation
2. Returns `False` immediately if fewer than 2 items point at `LCMSummary` nodes at the given `depth`
3. Batches the oldest eligible summaries up to `max_chunk_tokens`
4. Calls the provider (same three-level escalation as leaf compaction)
5. Writes a new `LCMSummary` at `depth + 1` with `LCMSummarySource` edges pointing at the input summaries
6. Replaces the consumed context items with a single new `item_kind="summary"` row

### Loop in `compact_leaf_if_needed`
After leaf compaction succeeds, runs condensation passes controlled by `settings.lcm_incremental_max_depth`:
- `0` — no condensation (leaf-only)
- `1` — one pass: fold depth-0 summaries into a depth-1 parent _(default)_
- `-1` — unlimited cascade (practical cap: 999 passes)

### Tests (8 in `test_lcm_condensation.py`)
- noop with only one summary (< 2 eligible)
- noop with no summaries
- creates depth-1 parent from two depth-0 summaries
- source edges point at the correct leaf summaries
- consumed context items replaced by single parent item
- `compact_leaf_if_needed` triggers condensation when `max_depth >= 1`
- `compact_leaf_if_needed` skips condensation when `max_depth == 0`
- `assemble_context` returns the parent summary after condensation

---

**Full backend suite after this PR: 432 passed, 2 skipped.**

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is the final PR (11/11) in the LCM stack, landing the condensation pass that folds accumulated same-depth summaries into deeper parent nodes after each leaf compaction, preventing unbounded growth of leaf summaries.

- Adds `condense.py` with `_condense_at_depth` and `run_condensation_cascade`, controlled by `lcm_incremental_max_depth` (0 = leaf-only, 1 = one pass, -1 = unlimited cascade up to 999 depths).
- Fixes `assemble_context` to walk items in reverse and preserve every summary item while capping raw messages to `fresh_tail_count`, resolving the context-drop bug identified in earlier passes.
- Completes the `provider_state` / Gemini `thought_signature` replay path: `LLMDoneEvent` and `AssistantMessage` use `NotRequired[dict[str, Any]]` (not `total=False`), and the Gemini stream function captures the native `ModelContent` to forward on follow-up turns.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The condensation logic, lock serialisation, assembly fix, and TypedDict changes are all correct; the two findings are non-blocking quality notes.

The core condensation path is well-structured: depth filtering is done at the DB layer, the refcount-based lock correctly prevents the serialisation race, and `assemble_context` now walks items in reverse to retain all summary rows. The `NotRequired` fix on `AssistantMessage` and `LLMDoneEvent` preserves required-field narrowing. The two findings — an unused `lcm_context_threshold` config and a broad `except Exception` in the extracted cost-ledger module — are style/quality issues that don't affect runtime correctness.

backend/app/core/config.py (unused lcm_context_threshold setting) and backend/app/channels/_turn_cost.py (broad exception catch for DB write)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/core/lcm/condense.py | New condensation module: `run_condensation_cascade` + `_condense_at_depth` correctly filter summaries at DB layer by depth and maintain transactional integrity within the shared session. |
| backend/app/core/lcm/__init__.py | Adds `ingest_message`, `assemble_context`, and `compact_leaf_if_needed`; `assemble_context` correctly walks items in reverse to keep all summaries while capping raw messages. |
| backend/app/core/lcm/background.py | New background compaction scheduler using a `_LockSlot` refcount approach that correctly serializes same-conversation passes without the `lock.locked()` race. |
| backend/app/core/agent_loop/types.py | Adds `provider_state: NotRequired[dict[str, Any]]` to `AssistantMessage` and `LLMDoneEvent` using `NotRequired` (not `total=False`), preserving required-field type-narrowing. |
| backend/app/channels/_turn_cost.py | New file extracting cost-ledger write from `turn_runner`. Logic is correct but uses broad `except Exception` for the DB write (should be `SQLAlchemyError`). |
| backend/app/core/config.py | Adds six LCM settings. `lcm_context_threshold` is documented as a compaction trigger but is never read by any LCM logic, making it a no-op config option. |
| backend/app/core/providers/gemini_provider.py | Wires `function_call_content_for` to capture native `ModelContent` from tool-call chunks and forward it as opaque `provider_state`; `_build_gemini_contents` replays it verbatim on follow-up turns. |
| backend/tests/test_lcm_condensation.py | 8 new tests covering noop paths, depth-1 parent creation, source edges, context-item replacement, cascade trigger/skip, and `assemble_context` after condensation. Both `_settings` bindings are patched correctly in integration tests. |
| backend/alembic/versions/015_add_lcm_tables.py | Creates `lcm_summaries`, `lcm_summary_sources`, and `lcm_context_items` with cascade FKs, unique `(conversation_id, ordinal)` constraint, and complete `downgrade()` teardown in reverse dependency order. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TR as turn_runner
    participant BG as background.py
    participant LCM as lcm/__init__.py
    participant CD as condense.py
    participant DB as Database

    TR->>BG: schedule_lcm_compaction(conv_id, user_id, model_id)
    Note over BG: refcount++, create_task
    BG->>BG: acquire slot.lock
    BG->>LCM: compact_leaf_if_needed(session)
    LCM->>DB: SELECT all LCMContextItems ORDER BY ordinal
    LCM->>DB: SELECT ChatMessages WHERE id IN eligible_ids
    LCM->>LCM: _summarize — 3-level escalation
    LCM->>DB: "INSERT LCMSummary depth=0"
    LCM->>DB: INSERT LCMSummarySource x N
    LCM->>DB: DELETE consumed LCMContextItems
    LCM->>DB: "INSERT LCMContextItem item_kind=summary"
    LCM->>CD: run_condensation_cascade(session)
    loop for depth in range(max_depth)
        CD->>DB: SELECT LCMContextItems all
        CD->>DB: "SELECT LCMSummary WHERE depth=d"
        alt 2 or more summaries at depth d
            CD->>CD: _summarize — 3-level escalation
            CD->>DB: "INSERT LCMSummary depth=d+1"
            CD->>DB: INSERT LCMSummarySource x N
            CD->>DB: DELETE consumed LCMContextItems
            CD->>DB: "INSERT LCMContextItem item_kind=summary"
        else fewer than 2 summaries
            CD-->>LCM: cascade complete
        end
    end
    LCM-->>BG: return True
    BG->>DB: COMMIT
    Note over BG: refcount--, remove slot if zero
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fapp%2Fchannels%2F_turn_cost.py%3A62-74%0AThe%20cost-ledger%20write%20is%20a%20DB%20operation%20%E2%80%94%20%60SQLAlchemyError%60%20is%20the%20appropriate%20narrow%20catch%20here.%20Bare%20%60except%20Exception%60%20swallows%20%60AttributeError%60%2C%20%60TypeError%60%2C%20and%20other%20programmer%20errors%20that%20should%20surface%20immediately%20rather%20than%20disappear%20under%20a%20%60COST_LEDGER_ERR%60%20log%20line.%20The%20project's%20%60python-logging-exceptions.md%60%20rule%20requires%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20record_turn_cost%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ledger%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20user_id%3Duser_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20provider%3Dprovider_slug%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20model_id%3Dmodel_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20input_tokens%3Daggregator.total_input_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20output_tokens%3Daggregator.total_output_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20cost_usd%3Daggregator.total_cost_usd%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20surface%3Dsurface%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20except%20SQLAlchemyError%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fapp%2Fcore%2Fconfig.py%3A754-756%0A**%60lcm_context_threshold%60%20has%20no%20effect**%0A%0A%60lcm_context_threshold%60%20is%20documented%20as%20%22auto-trigger%20compaction%20when%20context%20is%20at%20or%20above%20this%20fraction%20of%20the%20model's%20window%2C%22%20but%20%60compact_leaf_if_needed%60%20triggers%20on%20%60total_items%20%3E%20fresh_tail_count%60%20and%20never%20reads%20this%20setting.%20Operators%20who%20tune%20%60lcm_context_threshold%60%20will%20see%20no%20change%20in%20behavior.%20Either%20wire%20it%20into%20the%20compaction%20gate%20or%20drop%20the%20setting%20until%20the%20token-window%20check%20is%20implemented.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Flcm-11%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Flcm-11%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fapp%2Fchannels%2F_turn_cost.py%3A62-74%0AThe%20cost-ledger%20write%20is%20a%20DB%20operation%20%E2%80%94%20%60SQLAlchemyError%60%20is%20the%20appropriate%20narrow%20catch%20here.%20Bare%20%60except%20Exception%60%20swallows%20%60AttributeError%60%2C%20%60TypeError%60%2C%20and%20other%20programmer%20errors%20that%20should%20surface%20immediately%20rather%20than%20disappear%20under%20a%20%60COST_LEDGER_ERR%60%20log%20line.%20The%20project's%20%60python-logging-exceptions.md%60%20rule%20requires%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20record_turn_cost%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ledger%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20user_id%3Duser_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20provider%3Dprovider_slug%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20model_id%3Dmodel_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20input_tokens%3Daggregator.total_input_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20output_tokens%3Daggregator.total_output_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20cost_usd%3Daggregator.total_cost_usd%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20surface%3Dsurface%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20except%20SQLAlchemyError%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fapp%2Fcore%2Fconfig.py%3A754-756%0A**%60lcm_context_threshold%60%20has%20no%20effect**%0A%0A%60lcm_context_threshold%60%20is%20documented%20as%20%22auto-trigger%20compaction%20when%20context%20is%20at%20or%20above%20this%20fraction%20of%20the%20model's%20window%2C%22%20but%20%60compact_leaf_if_needed%60%20triggers%20on%20%60total_items%20%3E%20fresh_tail_count%60%20and%20never%20reads%20this%20setting.%20Operators%20who%20tune%20%60lcm_context_threshold%60%20will%20see%20no%20change%20in%20behavior.%20Either%20wire%20it%20into%20the%20compaction%20gate%20or%20drop%20the%20setting%20until%20the%20token-window%20check%20is%20implemented.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Flcm-11%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Flcm-11%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fapp%2Fchannels%2F_turn_cost.py%3A62-74%0AThe%20cost-ledger%20write%20is%20a%20DB%20operation%20%E2%80%94%20%60SQLAlchemyError%60%20is%20the%20appropriate%20narrow%20catch%20here.%20Bare%20%60except%20Exception%60%20swallows%20%60AttributeError%60%2C%20%60TypeError%60%2C%20and%20other%20programmer%20errors%20that%20should%20surface%20immediately%20rather%20than%20disappear%20under%20a%20%60COST_LEDGER_ERR%60%20log%20line.%20The%20project's%20%60python-logging-exceptions.md%60%20rule%20requires%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20record_turn_cost%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ledger%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20user_id%3Duser_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20provider%3Dprovider_slug%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20model_id%3Dmodel_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20input_tokens%3Daggregator.total_input_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20output_tokens%3Daggregator.total_output_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20cost_usd%3Daggregator.total_cost_usd%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20surface%3Dsurface%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20except%20SQLAlchemyError%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fapp%2Fcore%2Fconfig.py%3A754-756%0A**%60lcm_context_threshold%60%20has%20no%20effect**%0A%0A%60lcm_context_threshold%60%20is%20documented%20as%20%22auto-trigger%20compaction%20when%20context%20is%20at%20or%20above%20this%20fraction%20of%20the%20model's%20window%2C%22%20but%20%60compact_leaf_if_needed%60%20triggers%20on%20%60total_items%20%3E%20fresh_tail_count%60%20and%20never%20reads%20this%20setting.%20Operators%20who%20tune%20%60lcm_context_threshold%60%20will%20see%20no%20change%20in%20behavior.%20Either%20wire%20it%20into%20the%20compaction%20gate%20or%20drop%20the%20setting%20until%20the%20token-window%20check%20is%20implemented.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fapp%2Fchannels%2F_turn_cost.py%3A62-74%0AThe%20cost-ledger%20write%20is%20a%20DB%20operation%20%E2%80%94%20%60SQLAlchemyError%60%20is%20the%20appropriate%20narrow%20catch%20here.%20Bare%20%60except%20Exception%60%20swallows%20%60AttributeError%60%2C%20%60TypeError%60%2C%20and%20other%20programmer%20errors%20that%20should%20surface%20immediately%20rather%20than%20disappear%20under%20a%20%60COST_LEDGER_ERR%60%20log%20line.%20The%20project's%20%60python-logging-exceptions.md%60%20rule%20requires%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20record_turn_cost%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ledger%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20user_id%3Duser_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20provider%3Dprovider_slug%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20model_id%3Dmodel_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20input_tokens%3Daggregator.total_input_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20output_tokens%3Daggregator.total_output_tokens%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20cost_usd%3Daggregator.total_cost_usd%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20surface%3Dsurface%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20except%20SQLAlchemyError%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fapp%2Fcore%2Fconfig.py%3A754-756%0A**%60lcm_context_threshold%60%20has%20no%20effect**%0A%0A%60lcm_context_threshold%60%20is%20documented%20as%20%22auto-trigger%20compaction%20when%20context%20is%20at%20or%20above%20this%20fraction%20of%20the%20model's%20window%2C%22%20but%20%60compact_leaf_if_needed%60%20triggers%20on%20%60total_items%20%3E%20fresh_tail_count%60%20and%20never%20reads%20this%20setting.%20Operators%20who%20tune%20%60lcm_context_threshold%60%20will%20see%20no%20change%20in%20behavior.%20Either%20wire%20it%20into%20the%20compaction%20gate%20or%20drop%20the%20setting%20until%20the%20token-window%20check%20is%20implemented.%0A%0A&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(lcm): address Greptile review (P1 + ..."](https://github.com/octaviantocan/pawrrtal-ai/commit/cc8b356682c6ceb5183f550f9780fcc2d17975fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32471534)</sub>

<!-- /greptile_comment -->