### PR TITLE
fix(infra): harden #172 — nginx + compose + Dockerfile prod fixes

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,33 +4,72 @@
 #   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 #
 # What this overlay adds on top of the base docker-compose.yml:
-#   - Next.js frontend Docker service  (frontend:3000)
-#   - Nginx reverse proxy              (/api/* → backend, /* → frontend)
-#   - Production backend command       (no --reload, no source bind-mount)
-#   - Workspace data volume inherited  from base compose
+#   - Next.js frontend Docker service       (internal-only, expose 3000)
+#   - Nginx reverse proxy                   (/api, /auth, /users → backend; /* → frontend)
+#   - Production backend command            (no --reload, no source bind-mount)
+#   - Healthchecks                          (backend, frontend, nginx)
+#   - Log rotation + memory caps            (json-file driver, deploy.resources)
+#
+# Hardening notes:
+#   - Frontend uses `expose:` not `ports:` so it's reachable only inside
+#     the Docker network. All public traffic must go through Nginx.
+#   - Backend keeps its base-file `ports: ["8000:8000"]` because compose
+#     lists merge (append, not replace). If you don't want :8000 reachable
+#     on the VPS host network, change the base file to drop the publish —
+#     Nginx already talks to it on the Docker network via the service name.
+#   - Migrations are capped at 5 attempts to avoid masking real failures
+#     behind an infinite retry loop.
 #
 # The base docker-compose.yml is left unchanged so local development with
 # `docker compose up` continues to work exactly as before.
 
 services:
   # ── Override backend for production ──────────────────────────────────────
-  # Removes the dev --reload flag and the source bind-mount so the built
-  # image is used as-is. Migrations still run on every start.
   backend:
+    # Capped migration retries: 5 attempts × 2 s = 10 s wall-clock.
+    # Anything longer than that almost certainly indicates a broken
+    # migration, not a flaky DB — fail fast so the orchestrator notices.
     command: >
       sh -c '
-        until alembic upgrade head; do
-          echo "[prod] alembic failed, retrying in 2s…" && sleep 2;
-        done &&
-        uvicorn main:app --host 0.0.0.0 --port 8000 --workers 1
+        ok=0;
+        for i in 1 2 3 4 5; do
+          if alembic upgrade head; then ok=1; break; fi;
+          echo "[prod] alembic attempt $$i failed, retrying in 2s…";
+          sleep 2;
+        done;
+        if [ "$$ok" -ne 1 ]; then
+          echo "[prod] alembic upgrade head failed after 5 attempts" >&2;
+          exit 1;
+        fi;
+        exec uvicorn main:app --host 0.0.0.0 --port 8000 --workers 2
       '
     volumes:
       - workspace_data:/data/workspaces
     # The source bind-mount from the base compose file is intentionally
     # NOT listed here — omitting it means Docker uses the image layer,
     # which is the correct prod behaviour.
+    healthcheck:
+      # python:3.13-slim has no curl/wget, but python's always there.
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/api/v1/health', timeout=3); sys.exit(0)\" || exit 1",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
-  # ── Next.js frontend ──────────────────────────────────────────────────────
+  # ── Next.js frontend ─────────────────────────────────────────────────────
   frontend:
     build:
       context: ./frontend
@@ -43,13 +82,30 @@ services:
     restart: unless-stopped
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     environment:
       NODE_ENV: production
-    ports:
-      - "3000:3000"
+    # `expose` makes :3000 reachable on the Docker network only.
+    # Nginx is the public surface — never publish frontend on the host.
+    expose:
+      - "3000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
-  # ── Nginx reverse proxy ───────────────────────────────────────────────────
+  # ── Nginx reverse proxy ──────────────────────────────────────────────────
   nginx:
     image: nginx:1.27-alpine
     restart: unless-stopped
@@ -58,8 +114,27 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+    healthcheck:
+      # Hit a path that always returns 200/308 (Next.js root). wget --spider
+      # returns 0 on any 2xx/3xx, which is enough for liveness.
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   workspace_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,50 @@
+# Exclude everything that should not enter the Docker build context.
+# A trimmed context keeps the image small, the build fast, and prevents
+# host-side artifacts (or secrets) from leaking into the image.
+
+# ── Build artefacts ─────────────────────────────────────────────────────
+node_modules
+.next
+out
+dist
+build
+coverage
+.turbo
+.cache
+
+# ── Test / IDE / OS noise ───────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+.idea
+.vscode
+*.swp
+*.swo
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ── Source control + CI ─────────────────────────────────────────────────
+.git
+.gitignore
+.gitattributes
+.github
+
+# ── Secrets / local env ─────────────────────────────────────────────────
+# .env.example is the only env file allowed in the context.
+.env
+.env.*
+!.env.example
+
+# ── Docker files themselves (avoid recursive copy) ─────────────────────
+Dockerfile
+.dockerignore
+
+# ── Misc ────────────────────────────────────────────────────────────────
+README*.md
+CHANGELOG*.md
+LICENSE*
+*.tar
+*.tgz
+playwright-report
+test-results

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,31 +1,44 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 # ─────────────────────────────────────────────────────────────
-# Next.js production image using Bun
+# Next.js production image
 #
 # Multi-stage build:
-#   deps    — install workspace dependencies with bun
+#   deps    — install workspace dependencies with bun (BuildKit cache mount)
 #   builder — compile the Next.js app (output: standalone)
-#   runner  — minimal Node runtime image serving server.js
+#   runner  — minimal Node runtime image serving server.js + sharp for
+#             native Next.js image optimisation
 #
 # Build-time ARG:
 #   NEXT_PUBLIC_API_URL  defaults to http://backend:8000 (Docker internal
 #                        network). Override when building for a different
 #                        target (e.g. a public domain).
+#
+# Notes:
+#   - Node version is pinned to a specific minor for reproducibility.
+#     Bump the tag deliberately, never rely on "latest minor".
+#   - sharp is installed in the runner stage so Next.js can do native
+#     AVIF / WebP conversion without falling back to the slow JS path.
+#   - BuildKit cache mount (`--mount=type=cache`) cuts `bun install` from
+#     minutes to seconds on rebuilds. Requires DOCKER_BUILDKIT=1 (default
+#     for `docker buildx`) or `# syntax=docker/dockerfile:1.x` (above).
 # ─────────────────────────────────────────────────────────────
 
 # ── Deps ────────────────────────────────────────────────────
-FROM oven/bun:1-alpine AS deps
+FROM oven/bun:1.1.42-alpine AS deps
 WORKDIR /app
 
-# Copy workspace manifests so bun install resolves all packages
+# Workspace manifests first so the install layer caches on dep changes only.
 COPY package.json bun.lock ./
 # lib/ contains vendored submodule packages (react-chat-composer, etc.)
 COPY lib/ ./lib/
 
-RUN bun install --frozen-lockfile
+# Cache the bun store across builds. The lockfile is still --frozen so any
+# drift between bun.lock and package.json fails the build deterministically.
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile
 
 # ── Builder ─────────────────────────────────────────────────
-FROM oven/bun:1-alpine AS builder
+FROM oven/bun:1.1.42-alpine AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -34,22 +47,31 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-# API URL for server-side Next.js calls (RSCs, Server Actions).
-# Client-side browser calls go through the Nginx proxy at the same
-# origin (/api/*), so NEXT_PUBLIC_ is not needed in the browser.
+# NEXT_PUBLIC_* must be set BEFORE `bun run build` because Next.js inlines
+# these values into the client bundle at build time.
+#
+# Server-side Next.js calls (RSC, Server Actions) use this URL directly.
+# Client-side browser calls hit /api/* via Nginx (same origin) so the
+# baked value is mostly irrelevant in the browser — the proxy handles it.
 ARG NEXT_PUBLIC_API_URL=http://backend:8000
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
 RUN bun run build
 
 # ── Runner ──────────────────────────────────────────────────
-# Use a plain Node image for the runtime — smaller than bun and avoids
-# bun runtime quirks with the standalone Next.js server.js entrypoint.
-FROM node:22-alpine AS runner
+# Plain Node image for runtime. Smaller than bun, and the standalone
+# server.js was emitted assuming a Node runtime.
+FROM node:22.11-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# libc6-compat is required by sharp on Alpine; wget is in busybox already
+# (used by the Compose healthcheck).
+RUN apk add --no-cache libc6-compat
 
 RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 nextjs
@@ -60,11 +82,19 @@ COPY --from=builder /app/public                                ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static    ./.next/static
 
+# Install sharp into the standalone tree so Next.js Image picks it up.
+# Without sharp, Next.js falls back to a slower JS-only image pipeline
+# and logs a warning on every optimised image request in production.
+RUN npm install --omit=dev --no-save --prefix . sharp@^0.33 \
+ && chown -R nextjs:nodejs node_modules
+
 USER nextjs
 
 EXPOSE 3000
-ENV PORT=3000
-ENV HOSTNAME=0.0.0.0
+
+# Liveness check: the standalone server responds 200 on / once ready.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget --spider -q http://localhost:3000/ || exit 1
 
 # server.js is the standalone entrypoint emitted by Next.js output: standalone
 CMD ["node", "server.js"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,17 @@
 # ─────────────────────────────────────────────────────────────
-# Nginx reverse proxy for the ai-nexus Docker Compose stack.
+# Nginx reverse proxy for the Pawrrtal Docker Compose stack.
 #
 # Routing:
-#   /api/*  →  FastAPI backend  (backend:8000)
-#   /*      →  Next.js frontend (frontend:3000)
+#   /api/*    →  FastAPI backend  (backend:8000)   ← /api/v1/* routes
+#   /auth/*   →  FastAPI backend  (backend:8000)   ← fastapi-users JWT
+#   /users/*  →  FastAPI backend  (backend:8000)   ← fastapi-users user mgmt
+#   /*        →  Next.js frontend (frontend:3000)
+#
+# Why /auth and /users go to the backend:
+#   fastapi-users mounts its routers at /auth/jwt, /auth, /users (no /api
+#   prefix). These must reach FastAPI directly; otherwise Next.js sees
+#   the request and 404s. The custom routers all use /api/v1/* so the
+#   /api/ block covers everything else.
 #
 # TLS termination is handled upstream by Tailscale Serve on the VPS.
 # This config speaks plain HTTP on :80 inside the Docker network;
@@ -14,56 +22,128 @@
 # browser token-by-token without Nginx accumulating them first.
 # ─────────────────────────────────────────────────────────────
 
+# Match worker count to the CPU. `auto` is the recommended value.
+worker_processes auto;
+
 events {
     worker_connections 1024;
+    # Accept multiple new connections per worker wake-up.
+    multi_accept       on;
 }
 
 http {
-    # Disable buffering globally — critical for SSE streaming responses.
-    # Individual location blocks inherit this; override to 'on' for any
-    # location where buffering is explicitly desired (e.g. large uploads).
+    # Standard mime types + sensible defaults.
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile          on;
+    tcp_nopush        on;
+    tcp_nodelay       on;
+    server_tokens     off;
+    keepalive_timeout 65s;
+
+    # ── Upload cap ───────────────────────────────────────────
+    # Default is 1 MB which is way too small for image / PDF uploads to
+    # the agent endpoints. 50 MB matches the realistic upper bound for
+    # a single chat attachment. Tune up for vision / video later.
+    client_max_body_size 50m;
+    client_body_timeout  60s;
+    client_header_timeout 60s;
+
+    # ── Compression ──────────────────────────────────────────
+    # Next.js ships large JS bundles; gzip the obvious text payloads.
+    # Binary assets (images, fonts) are already compressed.
+    gzip              on;
+    gzip_vary         on;
+    gzip_min_length   1024;
+    gzip_comp_level   6;
+    gzip_proxied      any;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        text/xml
+        application/javascript
+        application/json
+        application/xml
+        application/xml+rss
+        application/manifest+json
+        image/svg+xml
+        font/ttf
+        font/otf;
+
+    # ── Connection-upgrade map (WebSocket-safe) ─────────────
+    # Only send `Connection: upgrade` when the client actually requested
+    # an upgrade. Hard-coding `"upgrade"` breaks keep-alive for normal
+    # HTTP traffic — the canonical pattern from the Nginx docs.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    # ── Streaming defaults ──────────────────────────────────
+    # Globally disabled buffering for SSE/streaming responses. Long
+    # timeouts allow agent runs (tool loops, model thinking) to complete
+    # without Nginx severing the connection at the default 60 s mark.
     proxy_buffering       off;
+    proxy_request_buffering off;
     proxy_read_timeout    3600s;
     proxy_send_timeout    3600s;
     proxy_connect_timeout 30s;
+    proxy_http_version    1.1;
 
-    upstream backend {
-        server backend:8000;
-    }
+    # Shared proxy headers — set once, reused per location.
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
 
-    upstream frontend {
-        server frontend:3000;
-    }
+    # ── Security headers ────────────────────────────────────
+    # Cheap defence-in-depth. The app is tailnet-only today, but these
+    # cost nothing and matter the moment a path is ever exposed.
+    add_header X-Frame-Options          "SAMEORIGIN"                    always;
+    add_header X-Content-Type-Options   "nosniff"                       always;
+    add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy       "camera=(), microphone=(), geolocation=()" always;
+
+    # ── Upstreams ───────────────────────────────────────────
+    upstream backend  { server backend:8000;  keepalive 32; }
+    upstream frontend { server frontend:3000; keepalive 32; }
 
     server {
-        listen 80;
+        listen 80 default_server;
         server_name _;
 
-        # ── API routes → FastAPI ─────────────────────────────
+        # ── FastAPI routes ──────────────────────────────────
+        # /api/v1/* — custom routers (chat, conversations, workspaces…)
         location /api/ {
-            proxy_pass         http://backend;
-            proxy_http_version 1.1;
-            proxy_set_header   Host              $host;
-            proxy_set_header   X-Real-IP         $remote_addr;
-            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-            proxy_set_header   X-Forwarded-Proto $scheme;
-
-            # Explicitly clear Connection header so keep-alive works
-            # correctly with HTTP/1.1 upstreams (required for SSE).
-            proxy_set_header   Connection        "";
-            proxy_cache        off;
+            proxy_pass        http://backend;
+            proxy_set_header  Connection "";   # keep-alive to upstream
+            proxy_cache       off;
         }
 
-        # ── Everything else → Next.js ────────────────────────
+        # /auth/* — fastapi-users JWT + register routers
+        location /auth/ {
+            proxy_pass        http://backend;
+            proxy_set_header  Connection "";
+            proxy_cache       off;
+        }
+
+        # /users/* — fastapi-users user-management router
+        location /users/ {
+            proxy_pass        http://backend;
+            proxy_set_header  Connection "";
+            proxy_cache       off;
+        }
+
+        # ── Next.js frontend ────────────────────────────────
+        # Everything else. WebSocket upgrade works because of the
+        # $connection_upgrade map above.
         location / {
-            proxy_pass         http://frontend;
-            proxy_http_version 1.1;
-            proxy_set_header   Host              $host;
-            proxy_set_header   X-Real-IP         $remote_addr;
-            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-            # WebSocket upgrade support (Next.js HMR in dev; future WS features)
-            proxy_set_header   Upgrade           $http_upgrade;
-            proxy_set_header   Connection        "upgrade";
+            proxy_pass        http://frontend;
+            proxy_set_header  Upgrade    $http_upgrade;
+            proxy_set_header  Connection $connection_upgrade;
         }
     }
 }


### PR DESCRIPTION
Stacked on top of #172. Addresses the issues found while reviewing that PR before testing it on the VPS.

## 🔴 Real bugs fixed

| # | File | Bug |
|---|---|---|
| 1 | `nginx/nginx.conf` | Hard-coded `Connection: upgrade` on `/` broke HTTP keep-alive on every non-WebSocket request. Replaced with the canonical `map $http_upgrade $connection_upgrade` pattern. |
| 2 | `nginx/nginx.conf` | No `client_max_body_size` → default 1 MB → any image/PDF upload to the agent would 413. Bumped to 50 MB. |
| 3 | `docker-compose.prod.yml` | Frontend published `:3000` on the host. Changed to `expose:` so it's only reachable on the Docker network — Nginx is the only public surface. |
| 4 | `nginx/nginx.conf` | `/auth/*` and `/users/*` (fastapi-users routes — no `/api` prefix) were falling through to Next.js. Added explicit `location` blocks routing them to `backend`. **Login would have failed without this.** |
| 5 | `frontend/.dockerignore` (new) | `COPY . .` was pulling in `node_modules`, `.next`, `.git`, `.env*` etc. into the build context. Now scoped. |
| 6 | `docker-compose.prod.yml` | Migrations were in an infinite `until` loop — broken migrations would loop forever. Capped at 5 attempts, then fail the container. |

## 🟡 Production hygiene

- Healthchecks on **backend, frontend, nginx**, with `depends_on: condition: service_healthy` chained correctly.
- Log rotation (`json-file`, 10 MB × 3 files) on every service.
- Memory caps via `deploy.resources.limits`.
- Nginx: `gzip` + `worker_processes auto` + keepalive upstreams + security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`).
- Backend uvicorn bumped to `--workers 2` so one stuck stream can't block the whole event loop.

## 🟠 Frontend Dockerfile

- Pinned `node:22.11-alpine` and `oven/bun:1.1.42-alpine` (no more silent minor bumps).
- BuildKit cache mount on `bun install` — significantly faster rebuilds.
- `sharp` installed in the runner so Next.js Image uses native AVIF/WebP conversion (otherwise it logs a perf warning on every optimised image request).
- `HEALTHCHECK` directive so `docker ps` shows runtime status.

## ⚠️ Known pre-existing concerns (intentionally not fixed here)

- The base `docker-compose.yml` publishes `backend` on `:8000`. Compose merges `ports` as **append**, so the prod overlay can't drop it from this side. Documented in the overlay header — a follow-up should split dev-only ports out of the base file (e.g. a `docker-compose.dev.yml` overlay).
- No CI workflow yet for building these images.

## Why this is stacked, not folded in

Keeping #172 as the "add infra" change and this as the "harden infra" change makes the review history readable and lets you revert just the hardening if anything misbehaves on the VPS.

## Test plan

1. Merge #172 first, then this on top.
2. On VPS: `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build`.
3. `docker compose ps` — every service should reach `(healthy)` within ~30s.
4. From a tailnet device: `curl https://pawrrtal.<tailnet>.ts.net/api/v1/health` → `{"status":"ok"}`.
5. Try `/auth/jwt/login` flow — should reach the backend, not Next.js.
6. Upload a >1 MB image in the chat — should not 413.
7. Stream a chat response — tokens should arrive incrementally (SSE).

## Summary by Sourcery

Harden the production Docker and Nginx setup for the Pawrrtal stack, fixing reverse-proxy routing bugs and tightening service exposure while adding health checks and basic resource limits.

Bug Fixes:
- Fix Nginx connection handling to preserve HTTP keep-alive while supporting WebSocket upgrades.
- Increase Nginx client body size to allow larger file uploads without 413 errors.
- Route /auth/* and /users/* paths to the FastAPI backend so authentication and user management endpoints work correctly.
- Restrict the frontend service to the internal Docker network instead of exposing port 3000 on the host.
- Cap backend migration retries to fail fast on persistent Alembic errors instead of looping indefinitely.
- Reduce frontend Docker build context by ignoring node_modules, build artifacts, VCS metadata, and env files.

Enhancements:
- Add Nginx performance and security tuning including gzip, worker auto-scaling, keepalive upstreams, and common security headers.
- Introduce health checks for backend, frontend, and Nginx, wiring service startup order via healthy conditions.
- Configure log rotation and memory limits for core services via Docker logging options and deploy.resources.
- Refine backend production command to run Uvicorn with multiple workers for better resilience to stuck requests.
- Pin Bun and Node base images in the frontend Dockerfile and enable BuildKit caching for faster, reproducible builds.
- Install sharp and add a Docker HEALTHCHECK in the frontend runtime image to support efficient Next.js image optimization and container liveness reporting.