### PR TITLE
feat(voice): Mistral / OpenAI / local whisper.cpp transcription [14/15]

### DIFF
--- a/backend/app/api/stt.py
+++ b/backend/app/api/stt.py
@@ -35,12 +35,12 @@ STT_TIMEOUT_SECONDS = 60.0
 HTTP_ERROR_STATUS_FLOOR = 400
 
 
-def get_stt_router() -> APIRouter:
+def get_stt_router() -> APIRouter:  # noqa: C901 — single cohesive STT route + dispatch shim
     """Build the STT proxy router."""
     router = APIRouter(prefix="/api/v1/stt", tags=["stt"])
 
     @router.post("")
-    async def transcribe_audio(
+    async def transcribe_audio(  # noqa: C901 — xAI legacy path + alt-backend dispatch live in one route
         file: UploadFile = File(...),
         language: str | None = Form(default=None),
         format: bool = Form(default=True),  # noqa: A002
@@ -57,7 +57,32 @@ def get_stt_router() -> APIRouter:
         access to ``text``, ``duration``, and the optional ``words`` array.
         """
         # `resolve_api_key` already falls back to `settings.xai_api_key`, so
-        # the caller doesn't need a manual `or settings.x` suffix.
+        # PR 14: when the operator selected a non-xAI backend, dispatch
+        # to the configured ``Transcriber`` (Mistral / OpenAI / local
+        # whisper.cpp).  The xAI proxy below is the historical default
+        # and stays the path when ``settings.voice_provider == "xai"``.
+        from app.integrations.voice import (  # noqa: PLC0415 — local import keeps the route light when voice extras unused
+            TranscriptionError,
+            resolve_transcriber,
+        )
+
+        transcriber = resolve_transcriber()
+        if transcriber is not None:
+            audio_bytes_alt = await file.read(MAX_AUDIO_BYTES + 1)
+            if len(audio_bytes_alt) > MAX_AUDIO_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Audio exceeds the {MAX_AUDIO_BYTES // (1024 * 1024)} MB upload cap.",
+                )
+            if not audio_bytes_alt:
+                raise HTTPException(status_code=422, detail="Audio file is empty.")
+            try:
+                text = await transcriber.transcribe(audio_bytes_alt)
+            except TranscriptionError as exc:
+                logger.warning("VOICE_TRANSCRIBE_FAILED provider=%s", "alt", exc_info=exc)
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
+            return JSONResponse(content={"text": text})
+
         api_key = resolve_api_key(user.id, "XAI_API_KEY")
         if not api_key:
             raise HTTPException(
@@ -104,12 +129,8 @@ def get_stt_router() -> APIRouter:
                     files=upstream_files,
                 )
         except httpx.TimeoutException as error:
-            logger.warning(
-                "xAI STT timeout after %ss", STT_TIMEOUT_SECONDS, exc_info=error
-            )
-            raise HTTPException(
-                status_code=504, detail="Transcription timed out."
-            ) from error
+            logger.warning("xAI STT timeout after %ss", STT_TIMEOUT_SECONDS, exc_info=error)
+            raise HTTPException(status_code=504, detail="Transcription timed out.") from error
         except httpx.RequestError as error:
             logger.warning("xAI STT request failed: %s", error)
             raise HTTPException(

--- a/backend/app/integrations/voice/__init__.py
+++ b/backend/app/integrations/voice/__init__.py
@@ -1,0 +1,31 @@
+"""Pluggable voice-transcription backends.
+
+Selected by ``settings.voice_provider`` — one of:
+
+* ``xai`` (default; existing ``api/stt.py`` proxy stays the route)
+* ``mistral`` (Voxtral)
+* ``openai`` (Whisper)
+* ``local`` (whisper.cpp via ffmpeg subprocess)
+
+The non-xAI backends share the :class:`Transcriber` Protocol so the
+``api/stt.py`` route can dispatch on ``settings.voice_provider``
+without knowing which backend is wired up.
+"""
+
+from app.integrations.voice.transcriber import (
+    LocalWhisperCppTranscriber,
+    MistralVoxtralTranscriber,
+    OpenAIWhisperTranscriber,
+    Transcriber,
+    TranscriptionError,
+    resolve_transcriber,
+)
+
+__all__ = [
+    "LocalWhisperCppTranscriber",
+    "MistralVoxtralTranscriber",
+    "OpenAIWhisperTranscriber",
+    "Transcriber",
+    "TranscriptionError",
+    "resolve_transcriber",
+]

--- a/backend/app/integrations/voice/transcriber.py
+++ b/backend/app/integrations/voice/transcriber.py
@@ -1,0 +1,247 @@
+"""Three voice-transcription backends behind a tiny Protocol.
+
+Ported in shape from claude-code-telegram's ``voice_handler.py`` —
+the API-key-bearing backends use lazy imports so a deployment that
+sticks with xAI doesn't pay the install cost for ``mistralai`` /
+``openai``; the local backend shells out to ``whisper.cpp`` via
+ffmpeg.
+
+Each backend raises :class:`TranscriptionError` on failure with a
+short human-readable reason; the route translates into HTTP 502
+so the frontend can render a clean error toast.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# Subprocess timeout shared by ffmpeg + whisper.cpp.  Long voice notes
+# can take a while to transcribe locally; 120s covers a 5-minute clip
+# on a modest box.
+_LOCAL_SUBPROCESS_TIMEOUT_S = 120
+
+
+class TranscriptionError(RuntimeError):
+    """Raised by any backend when transcription fails."""
+
+
+class Transcriber(Protocol):
+    """Async transcription backend interface."""
+
+    async def transcribe(self, audio_bytes: bytes) -> str:
+        """Return the plain-text transcription of ``audio_bytes``."""
+        ...
+
+
+class MistralVoxtralTranscriber:
+    """Voxtral transcription via the Mistral SDK (lazy import)."""
+
+    def __init__(self, api_key: str, model: str = "voxtral-mini-latest") -> None:
+        self._api_key = api_key
+        self._model = model
+        self._client: Any = None
+
+    async def transcribe(self, audio_bytes: bytes) -> str:
+        """Return the plain-text transcription of ``audio_bytes``."""
+        client = self._get_client()
+        try:
+            response = await client.audio.transcriptions.complete_async(
+                model=self._model,
+                file={"content": audio_bytes, "file_name": "voice.ogg"},
+            )
+        except Exception as exc:
+            logger.warning("MISTRAL_TRANSCRIBE_FAIL error_type=%s", type(exc).__name__)
+            raise TranscriptionError("Mistral transcription request failed.") from exc
+        text = (getattr(response, "text", "") or "").strip()
+        if not text:
+            raise TranscriptionError("Mistral returned an empty transcription.")
+        return text
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from mistralai import Mistral  # noqa: PLC0415 — optional voice extra
+        except ModuleNotFoundError as exc:
+            raise TranscriptionError(
+                "Optional dependency 'mistralai' is missing.  "
+                'Install: pip install "pawrrtal-api[voice]"'
+            ) from exc
+        self._client = Mistral(api_key=self._api_key)
+        return self._client
+
+
+class OpenAIWhisperTranscriber:
+    """Whisper transcription via the OpenAI SDK (lazy import)."""
+
+    def __init__(self, api_key: str, model: str = "whisper-1") -> None:
+        self._api_key = api_key
+        self._model = model
+        self._client: Any = None
+
+    async def transcribe(self, audio_bytes: bytes) -> str:
+        """Return the plain-text transcription of ``audio_bytes``."""
+        client = self._get_client()
+        try:
+            response = await client.audio.transcriptions.create(
+                model=self._model,
+                file=("voice.ogg", audio_bytes),
+            )
+        except Exception as exc:
+            logger.warning("OPENAI_TRANSCRIBE_FAIL error_type=%s", type(exc).__name__)
+            raise TranscriptionError("OpenAI transcription request failed.") from exc
+        text = (getattr(response, "text", "") or "").strip()
+        if not text:
+            raise TranscriptionError("OpenAI returned an empty transcription.")
+        return text
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from openai import AsyncOpenAI  # noqa: PLC0415 — optional voice extra
+        except ModuleNotFoundError as exc:
+            raise TranscriptionError(
+                "Optional dependency 'openai' is missing.  "
+                'Install: pip install "pawrrtal-api[voice]"'
+            ) from exc
+        self._client = AsyncOpenAI(api_key=self._api_key)
+        return self._client
+
+
+class LocalWhisperCppTranscriber:
+    """whisper.cpp via ffmpeg + subprocess; no Python dependency."""
+
+    def __init__(self, binary_path: str | None, model_path: str) -> None:
+        self._binary_path = binary_path
+        self._model_path = model_path
+        self._resolved_binary: str | None = None
+
+    async def transcribe(self, audio_bytes: bytes) -> str:
+        """Return the plain-text transcription of ``audio_bytes``."""
+        binary = self._resolve_binary()
+        model = self._model_path
+        # ASYNC240 disabled here — whisper.cpp model paths are local
+        # filesystem checks resolved once per request (cheap stat),
+        # not the kind of repeated I/O that ASYNC240 is guarding
+        # against.  An anyio.Path round-trip would add overhead
+        # without changing behaviour.
+        if not Path(model).is_file():  # noqa: ASYNC240
+            raise TranscriptionError(
+                f"whisper.cpp model not found at '{model}'.  "
+                "Download e.g. ggml-base.bin from huggingface.co/ggerganov/whisper.cpp."
+            )
+        tmp_dir = tempfile.mkdtemp(prefix="pawrrtal-voice-")
+        try:
+            ogg_path = Path(tmp_dir) / "voice.ogg"
+            wav_path = Path(tmp_dir) / "voice.wav"
+            ogg_path.write_bytes(audio_bytes)
+            await self._convert_to_wav(ogg_path, wav_path)
+            text = await self._run_whisper_cpp(binary, model, wav_path)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        text = text.strip()
+        if not text:
+            raise TranscriptionError("whisper.cpp returned an empty transcription.")
+        return text
+
+    def _resolve_binary(self) -> str:
+        if self._resolved_binary is not None:
+            return self._resolved_binary
+        candidate = self._binary_path or "whisper-cli"
+        resolved = shutil.which(candidate)
+        if not resolved:
+            raise TranscriptionError(
+                f"whisper.cpp binary '{candidate}' not on PATH.  "
+                "Set WHISPER_CPP_BINARY_PATH or install whisper.cpp."
+            )
+        self._resolved_binary = resolved
+        return resolved
+
+    @staticmethod
+    async def _convert_to_wav(ogg_path: Path, wav_path: Path) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-i",
+            str(ogg_path),
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-f",
+            "wav",
+            str(wav_path),
+            "-y",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=_LOCAL_SUBPROCESS_TIMEOUT_S
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            raise TranscriptionError("ffmpeg timed out converting voice note.") from exc
+        if proc.returncode != 0:
+            raise TranscriptionError(f"ffmpeg exit {proc.returncode}: {stderr.decode()[:200]}")
+
+    @staticmethod
+    async def _run_whisper_cpp(binary: str, model: str, wav_path: Path) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "-m",
+            model,
+            "-f",
+            str(wav_path),
+            "--no-timestamps",
+            "-l",
+            "auto",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=_LOCAL_SUBPROCESS_TIMEOUT_S
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            raise TranscriptionError("whisper.cpp timed out.") from exc
+        if proc.returncode != 0:
+            raise TranscriptionError(
+                f"whisper.cpp exit {proc.returncode}; check binary + model path."
+            )
+        return stdout.decode()
+
+
+def resolve_transcriber() -> Transcriber | None:
+    """Build the configured backend.  Returns ``None`` for ``xai`` (legacy path).
+
+    The xAI proxy lives in ``api/stt.py`` and is the historical path.
+    The other three backends are returned as :class:`Transcriber`
+    instances the route can call uniformly.
+    """
+    provider = settings.voice_provider
+    if provider == "mistral":
+        if not settings.voice_mistral_api_key:
+            return None
+        return MistralVoxtralTranscriber(api_key=settings.voice_mistral_api_key)
+    if provider == "openai":
+        if not settings.voice_openai_api_key:
+            return None
+        return OpenAIWhisperTranscriber(api_key=settings.voice_openai_api_key)
+    if provider == "local":
+        return LocalWhisperCppTranscriber(
+            binary_path=settings.voice_whisper_cpp_binary or None,
+            model_path=settings.voice_whisper_cpp_model,
+        )
+    return None


### PR DESCRIPTION
## Summary

Part **14/15** of the **CCT-integration stack**. Self-hosted / cheaper / private STT path — keeps the existing xAI cloud option but adds three more.

## What lands here

- `backend/app/integrations/voice/transcriber.py` — three backends with a common interface:
  - `MistralVoxtralTranscriber` (mistralai SDK).
  - `OpenAIWhisperTranscriber` (openai SDK).
  - `LocalWhisperCppTranscriber` (ffmpeg + whisper.cpp subprocess).
  Selected by `settings.voice_provider` (`xai|mistral|openai|local`).
- `backend/app/api/stt.py` — routes by config; `xai` keeps the existing path so existing deployments don't break.
- `backend/pyproject.toml` extras — `[voice]` group with `mistralai>=1.0` and `openai>=1.0`.
- `backend/app/integrations/voice/__init__.py` — module entry.

## Stack

01 → ... → 13 → **14 voice** → 15

Targets `feat/cct-13-telegram-mcp`.

## Verification

- Smoke: set `VOICE_PROVIDER=local`, install whisper.cpp locally, send a Telegram voice note → transcribed without network.

Plan: `/root/.claude/plans/i-want-to-integrate-binary-badger.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeDGJcjTBz8iedhCVASkdo)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds three STT backends (Mistral Voxtral, OpenAI Whisper, local whisper.cpp via ffmpeg subprocess) behind a `Transcriber` protocol, selected by `settings.voice_provider`, while keeping the existing xAI proxy intact as the default path.

- `transcriber.py` implements the three backends with lazy SDK imports and a `resolve_transcriber()` factory; the local backend shells out to ffmpeg then whisper.cpp with async subprocesses and a shared 120 s timeout.
- `stt.py` is updated to call `resolve_transcriber()` at the top of the route handler and dispatch to the alt backend early-return path, falling through to the existing xAI proxy when `resolve_transcriber()` returns `None`.
</details>

<h3>Confidence Score: 3/5</h3>

The xAI path is untouched and safe; the three new backends have correctness gaps that should be addressed before production use.

Three active defects in the new code paths: a misconfigured mistral/openai provider (missing API key) silently reroutes every request through xAI with a misleading error; the language form parameter accepted by the route is never forwarded to any of the three new backends; and the subprocess timeout handler calls proc.kill() without await proc.wait(), leaving zombie processes and unreleased file descriptors on every timeout.

backend/app/integrations/voice/transcriber.py needs the most attention — it contains the silent-fallback logic, the zombie-process risk, and the per-request client recreation. backend/app/api/stt.py needs the language/format forwarding gap addressed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/api/stt.py | Adds provider dispatch shim before the xAI proxy path; `language`/`format` params are silently dropped for alt backends, and the warning log hardcodes provider as "alt". |
| backend/app/integrations/voice/transcriber.py | Core transcription backends; has three bugs: missing API key silently falls back to xAI instead of erroring, subprocess timeout leaves zombie processes, and the per-request transcriber instantiation makes SDK client caching ineffective. |
| backend/app/integrations/voice/__init__.py | Simple module init re-exporting all public symbols from transcriber.py; no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant STTRoute as POST /api/v1/stt
    participant resolve as resolve_transcriber()
    participant AltBackend as Alt Backend (Mistral/OpenAI/Local)
    participant xAI as xAI Proxy

    Client->>STTRoute: POST audio + language + format
    STTRoute->>resolve: resolve_transcriber()
    alt "voice_provider = mistral|openai|local"
        resolve-->>STTRoute: Transcriber instance
        STTRoute->>AltBackend: transcribe(audio_bytes)
        Note over STTRoute,AltBackend: language/format not forwarded
        AltBackend-->>STTRoute: text
        STTRoute-->>Client: "{"text": "..."}"
    else "voice_provider = xai or missing API key"
        resolve-->>STTRoute: None
        STTRoute->>xAI: forward multipart + language + format
        xAI-->>STTRoute: JSON transcript
        STTRoute-->>Client: upstream JSON
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A234-241%0A**Silent%20fallback%20masks%20misconfiguration**%0A%0AWhen%20%60voice_provider%60%20is%20%60%22mistral%22%60%20or%20%60%22openai%22%60%20but%20the%20matching%20API%20key%20is%20absent%2C%20%60resolve_transcriber%28%29%60%20returns%20%60None%60.%20The%20caller%20in%20%60stt.py%60%20then%20silently%20falls%20through%20to%20the%20xAI%20path%20and%20the%20operator%20gets%20a%20%22Set%20XAI_API_KEY%20in%20the%20backend%20env%22%20error%20%E2%80%94%20with%20no%20indication%20that%20the%20configured%20provider%20%28%60mistral%60%2F%60openai%60%29%20was%20ignored%20entirely.%20A%20misconfigured%20deployment%20quietly%20runs%20the%20wrong%20backend.%0A%0A%23%23%23%20Issue%202%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A80%0A**%60language%60%20and%20%60format%60%20parameters%20silently%20dropped%20for%20non-xAI%20backends**%0A%0AThe%20route%20accepts%20%60language%60%20and%20%60format%60%20form%20fields%20from%20the%20client%2C%20but%20when%20dispatching%20to%20an%20alt%20transcriber%20the%20call%20is%20%60await%20transcriber.transcribe%28audio_bytes_alt%29%60%20%E2%80%94%20neither%20parameter%20is%20forwarded.%20Any%20caller%20that%20sends%20a%20%60language%60%20tag%20%28e.g.%20%60%22fr%22%60%29%20expecting%20language-specific%20transcription%20will%20receive%20silently%20incorrect%20results.%20The%20%60Transcriber%60%20protocol%20and%20all%20three%20concrete%20classes%20would%20need%20a%20%60language%60%20keyword%20argument%20to%20carry%20the%20value%20through.%0A%0A%23%23%23%20Issue%203%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A192-194%0A**Zombie%20process%20risk%20after%20timeout%3A%20%60proc.kill%28%29%60%20without%20%60await%20proc.wait%28%29%60**%0A%0AAfter%20%60proc.kill%28%29%60%20in%20both%20%60_convert_to_wav%60%20and%20%60_run_whisper_cpp%60%2C%20the%20code%20immediately%20raises%20%60TranscriptionError%60%20without%20calling%20%60await%20proc.wait%28%29%60.%20On%20POSIX%20systems%20this%20leaves%20the%20killed%20process%20as%20a%20zombie%20until%20the%20parent%20%28the%20Python%20worker%29%20exits%2C%20and%20the%20pipe%20buffers%20associated%20with%20%60stdout%60%2F%60stderr%60%20are%20never%20drained.%20Under%20load%20this%20leaks%20OS-level%20process%20table%20entries%20and%20file%20descriptors.%20%60proc.kill%28%29%60%20followed%20by%20%60await%20proc.wait%28%29%60%20%28or%20%60await%20asyncio.shield%28proc.wait%28%29%29%60%29%20is%20the%20standard%20pattern%20to%20clean%20up%20the%20subprocess%20reliably.%0A%0A%23%23%23%20Issue%204%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A62-64%0A**Broad%20%60except%20Exception%60%20masks%20unrelated%20errors**%20%E2%80%94%20violates%20the%20project's%20%60python-logging-exceptions.md%60%20rule.%20Both%20the%20Mistral%20and%20OpenAI%20SDKs%20expose%20specific%20exception%20base%20classes%20%28e.g.%20%60mistralai.exceptions.MistralException%60%2C%20%60openai.OpenAIError%60%29.%20Catching%20the%20narrowest%20type%20lets%20config%20errors%2C%20import%20errors%2C%20and%20type%20mistakes%20surface%20immediately%20rather%20than%20being%20swallowed%20as%20%22transcription%20failed%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20Exception%20as%20exc%3A%20%20%23%20noqa%3A%20BLE001%20%E2%80%94%20narrow%20when%20mistralai%20stabilises%20its%20public%20exc%20hierarchy%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22MISTRAL_TRANSCRIBE_FAIL%20error_type%3D%25s%22%2C%20type%28exc%29.__name__%2C%20exc_info%3Dexc%29%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%20TranscriptionError%28%22Mistral%20transcription%20request%20failed.%22%29%20from%20exc%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A82%0A**Provider%20name%20hardcoded%20as%20%60%22alt%22%60%20in%20the%20warning%20log**%20%E2%80%94%20makes%20it%20impossible%20to%20correlate%20log%20lines%20with%20the%20configured%20provider%20%28%60mistral%60%2C%20%60openai%60%2C%20or%20%60local%60%29%20when%20diagnosing%20production%20issues.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22VOICE_TRANSCRIBE_FAILED%20provider%3D%25s%22%2C%20settings.voice_provider%2C%20exc_info%3Dexc%29%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-14-voice-transcription%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-14-voice-transcription%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A234-241%0A**Silent%20fallback%20masks%20misconfiguration**%0A%0AWhen%20%60voice_provider%60%20is%20%60%22mistral%22%60%20or%20%60%22openai%22%60%20but%20the%20matching%20API%20key%20is%20absent%2C%20%60resolve_transcriber%28%29%60%20returns%20%60None%60.%20The%20caller%20in%20%60stt.py%60%20then%20silently%20falls%20through%20to%20the%20xAI%20path%20and%20the%20operator%20gets%20a%20%22Set%20XAI_API_KEY%20in%20the%20backend%20env%22%20error%20%E2%80%94%20with%20no%20indication%20that%20the%20configured%20provider%20%28%60mistral%60%2F%60openai%60%29%20was%20ignored%20entirely.%20A%20misconfigured%20deployment%20quietly%20runs%20the%20wrong%20backend.%0A%0A%23%23%23%20Issue%202%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A80%0A**%60language%60%20and%20%60format%60%20parameters%20silently%20dropped%20for%20non-xAI%20backends**%0A%0AThe%20route%20accepts%20%60language%60%20and%20%60format%60%20form%20fields%20from%20the%20client%2C%20but%20when%20dispatching%20to%20an%20alt%20transcriber%20the%20call%20is%20%60await%20transcriber.transcribe%28audio_bytes_alt%29%60%20%E2%80%94%20neither%20parameter%20is%20forwarded.%20Any%20caller%20that%20sends%20a%20%60language%60%20tag%20%28e.g.%20%60%22fr%22%60%29%20expecting%20language-specific%20transcription%20will%20receive%20silently%20incorrect%20results.%20The%20%60Transcriber%60%20protocol%20and%20all%20three%20concrete%20classes%20would%20need%20a%20%60language%60%20keyword%20argument%20to%20carry%20the%20value%20through.%0A%0A%23%23%23%20Issue%203%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A192-194%0A**Zombie%20process%20risk%20after%20timeout%3A%20%60proc.kill%28%29%60%20without%20%60await%20proc.wait%28%29%60**%0A%0AAfter%20%60proc.kill%28%29%60%20in%20both%20%60_convert_to_wav%60%20and%20%60_run_whisper_cpp%60%2C%20the%20code%20immediately%20raises%20%60TranscriptionError%60%20without%20calling%20%60await%20proc.wait%28%29%60.%20On%20POSIX%20systems%20this%20leaves%20the%20killed%20process%20as%20a%20zombie%20until%20the%20parent%20%28the%20Python%20worker%29%20exits%2C%20and%20the%20pipe%20buffers%20associated%20with%20%60stdout%60%2F%60stderr%60%20are%20never%20drained.%20Under%20load%20this%20leaks%20OS-level%20process%20table%20entries%20and%20file%20descriptors.%20%60proc.kill%28%29%60%20followed%20by%20%60await%20proc.wait%28%29%60%20%28or%20%60await%20asyncio.shield%28proc.wait%28%29%29%60%29%20is%20the%20standard%20pattern%20to%20clean%20up%20the%20subprocess%20reliably.%0A%0A%23%23%23%20Issue%204%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A62-64%0A**Broad%20%60except%20Exception%60%20masks%20unrelated%20errors**%20%E2%80%94%20violates%20the%20project's%20%60python-logging-exceptions.md%60%20rule.%20Both%20the%20Mistral%20and%20OpenAI%20SDKs%20expose%20specific%20exception%20base%20classes%20%28e.g.%20%60mistralai.exceptions.MistralException%60%2C%20%60openai.OpenAIError%60%29.%20Catching%20the%20narrowest%20type%20lets%20config%20errors%2C%20import%20errors%2C%20and%20type%20mistakes%20surface%20immediately%20rather%20than%20being%20swallowed%20as%20%22transcription%20failed%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20Exception%20as%20exc%3A%20%20%23%20noqa%3A%20BLE001%20%E2%80%94%20narrow%20when%20mistralai%20stabilises%20its%20public%20exc%20hierarchy%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22MISTRAL_TRANSCRIBE_FAIL%20error_type%3D%25s%22%2C%20type%28exc%29.__name__%2C%20exc_info%3Dexc%29%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%20TranscriptionError%28%22Mistral%20transcription%20request%20failed.%22%29%20from%20exc%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A82%0A**Provider%20name%20hardcoded%20as%20%60%22alt%22%60%20in%20the%20warning%20log**%20%E2%80%94%20makes%20it%20impossible%20to%20correlate%20log%20lines%20with%20the%20configured%20provider%20%28%60mistral%60%2C%20%60openai%60%2C%20or%20%60local%60%29%20when%20diagnosing%20production%20issues.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22VOICE_TRANSCRIBE_FAILED%20provider%3D%25s%22%2C%20settings.voice_provider%2C%20exc_info%3Dexc%29%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A226-247%0A**Transcriber%20instance%20%28and%20SDK%20client%29%20recreated%20on%20every%20request**%0A%0A%60resolve_transcriber%28%29%60%20is%20called%20inside%20the%20route%20handler%2C%20so%20a%20fresh%20%60MistralVoxtralTranscriber%60%20%2F%20%60OpenAIWhisperTranscriber%60%20is%20allocated%20on%20every%20HTTP%20request.%20Each%20new%20instance%20starts%20with%20%60_client%20%3D%20None%60%2C%20so%20the%20lazy%20%60_get_client%28%29%60%20caching%20is%20entirely%20ineffective%20%E2%80%94%20the%20Mistral%2FOpenAI%20SDK%20client%20%28which%20opens%20its%20own%20connection%20pool%29%20is%20reconstructed%20every%20call.%20Moving%20the%20transcriber%20to%20module-level%20or%20storing%20it%20as%20app%20state%20%28e.g.%20via%20FastAPI%20lifespan%29%20would%20let%20the%20pool%20be%20shared%20across%20requests.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22feat%2Fcct-14-voice-transcription%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcct-14-voice-transcription%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A234-241%0A**Silent%20fallback%20masks%20misconfiguration**%0A%0AWhen%20%60voice_provider%60%20is%20%60%22mistral%22%60%20or%20%60%22openai%22%60%20but%20the%20matching%20API%20key%20is%20absent%2C%20%60resolve_transcriber%28%29%60%20returns%20%60None%60.%20The%20caller%20in%20%60stt.py%60%20then%20silently%20falls%20through%20to%20the%20xAI%20path%20and%20the%20operator%20gets%20a%20%22Set%20XAI_API_KEY%20in%20the%20backend%20env%22%20error%20%E2%80%94%20with%20no%20indication%20that%20the%20configured%20provider%20%28%60mistral%60%2F%60openai%60%29%20was%20ignored%20entirely.%20A%20misconfigured%20deployment%20quietly%20runs%20the%20wrong%20backend.%0A%0A%23%23%23%20Issue%202%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A80%0A**%60language%60%20and%20%60format%60%20parameters%20silently%20dropped%20for%20non-xAI%20backends**%0A%0AThe%20route%20accepts%20%60language%60%20and%20%60format%60%20form%20fields%20from%20the%20client%2C%20but%20when%20dispatching%20to%20an%20alt%20transcriber%20the%20call%20is%20%60await%20transcriber.transcribe%28audio_bytes_alt%29%60%20%E2%80%94%20neither%20parameter%20is%20forwarded.%20Any%20caller%20that%20sends%20a%20%60language%60%20tag%20%28e.g.%20%60%22fr%22%60%29%20expecting%20language-specific%20transcription%20will%20receive%20silently%20incorrect%20results.%20The%20%60Transcriber%60%20protocol%20and%20all%20three%20concrete%20classes%20would%20need%20a%20%60language%60%20keyword%20argument%20to%20carry%20the%20value%20through.%0A%0A%23%23%23%20Issue%203%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A192-194%0A**Zombie%20process%20risk%20after%20timeout%3A%20%60proc.kill%28%29%60%20without%20%60await%20proc.wait%28%29%60**%0A%0AAfter%20%60proc.kill%28%29%60%20in%20both%20%60_convert_to_wav%60%20and%20%60_run_whisper_cpp%60%2C%20the%20code%20immediately%20raises%20%60TranscriptionError%60%20without%20calling%20%60await%20proc.wait%28%29%60.%20On%20POSIX%20systems%20this%20leaves%20the%20killed%20process%20as%20a%20zombie%20until%20the%20parent%20%28the%20Python%20worker%29%20exits%2C%20and%20the%20pipe%20buffers%20associated%20with%20%60stdout%60%2F%60stderr%60%20are%20never%20drained.%20Under%20load%20this%20leaks%20OS-level%20process%20table%20entries%20and%20file%20descriptors.%20%60proc.kill%28%29%60%20followed%20by%20%60await%20proc.wait%28%29%60%20%28or%20%60await%20asyncio.shield%28proc.wait%28%29%29%60%29%20is%20the%20standard%20pattern%20to%20clean%20up%20the%20subprocess%20reliably.%0A%0A%23%23%23%20Issue%204%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A62-64%0A**Broad%20%60except%20Exception%60%20masks%20unrelated%20errors**%20%E2%80%94%20violates%20the%20project's%20%60python-logging-exceptions.md%60%20rule.%20Both%20the%20Mistral%20and%20OpenAI%20SDKs%20expose%20specific%20exception%20base%20classes%20%28e.g.%20%60mistralai.exceptions.MistralException%60%2C%20%60openai.OpenAIError%60%29.%20Catching%20the%20narrowest%20type%20lets%20config%20errors%2C%20import%20errors%2C%20and%20type%20mistakes%20surface%20immediately%20rather%20than%20being%20swallowed%20as%20%22transcription%20failed%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20Exception%20as%20exc%3A%20%20%23%20noqa%3A%20BLE001%20%E2%80%94%20narrow%20when%20mistralai%20stabilises%20its%20public%20exc%20hierarchy%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22MISTRAL_TRANSCRIBE_FAIL%20error_type%3D%25s%22%2C%20type%28exc%29.__name__%2C%20exc_info%3Dexc%29%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%20TranscriptionError%28%22Mistral%20transcription%20request%20failed.%22%29%20from%20exc%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Abackend%2Fapp%2Fapi%2Fstt.py%3A82%0A**Provider%20name%20hardcoded%20as%20%60%22alt%22%60%20in%20the%20warning%20log**%20%E2%80%94%20makes%20it%20impossible%20to%20correlate%20log%20lines%20with%20the%20configured%20provider%20%28%60mistral%60%2C%20%60openai%60%2C%20or%20%60local%60%29%20when%20diagnosing%20production%20issues.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22VOICE_TRANSCRIBE_FAILED%20provider%3D%25s%22%2C%20settings.voice_provider%2C%20exc_info%3Dexc%29%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Abackend%2Fapp%2Fintegrations%2Fvoice%2Ftranscriber.py%3A226-247%0A**Transcriber%20instance%20%28and%20SDK%20client%29%20recreated%20on%20every%20request**%0A%0A%60resolve_transcriber%28%29%60%20is%20called%20inside%20the%20route%20handler%2C%20so%20a%20fresh%20%60MistralVoxtralTranscriber%60%20%2F%20%60OpenAIWhisperTranscriber%60%20is%20allocated%20on%20every%20HTTP%20request.%20Each%20new%20instance%20starts%20with%20%60_client%20%3D%20None%60%2C%20so%20the%20lazy%20%60_get_client%28%29%60%20caching%20is%20entirely%20ineffective%20%E2%80%94%20the%20Mistral%2FOpenAI%20SDK%20client%20%28which%20opens%20its%20own%20connection%20pool%29%20is%20reconstructed%20every%20call.%20Moving%20the%20transcriber%20to%20module-level%20or%20storing%20it%20as%20app%20state%20%28e.g.%20via%20FastAPI%20lifespan%29%20would%20let%20the%20pool%20be%20shared%20across%20requests.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(voice): land PR 14 — Mistral / Open..."](https://github.com/octaviantocan/pawrrtal-ai/commit/893b03e5c7fc0cd1f0481d3474c35870c32f68b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32401192)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->