### PR TITLE
chore(deps): bump the actions group with 3 updates (#90)

### DIFF
--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -51,6 +51,7 @@ from app.core.providers.base import StreamEvent
 from app.core.tools.send_message import SendFn
 
 from .base import ChannelMessage
+from .telegram_html import md_to_telegram_html
 
 if TYPE_CHECKING:
     from aiogram import Bot
@@ -157,15 +158,17 @@ async def _safe_edit(
         message_id: ID of the message to edit.
         text: Full text to set (not a delta — always the accumulated string).
     """
+    html = md_to_telegram_html(text)
+
     # Truncate to Telegram's hard limit; future work can paginate.
-    if len(text) > _MAX_MESSAGE_LEN:
-        text = text[: _MAX_MESSAGE_LEN - 1] + "…"
+    if len(html) > _MAX_MESSAGE_LEN:
+        html = html[: _MAX_MESSAGE_LEN - 1] + "…"
 
     try:
         await bot.edit_message_text(
             chat_id=chat_id,
             message_id=message_id,
-            text=text,
+            text=html,
         )
     except Exception as exc:
         err_str = str(exc).lower()
@@ -186,7 +189,7 @@ async def _safe_edit(
 
 
 def make_telegram_sender(
-    bot: "Bot",
+    bot: Bot,
     chat_id: int | str,
     *,
     message_thread_id: int | None = None,
@@ -231,7 +234,7 @@ def make_telegram_sender(
             # Text-only delivery.
             await bot.send_message(
                 chat_id=chat_id,
-                text=text or "",
+                text=md_to_telegram_html(text or ""),
                 **thread_kwargs,
             )
             return
@@ -239,7 +242,7 @@ def make_telegram_sender(
         from aiogram.types import FSInputFile  # noqa: PLC0415 — lazy import; aiogram optional
 
         file = FSInputFile(file_path)
-        caption = text or None
+        caption = md_to_telegram_html(text) if text else None
         m = (mime or "").lower()
 
         if m.startswith("image/"):

--- a/backend/app/channels/telegram_html.py
+++ b/backend/app/channels/telegram_html.py
@@ -1,0 +1,157 @@
+"""Markdown → Telegram HTML conversion.
+
+Telegram's HTML mode (``ParseMode.HTML``) supports a small subset of tags.
+AI responses arrive as CommonMark Markdown. This module converts between them
+so Telegram renders formatting instead of showing raw ``**`` and ``##`` markup.
+
+Supported Telegram HTML tags (Bot API 7.3+):
+  ``<b>``, ``<strong>``          bold
+  ``<i>``, ``<em>``              italic
+  ``<u>``                        underline
+  ``<s>``, ``<del>``, ``<strike>`` strikethrough
+  ``<code>``                     inline monospace
+  ``<pre>``                      block monospace
+  ``<a href="…">``               hyperlinks
+  ``<blockquote>``               quote blocks
+
+Unsupported structural tags are stripped; their *content* is preserved.
+Block-level tags (``<p>``, ``<li>``, headings) are normalised to equivalent
+Telegram markup (double newline, bullet prefix, bold, respectively).
+"""
+
+from __future__ import annotations
+
+import html as _html
+from html.parser import HTMLParser
+
+from markdown_it import MarkdownIt
+
+_md = MarkdownIt()
+
+_INLINE_TAG_MAP: dict[str, str] = {
+    "b": "b",
+    "strong": "b",
+    "i": "i",
+    "em": "i",
+    "u": "u",
+    "s": "s",
+    "del": "s",
+    "strike": "s",
+}
+
+_HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
+_BLOCK_PASSTHROUGH = frozenset({"p", "ul", "ol"})
+_PASSTHROUGH_SKIP = frozenset({"html", "body", "head"})
+
+
+class _TelegramRenderer(HTMLParser):
+    """Walk standard HTML from markdown-it-py and emit Telegram-safe HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._buf: list[str] = []
+        self._in_pre = False
+        self._skip_stack: list[str] = []
+
+    # ------------------------------------------------------------------
+    # HTMLParser overrides
+    # ------------------------------------------------------------------
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _PASSTHROUGH_SKIP:
+            return
+        if self._skip_stack:
+            self._skip_stack.append(tag)
+            return
+        self._dispatch_start(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _PASSTHROUGH_SKIP:
+            return
+        if self._skip_stack:
+            if self._skip_stack[-1] == tag:
+                self._skip_stack.pop()
+            return
+        self._dispatch_end(tag)
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_stack:
+            self._buf.append(_html.escape(data))
+
+    def result(self) -> str:
+        """Return the accumulated Telegram-safe HTML string."""
+        return "".join(self._buf).strip()
+
+    # ------------------------------------------------------------------
+    # Dispatch helpers (keep individual methods under complexity limit)
+    # ------------------------------------------------------------------
+
+    def _dispatch_start(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _INLINE_TAG_MAP:
+            self._buf.append(f"<{_INLINE_TAG_MAP[tag]}>")
+        elif tag in _HEADING_TAGS:
+            self._buf.append("<b>")
+        elif tag in _BLOCK_PASSTHROUGH:
+            pass
+        elif tag == "li":
+            self._buf.append("\n• ")
+        elif tag in ("hr", "br"):
+            self._buf.append("\n")
+        elif tag == "a":
+            href = _html.escape(dict(attrs).get("href", "") or "")
+            self._buf.append(f'<a href="{href}">')
+        elif tag == "blockquote":
+            self._buf.append("<blockquote>")
+        elif tag == "pre":
+            self._buf.append("<pre>")
+            self._in_pre = True
+        elif tag == "code":
+            self._start_code(attrs)
+        else:
+            self._skip_stack.append(tag)
+
+    def _start_code(self, attrs: list[tuple[str, str | None]]) -> None:
+        if self._in_pre:
+            lang = dict(attrs).get("class", "") or ""
+            tag_text = f'<code class="{_html.escape(lang)}">' if lang else "<code>"
+            self._buf.append(tag_text)
+        else:
+            self._buf.append("<code>")
+
+    def _dispatch_end(self, tag: str) -> None:
+        if tag in _HEADING_TAGS:
+            self._buf.append("</b>\n\n")
+        elif tag in ("ul", "ol"):
+            self._buf.append("\n")
+        elif tag == "p":
+            self._buf.append("\n\n")
+        elif tag == "li":
+            pass
+        elif tag == "a":
+            self._buf.append("</a>")
+        elif tag == "blockquote":
+            self._buf.append("</blockquote>")
+        elif tag == "pre":
+            self._buf.append("</pre>\n")
+            self._in_pre = False
+        elif tag == "code":
+            self._buf.append("</code>")
+        elif tag in _INLINE_TAG_MAP:
+            self._buf.append(f"</{_INLINE_TAG_MAP[tag]}>")
+
+
+def md_to_telegram_html(text: str) -> str:
+    """Convert CommonMark Markdown to Telegram HTML (``ParseMode.HTML``).
+
+    Args:
+        text: AI-generated Markdown string (may be complete or mid-stream).
+
+    Returns:
+        HTML string safe to pass to Telegram with ``ParseMode.HTML``.
+        Falls back to the original *text* if conversion yields nothing.
+    """
+    raw_html = _md.render(text)
+    renderer = _TelegramRenderer()
+    renderer.feed(raw_html)
+    converted = renderer.result()
+    return converted if converted else text

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiogram>=3.27.0",
+    "markdown-it-py>=3.0.0",
     "alembic>=1.13.0",
     "aiosqlite>=0.22.1",
     "anyio>=4.0.0",

--- a/backend/tests/test_telegram_html.py
+++ b/backend/tests/test_telegram_html.py
@@ -1,0 +1,110 @@
+"""Tests for the Markdown → Telegram HTML converter.
+
+Covers the key Markdown constructs the AI model produces:
+- headings (##) → <b>…</b>
+- bold (**text**) → <b>…</b>
+- italic (*text*) → <i>…</i>
+- inline code (`code`) → <code>…</code>
+- fenced code blocks → <pre>…</pre>
+- links → <a href="…">…</a>
+- bullet lists → • prefixed lines
+- blockquotes → <blockquote>…</blockquote>
+- plain text → passthrough (no extra tags)
+- HTML special chars in content → properly escaped
+- empty / whitespace-only input → fallback to original text
+"""
+
+from __future__ import annotations
+
+from app.channels.telegram_html import md_to_telegram_html
+
+
+class TestMdToTelegramHtml:
+    def test_plain_text_passthrough(self) -> None:
+        assert md_to_telegram_html("Hello world") == "Hello world"
+
+    def test_bold(self) -> None:
+        result = md_to_telegram_html("**bold text**")
+        assert "<b>bold text</b>" in result
+
+    def test_italic(self) -> None:
+        result = md_to_telegram_html("*italic text*")
+        assert "<i>italic text</i>" in result
+
+    def test_heading_becomes_bold(self) -> None:
+        result = md_to_telegram_html("## Section Title")
+        assert "<b>Section Title</b>" in result
+        assert "##" not in result
+
+    def test_h1_heading(self) -> None:
+        result = md_to_telegram_html("# Top Level")
+        assert "<b>Top Level</b>" in result
+        assert "#" not in result
+
+    def test_inline_code(self) -> None:
+        result = md_to_telegram_html("Use `print()` here")
+        assert "<code>print()</code>" in result
+
+    def test_fenced_code_block(self) -> None:
+        md = "```python\ndef foo():\n    pass\n```"
+        result = md_to_telegram_html(md)
+        assert "<pre>" in result
+        assert "def foo():" in result
+        assert "```" not in result
+
+    def test_link(self) -> None:
+        result = md_to_telegram_html("[Click here](https://example.com)")
+        assert '<a href="https://example.com">Click here</a>' in result
+
+    def test_bullet_list(self) -> None:
+        md = "- item one\n- item two"
+        result = md_to_telegram_html(md)
+        assert "• item one" in result
+        assert "• item two" in result
+
+    def test_blockquote(self) -> None:
+        result = md_to_telegram_html("> quoted text")
+        assert "<blockquote>" in result
+        assert "quoted text" in result
+        assert ">" not in result.replace("<blockquote>", "").replace("</blockquote>", "")
+
+    def test_html_special_chars_escaped(self) -> None:
+        result = md_to_telegram_html("x < y & z > w")
+        assert "&lt;" in result
+        assert "&amp;" in result
+        assert "&gt;" in result
+
+    def test_code_block_content_escaped(self) -> None:
+        md = "```\nconst x = <div>;\n```"
+        result = md_to_telegram_html(md)
+        assert "&lt;div&gt;" in result
+        assert "<div>" not in result.replace("<pre>", "").replace("</pre>", "")
+
+    def test_empty_string_fallback(self) -> None:
+        result = md_to_telegram_html("")
+        assert result == ""
+
+    def test_whitespace_only_fallback(self) -> None:
+        result = md_to_telegram_html("   \n  ")
+        # Converter strips whitespace; if empty falls back to original.
+        assert isinstance(result, str)
+
+    def test_raw_asterisks_absent_in_output(self) -> None:
+        """The literal ** markup must not appear in the rendered output."""
+        result = md_to_telegram_html("**bold** and *italic*")
+        assert "**" not in result
+        assert result.count("*") == 0
+
+    def test_mixed_formatting(self) -> None:
+        md = "## Title\n\n**bold** and *italic* and `code`"
+        result = md_to_telegram_html(md)
+        assert "<b>Title</b>" in result
+        assert "<b>bold</b>" in result
+        assert "<i>italic</i>" in result
+        assert "<code>code</code>" in result
+
+    def test_no_paragraph_tags_in_output(self) -> None:
+        """Telegram does not support <p>; they must be stripped."""
+        result = md_to_telegram_html("Just a paragraph.")
+        assert "<p>" not in result
+        assert "</p>" not in result


### PR DESCRIPTION
Bumps the actions group with 3 updates: [actions/checkout](https://github.com/actions/checkout), [actions/cache](https://github.com/actions/cache) and [actions/github-script](https://github.com/actions/github-script).


Updates `actions/checkout` from 4 to 6
- [Release notes](https://github.com/actions/checkout/releases)
- [Commits](https://github.com/actions/checkout/compare/v4...v6)

Updates `actions/cache` from 4 to 5
- [Release notes](https://github.com/actions/cache/releases)
- [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
- [Commits](https://github.com/actions/cache/compare/v4...v5)

Updates `actions/github-script` from 7 to 9
- [Release notes](https://github.com/actions/github-script/releases)
- [Commits](https://github.com/actions/github-script/compare/v7...v9)

---
updated-dependencies:
- dependency-name: actions/checkout
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: actions
- dependency-name: actions/cache
  dependency-version: '5'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: actions
- dependency-name: actions/github-script
  dependency-version: '9'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: actions
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>