### PR TITLE
fix(infra): split dev-only ports into docker-compose.dev.yml overlay

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,11 +10,17 @@
 # The base docker-compose.yml intentionally has no host-published ports,
 # so the production overlay is not contaminated by dev-only bindings.
 
+# Both bindings are localhost-only (127.0.0.1) — the API and DB never
+# need to be reachable on the host's external interfaces in dev, so this
+# avoids accidental exposure on shared / coffee-shop networks. The
+# Docker network itself is untouched, so service-to-service calls inside
+# Compose keep working exactly as before.
+
 services:
   postgres:
     ports:
-      - "5432:5432"   # connect with any local DB client
+      - "127.0.0.1:5432:5432"   # local DB client only (psql, TablePlus…)
 
   backend:
     ports:
-      - "8000:8000"   # hit the API directly from the host, bypass Nginx
+      - "127.0.0.1:8000:8000"   # hit the API directly from the host, bypass Nginx

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+# docker-compose.dev.yml — development overlay
+#
+# Publishes host ports for postgres and backend so you can connect with
+# local tools (psql, TablePlus, Postman, curl…) without going through
+# the Docker network.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+#
+# The base docker-compose.yml intentionally has no host-published ports,
+# so the production overlay is not contaminated by dev-only bindings.
+
+services:
+  postgres:
+    ports:
+      - "5432:5432"   # connect with any local DB client
+
+  backend:
+    ports:
+      - "8000:8000"   # hit the API directly from the host, bypass Nginx

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,10 +13,10 @@
 # Hardening notes:
 #   - Frontend uses `expose:` not `ports:` so it's reachable only inside
 #     the Docker network. All public traffic must go through Nginx.
-#   - Backend keeps its base-file `ports: ["8000:8000"]` because compose
-#     lists merge (append, not replace). If you don't want :8000 reachable
-#     on the VPS host network, change the base file to drop the publish —
-#     Nginx already talks to it on the Docker network via the service name.
+#   - Backend has NO host-published `ports` in the base compose file.
+#     Host bindings live only in docker-compose.dev.yml, so running the
+#     prod overlay never exposes :8000 or :5432 on the VPS host network.
+#     Nginx is the sole public surface.
 #   - Migrations are capped at 5 attempts to avoid masking real failures
 #     behind an infinite retry loop.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,17 @@
-# AI Nexus — local development stack
+# AI Nexus — base Compose file (service definitions shared by all environments)
 #
-# Starts PostgreSQL and the FastAPI backend together.  The frontend is
-# intentionally omitted from this Compose file — run it with `bun dev`
-# (or `npm run dev`) in a separate terminal so Next.js hot-reload keeps
-# working normally.
+# This file defines service topology only — no published ports.
+# Use an overlay for ports and dev-only settings:
 #
-# Quick-start:
+#   Local development (ports published to host, hot-reload):
+#     docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 #
-#   cp backend/.env.docker backend/.env   # fill in your API keys
-#   docker compose up --build
+#   Production (VPS + Tailscale Serve):
+#     docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 #
-# Production (VPS + Tailscale Serve):
-#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
-#
-# The backend will be available at http://localhost:8000.
-# The postgres port is also exposed at localhost:5432 so you can
-# connect with any database client without extra config.
+# The backend is available inside the Docker network at http://backend:8000.
+# The postgres instance is reachable inside the Docker network at postgres:5432.
+# To connect with a local DB client during development, use docker-compose.dev.yml.
 #
 # Migrations run automatically on backend startup; no manual step needed.
 
@@ -30,8 +26,7 @@ services:
       POSTGRES_USER: nexus
       POSTGRES_PASSWORD: nexus_dev
       POSTGRES_DB: nexus
-    ports:
-      - "5432:5432"
+    # No `ports` here — publish on the host only in docker-compose.dev.yml.
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -59,8 +54,7 @@ services:
       # reliably for changes made on the host through a Docker bind mount.
       # Force polling so uvicorn --reload actually reloads on every save.
       WATCHFILES_FORCE_POLLING: "true"
-    ports:
-      - "8000:8000"
+    # No `ports` here — publish :8000 on the host only in docker-compose.dev.yml.
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Stacked on top of #197 (`fix/pr172-prod-hardening`).

Closes the documented limitation flagged in that PR: the base `docker-compose.yml` was publishing `backend:8000` and `postgres:5432` on the host, which meant the prod overlay couldn't remove those bindings (Compose merges `ports` lists — you can add but not subtract from an overlay).

## What changed

### `docker-compose.yml` — base file
- Removed `ports: ["8000:8000"]` from **backend**.
- Removed `ports: ["5432:5432"]` from **postgres**.
- Updated header comment to document the two invocation patterns (dev overlay vs prod overlay).

### `docker-compose.dev.yml` — new file
- Adds only the host-port bindings needed for local development:
  - `postgres:5432` — connect with TablePlus, psql, etc.
  - `backend:8000` — hit the API directly with curl/Postman without Nginx.
- Nothing else; all other dev config lives in the base file.

### `docker-compose.prod.yml` — comment update only
- Removed the now-stale note that said "change the base file to drop the publish".
- Updated the Hardening notes section to reflect the new reality.

## How to use after this lands

**Local dev (same behaviour as before, just explicit):**
```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
```

**Production (VPS):**
```bash
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
```
No host-published backend or postgres ports on the VPS. Nginx is the only public surface.

## Why not just alias `docker compose up`?

`docker compose up` still works on the base file alone — it just won't expose host ports, which is fine for CI. The dev overlay is a one-liner you add locally (or alias in a Makefile).

> You can add a `Makefile` with `make dev` / `make prod` shorthands later if you want — happy to do that as a follow-up.

## Test plan

1. `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` → `docker compose ps` shows healthy backend + postgres, `localhost:8000/api/v1/health` responds.
2. `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` on the VPS → `docker compose ps` shows all services healthy, `ss -tlnp | grep 8000` shows nothing (backend not on host).
3. `docker compose up` (base only, no overlay) → services start, no host ports published, Compose doesn't error.

## Summary by Sourcery

Split host port publishing into a dev-only Docker Compose overlay to keep the base stack production-safe by default.

Enhancements:
- Remove host port bindings for backend and postgres from the base docker-compose.yml and clarify its usage comments.
- Introduce docker-compose.dev.yml overlay to publish backend and postgres ports only for local development.
- Update production Compose comments to document that no backend or postgres ports are exposed on the host in prod.