### PR TITLE
feat(tools): add convert_to_markdown tool via markitdown

### DIFF
--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -35,6 +35,7 @@ from app.core.keys import resolve_api_key
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
 from app.core.tools.image_gen_agent import make_image_gen_tool
+from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
@@ -118,6 +119,10 @@ def build_agent_tools(
         codex_token = None
     if codex_token:
         tools.append(make_image_gen_tool(workspace_root=workspace_root, user_id=user_id))
+
+    # Document-to-Markdown conversion via markitdown.  Always present —
+    # no external API key required; all conversion happens locally.
+    tools.append(make_markitdown_tool(workspace_root=workspace_root))
 
     # Channel delivery — present for both web (asyncio-queue SSE drain)
     # and Telegram (MIME-aware bot API calls).  The mechanism differs;

--- a/backend/app/core/tools/markitdown_convert.py
+++ b/backend/app/core/tools/markitdown_convert.py
@@ -1,0 +1,130 @@
+"""Convert workspace files to Markdown via the markitdown library.
+
+Provides ``make_markitdown_tool`` which returns an ``AgentTool`` that lets
+the agent convert documents (PDF, DOCX, XLSX, PPTX, HTML, …) to Markdown
+text.  The returned string can be inspected inline or saved with
+``write_file``.
+
+markitdown is a synchronous library.  All conversion calls are offloaded
+to a thread via ``anyio.to_thread.run_sync`` so the event loop is not
+blocked during potentially long-running conversions (e.g. large PDFs).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import anyio
+from markitdown import MarkItDown
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.errors import ToolError, ToolErrorCode
+
+log = logging.getLogger(__name__)
+
+_EMPTY_DOCUMENT_PLACEHOLDER = "(empty document)"
+
+
+def _resolve_safe(root: Path, rel_path: str) -> Path:
+    """Resolve *rel_path* within *root*, rejecting path traversal.
+
+    Args:
+        root: Absolute, resolved workspace root.
+        rel_path: Workspace-relative path supplied by the agent.
+
+    Raises:
+        ToolError: ``INVALID_PATH`` when the path cannot be resolved,
+            ``OUT_OF_ROOT`` when it escapes the workspace.
+    """
+    try:
+        target = (root / rel_path.lstrip("/")).resolve()
+    except (OSError, ValueError) as exc:
+        raise ToolError(
+            ToolErrorCode.INVALID_PATH,
+            f"Could not resolve path '{rel_path}': {exc}",
+        ) from exc
+    if not str(target).startswith(str(root)):
+        raise ToolError(
+            ToolErrorCode.OUT_OF_ROOT,
+            f"Path '{rel_path}' resolves outside the workspace root.",
+        )
+    return target
+
+
+def make_markitdown_tool(*, workspace_root: Path) -> AgentTool:
+    """Return a ``convert_to_markdown`` AgentTool scoped to *workspace_root*.
+
+    The tool accepts a workspace-relative file path and returns the
+    Markdown representation produced by markitdown.  Supported source
+    formats include PDF, Word (.docx), PowerPoint (.pptx), Excel (.xlsx),
+    HTML, CSV, JSON, XML, EPUB, ZIP, and plain-text files.
+
+    Args:
+        workspace_root: Absolute path to the workspace directory.
+
+    Returns:
+        An ``AgentTool`` named ``"convert_to_markdown"``.
+    """
+    root = Path(workspace_root).resolve()
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        raw_path: str = kwargs.get("path") or ""
+        if not raw_path:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "The 'path' argument is required.",
+            ).render()
+
+        try:
+            target = _resolve_safe(root, raw_path)
+        except ToolError as err:
+            return err.render()
+
+        if not target.exists():
+            return ToolError(ToolErrorCode.NOT_FOUND, f"'{raw_path}' does not exist.").render()
+        if not target.is_file():
+            return ToolError(
+                ToolErrorCode.WRONG_KIND,
+                f"'{raw_path}' is a directory, not a file.",
+            ).render()
+
+        def _run() -> str:
+            # Instantiate per-call to avoid any cross-thread state sharing.
+            result = MarkItDown(enable_plugins=False).convert(str(target))
+            return result.text_content or _EMPTY_DOCUMENT_PLACEHOLDER
+
+        try:
+            return await anyio.to_thread.run_sync(_run)
+        except Exception as exc:
+            log.exception("markitdown conversion failed for '%s'", raw_path)
+            return ToolError(
+                ToolErrorCode.IO_ERROR,
+                f"Failed to convert '{raw_path}': {exc}",
+            ).render()
+
+    return AgentTool(
+        name="convert_to_markdown",
+        description=(
+            "Convert a file in the workspace to Markdown text. "
+            "Supports PDF, Word (.docx), PowerPoint (.pptx), Excel (.xlsx), "
+            "HTML, CSV, JSON, XML, EPUB, ZIP archives, and plain-text formats. "
+            "Returns the Markdown content as a string — inspect it inline "
+            "or pass it to write_file to save as a .md file."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Workspace-relative path to the file to convert, "
+                        "e.g. 'documents/report.pdf' or 'uploads/slides.pptx'."
+                    ),
+                }
+            },
+            "required": ["path"],
+        },
+        execute=execute,
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.50b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-logging>=0.50b0",
+    "markitdown[all]>=0.1.1",
 ]
 
 # Optional voice transcription backends (PR 14). The ``api/stt.py``
@@ -201,7 +202,7 @@ disallow_untyped_defs = false  # test fixtures are fine without explicit types
 
 [[tool.mypy.overrides]]
 # Third-party packages without complete type stubs.
-module = ["sqlalchemy_utils.*", "mcp.*"]
+module = ["sqlalchemy_utils.*", "mcp.*", "markitdown.*"]
 ignore_missing_imports = true
 
 # --- bandit: security scanner ------------------------------------------------

--- a/backend/tests/test_agent_tools.py
+++ b/backend/tests/test_agent_tools.py
@@ -3,19 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.core.agent_tools import build_agent_tools
 
-@pytest.fixture()
+
+@pytest.fixture
 def tmp_workspace(tmp_path: Path) -> Path:
     """Return a minimal workspace directory with required files."""
     (tmp_path / "AGENTS.md").write_text("# Test workspace")
     return tmp_path
 
 
-def _make_send_fn():
+def _make_send_fn() -> AsyncMock:
     """Return a no-op async send function."""
     return AsyncMock(return_value=None)
 
@@ -24,19 +26,13 @@ class TestBuildAgentToolsWithoutSendFn:
     """send_message tool must NOT appear when send_fn is omitted."""
 
     def test_send_message_absent_by_default(self, tmp_workspace: Path) -> None:
-        from app.core.agent_tools import build_agent_tools
-
         with patch("app.core.keys.resolve_api_key", return_value=None):
             tools = build_agent_tools(workspace_root=tmp_workspace)
 
         names = [t.name for t in tools]
         assert "send_message" not in names
 
-    def test_send_message_absent_when_send_fn_is_none(
-        self, tmp_workspace: Path
-    ) -> None:
-        from app.core.agent_tools import build_agent_tools
-
+    def test_send_message_absent_when_send_fn_is_none(self, tmp_workspace: Path) -> None:
         with patch("app.core.keys.resolve_api_key", return_value=None):
             tools = build_agent_tools(workspace_root=tmp_workspace, send_fn=None)
 
@@ -47,11 +43,7 @@ class TestBuildAgentToolsWithoutSendFn:
 class TestBuildAgentToolsWithSendFn:
     """send_message tool MUST appear when send_fn is provided."""
 
-    def test_send_message_present_when_send_fn_provided(
-        self, tmp_workspace: Path
-    ) -> None:
-        from app.core.agent_tools import build_agent_tools
-
+    def test_send_message_present_when_send_fn_provided(self, tmp_workspace: Path) -> None:
         send_fn = _make_send_fn()
         with patch("app.core.keys.resolve_api_key", return_value=None):
             tools = build_agent_tools(workspace_root=tmp_workspace, send_fn=send_fn)
@@ -61,20 +53,14 @@ class TestBuildAgentToolsWithSendFn:
 
     def test_send_message_is_last_tool(self, tmp_workspace: Path) -> None:
         """send_message appended after workspace + artifact tools."""
-        from app.core.agent_tools import build_agent_tools
-
         send_fn = _make_send_fn()
         with patch("app.core.keys.resolve_api_key", return_value=None):
             tools = build_agent_tools(workspace_root=tmp_workspace, send_fn=send_fn)
 
         assert tools[-1].name == "send_message"
 
-    def test_other_tools_still_present_with_send_fn(
-        self, tmp_workspace: Path
-    ) -> None:
+    def test_other_tools_still_present_with_send_fn(self, tmp_workspace: Path) -> None:
         """Workspace and artifact tools survive alongside send_message."""
-        from app.core.agent_tools import build_agent_tools
-
         send_fn = _make_send_fn()
         with patch("app.core.keys.resolve_api_key", return_value=None):
             tools = build_agent_tools(workspace_root=tmp_workspace, send_fn=send_fn)

--- a/backend/tests/test_markitdown_convert.py
+++ b/backend/tests/test_markitdown_convert.py
@@ -1,0 +1,158 @@
+"""Tests for the convert_to_markdown AgentTool.
+
+Covers:
+  - Path-traversal protection (OUT_OF_ROOT).
+  - INVALID_PATH when 'path' argument is omitted.
+  - NOT_FOUND when the target file does not exist.
+  - WRONG_KIND when the target is a directory.
+  - IO_ERROR surfaced when markitdown raises.
+  - Happy path returns the text_content from markitdown.
+  - Tool registered in build_agent_tools output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.agent_tools import build_agent_tools
+from app.core.tools.errors import ToolErrorCode
+from app.core.tools.markitdown_convert import make_markitdown_tool
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Return a minimal workspace with a sample convertible file."""
+    (tmp_path / "report.html").write_text("<h1>Hello</h1>", encoding="utf-8")
+    (tmp_path / "subdir").mkdir()
+    return tmp_path
+
+
+def _tool(root: Path) -> object:
+    return make_markitdown_tool(workspace_root=root)
+
+
+def _fake_converter(text: str) -> MagicMock:
+    """Return a mock MarkItDown whose convert() returns *text* as text_content."""
+    instance = MagicMock()
+    instance.convert.return_value = SimpleNamespace(text_content=text)
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_missing_path_returns_invalid_path(workspace: Path) -> None:
+    tool = _tool(workspace)
+    out = await tool.execute("call-1")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.INVALID_PATH.value}]")
+
+
+@pytest.mark.anyio
+async def test_empty_path_returns_invalid_path(workspace: Path) -> None:
+    tool = _tool(workspace)
+    out = await tool.execute("call-2", path="")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.INVALID_PATH.value}]")
+
+
+# ---------------------------------------------------------------------------
+# Path traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_traversal_attempt_returns_out_of_root(workspace: Path) -> None:
+    tool = _tool(workspace)
+    out = await tool.execute("call-3", path="../../etc/passwd")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.OUT_OF_ROOT.value}]")
+
+
+# ---------------------------------------------------------------------------
+# File existence checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_missing_file_returns_not_found(workspace: Path) -> None:
+    tool = _tool(workspace)
+    out = await tool.execute("call-4", path="missing.pdf")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.NOT_FOUND.value}]")
+
+
+@pytest.mark.anyio
+async def test_directory_target_returns_wrong_kind(workspace: Path) -> None:
+    tool = _tool(workspace)
+    out = await tool.execute("call-5", path="subdir")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.WRONG_KIND.value}]")
+
+
+# ---------------------------------------------------------------------------
+# Conversion happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_successful_conversion_returns_markdown(workspace: Path) -> None:
+    fake_cls = _fake_converter("# Hello\n")
+    with patch("app.core.tools.markitdown_convert.MarkItDown", fake_cls):
+        tool = _tool(workspace)
+        out = await tool.execute("call-6", path="report.html")  # type: ignore[union-attr]
+    assert out == "# Hello\n"
+
+
+@pytest.mark.anyio
+async def test_empty_text_content_returns_placeholder(workspace: Path) -> None:
+    fake_cls = _fake_converter("")
+    with patch("app.core.tools.markitdown_convert.MarkItDown", fake_cls):
+        tool = _tool(workspace)
+        out = await tool.execute("call-7", path="report.html")  # type: ignore[union-attr]
+    assert out == "(empty document)"
+
+
+# ---------------------------------------------------------------------------
+# Conversion failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_converter_exception_returns_io_error(workspace: Path) -> None:
+    instance = MagicMock()
+    instance.convert.side_effect = RuntimeError("unsupported format")
+    fake_cls = MagicMock(return_value=instance)
+    with patch("app.core.tools.markitdown_convert.MarkItDown", fake_cls):
+        tool = _tool(workspace)
+        out = await tool.execute("call-8", path="report.html")  # type: ignore[union-attr]
+    assert out.startswith(f"[{ToolErrorCode.IO_ERROR.value}]")
+    assert "unsupported format" in out
+
+
+# ---------------------------------------------------------------------------
+# Tool registration in build_agent_tools
+# ---------------------------------------------------------------------------
+
+
+def test_convert_to_markdown_in_build_agent_tools(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("# Test workspace")
+    with patch("app.core.keys.resolve_api_key", return_value=None):
+        tools = build_agent_tools(workspace_root=tmp_path)
+
+    names = [t.name for t in tools]
+    assert "convert_to_markdown" in names
+
+
+def test_convert_to_markdown_precedes_send_message(tmp_path: Path) -> None:
+    """convert_to_markdown must be registered before send_message."""
+    (tmp_path / "AGENTS.md").write_text("# Test workspace")
+    send_fn = AsyncMock(return_value=None)
+    with patch("app.core.keys.resolve_api_key", return_value=None):
+        tools = build_agent_tools(workspace_root=tmp_path, send_fn=send_fn)
+
+    names = [t.name for t in tools]
+    assert names.index("convert_to_markdown") < names.index("send_message")


### PR DESCRIPTION
## Summary

- Adds a new `convert_to_markdown` AgentTool backed by [microsoft/markitdown](https://github.com/microsoft/markitdown), letting agents convert PDF, Word (.docx), PowerPoint (.pptx), Excel (.xlsx), HTML, CSV, JSON, XML, EPUB, ZIP, and plain-text workspace files to Markdown text
- Tool is always present (no API key gate) — conversion runs locally via `anyio.to_thread.run_sync` to keep the event loop unblocked during heavy conversions like large PDFs
- Registered in `build_agent_tools` after artifact/image tools, before `send_message`, preserving stable tool-list ordering

## Files changed

- `backend/app/core/tools/markitdown_convert.py` — new tool following the three-layer pattern (path resolve → validate → execute in thread)
- `backend/app/core/agent_tools.py` — import + registration of `make_markitdown_tool`
- `backend/pyproject.toml` — adds `markitdown[all]>=0.1.1` dependency + mypy `ignore_missing_imports` override
- `backend/tests/test_markitdown_convert.py` — covers path-traversal rejection, missing/directory targets, happy-path (mocked), empty-document placeholder, converter exception → `IO_ERROR`, and registration order
- `backend/tests/test_agent_tools.py` — fixes pre-existing `PLC0415` / `PT001` / `F401` lint warnings

## Test plan

- [ ] `cd backend && uv run pytest tests/test_markitdown_convert.py -v` — all 10 tests pass
- [ ] `cd backend && uv run pytest tests/test_agent_tools.py -v` — existing composition tests still pass
- [ ] `ruff check backend/app/core/tools/markitdown_convert.py backend/app/core/agent_tools.py backend/tests/` — no warnings
- [ ] Manually: upload a `.docx` or `.pdf` to a workspace and ask the agent to convert it; verify Markdown is returned and can be saved with `write_file`

https://claude.ai/code/session_01RSkHZYF7dTzqAzKusGrWgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSkHZYF7dTzqAzKusGrWgR)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `convert_to_markdown` AgentTool backed by `markitdown`, allowing agents to convert workspace documents (PDF, DOCX, PPTX, XLSX, HTML, CSV, etc.) to Markdown text without any external API key. Conversion runs in a thread via `anyio.to_thread.run_sync` to avoid blocking the event loop.

- **`markitdown_convert.py`** — new three-layer tool (resolve → validate → execute in thread) registered unconditionally in `build_agent_tools`, before `send_message`.
- **`pyproject.toml`** — adds `markitdown[all]>=0.1.1`; the `[all]` extra brings in Azure Document Intelligence, Azure Speech, and Playwright backends that are unused by this local-only tool.
- **`test_markitdown_convert.py`** — 10-test suite covering path-traversal, missing/directory targets, happy path, empty-document placeholder, exception propagation, and registration order.
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge until the sandbox escape in _resolve_safe is fixed — the string-prefix check allows sibling directories to bypass the workspace boundary.

The path-containment check on line 48 uses a raw string prefix comparison that passes for sibling directories whose names share a prefix with the workspace root. This is a concrete sandbox escape allowing the agent to read arbitrary host files. The fix is one line but must land before the tool is enabled in production.

backend/app/core/tools/markitdown_convert.py — specifically the _resolve_safe containment check (line 48) and the exception handler (line 100)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/app/core/tools/markitdown_convert.py | New convert_to_markdown tool implementation; has two previously-flagged issues (path-traversal sandbox bypass via string prefix check and overly broad except Exception catch) that remain unresolved in this diff. |
| backend/app/core/agent_tools.py | Adds import and unconditional registration of make_markitdown_tool before send_message, preserving the expected tool ordering. Change is minimal and correct. |
| backend/pyproject.toml | Adds markitdown[all]>=0.1.1 and a mypy ignore_missing_imports override; [all] extra pulls in Azure and Playwright cloud backends that are unused by this local-only tool, inflating the image. |
| backend/tests/test_markitdown_convert.py | Well-structured test suite covering path-traversal, missing/directory targets, happy-path, empty-document placeholder, converter exceptions, and registration order. |
| backend/tests/test_agent_tools.py | Moves the build_agent_tools import to module level and fixes pre-existing lint warnings; no functional changes to existing tests. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant Tool as convert_to_markdown
    participant Resolver as _resolve_safe
    participant Thread as anyio thread
    participant MarkItDown

    Agent->>Tool: execute(tool_call_id, path)
    Tool->>Resolver: _resolve_safe(root, raw_path)
    Resolver-->>Tool: resolved Path (or ToolError)
    Tool->>Tool: target.exists() / target.is_file()
    Tool->>Thread: anyio.to_thread.run_sync(_run)
    Thread->>MarkItDown: "MarkItDown(enable_plugins=False).convert(str(target))"
    MarkItDown-->>Thread: result.text_content
    Thread-->>Tool: Markdown string
    Tool-->>Agent: Markdown content (or [error_code] message)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/pyproject.toml`, line 168 ([link](https://github.com/octaviantocan/pawrrtal-ai/blob/a2867e7affa5f946281b19221381dcd848603cca/backend/pyproject.toml#L168)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`markitdown[all]` installs heavy cloud-service extras**

   The `[all]` extra pulls in optional backends including Azure Document Intelligence, Azure Speech Services, and Playwright for browser-based rendering — none of which are used by this tool. Installing them inflates the Docker image and adds cloud-SDK dependencies to a feature explicitly described as "conversion runs locally." Consider using `markitdown` (no extras) or a targeted subset so only the local converters are installed.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpyproject.toml%0ALine%3A%20168%0A%0AComment%3A%0A**%60markitdown%5Ball%5D%60%20installs%20heavy%20cloud-service%20extras**%0A%0AThe%20%60%5Ball%5D%60%20extra%20pulls%20in%20optional%20backends%20including%20Azure%20Document%20Intelligence%2C%20Azure%20Speech%20Services%2C%20and%20Playwright%20for%20browser-based%20rendering%20%E2%80%94%20none%20of%20which%20are%20used%20by%20this%20tool.%20Installing%20them%20inflates%20the%20Docker%20image%20and%20adds%20cloud-SDK%20dependencies%20to%20a%20feature%20explicitly%20described%20as%20%22conversion%20runs%20locally.%22%20Consider%20using%20%60markitdown%60%20%28no%20extras%29%20or%20a%20targeted%20subset%20so%20only%20the%20local%20converters%20are%20installed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai&pr=207&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpyproject.toml%0ALine%3A%20168%0A%0AComment%3A%0A**%60markitdown%5Ball%5D%60%20installs%20heavy%20cloud-service%20extras**%0A%0AThe%20%60%5Ball%5D%60%20extra%20pulls%20in%20optional%20backends%20including%20Azure%20Document%20Intelligence%2C%20Azure%20Speech%20Services%2C%20and%20Playwright%20for%20browser-based%20rendering%20%E2%80%94%20none%20of%20which%20are%20used%20by%20this%20tool.%20Installing%20them%20inflates%20the%20Docker%20image%20and%20adds%20cloud-SDK%20dependencies%20to%20a%20feature%20explicitly%20described%20as%20%22conversion%20runs%20locally.%22%20Consider%20using%20%60markitdown%60%20%28no%20extras%29%20or%20a%20targeted%20subset%20so%20only%20the%20local%20converters%20are%20installed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpyproject.toml%0ALine%3A%20168%0A%0AComment%3A%0A**%60markitdown%5Ball%5D%60%20installs%20heavy%20cloud-service%20extras**%0A%0AThe%20%60%5Ball%5D%60%20extra%20pulls%20in%20optional%20backends%20including%20Azure%20Document%20Intelligence%2C%20Azure%20Speech%20Services%2C%20and%20Playwright%20for%20browser-based%20rendering%20%E2%80%94%20none%20of%20which%20are%20used%20by%20this%20tool.%20Installing%20them%20inflates%20the%20Docker%20image%20and%20adds%20cloud-SDK%20dependencies%20to%20a%20feature%20explicitly%20described%20as%20%22conversion%20runs%20locally.%22%20Consider%20using%20%60markitdown%60%20%28no%20extras%29%20or%20a%20targeted%20subset%20so%20only%20the%20local%20converters%20are%20installed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2" height="20"></picture></a>

2. `backend/tests/test_turn_runner.py`, line 1724-1744 ([link](https://github.com/octaviantocan/pawrrtal-ai/blob/a2867e7affa5f946281b19221381dcd848603cca/backend/tests/test_turn_runner.py#L1724-L1744)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Sync fixture uses deprecated `get_event_loop().run_until_complete()`**

   The `conversation_id` fixture calls `asyncio.get_event_loop().run_until_complete(_seed())` from a synchronous fixture body. In Python 3.10+ this emits a `DeprecationWarning` when no running loop is present, and will raise `RuntimeError: This event loop is already running` if the fixture is ever invoked from inside an async test that anyio has already started. The fixture also appears unused by any test in this file. Consider removing it or rewriting it as an `async` fixture.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_turn_runner.py%0ALine%3A%201724-1744%0A%0AComment%3A%0A**Sync%20fixture%20uses%20deprecated%20%60get_event_loop%28%29.run_until_complete%28%29%60**%0A%0AThe%20%60conversation_id%60%20fixture%20calls%20%60asyncio.get_event_loop%28%29.run_until_complete%28_seed%28%29%29%60%20from%20a%20synchronous%20fixture%20body.%20In%20Python%203.10%2B%20this%20emits%20a%20%60DeprecationWarning%60%20when%20no%20running%20loop%20is%20present%2C%20and%20will%20raise%20%60RuntimeError%3A%20This%20event%20loop%20is%20already%20running%60%20if%20the%20fixture%20is%20ever%20invoked%20from%20inside%20an%20async%20test%20that%20anyio%20has%20already%20started.%20The%20fixture%20also%20appears%20unused%20by%20any%20test%20in%20this%20file.%20Consider%20removing%20it%20or%20rewriting%20it%20as%20an%20%60async%60%20fixture.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai&pr=207&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_turn_runner.py%0ALine%3A%201724-1744%0A%0AComment%3A%0A**Sync%20fixture%20uses%20deprecated%20%60get_event_loop%28%29.run_until_complete%28%29%60**%0A%0AThe%20%60conversation_id%60%20fixture%20calls%20%60asyncio.get_event_loop%28%29.run_until_complete%28_seed%28%29%29%60%20from%20a%20synchronous%20fixture%20body.%20In%20Python%203.10%2B%20this%20emits%20a%20%60DeprecationWarning%60%20when%20no%20running%20loop%20is%20present%2C%20and%20will%20raise%20%60RuntimeError%3A%20This%20event%20loop%20is%20already%20running%60%20if%20the%20fixture%20is%20ever%20invoked%20from%20inside%20an%20async%20test%20that%20anyio%20has%20already%20started.%20The%20fixture%20also%20appears%20unused%20by%20any%20test%20in%20this%20file.%20Consider%20removing%20it%20or%20rewriting%20it%20as%20an%20%60async%60%20fixture.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_turn_runner.py%0ALine%3A%201724-1744%0A%0AComment%3A%0A**Sync%20fixture%20uses%20deprecated%20%60get_event_loop%28%29.run_until_complete%28%29%60**%0A%0AThe%20%60conversation_id%60%20fixture%20calls%20%60asyncio.get_event_loop%28%29.run_until_complete%28_seed%28%29%29%60%20from%20a%20synchronous%20fixture%20body.%20In%20Python%203.10%2B%20this%20emits%20a%20%60DeprecationWarning%60%20when%20no%20running%20loop%20is%20present%2C%20and%20will%20raise%20%60RuntimeError%3A%20This%20event%20loop%20is%20already%20running%60%20if%20the%20fixture%20is%20ever%20invoked%20from%20inside%20an%20async%20test%20that%20anyio%20has%20already%20started.%20The%20fixture%20also%20appears%20unused%20by%20any%20test%20in%20this%20file.%20Consider%20removing%20it%20or%20rewriting%20it%20as%20an%20%60async%60%20fixture.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fcore%2Ftools%2Fmarkitdown_convert.py%3A93-96%0ANo%20upper%20bound%20on%20returned%20content%20size.%20%60text_content%60%20for%20a%20large%20PDF%20or%20a%20multi-file%20ZIP%20archive%20can%20easily%20reach%20hundreds%20of%20kilobytes%2C%20which%20will%20be%20inserted%20verbatim%20into%20the%20LLM's%20context%20window.%20Consider%20capping%20the%20output%20and%20reporting%20a%20truncation%20notice%20so%20the%20agent%20can%20decide%20whether%20to%20save%20the%20result%20to%20disk%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20_MAX_INLINE_CHARS%20%3D%20100_000%20%20%23%20~25%20k%20tokens%3B%20larger%20results%20should%20be%20written%20to%20disk%0A%0A%20%20%20%20%20%20%20%20def%20_run%28%29%20-%3E%20str%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Instantiate%20per-call%20to%20avoid%20any%20cross-thread%20state%20sharing.%0A%20%20%20%20%20%20%20%20%20%20%20%20result%20%3D%20MarkItDown%28enable_plugins%3DFalse%29.convert%28str%28target%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20result.text_content%20or%20_EMPTY_DOCUMENT_PLACEHOLDER%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20len%28text%29%20%3E%20_MAX_INLINE_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20text%5B%3A_MAX_INLINE_CHARS%5D%20%2B%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%5Cn%5Cn%E2%80%A6%20%5Btruncated%20%E2%80%93%20%7Blen%28result.text_content%29%3A%2C%7D%20chars%20total%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20Use%20write_file%20to%20save%20the%20full%20content.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20text%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=207&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fcore%2Ftools%2Fmarkitdown_convert.py%3A93-96%0ANo%20upper%20bound%20on%20returned%20content%20size.%20%60text_content%60%20for%20a%20large%20PDF%20or%20a%20multi-file%20ZIP%20archive%20can%20easily%20reach%20hundreds%20of%20kilobytes%2C%20which%20will%20be%20inserted%20verbatim%20into%20the%20LLM's%20context%20window.%20Consider%20capping%20the%20output%20and%20reporting%20a%20truncation%20notice%20so%20the%20agent%20can%20decide%20whether%20to%20save%20the%20result%20to%20disk%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20_MAX_INLINE_CHARS%20%3D%20100_000%20%20%23%20~25%20k%20tokens%3B%20larger%20results%20should%20be%20written%20to%20disk%0A%0A%20%20%20%20%20%20%20%20def%20_run%28%29%20-%3E%20str%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Instantiate%20per-call%20to%20avoid%20any%20cross-thread%20state%20sharing.%0A%20%20%20%20%20%20%20%20%20%20%20%20result%20%3D%20MarkItDown%28enable_plugins%3DFalse%29.convert%28str%28target%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20result.text_content%20or%20_EMPTY_DOCUMENT_PLACEHOLDER%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20len%28text%29%20%3E%20_MAX_INLINE_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20text%5B%3A_MAX_INLINE_CHARS%5D%20%2B%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%5Cn%5Cn%E2%80%A6%20%5Btruncated%20%E2%80%93%20%7Blen%28result.text_content%29%3A%2C%7D%20chars%20total%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20Use%20write_file%20to%20save%20the%20full%20content.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20text%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadd-markdown-conversion-tool-gopBN%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fcore%2Ftools%2Fmarkitdown_convert.py%3A93-96%0ANo%20upper%20bound%20on%20returned%20content%20size.%20%60text_content%60%20for%20a%20large%20PDF%20or%20a%20multi-file%20ZIP%20archive%20can%20easily%20reach%20hundreds%20of%20kilobytes%2C%20which%20will%20be%20inserted%20verbatim%20into%20the%20LLM's%20context%20window.%20Consider%20capping%20the%20output%20and%20reporting%20a%20truncation%20notice%20so%20the%20agent%20can%20decide%20whether%20to%20save%20the%20result%20to%20disk%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20_MAX_INLINE_CHARS%20%3D%20100_000%20%20%23%20~25%20k%20tokens%3B%20larger%20results%20should%20be%20written%20to%20disk%0A%0A%20%20%20%20%20%20%20%20def%20_run%28%29%20-%3E%20str%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Instantiate%20per-call%20to%20avoid%20any%20cross-thread%20state%20sharing.%0A%20%20%20%20%20%20%20%20%20%20%20%20result%20%3D%20MarkItDown%28enable_plugins%3DFalse%29.convert%28str%28target%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20result.text_content%20or%20_EMPTY_DOCUMENT_PLACEHOLDER%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20len%28text%29%20%3E%20_MAX_INLINE_CHARS%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20text%20%3D%20text%5B%3A_MAX_INLINE_CHARS%5D%20%2B%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%5Cn%5Cn%E2%80%A6%20%5Btruncated%20%E2%80%93%20%7Blen%28result.text_content%29%3A%2C%7D%20chars%20total%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20Use%20write_file%20to%20save%20the%20full%20content.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20text%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat(tools): add convert\_to\_markdown too..."](https://github.com/octaviantocan/pawrrtal-ai/commit/b5ec64c925fdc46cde3b2a4ed520fe4fd671b0cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32417316)</sub>

<!-- /greptile_comment -->