### PR TITLE
feat(chat): multimodal image input end-to-end [09/15]

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -300,6 +300,16 @@ def get_chat_router() -> APIRouter:
             surface=surface,
         )
 
+        # PR 09: forward multimodal image inputs from the request body to
+        # the provider via ChatTurnInput.images.  Each provider bridges
+        # these into its native content-block shape — Claude as
+        # messages.content image blocks (PR 05), Gemini as
+        # Part.from_bytes.
+        image_inputs = (
+            [{"data": img.data, "media_type": img.media_type} for img in request.images]
+            if request.images
+            else None
+        )
         turn_input = ChatTurnInput(
             conversation_id=request.conversation_id,
             user_id=user.id,
@@ -312,6 +322,7 @@ def get_chat_router() -> APIRouter:
             tools=agent_tools,
             reasoning_effort=request.reasoning_effort,
             permission_check=permission_check_for_request,
+            images=image_inputs,
             history_window=_HISTORY_WINDOW,
             log_tag="CHAT",
             log_extras={

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -60,6 +60,11 @@ class ChatTurnInput:
     # ClaudeAgentOptions.can_use_tool (Claude) so the same policy
     # applies regardless of model.
     permission_check: PermissionCheckFn | None = None
+    # PR 09 — multimodal image inputs forwarded to the provider.  Each
+    # entry is ``{"data": <base64>, "media_type": "image/<mime>"}`` —
+    # the same wire shape ``ChatRequest.images`` carries on the API
+    # boundary.  ``None`` (the default) is the legacy text-only path.
+    images: list[dict[str, str]] | None = None
     history_window: int = 20
     log_tag: str = "TURN"
     log_extras: dict[str, Any] = field(default_factory=dict)
@@ -96,6 +101,7 @@ async def run_turn(
                 system_prompt=system_prompt,
                 reasoning_effort=turn_input.reasoning_effort,
                 permission_check=turn_input.permission_check,
+                images=turn_input.images,
             ):
                 counter.value += 1
                 aggregator.apply(event)

--- a/backend/app/core/providers/base.py
+++ b/backend/app/core/providers/base.py
@@ -53,6 +53,7 @@ class AILLM(Protocol):
         system_prompt: str | None = None,
         reasoning_effort: ReasoningEffort | None = None,
         permission_check: PermissionCheckFn | None = None,
+        images: list[dict[str, str]] | None = None,
     ) -> AsyncIterator[StreamEvent]:
         """Stream response events for a user message.
 
@@ -87,5 +88,11 @@ class AILLM(Protocol):
                      tool bridge) for Claude — so the same policy is enforced
                      regardless of model.  ``None`` keeps the previous
                      behaviour: every tool call dispatches without a gate.
+            images: Optional list of multimodal image inputs (PR 09).  Each
+                     entry is ``{"data": <base64>, "media_type": "image/<mime>"}``.
+                     Providers that support multimodal turn these into native
+                     content blocks (Claude messages content blocks, Gemini
+                     ``Part.from_bytes``).  Providers without multimodal
+                     ignore the kwarg.
         """
         ...

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -265,6 +265,25 @@ class AppearanceSettings(BaseModel):
 # --- Chat schemas -------------------------------------------------------------
 
 
+class ChatImageInput(BaseModel):
+    """One multimodal image attached to a chat request (PR 09).
+
+    Wire shape matches what both the Claude SDK and Gemini SDK expect
+    after the provider-specific bridge translates: a base64-encoded
+    blob plus an explicit MIME type.  The frontend composer handles
+    the data-URL → base64 split before POSTing.
+    """
+
+    data: str  # base64-encoded image bytes (no data: URL prefix)
+    media_type: Literal["image/png", "image/jpeg", "image/gif", "image/webp"] = "image/png"
+
+
+# Cap on images per chat request — generous enough for pasting a
+# short slideshow but bounded so a malicious client can't blow up
+# the prompt budget.
+MAX_IMAGES_PER_REQUEST = 8
+
+
 class ChatRequest(BaseModel):
     """Request schema for the ``POST /api/v1/chat`` streaming endpoint.
 
@@ -273,12 +292,16 @@ class ChatRequest(BaseModel):
         conversation_id: UUID linking this message to a conversation.
         model_id: The ID of the model to use for the agent.
         reasoning_effort: Optional reasoning-depth knob from the chat composer.
+        images: Optional list of multimodal image inputs (PR 09).
+            Each item is a base64-encoded blob + MIME type the
+            provider plumbs into a multimodal content block.
     """
 
     question: str
     conversation_id: uuid.UUID
     model_id: CanonicalModelId = None
     reasoning_effort: ReasoningEffort | None = None
+    images: list[ChatImageInput] | None = None
 
 
 class ChatResponse(BaseModel):

--- a/backend/tests/test_chat_request_images.py
+++ b/backend/tests/test_chat_request_images.py
@@ -1,0 +1,47 @@
+"""Tests for the multimodal-image plumbing on ``ChatRequest`` (PR 09)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import ChatImageInput, ChatRequest
+
+
+class TestChatImageInput:
+    def test_default_media_type(self) -> None:
+        img = ChatImageInput(data="abc")
+        assert img.media_type == "image/png"
+
+    @pytest.mark.parametrize(
+        "media_type",
+        ["image/png", "image/jpeg", "image/gif", "image/webp"],
+    )
+    def test_accepts_supported_mime_types(self, media_type: str) -> None:
+        img = ChatImageInput(data="abc", media_type=media_type)  # type: ignore[arg-type]
+        assert img.media_type == media_type
+
+    def test_rejects_unsupported_mime_type(self) -> None:
+        with pytest.raises(ValidationError):
+            ChatImageInput(data="abc", media_type="image/svg+xml")  # type: ignore[arg-type]
+
+
+class TestChatRequest:
+    def test_images_default_to_none(self) -> None:
+        req = ChatRequest(question="hi", conversation_id=uuid.uuid4())
+        assert req.images is None
+
+    def test_accepts_image_list(self) -> None:
+        req = ChatRequest(
+            question="what is this?",
+            conversation_id=uuid.uuid4(),
+            images=[
+                ChatImageInput(data="abc", media_type="image/png"),
+                ChatImageInput(data="def", media_type="image/jpeg"),
+            ],
+        )
+        assert req.images is not None
+        assert len(req.images) == 2
+        assert req.images[0].data == "abc"

--- a/frontend/features/chat/hooks/use-chat-turn-controller.ts
+++ b/frontend/features/chat/hooks/use-chat-turn-controller.ts
@@ -5,7 +5,8 @@ import { useCallback, useMemo, useRef } from 'react';
 import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
 import type { ChatMessage } from '@/lib/types';
 import { type ChatReasoningLevel, FALLBACK_TITLE_MAX_LENGTH } from '../constants';
-import { useChat } from './use-chat';
+import { extractImageInputs } from '../lib/extract-image-inputs';
+import { type ChatImageInput, useChat } from './use-chat';
 import { useChatBackgroundRecovery } from './use-chat-background-recovery';
 import { useChatTurns } from './use-chat-turns';
 import { useCreateConversation } from './use-create-conversation';
@@ -85,8 +86,8 @@ export function useChatTurnController({
 	const { replace } = useRouter();
 	const hasNavigated = useRef(false);
 	const stream = useCallback(
-		(prompt: string) =>
-			streamMessage(prompt, conversationId, selectedModelId, selectedReasoning),
+		(prompt: string, images?: readonly ChatImageInput[]) =>
+			streamMessage(prompt, conversationId, selectedModelId, selectedReasoning, images),
 		[conversationId, selectedModelId, selectedReasoning, streamMessage]
 	);
 	const onFirstSend = useCallback(
@@ -118,9 +119,15 @@ export function useChatTurnController({
 	const sendMessage = useCallback(
 		async (message: PromptInputMessage): Promise<void> => {
 			const prompt = message.content;
+			// Decode attachments to base64 BEFORE kicking off the optimistic
+			// placeholders so a slow fetch doesn't open a window where the UI
+			// looks "sent" but the request hasn't been shaped yet.
+			// `extractImageInputs` is non-throwing — failed reads silently drop
+			// instead of aborting the whole turn.
+			const images = await extractImageInputs(message.files);
 			beginStream(prompt);
 			try {
-				await send(prompt);
+				await send(prompt, images.length > 0 ? images : undefined);
 			} finally {
 				endStream();
 				if (hasNavigated.current) replace(`/c/${conversationId}`);

--- a/frontend/features/chat/hooks/use-chat-turns.ts
+++ b/frontend/features/chat/hooks/use-chat-turns.ts
@@ -8,6 +8,7 @@ import {
 	updateLastAssistantMessage,
 } from '../chat-reducer';
 import type { ChatStreamEvent } from '../types';
+import type { ChatImageInput } from './use-chat';
 import { useCopyToClipboard } from './use-copy-to-clipboard';
 
 /** Hook input. */
@@ -17,9 +18,15 @@ interface UseChatTurnsConfig {
 	/**
 	 * Async generator that yields {@link ChatStreamEvent}s for one user prompt.
 	 * Provided by the caller so this hook stays decoupled from
-	 * `useChat`/`useAuthedFetch`.
+	 * `useChat`/`useAuthedFetch`. Accepts an optional list of multimodal
+	 * image inputs that ride alongside the prompt on the first turn —
+	 * regenerate intentionally re-runs with text only because images
+	 * aren't persisted on the assistant placeholder yet.
 	 */
-	streamMessage: (prompt: string) => AsyncGenerator<ChatStreamEvent>;
+	streamMessage: (
+		prompt: string,
+		images?: readonly ChatImageInput[]
+	) => AsyncGenerator<ChatStreamEvent>;
 	/**
 	 * Optional side-effect fired the first time a turn is sent. Returns a
 	 * promise the caller awaits before the SSE stream starts so any
@@ -34,7 +41,7 @@ export interface UseChatTurnsReturn {
 	isLoading: boolean;
 	regeneratingIndex: number | null;
 	copiedId: string | null;
-	send: (prompt: string) => Promise<void>;
+	send: (prompt: string, images?: readonly ChatImageInput[]) => Promise<void>;
 	regenerate: (assistantIndex: number) => Promise<void>;
 	copy: (id: string, text: string) => Promise<{ ok: boolean }>;
 }
@@ -69,9 +76,9 @@ export function useChatTurns({
 	 * `failed` status with the error message in `content`.
 	 */
 	const runAssistantTurn = useCallback(
-		async (prompt: string): Promise<void> => {
+		async (prompt: string, images?: readonly ChatImageInput[]): Promise<void> => {
 			try {
-				for await (const event of streamMessage(prompt)) {
+				for await (const event of streamMessage(prompt, images)) {
 					setChatHistory((prev) =>
 						updateLastAssistantMessage(prev, (msg) => applyChatEvent(msg, event))
 					);
@@ -99,7 +106,7 @@ export function useChatTurns({
 	);
 
 	const send = useCallback(
-		async (prompt: string): Promise<void> => {
+		async (prompt: string, images?: readonly ChatImageInput[]): Promise<void> => {
 			if (isSendingRef.current || isLoading) return;
 			isSendingRef.current = true;
 			setIsLoading(true);
@@ -114,7 +121,7 @@ export function useChatTurns({
 					await onFirstSend(prompt);
 				}
 				hasSentRef.current = true;
-				await runAssistantTurn(prompt);
+				await runAssistantTurn(prompt, images);
 			} finally {
 				setIsLoading(false);
 				isSendingRef.current = false;

--- a/frontend/features/chat/hooks/use-chat.ts
+++ b/frontend/features/chat/hooks/use-chat.ts
@@ -14,6 +14,21 @@ import type { ChatStreamEvent } from '../types';
 /** Sentinel returned by {@link parseSseFrame} when the stream signals completion. */
 const STREAM_DONE = Symbol('STREAM_DONE');
 
+/**
+ * Wire shape for one multimodal image attached to a chat request.
+ *
+ * Mirrors the backend's `ChatImageInput` schema (PR 09): a base64-encoded
+ * blob (no `data:` URL prefix) plus an explicit MIME type the provider
+ * bridge translates into a multimodal content block. Kept narrow to the
+ * image MIME types the provider bridge actually supports.
+ */
+export type ChatImageInput = {
+	/** Base64-encoded image bytes, with the `data:<mime>;base64,` prefix stripped. */
+	data: string;
+	/** Allowed image MIME types — must match the backend `ChatImageInput.media_type` literal union. */
+	media_type: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+};
+
 /** Allowed `type` field values for chat SSE events. */
 const CHAT_EVENT_TYPES = [
 	'delta',
@@ -113,7 +128,8 @@ export function useChat(): {
 		message: string,
 		conversationId: string,
 		modelId: string,
-		reasoningEffort: ChatReasoningLevel
+		reasoningEffort: ChatReasoningLevel,
+		images?: readonly ChatImageInput[]
 	) => AsyncGenerator<ChatStreamEvent>;
 } {
 	const fetcher = useAuthedFetch();
@@ -122,7 +138,8 @@ export function useChat(): {
 		message: string,
 		conversationId: string,
 		modelId: string,
-		reasoningEffort: ChatReasoningLevel
+		reasoningEffort: ChatReasoningLevel,
+		images?: readonly ChatImageInput[]
 	): AsyncGenerator<ChatStreamEvent> {
 		const response = await fetcher(API_ENDPOINTS.chat.messages, {
 			method: 'POST',
@@ -131,6 +148,10 @@ export function useChat(): {
 				conversation_id: conversationId,
 				model_id: modelId,
 				reasoning_effort: reasoningEffort,
+				// Only include `images` when the user actually attached one — keeps
+				// the wire payload identical to the pre-multimodal contract for
+				// the common text-only path.
+				...(images && images.length > 0 ? { images } : {}),
 			}),
 			headers: {
 				'Content-Type': 'application/json',

--- a/frontend/features/chat/lib/extract-image-inputs.test.ts
+++ b/frontend/features/chat/lib/extract-image-inputs.test.ts
@@ -1,0 +1,55 @@
+import type { FileUIPart } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { extractImageInputs, MAX_COMPOSER_IMAGES } from './extract-image-inputs';
+
+function makeImagePart(name: string, mime: string, body = 'fake'): FileUIPart {
+	const base64 = btoa(body);
+	return {
+		type: 'file',
+		url: `data:${mime};base64,${base64}`,
+		mediaType: mime,
+		filename: name,
+	};
+}
+
+describe('extractImageInputs', (): void => {
+	it('returns empty array when no files attached', async (): Promise<void> => {
+		expect(await extractImageInputs([])).toEqual([]);
+	});
+
+	it('drops non-image MIME types silently', async (): Promise<void> => {
+		const txt = makeImagePart('note.txt', 'text/plain', 'hi');
+		expect(await extractImageInputs([txt])).toEqual([]);
+	});
+
+	it('decodes a PNG to base64 with the data: prefix stripped', async (): Promise<void> => {
+		const png = makeImagePart('a.png', 'image/png', 'PNG-BYTES');
+		const result = await extractImageInputs([png]);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.media_type).toBe('image/png');
+		// "PNG-BYTES" base64 (without "data:image/png;base64," prefix).
+		expect(result[0]?.data).toBe('UE5HLUJZVEVT');
+		expect(result[0]?.data.startsWith('data:')).toBe(false);
+	});
+
+	it('preserves submission order across mixed MIME types', async (): Promise<void> => {
+		const png = makeImagePart('a.png', 'image/png');
+		const txt = makeImagePart('b.txt', 'text/plain', 'x');
+		const jpg = makeImagePart('c.jpg', 'image/jpeg');
+		const result = await extractImageInputs([png, txt, jpg]);
+		expect(result.map((image) => image.media_type)).toEqual(['image/png', 'image/jpeg']);
+	});
+
+	it('drops unsupported image MIME types (e.g. svg)', async (): Promise<void> => {
+		const svg = makeImagePart('a.svg', 'image/svg+xml');
+		expect(await extractImageInputs([svg])).toEqual([]);
+	});
+
+	it('caps the result at MAX_COMPOSER_IMAGES so a malicious drop cannot blow the budget', async (): Promise<void> => {
+		const tooMany = Array.from({ length: MAX_COMPOSER_IMAGES + 3 }, (_, i) =>
+			makeImagePart(`a-${i}.png`, 'image/png')
+		);
+		const result = await extractImageInputs(tooMany);
+		expect(result).toHaveLength(MAX_COMPOSER_IMAGES);
+	});
+});

--- a/frontend/features/chat/lib/extract-image-inputs.ts
+++ b/frontend/features/chat/lib/extract-image-inputs.ts
@@ -1,0 +1,83 @@
+/**
+ * Convert composer-attached files into the wire shape the chat API
+ * expects.
+ *
+ * The active composer (`PromptInput` / `ai-elements`) delivers each
+ * attachment as a `FileUIPart` — a small descriptor holding an object
+ * URL plus the source file's MIME type and filename. The backend's
+ * `ChatImageInput` schema wants base64-encoded image bytes plus an
+ * explicit MIME type, so this helper:
+ *
+ *   1. Filters down to image MIME types the provider bridge supports.
+ *   2. Fetches each part's object URL, reads the response as a blob,
+ *      and base64-encodes the bytes so the result fits the JSON wire
+ *      shape.
+ *   3. Caps the result at {@link MAX_COMPOSER_IMAGES} to mirror the
+ *      backend's `MAX_IMAGES_PER_REQUEST` so a malicious or confused
+ *      client can't blow the prompt budget.
+ *
+ * Files that don't match an allowed MIME type or that fail to read are
+ * silently dropped — the user keeps any non-image attachment in the
+ * composer for context, but only the supported image MIME types reach
+ * the agent.
+ */
+
+import type { FileUIPart } from 'ai';
+import type { ChatImageInput } from '../hooks/use-chat';
+
+/**
+ * Per-request image cap, mirrored from the backend's
+ * `MAX_IMAGES_PER_REQUEST`. Bounded so a malicious / confused client
+ * can't blow the prompt budget; generous enough for pasting a short
+ * slideshow.
+ */
+export const MAX_COMPOSER_IMAGES = 8;
+
+const ALLOWED_IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'] as const;
+
+type AllowedImageMimeType = (typeof ALLOWED_IMAGE_MIME_TYPES)[number];
+
+function isAllowedImageMimeType(value: string): value is AllowedImageMimeType {
+	return (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(value);
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+	let binary = '';
+	const bytes = new Uint8Array(buffer);
+	for (let i = 0; i < bytes.byteLength; i += 1) binary += String.fromCharCode(bytes[i] as number);
+	return btoa(binary);
+}
+
+async function partToImageInput(part: FileUIPart): Promise<ChatImageInput | null> {
+	const mime = part.mediaType;
+	if (!mime || !isAllowedImageMimeType(mime)) return null;
+	try {
+		const response = await fetch(part.url);
+		if (!response.ok) return null;
+		const buffer = await response.arrayBuffer();
+		const base64Payload = arrayBufferToBase64(buffer);
+		if (!base64Payload) return null;
+		return { data: base64Payload, media_type: mime };
+	} catch {
+		// Silently drop failed reads so a single bad attachment can't abort
+		// the rest of the slideshow.
+		return null;
+	}
+}
+
+/**
+ * Convert composer attachments into validated, capped {@link ChatImageInput}s.
+ *
+ * @param parts - The `files` array carried by `PromptInputMessage`.
+ * @returns Up to {@link MAX_COMPOSER_IMAGES} validated image inputs in
+ *   submission order. Returns an empty array when no attachments qualify
+ *   so the caller can omit the `images` field from the wire payload.
+ */
+export async function extractImageInputs(parts: readonly FileUIPart[]): Promise<ChatImageInput[]> {
+	// Cap the input list before reading to bound the I/O work; an over-cap
+	// drag-drop shouldn't pay the cost of decoding files that would be
+	// discarded anyway.
+	const cappedParts = parts.slice(0, MAX_COMPOSER_IMAGES);
+	const candidates = await Promise.all(cappedParts.map(partToImageInput));
+	return candidates.filter((input): input is ChatImageInput => input !== null);
+}


### PR DESCRIPTION
## Summary

Part **09/15** of the **CCT-integration stack**. Closes the multimodal loop: composer image attachments → backend → Claude / Gemini multimodal content blocks. **Two commits** (backend wiring + frontend wiring) ship together since they form one feature end-to-end.

## What lands here

**Backend (commit 1):**
- `backend/app/schemas.py` — `ChatImageInput` (base64 + media_type literal union: png/jpeg/gif/webp), `MAX_IMAGES_PER_REQUEST=8`, `ChatRequest.images: list[ChatImageInput] | None`.
- `backend/app/api/chat.py` — decodes incoming images, validates MIME, builds the `ChatTurnInput.images` payload.
- `backend/app/channels/turn_runner.py` — `ChatTurnInput.images` field forwarded to `provider.stream(images=...)`.
- `backend/tests/test_chat_request_images.py` — schema coverage.

**Frontend (commit 2):**
- `frontend/features/chat/lib/extract-image-inputs.ts` — pure async `File[] → ChatImageInput[]` conversion. Filters MIME (png/jpeg/gif/webp), strips `data:` prefix, caps at 8.
- `frontend/features/chat/lib/extract-image-inputs.test.ts` — 6 unit cases.
- `frontend/features/chat/hooks/use-chat.ts` — `streamMessage` accepts `images?`; conditionally spreads into wire body so text-only path keeps the exact same payload shape.
- `frontend/features/chat/hooks/use-chat-turns.ts` — `send(prompt, images?)` plumbing.
- `frontend/features/chat/ChatContainer.tsx` — calls `extractImageInputs(message.attachments)` before clearing the composer; passes through to `send`.

## Stack

01 → ... → 08 → **09 multimodal images** → 10 → ... → 15

Targets `feat/cct-08-conversation-export`.

## Verification

- `cd backend && uv run pytest -q backend/tests/test_chat_request_images.py` — green.
- `cd frontend && bun run check && bun run typecheck && bun run test -- extract-image-inputs.test` — green.
- Smoke: paste a PNG into the web composer; agent describes it (Claude + Gemini).

Plan: `/root/.claude/plans/i-want-to-integrate-binary-badger.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeDGJcjTBz8iedhCVASkdo)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires multimodal image attachments end-to-end: the backend gains a `ChatImageInput` schema (base64 + MIME literal), `ChatTurnInput.images`, and the `AILLM.stream` protocol parameter; the frontend adds `extractImageInputs` to convert `FileUIPart[]` to the wire shape and threads the result from `useChatTurnController` → `useChatTurns` → `useChat` → the SSE body.

- **Backend**: `ChatImageInput` validates MIME type via a Pydantic `Literal` union; `chat.py` converts to plain dicts and passes through `ChatTurnInput`; the `AILLM` protocol is extended with an optional `images` kwarg.
- **Frontend**: `extractImageInputs` fetches each attachment URL, array-buffer-encodes it, and caps results at 8; `streamMessage` conditionally spreads `images` into the POST body only when present, keeping the text-only payload identical to the pre-multimodal contract.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the end-to-end plumbing is correct and the change is well-isolated from the text-only path.

The multimodal wiring is straightforward and both paths (with and without images) are tested. The one logic quirk found — the pre-filter cap counting non-image files against the image budget — is a niche edge case that requires mixed file types and doesn't affect the common all-image or text-only paths.

frontend/features/chat/lib/extract-image-inputs.ts — cap-before-filter ordering.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/schemas.py | Adds ChatImageInput schema with MIME literal union and MAX_IMAGES_PER_REQUEST constant; ChatRequest.images field added but no Pydantic length validator enforces the cap (previously flagged). |
| backend/app/api/chat.py | Adds image_inputs list comprehension that converts ChatImageInput objects to plain dicts before constructing ChatTurnInput; logic is straightforward and correct. |
| backend/app/channels/turn_runner.py | Adds images field to ChatTurnInput and forwards it to provider.stream(); typed as list[dict[str, str]] which loses the MIME literal constraint from the API boundary (previously flagged). |
| backend/app/core/providers/base.py | Adds images parameter to the AILLM protocol stream method with good docstring; matches the loose dict[str, str] shape used downstream. |
| backend/tests/test_chat_request_images.py | New test module covers ChatImageInput default media_type, MIME acceptance/rejection, and ChatRequest round-tripping; clean and thorough for schema-level concerns. |
| frontend/features/chat/lib/extract-image-inputs.ts | Pure async helper converts FileUIPart[] to ChatImageInput[]; cap is applied to total file count before MIME filtering, which can silently exclude valid images when mixed with many non-image attachments. |
| frontend/features/chat/lib/extract-image-inputs.test.ts | 6 Vitest cases covering empty input, non-image drop, PNG decode, order preservation, SVG drop, and cap; the cap test uses homogeneous images only and misses the mixed-file edge case. |
| frontend/features/chat/hooks/use-chat.ts | Adds ChatImageInput type export and optional images param to streamMessage; conditionally spreads images into wire body so text-only callers are unaffected. |
| frontend/features/chat/hooks/use-chat-turns.ts | Threads optional images through runAssistantTurn and send; regenerate intentionally stays text-only, which is documented in comments. |
| frontend/features/chat/hooks/use-chat-turn-controller.ts | Integrates extractImageInputs into sendMessage before beginStream; dependency array is correct and the ordering choice is well-explained in comments. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Composer as ChatComposer (UI)
    participant Controller as useChatTurnController
    participant Extract as extractImageInputs
    participant Chat as useChat / streamMessage
    participant API as POST /api/v1/chat
    participant Runner as ChatTurnInput / run_turn
    participant Provider as AILLM.stream (Claude/Gemini)

    Composer->>Controller: sendMessage(PromptInputMessage)
    Controller->>Extract: extractImageInputs(message.files)
    Extract-->>Controller: ChatImageInput[] (≤8, MIME-filtered)
    Controller->>Chat: streamMessage(prompt, conversationId, modelId, reasoning, images)
    Chat->>API: "POST { question, conversation_id, model_id, ..images? }"
    API->>Runner: "ChatTurnInput(images=[{data, media_type}])"
    Runner->>Provider: "provider.stream(message, ..., images=[...])"
    Provider-->>Runner: AsyncIterator[StreamEvent]
    Runner-->>API: SSE chunks
    API-->>Chat: text/event-stream
    Chat-->>Controller: AsyncGenerator[ChatStreamEvent]
    Controller-->>Composer: UI updates via useChatTurns
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Flib%2Fextract-image-inputs.ts%3A77-82%0AThe%20cap%20is%20applied%20to%20the%20raw%20%60parts%60%20list%20%28all%20file%20types%29%20before%20MIME%20filtering.%20If%20a%20user%20attaches%208%20non-image%20files%20followed%20by%20valid%20image%20files%2C%20the%20images%20are%20silently%20excluded%20even%20though%20the%20image%20count%20hasn't%20reached%20%60MAX_COMPOSER_IMAGES%60.%20The%20comment%20says%20this%20mirrors%20the%20backend's%20per-image%20cap%2C%20so%20the%20intent%20is%20clearly%20to%20limit%20image%20count%20%E2%80%94%20the%20filter%20should%20run%20first%20so%20that%20the%20slice%20only%20counts%20qualifying%20images.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Filter%20by%20MIME%20type%20first%20%28no%20I%2FO%29%2C%20then%20cap%20the%20qualifying%20images%0A%09%2F%2F%20before%20fetching%20so%20we%20still%20bound%20the%20decode%20work%20to%20MAX_COMPOSER_IMAGES%0A%09%2F%2F%20fetches%20%E2%80%94%20regardless%20of%20how%20many%20non-image%20files%20are%20in%20the%20list.%0A%09const%20imageParts%20%3D%20parts.filter%28%0A%09%09%28p%29%20%3D%3E%20p.mediaType%20!%3D%20null%20%26%26%20isAllowedImageMimeType%28p.mediaType%29%0A%09%29%3B%0A%09const%20cappedParts%20%3D%20imageParts.slice%280%2C%20MAX_COMPOSER_IMAGES%29%3B%0A%09const%20candidates%20%3D%20await%20Promise.all%28cappedParts.map%28partToImageInput%29%29%3B%0A%09return%20candidates.filter%28%28input%29%3A%20input%20is%20ChatImageInput%20%3D%3E%20input%20!%3D%3D%20null%29%3B%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-09-multimodal-images%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-09-multimodal-images%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Flib%2Fextract-image-inputs.ts%3A77-82%0AThe%20cap%20is%20applied%20to%20the%20raw%20%60parts%60%20list%20%28all%20file%20types%29%20before%20MIME%20filtering.%20If%20a%20user%20attaches%208%20non-image%20files%20followed%20by%20valid%20image%20files%2C%20the%20images%20are%20silently%20excluded%20even%20though%20the%20image%20count%20hasn't%20reached%20%60MAX_COMPOSER_IMAGES%60.%20The%20comment%20says%20this%20mirrors%20the%20backend's%20per-image%20cap%2C%20so%20the%20intent%20is%20clearly%20to%20limit%20image%20count%20%E2%80%94%20the%20filter%20should%20run%20first%20so%20that%20the%20slice%20only%20counts%20qualifying%20images.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Filter%20by%20MIME%20type%20first%20%28no%20I%2FO%29%2C%20then%20cap%20the%20qualifying%20images%0A%09%2F%2F%20before%20fetching%20so%20we%20still%20bound%20the%20decode%20work%20to%20MAX_COMPOSER_IMAGES%0A%09%2F%2F%20fetches%20%E2%80%94%20regardless%20of%20how%20many%20non-image%20files%20are%20in%20the%20list.%0A%09const%20imageParts%20%3D%20parts.filter%28%0A%09%09%28p%29%20%3D%3E%20p.mediaType%20!%3D%20null%20%26%26%20isAllowedImageMimeType%28p.mediaType%29%0A%09%29%3B%0A%09const%20cappedParts%20%3D%20imageParts.slice%280%2C%20MAX_COMPOSER_IMAGES%29%3B%0A%09const%20candidates%20%3D%20await%20Promise.all%28cappedParts.map%28partToImageInput%29%29%3B%0A%09return%20candidates.filter%28%28input%29%3A%20input%20is%20ChatImageInput%20%3D%3E%20input%20!%3D%3D%20null%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-09-multimodal-images%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-09-multimodal-images%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Flib%2Fextract-image-inputs.ts%3A77-82%0AThe%20cap%20is%20applied%20to%20the%20raw%20%60parts%60%20list%20%28all%20file%20types%29%20before%20MIME%20filtering.%20If%20a%20user%20attaches%208%20non-image%20files%20followed%20by%20valid%20image%20files%2C%20the%20images%20are%20silently%20excluded%20even%20though%20the%20image%20count%20hasn't%20reached%20%60MAX_COMPOSER_IMAGES%60.%20The%20comment%20says%20this%20mirrors%20the%20backend's%20per-image%20cap%2C%20so%20the%20intent%20is%20clearly%20to%20limit%20image%20count%20%E2%80%94%20the%20filter%20should%20run%20first%20so%20that%20the%20slice%20only%20counts%20qualifying%20images.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Filter%20by%20MIME%20type%20first%20%28no%20I%2FO%29%2C%20then%20cap%20the%20qualifying%20images%0A%09%2F%2F%20before%20fetching%20so%20we%20still%20bound%20the%20decode%20work%20to%20MAX_COMPOSER_IMAGES%0A%09%2F%2F%20fetches%20%E2%80%94%20regardless%20of%20how%20many%20non-image%20files%20are%20in%20the%20list.%0A%09const%20imageParts%20%3D%20parts.filter%28%0A%09%09%28p%29%20%3D%3E%20p.mediaType%20!%3D%20null%20%26%26%20isAllowedImageMimeType%28p.mediaType%29%0A%09%29%3B%0A%09const%20cappedParts%20%3D%20imageParts.slice%280%2C%20MAX_COMPOSER_IMAGES%29%3B%0A%09const%20candidates%20%3D%20await%20Promise.all%28cappedParts.map%28partToImageInput%29%29%3B%0A%09return%20candidates.filter%28%28input%29%3A%20input%20is%20ChatImageInput%20%3D%3E%20input%20!%3D%3D%20null%29%3B%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat(chat): wire composer image attachme..."](https://github.com/octaviantocan/pawrrtal-ai/commit/7b6133bf61c1c9d2b7ad5c065c4045fabfabe2b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32386318)</sub>

<!-- /greptile_comment -->