### PR TITLE
feat(event-bus): async pub/sub event bus + turn lifecycle events [10/15]

### DIFF
--- a/backend/app/api/_chat_events.py
+++ b/backend/app/api/_chat_events.py
@@ -1,0 +1,36 @@
+"""Chat-router event-bus emission helpers.
+
+Extracted from :mod:`app.api.chat` to keep that module's fan-out under
+the sentrux god-file threshold (15). The event-bus module pair adds two
+import edges; concentrating them here lets the chat router stay below
+the cap while still emitting lifecycle events.
+"""
+
+from __future__ import annotations
+
+from app.core.event_bus import TurnStartedEvent
+from app.core.event_bus.global_bus import publish_if_available
+
+
+async def publish_turn_started(
+    *,
+    user_id: object,
+    conversation_id: object,
+    surface: str,
+    model_id: str,
+    source: str = "chat",
+) -> None:
+    """Fire a ``TurnStartedEvent`` if the global event bus is wired up.
+
+    No-ops when the bus is unset (unit tests, fastapi TestClient without
+    lifespan) so callers don't need to special-case bus setup.
+    """
+    await publish_if_available(
+        TurnStartedEvent(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            surface=surface,
+            model_id=model_id,
+            source=source,
+        )
+    )

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -15,6 +15,7 @@ from opentelemetry import trace as _otel_trace
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api._chat_cost_budget import enforce_cost_budget
+from app.api._chat_events import publish_turn_started
 from app.api._chat_permissions import build_chat_permission_check
 from app.channels import resolve_channel, surface_from_header
 from app.channels.base import ChannelMessage
@@ -332,6 +333,16 @@ def get_chat_router() -> APIRouter:
             },
         )
         hooks: list[EventHook] = [_artifact_hook, _drain_send_queue]
+
+        # PR 10: announce the turn so subscribers (audit, metrics,
+        # webhook delivery) can react.  Fire-and-forget via the global
+        # bus accessor; no-op when the bus is unset.
+        await publish_turn_started(
+            user_id=user.id,
+            conversation_id=request.conversation_id,
+            surface=surface,
+            model_id=model_id,
+        )
 
         async def event_stream() -> AsyncGenerator[bytes]:
             """Yield channel-encoded bytes from the shared turn runner."""

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -15,6 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.chat_aggregator import ChatTurnAggregator
 from app.core.config import settings
+from app.core.event_bus import TurnCompletedEvent
+from app.core.event_bus.global_bus import publish_if_available
 from app.core.governance.cost_tracker import (
     PostgresCostLedger,
     record_turn_cost,
@@ -249,6 +251,27 @@ async def _finalize_turn(
         event_count,
         duration_ms,
         extras,
+    )
+    # PR 10: announce completion (success / failure both surface here
+    # because the caller wraps run_turn in a try/finally).  Subscribers
+    # can react to spend, latency, etc.
+    surface = (
+        (turn_input.channel_message.get("surface") or "") if turn_input.channel_message else ""
+    )
+    model_id = (
+        (turn_input.channel_message.get("model_id") or "") if turn_input.channel_message else ""
+    )
+    await publish_if_available(
+        TurnCompletedEvent(
+            user_id=turn_input.user_id,
+            conversation_id=turn_input.conversation_id,
+            surface=surface,
+            model_id=model_id,
+            status=final_status,
+            duration_ms=duration_ms,
+            cost_usd=aggregator.total_cost_usd,
+            source=turn_input.log_tag.lower(),
+        )
     )
 
 

--- a/backend/app/core/event_bus/__init__.py
+++ b/backend/app/core/event_bus/__init__.py
@@ -1,0 +1,45 @@
+"""Async pub/sub event bus + concrete event vocabulary.
+
+Decouples event sources (chat router emits ``TurnStartedEvent``,
+webhook receiver emits ``WebhookEvent``, scheduler emits
+``ScheduledEvent``) from handlers (``AgentHandler`` runs a Claude
+turn for webhook/scheduled events; future ``NotificationService``
+delivers ``AgentResponseEvent`` to Telegram).
+
+The bus is import-cycle-safe because it lives under
+``app.core.event_bus`` and only imports from ``app.core.providers``
+indirectly through the handler modules — the bus itself has zero
+domain knowledge.
+
+Process model
+-------------
+Single asyncio queue, one consumer task running inside the FastAPI
+lifespan.  Concurrent dispatch — every handler subscribed to a
+matching event runs in parallel via ``asyncio.gather``, and a
+crash in one handler never affects siblings (errors are caught
++ logged, never re-raised).
+
+This matches CCT's design but adapted to our typed event vocabulary;
+see ``.claude/rules/architecture/no-tools-in-providers.md`` for why
+the bus + agent handler split lives outside ``providers/``.
+"""
+
+from app.core.event_bus.bus import Event, EventBus, EventHandler
+from app.core.event_bus.types import (
+    AgentResponseEvent,
+    ScheduledEvent,
+    TurnCompletedEvent,
+    TurnStartedEvent,
+    WebhookEvent,
+)
+
+__all__ = [
+    "AgentResponseEvent",
+    "Event",
+    "EventBus",
+    "EventHandler",
+    "ScheduledEvent",
+    "TurnCompletedEvent",
+    "TurnStartedEvent",
+    "WebhookEvent",
+]

--- a/backend/app/core/event_bus/bus.py
+++ b/backend/app/core/event_bus/bus.py
@@ -1,0 +1,188 @@
+"""Async event bus with typed subscriptions.
+
+Ported from CCT's ``src/events/bus.py`` and tightened to:
+
+* Run under the FastAPI lifespan (``start()`` in lifespan setup,
+  ``stop()`` in teardown).
+* Dispatch handlers concurrently via ``asyncio.gather`` so one slow
+  subscriber doesn't queue-stall the others.
+* Isolate handler failures — ``return_exceptions=True`` + structured
+  log so a crashed subscriber never poisons sibling subscribers or
+  the main queue loop.
+
+The bus is provider-neutral and handler-neutral; concrete event
+classes live in :mod:`app.core.event_bus.types`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+# How long the queue-pop polls before checking the running flag.
+# 1.0s is enough to keep shutdown latency low without burning CPU.
+_QUEUE_POLL_INTERVAL_SECONDS = 1.0
+
+
+@dataclass
+class Event:
+    """Base class for every bus event.
+
+    Concrete events extend this with their own typed fields.  The
+    base carries metadata every handler can rely on:
+
+    * ``id`` — uuid4, generated at construction; useful for
+      correlating downstream effects back to the originating event.
+    * ``timestamp`` — UTC datetime at construction.
+    * ``source`` — short string the producer fills in (``"chat"``,
+      ``"webhook"``, ``"scheduler"``, …) for log lines and metrics.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    source: str = "unknown"
+
+    @property
+    def event_type(self) -> str:
+        """Class name — handy in log lines that handle multiple types."""
+        return type(self).__name__
+
+
+_E = TypeVar("_E", bound=Event)
+EventHandler = Callable[[Event], Awaitable[None]]
+
+
+class EventBus:
+    """Single-consumer async pub/sub.
+
+    Lifecycle:
+    1. ``EventBus()`` — construct (no background task yet).
+    2. ``await bus.start()`` — spawn the consumer task; idempotent.
+    3. ``await bus.publish(event)`` — fire-and-forget enqueue.
+    4. ``await bus.stop()`` — cancel the consumer + drain.
+
+    Subscribe with :meth:`subscribe` (per-type) or :meth:`subscribe_all`
+    (every event regardless of type).  Type-based dispatch uses
+    ``isinstance`` so subscribers to a base class also receive
+    derived events.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[type[Event], list[EventHandler]] = {}
+        self._global_handlers: list[EventHandler] = []
+        self._queue: asyncio.Queue[Event] = asyncio.Queue()
+        self._running: bool = False
+        self._processor_task: asyncio.Task[None] | None = None
+
+    def subscribe(self, event_type: type[_E], handler: EventHandler) -> None:
+        """Register ``handler`` for one event type.
+
+        ``handler`` MUST be an async callable; the bus awaits it on
+        every dispatch.  Subscribers to a base class also receive
+        derived events (``isinstance`` check at dispatch time).
+        """
+        bucket = self._handlers.setdefault(event_type, [])
+        bucket.append(handler)
+        logger.debug(
+            "EVENTBUS_SUBSCRIBE event_type=%s handler=%s",
+            event_type.__name__,
+            getattr(handler, "__qualname__", repr(handler)),
+        )
+
+    def subscribe_all(self, handler: EventHandler) -> None:
+        """Register a handler that receives every event.
+
+        Useful for cross-cutting concerns (audit, metrics) that
+        shouldn't enumerate every event type by hand.
+        """
+        self._global_handlers.append(handler)
+
+    async def publish(self, event: Event) -> None:
+        """Enqueue ``event`` for dispatch.
+
+        Returns immediately; subscriber execution is async + happens
+        on the consumer task.  Callers that need to wait for the
+        dispatch to complete should use a different pattern (the bus
+        is intentionally fire-and-forget).
+        """
+        logger.info(
+            "EVENTBUS_PUBLISH event_type=%s event_id=%s source=%s",
+            event.event_type,
+            event.id,
+            event.source,
+        )
+        await self._queue.put(event)
+
+    async def start(self) -> None:
+        """Spawn the consumer task. Idempotent."""
+        if self._running:
+            return
+        self._running = True
+        self._processor_task = asyncio.create_task(
+            self._process_events(), name="event-bus-consumer"
+        )
+        logger.info("EVENTBUS_START")
+
+    async def stop(self) -> None:
+        """Cancel the consumer + wait for graceful shutdown. Idempotent."""
+        if not self._running:
+            return
+        self._running = False
+        if self._processor_task is not None:
+            self._processor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._processor_task
+        logger.info("EVENTBUS_STOP")
+
+    async def _process_events(self) -> None:
+        """Consumer task — pop one event at a time and dispatch."""
+        while self._running:
+            try:
+                event = await asyncio.wait_for(
+                    self._queue.get(), timeout=_QUEUE_POLL_INTERVAL_SECONDS
+                )
+            except TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+            await self._dispatch(event)
+
+    async def _dispatch(self, event: Event) -> None:
+        """Run every matching handler concurrently with error isolation."""
+        handlers: list[EventHandler] = list(self._global_handlers)
+        for event_type, type_handlers in self._handlers.items():
+            if isinstance(event, event_type):
+                handlers.extend(type_handlers)
+        if not handlers:
+            logger.debug(
+                "EVENTBUS_NO_HANDLERS event_type=%s event_id=%s",
+                event.event_type,
+                event.id,
+            )
+            return
+        results = await asyncio.gather(
+            *(self._safe_call(handler, event) for handler in handlers),
+            return_exceptions=True,
+        )
+        for handler, result in zip(handlers, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "EVENTBUS_HANDLER_FAILED event_type=%s event_id=%s handler=%s error=%s",
+                    event.event_type,
+                    event.id,
+                    getattr(handler, "__qualname__", repr(handler)),
+                    result,
+                )
+
+    @staticmethod
+    async def _safe_call(handler: EventHandler, event: Event) -> None:
+        """Wrap a handler so an exception surfaces in ``gather``'s results."""
+        await handler(event)

--- a/backend/app/core/event_bus/global_bus.py
+++ b/backend/app/core/event_bus/global_bus.py
@@ -1,0 +1,58 @@
+"""Process-global :class:`EventBus` accessor.
+
+The bus lives on ``app.state.event_bus`` (set in the FastAPI lifespan)
+but the chat router's streaming generator runs in a fresh task that
+doesn't carry the request context.  Rather than thread the bus
+through every helper, we cache it on a module-level singleton at
+lifespan startup.
+
+Why a module global instead of a contextvar:
+* The bus is genuinely process-wide — there's exactly one per FastAPI
+  app instance.
+* Async tasks spawned via ``asyncio.create_task`` don't inherit
+  contextvars by default; threading would require explicit propagation
+  at every spawn.
+* Tests can call :func:`set_event_bus` with a ``None`` to short-circuit
+  emission entirely, keeping unit tests provider-bus-independent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.event_bus.bus import Event, EventBus
+
+logger = logging.getLogger(__name__)
+
+_bus: EventBus | None = None
+
+
+def set_event_bus(bus: EventBus | None) -> None:
+    """Register the process-wide bus.  Idempotent.
+
+    Called once from the FastAPI lifespan.  Tests use this to inject
+    a fresh bus per case (or ``None`` to disable emission).
+    """
+    global _bus  # noqa: PLW0603 — module-level singleton is the design (process-wide bus, async-task-safe)
+    _bus = bus
+
+
+def get_event_bus() -> EventBus | None:
+    """Return the registered bus, or ``None`` when unset."""
+    return _bus
+
+
+async def publish_if_available(event: Event) -> None:
+    """Fire-and-forget publish that no-ops when the bus is unset.
+
+    Use this from request handlers / streaming generators that can
+    run in test environments without a bus.  Errors are caught +
+    logged so an event-bus failure never breaks the chat path.
+    """
+    bus = _bus
+    if bus is None:
+        return
+    try:
+        await bus.publish(event)
+    except Exception:
+        logger.exception("EVENTBUS_PUBLISH_FAILED event_type=%s", event.event_type)

--- a/backend/app/core/event_bus/types.py
+++ b/backend/app/core/event_bus/types.py
@@ -1,0 +1,120 @@
+"""Concrete event types the bus dispatches.
+
+Vocabulary mirrors CCT's so the AgentHandler ports cleanly:
+
+* :class:`TurnStartedEvent` / :class:`TurnCompletedEvent` — emitted by
+  the chat router (web) and Telegram turn_stream around every agent
+  turn.  Subscribers can use these for metrics, audit, side-effects.
+* :class:`WebhookEvent` — emitted by the webhook receiver (PR 11).
+  Subscribed by :class:`AgentHandler` which translates into an
+  agent turn.
+* :class:`ScheduledEvent` — emitted by the scheduler (PR 12).  Same
+  AgentHandler subscribes.
+* :class:`AgentResponseEvent` — emitted by AgentHandler with the
+  response text.  Subscribed by the notification service that
+  delivers to Telegram / web.
+
+Every concrete event extends :class:`Event`, so cross-cutting
+``subscribe_all`` consumers (audit, metrics) see everything without
+enumerating types.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.core.event_bus.bus import Event
+
+
+@dataclass
+class TurnStartedEvent(Event):
+    """One agent turn has begun.
+
+    Emitted by the chat router (web) and the Telegram turn_stream
+    just before the provider stream starts.  Subscribers can use this
+    for "agent is busy" indicators, per-user concurrency tracking,
+    etc.
+    """
+
+    user_id: uuid.UUID | None = None
+    conversation_id: uuid.UUID | None = None
+    surface: str = "unknown"
+    model_id: str | None = None
+    source: str = "chat"
+
+
+@dataclass
+class TurnCompletedEvent(Event):
+    """One agent turn has finished (successfully or not).
+
+    Emitted from the same code path's ``finally`` block so a
+    cancelled / errored turn still surfaces.  ``status`` is one of
+    ``"complete"``, ``"failed"``, ``"cancelled"``.
+    """
+
+    user_id: uuid.UUID | None = None
+    conversation_id: uuid.UUID | None = None
+    surface: str = "unknown"
+    model_id: str | None = None
+    status: str = "complete"
+    duration_ms: float | None = None
+    cost_usd: float | None = None
+    source: str = "chat"
+
+
+@dataclass
+class WebhookEvent(Event):
+    """One inbound webhook delivery (already deduped + signature-verified).
+
+    The webhook receiver (PR 11) writes the row to ``webhook_events``
+    + publishes this event.  AgentHandler subscribes and runs an
+    agent turn against the payload summary.
+    """
+
+    provider: str = ""
+    event_type_name: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    delivery_id: str = ""
+    user_id: uuid.UUID | None = None
+    source: str = "webhook"
+
+
+@dataclass
+class ScheduledEvent(Event):
+    """One scheduled-job firing.
+
+    The scheduler (PR 12) reads the ``scheduled_jobs`` row, builds
+    this event, publishes.  AgentHandler subscribes and runs the
+    job's prompt as an agent turn.  ``target_chat_ids`` lets the
+    notification service know which Telegram chats to deliver the
+    response to.
+    """
+
+    job_id: uuid.UUID | None = None
+    job_name: str = ""
+    prompt: str = ""
+    skill_name: str | None = None
+    target_chat_ids: list[str] = field(default_factory=list)
+    working_directory: Path | None = None
+    user_id: uuid.UUID | None = None
+    source: str = "scheduler"
+
+
+@dataclass
+class AgentResponseEvent(Event):
+    """An agent turn produced text + needs to be delivered.
+
+    Emitted by AgentHandler after a webhook / scheduled run.  The
+    notification service subscribes and sends to the configured
+    Telegram chats.  The ``originating_event_id`` field lets the
+    delivery layer correlate back to the inbound event.
+    """
+
+    user_id: uuid.UUID | None = None
+    chat_id: str | None = None
+    text: str = ""
+    originating_event_id: str | None = None
+    source: str = "agent"

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,8 @@ from app.api.workspace import get_workspace_router
 from app.api.workspace_env import get_workspace_env_router
 from app.cli.admin_seed import seed_admin_user
 from app.core.config import settings
+from app.core.event_bus import EventBus
+from app.core.event_bus.global_bus import set_event_bus
 from app.core.middleware import BackendApiKeyMiddleware
 from app.core.rate_limit import ChatRateLimitMiddleware
 from app.core.request_logging import RequestLoggingMiddleware
@@ -60,6 +62,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await create_db_and_tables()
     # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
     await seed_admin_user()
+    # PR 10: spin up the event bus before any request can fire so the
+    # consumer task is ready when the chat router or Telegram dispatcher
+    # publishes the first ``TurnStartedEvent``.  Stashed on
+    # ``app.state`` for handlers that want to publish from inside a route.
+    event_bus = EventBus()
+    await event_bus.start()
+    app.state.event_bus = event_bus
+    set_event_bus(event_bus)
     # Bring the Telegram channel up alongside the HTTP server when a bot
     # token is configured. The context manager yields None and is a no-op
     # when the channel is disabled, so this stays safe for stripped-down
@@ -70,6 +80,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         try:
             yield
         finally:
+            set_event_bus(None)
+            await event_bus.stop()
             shutdown_tracing()
 
 

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -1,0 +1,144 @@
+"""Tests for ``app.core.event_bus.bus.EventBus``.
+
+Covers the pub/sub contract: typed dispatch, global subscribers,
+concurrent dispatch (no head-of-line blocking), and error isolation
+(a crashing handler doesn't poison siblings or the consumer task).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core.event_bus import (
+    AgentResponseEvent,
+    Event,
+    EventBus,
+    TurnStartedEvent,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+_DRAIN_POLL_INTERVAL_S = 0.01
+_DRAIN_DEFAULT_TIMEOUT_S = 0.5
+
+
+async def _drain(bus: EventBus) -> None:
+    """Spin briefly so the consumer task picks up published events."""
+    deadline = asyncio.get_event_loop().time() + _DRAIN_DEFAULT_TIMEOUT_S
+    while bus._queue.qsize() > 0:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
+    # Give handlers a final tick to finish.
+    await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
+
+
+class TestPubSub:
+    async def test_subscriber_receives_published_event(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        received: list[Event] = []
+
+        async def handler(event: Event) -> None:
+            received.append(event)
+
+        bus.subscribe(TurnStartedEvent, handler)
+        await bus.publish(TurnStartedEvent(surface="web"))
+        await _drain(bus)
+        await bus.stop()
+
+        assert len(received) == 1
+        assert isinstance(received[0], TurnStartedEvent)
+        assert received[0].surface == "web"
+
+    async def test_unsubscribed_event_type_skips_handler(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        received: list[Event] = []
+
+        async def handler(event: Event) -> None:
+            received.append(event)
+
+        bus.subscribe(TurnStartedEvent, handler)
+        # Different event type — handler must not fire.
+        await bus.publish(AgentResponseEvent(text="hello"))
+        await _drain(bus)
+        await bus.stop()
+        assert received == []
+
+    async def test_subscribe_all_receives_every_event(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        received: list[Event] = []
+
+        async def handler(event: Event) -> None:
+            received.append(event)
+
+        bus.subscribe_all(handler)
+        await bus.publish(TurnStartedEvent(surface="web"))
+        await bus.publish(AgentResponseEvent(text="x"))
+        await _drain(bus)
+        await bus.stop()
+        assert len(received) == 2
+
+
+class TestErrorIsolation:
+    async def test_handler_crash_does_not_break_siblings(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        received: list[Event] = []
+
+        async def crashing(_event: Event) -> None:
+            raise RuntimeError("boom")
+
+        async def good(event: Event) -> None:
+            received.append(event)
+
+        bus.subscribe(TurnStartedEvent, crashing)
+        bus.subscribe(TurnStartedEvent, good)
+        await bus.publish(TurnStartedEvent(surface="telegram"))
+        await _drain(bus)
+        await bus.stop()
+        # Sibling fired despite the crashing handler.
+        assert len(received) == 1
+
+    async def test_handler_crash_does_not_kill_consumer(self) -> None:
+        """A crashing handler must not stop the bus from processing the next event."""
+        bus = EventBus()
+        await bus.start()
+        received: list[Event] = []
+
+        async def crashing(_event: Event) -> None:
+            raise RuntimeError("boom")
+
+        async def good(event: Event) -> None:
+            received.append(event)
+
+        bus.subscribe(TurnStartedEvent, crashing)
+        bus.subscribe(AgentResponseEvent, good)
+
+        await bus.publish(TurnStartedEvent(surface="web"))
+        await _drain(bus)
+        await bus.publish(AgentResponseEvent(text="still alive"))
+        await _drain(bus)
+        await bus.stop()
+
+        assert len(received) == 1
+        assert isinstance(received[0], AgentResponseEvent)
+
+
+class TestLifecycle:
+    async def test_start_is_idempotent(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        await bus.start()  # second call must be a no-op
+        await bus.stop()
+
+    async def test_stop_is_idempotent(self) -> None:
+        bus = EventBus()
+        await bus.start()
+        await bus.stop()
+        await bus.stop()  # second call must be a no-op


### PR DESCRIPTION
## Summary

Part **10/15** of the **CCT-integration stack**. Minimal pub/sub so PRs 11 (webhooks) and 12 (scheduler) are clean subscribers, not direct call chains. Tier 3 of the original CCT yoink plan.

## What lands here

- `backend/app/core/event_bus/bus.py` — `Event`, `EventBus`, `EventHandler` types. `subscribe(event_type, handler)` + `publish(event)` with concurrent dispatch via `asyncio.gather(..., return_exceptions=True)` so one handler raising never kills the bus.
- `backend/app/core/event_bus/types.py` — `TurnStartedEvent`, `TurnCompletedEvent`, `WebhookEvent`, `ScheduledEvent`, `AgentResponseEvent`.
- `backend/app/core/event_bus/global_bus.py` — module-level singleton accessor `get_event_bus()` / `set_event_bus()` / `publish_if_available()`. Lets producers fire-and-forget without threading the bus through every call site.
- `backend/app/api/chat.py` + `backend/app/channels/turn_runner.py` — `TurnStartedEvent` published from chat router; `TurnCompletedEvent` published inside `_finalize_turn` so **all surfaces** (web + Telegram) emit it.
- `backend/main.py` lifespan — instantiates `EventBus`, calls `start()`, exposes on `app.state.event_bus`, calls `stop()` on shutdown.
- `backend/tests/test_event_bus.py` — sub/pub, concurrent dispatch, error isolation.

## Stack

01 → ... → 09 → **10 event bus** → 11 → ... → 15

Targets `feat/cct-09-multimodal-images`.

## Verification

- `cd backend && uv run pytest -q backend/tests/test_event_bus.py` — green.
- Smoke: any chat turn fires both `TurnStartedEvent` and `TurnCompletedEvent` (verify via a debug bus subscriber).

Plan: `/root/.claude/plans/i-want-to-integrate-binary-badger.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UeDGJcjTBz8iedhCVASkdo)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Introduces a typed async pub/sub event bus (`EventBus`, `Event`, `EventHandler`) with a single-consumer asyncio queue, module-level singleton accessor, and five concrete event types. `TurnStartedEvent` is published from the chat router; `TurnCompletedEvent` is published from `_finalize_turn` so both web and Telegram surfaces emit lifecycle events.

- **`bus.py`** \u2014 `EventBus` with typed `subscribe`/`subscribe_all`/`publish`, concurrent dispatch via `asyncio.gather(return_exceptions=True)`, and idempotent `start`/`stop`.
- **`global_bus.py`** \u2014 process-wide singleton that lets producers fire events without threading the bus through every call site; no-ops cleanly in test environments.
- **`turn_runner.py` + `chat.py`** \u2014 emit `TurnStartedEvent` before streaming and `TurnCompletedEvent` in `_finalize_turn`'s finally path, covering both success and error outcomes.
</details>


<h3>Confidence Score: 3/5</h3>

Two correctness gaps in the event bus need addressing before the downstream PRs (webhooks, scheduler) build on top of this layer.

The shutdown path in `stop()` cancels the consumer task immediately without draining the queue, so events published during graceful shutdown are silently discarded. Separately, `_finalize_turn` derives `final_status` from `aggregator.error_text` only, so a cancelled turn is always emitted as `"complete"` rather than `"cancelled"`, producing inaccurate data for any subscriber that branches on status.

`backend/app/core/event_bus/bus.py` (shutdown drain) and `backend/app/channels/turn_runner.py` (cancelled-status logic) need attention before this layer is treated as stable.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/app/core/event_bus/bus.py | Core event bus; `stop()` cancels the consumer task without draining the queue first, silently dropping enqueued events at shutdown. |
| backend/app/channels/turn_runner.py | Publishes `TurnCompletedEvent` from `_finalize_turn`; `status` is never set to `"cancelled"` despite the documented third value, causing incorrectly-labelled events for cancelled turns. |
| backend/app/core/event_bus/global_bus.py | Module-level singleton accessor; broad `except Exception` in `publish_if_available` violates the narrowest-catch rule. |
| backend/app/core/event_bus/types.py | Clean typed event vocabulary; dataclass field shadowing of `source` across the hierarchy is intentional and correct. |
| backend/main.py | Lifespan correctly instantiates, starts, exposes, and stops the bus; `set_event_bus(None)` before `stop()` correctly prevents new publishes during teardown. |
| backend/tests/test_event_bus.py | Good coverage of happy path, error isolation, and lifecycle idempotency; `asyncio.get_event_loop()` should be `asyncio.get_running_loop()`. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CR as chat.py (router)
    participant GB as global_bus
    participant EB as EventBus (queue)
    participant CT as consumer task
    participant H as subscriber handlers

    Note over CR: Request arrives
    CR->>GB: publish_if_available(TurnStartedEvent)
    GB->>EB: queue.put(event)
    CR->>CT: run_turn() streams...
    CT-->>CR: chunks yielded
    Note over CR: finally block
    CR->>GB: publish_if_available(TurnCompletedEvent)
    GB->>EB: queue.put(event)
    loop _process_events
        EB->>CT: queue.get() event
        CT->>H: asyncio.gather handlers
        H-->>CT: results logged
    end
    Note over EB: shutdown
    GB->>GB: set_event_bus(None)
    EB->>CT: task.cancel()
    Note over EB: queued events dropped
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/app/channels/turn_runner.py`, line 219 ([link](https://github.com/octaviantocan/pawrrtal-ai/blob/96895773239f6d9024a4543662844c077fcfcfec/backend/app/channels/turn_runner.py#L219)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> `final_status` is only ever `"complete"` or `"failed"` — `"cancelled"` (documented in both the PR description and `TurnCompletedEvent`'s docstring) is never emitted. If a request is cancelled mid-stream (client disconnect, OS signal), the aggregator has no `error_text`, so the event incorrectly reports `status="complete"` rather than `"cancelled"`.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapp%2Fchannels%2Fturn_runner.py%0ALine%3A%20219%0A%0AComment%3A%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-10-event-bus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-10-event-bus%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapp%2Fchannels%2Fturn_runner.py%0ALine%3A%20219%0A%0AComment%3A%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-10-event-bus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-10-event-bus%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapp%2Fchannels%2Fturn_runner.py%0ALine%3A%20219%0A%0AComment%3A%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fbus.py%3A134-143%0A**%60stop%28%29%60%20cancels%20without%20draining%20%E2%80%94%20queued%20events%20are%20silently%20lost**%0A%0AThe%20docstring%20says%20%22Cancel%20the%20consumer%20%2B%20drain%22%20but%20there%20is%20no%20drain.%20Setting%20%60_running%20%3D%20False%60%20then%20immediately%20cancelling%20the%20task%20abandons%20all%20events%20still%20sitting%20in%20%60self._queue%60.%20Any%20%60TurnCompletedEvent%60%20published%20in%20the%20final%20milliseconds%20before%20%60event_bus.stop%28%29%60%20is%20called%20in%20the%20lifespan%20will%20never%20be%20dispatched.%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fchannels%2Fturn_runner.py%3A219%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fglobal_bus.py%3A55-58%0APer%20the%20project's%20Python%20logging%2Fexception%20rule%2C%20broad%20%60except%20Exception%60%20should%20be%20narrowed%20to%20the%20specific%20exception%20types%20that%20can%20actually%20be%20raised.%20%60bus.publish%28%29%60%20only%20calls%20%60asyncio.Queue.put%28%29%60%2C%20which%20raises%20%60asyncio.QueueFull%60%20when%20a%20%60maxsize%60%20is%20set%20%28none%20here%29.%20Narrowing%20the%20catch%20makes%20the%20intent%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20bus.publish%28event%29%0A%20%20%20%20except%20asyncio.QueueFull%3A%0A%20%20%20%20%20%20%20%20logger.exception%28%22EVENTBUS_PUBLISH_FAILED%20event_type%3D%25s%22%2C%20event.event_type%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Ftests%2Ftest_event_bus.py%3A28-34%0A%60asyncio.get_event_loop%28%29%60%20is%20deprecated%20inside%20a%20running%20coroutine%20in%20Python%203.10%2B%3B%20the%20idiomatic%20replacement%20is%20%60asyncio.get_running_loop%28%29%60%2C%20which%20is%20always%20correct%20and%20emits%20no%20deprecation%20warning.%0A%0A%60%60%60suggestion%0Aasync%20def%20_drain%28bus%3A%20EventBus%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Spin%20briefly%20so%20the%20consumer%20task%20picks%20up%20published%20events.%22%22%22%0A%20%20%20%20loop%20%3D%20asyncio.get_running_loop%28%29%0A%20%20%20%20deadline%20%3D%20loop.time%28%29%20%2B%20_DRAIN_DEFAULT_TIMEOUT_S%0A%20%20%20%20while%20bus._queue.qsize%28%29%20%3E%200%3A%0A%20%20%20%20%20%20%20%20if%20loop.time%28%29%20%3E%20deadline%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20await%20asyncio.sleep%28_DRAIN_POLL_INTERVAL_S%29%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-10-event-bus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-10-event-bus%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fbus.py%3A134-143%0A**%60stop%28%29%60%20cancels%20without%20draining%20%E2%80%94%20queued%20events%20are%20silently%20lost**%0A%0AThe%20docstring%20says%20%22Cancel%20the%20consumer%20%2B%20drain%22%20but%20there%20is%20no%20drain.%20Setting%20%60_running%20%3D%20False%60%20then%20immediately%20cancelling%20the%20task%20abandons%20all%20events%20still%20sitting%20in%20%60self._queue%60.%20Any%20%60TurnCompletedEvent%60%20published%20in%20the%20final%20milliseconds%20before%20%60event_bus.stop%28%29%60%20is%20called%20in%20the%20lifespan%20will%20never%20be%20dispatched.%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fchannels%2Fturn_runner.py%3A219%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fglobal_bus.py%3A55-58%0APer%20the%20project's%20Python%20logging%2Fexception%20rule%2C%20broad%20%60except%20Exception%60%20should%20be%20narrowed%20to%20the%20specific%20exception%20types%20that%20can%20actually%20be%20raised.%20%60bus.publish%28%29%60%20only%20calls%20%60asyncio.Queue.put%28%29%60%2C%20which%20raises%20%60asyncio.QueueFull%60%20when%20a%20%60maxsize%60%20is%20set%20%28none%20here%29.%20Narrowing%20the%20catch%20makes%20the%20intent%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20bus.publish%28event%29%0A%20%20%20%20except%20asyncio.QueueFull%3A%0A%20%20%20%20%20%20%20%20logger.exception%28%22EVENTBUS_PUBLISH_FAILED%20event_type%3D%25s%22%2C%20event.event_type%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Ftests%2Ftest_event_bus.py%3A28-34%0A%60asyncio.get_event_loop%28%29%60%20is%20deprecated%20inside%20a%20running%20coroutine%20in%20Python%203.10%2B%3B%20the%20idiomatic%20replacement%20is%20%60asyncio.get_running_loop%28%29%60%2C%20which%20is%20always%20correct%20and%20emits%20no%20deprecation%20warning.%0A%0A%60%60%60suggestion%0Aasync%20def%20_drain%28bus%3A%20EventBus%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Spin%20briefly%20so%20the%20consumer%20task%20picks%20up%20published%20events.%22%22%22%0A%20%20%20%20loop%20%3D%20asyncio.get_running_loop%28%29%0A%20%20%20%20deadline%20%3D%20loop.time%28%29%20%2B%20_DRAIN_DEFAULT_TIMEOUT_S%0A%20%20%20%20while%20bus._queue.qsize%28%29%20%3E%200%3A%0A%20%20%20%20%20%20%20%20if%20loop.time%28%29%20%3E%20deadline%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20await%20asyncio.sleep%28_DRAIN_POLL_INTERVAL_S%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-10-event-bus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-10-event-bus%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fbus.py%3A134-143%0A**%60stop%28%29%60%20cancels%20without%20draining%20%E2%80%94%20queued%20events%20are%20silently%20lost**%0A%0AThe%20docstring%20says%20%22Cancel%20the%20consumer%20%2B%20drain%22%20but%20there%20is%20no%20drain.%20Setting%20%60_running%20%3D%20False%60%20then%20immediately%20cancelling%20the%20task%20abandons%20all%20events%20still%20sitting%20in%20%60self._queue%60.%20Any%20%60TurnCompletedEvent%60%20published%20in%20the%20final%20milliseconds%20before%20%60event_bus.stop%28%29%60%20is%20called%20in%20the%20lifespan%20will%20never%20be%20dispatched.%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fchannels%2Fturn_runner.py%3A219%0A%60final_status%60%20is%20only%20ever%20%60%22complete%22%60%20or%20%60%22failed%22%60%20%E2%80%94%20%60%22cancelled%22%60%20%28documented%20in%20both%20the%20PR%20description%20and%20%60TurnCompletedEvent%60's%20docstring%29%20is%20never%20emitted.%20If%20a%20request%20is%20cancelled%20mid-stream%20%28client%20disconnect%2C%20OS%20signal%29%2C%20the%20aggregator%20has%20no%20%60error_text%60%2C%20so%20the%20event%20incorrectly%20reports%20%60status%3D%22complete%22%60%20rather%20than%20%60%22cancelled%22%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20final_status%20%3D%20%28%0A%20%20%20%20%20%20%20%20%22cancelled%22%0A%20%20%20%20%20%20%20%20if%20aggregator.is_cancelled%0A%20%20%20%20%20%20%20%20else%20%28%22failed%22%20if%20aggregator.error_text%20else%20%22complete%22%29%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Fevent_bus%2Fglobal_bus.py%3A55-58%0APer%20the%20project's%20Python%20logging%2Fexception%20rule%2C%20broad%20%60except%20Exception%60%20should%20be%20narrowed%20to%20the%20specific%20exception%20types%20that%20can%20actually%20be%20raised.%20%60bus.publish%28%29%60%20only%20calls%20%60asyncio.Queue.put%28%29%60%2C%20which%20raises%20%60asyncio.QueueFull%60%20when%20a%20%60maxsize%60%20is%20set%20%28none%20here%29.%20Narrowing%20the%20catch%20makes%20the%20intent%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20bus.publish%28event%29%0A%20%20%20%20except%20asyncio.QueueFull%3A%0A%20%20%20%20%20%20%20%20logger.exception%28%22EVENTBUS_PUBLISH_FAILED%20event_type%3D%25s%22%2C%20event.event_type%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Ftests%2Ftest_event_bus.py%3A28-34%0A%60asyncio.get_event_loop%28%29%60%20is%20deprecated%20inside%20a%20running%20coroutine%20in%20Python%203.10%2B%3B%20the%20idiomatic%20replacement%20is%20%60asyncio.get_running_loop%28%29%60%2C%20which%20is%20always%20correct%20and%20emits%20no%20deprecation%20warning.%0A%0A%60%60%60suggestion%0Aasync%20def%20_drain%28bus%3A%20EventBus%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Spin%20briefly%20so%20the%20consumer%20task%20picks%20up%20published%20events.%22%22%22%0A%20%20%20%20loop%20%3D%20asyncio.get_running_loop%28%29%0A%20%20%20%20deadline%20%3D%20loop.time%28%29%20%2B%20_DRAIN_DEFAULT_TIMEOUT_S%0A%20%20%20%20while%20bus._queue.qsize%28%29%20%3E%200%3A%0A%20%20%20%20%20%20%20%20if%20loop.time%28%29%20%3E%20deadline%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20await%20asyncio.sleep%28_DRAIN_POLL_INTERVAL_S%29%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(event-bus): land PR 10 — async pub/..."](https://github.com/octaviantocan/pawrrtal-ai/commit/96895773239f6d9024a4543662844c077fcfcfec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32389400)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->