### PR TITLE
refactor(frontend): invert lib ↔ features/chat type direction

### DIFF
--- a/frontend/features/chat/types.ts
+++ b/frontend/features/chat/types.ts
@@ -8,9 +8,25 @@
  * {@link import('@/lib/types').ChatMessage} that the UI can render —
  * reasoning panel above the body, chronologically-ordered tool rows, source
  * chips, and a reply-action toolbar.
+ *
+ * The generic message-shape types (`ChatToolCallBase`, `ChatTimelineEntry`,
+ * `AssistantMessageStatus`, `ChatArtifactPayload`, `ChatToolCallStatus`)
+ * live in `@/lib/types` so the chat layer doesn't sit above its own data
+ * model. We re-export them here so existing importers (`chat-reducer`,
+ * `AssistantMessage`, the artifact components) keep working without
+ * rewriting their imports.
  */
 
+import type {
+	AssistantMessageStatus,
+	ChatArtifactPayload,
+	ChatTimelineEntry,
+	ChatToolCallBase,
+	ChatToolCallStatus,
+} from '@/lib/types';
 import type { CalendarEventInfo, MemoryResultInfo, WebSourceInfo } from './tool-result-parsers';
+
+export type { AssistantMessageStatus, ChatArtifactPayload, ChatTimelineEntry, ChatToolCallStatus };
 
 /** Plain text chunk from the assistant's main response. */
 export interface ChatDeltaEvent {
@@ -58,35 +74,6 @@ export interface ChatAgentTerminatedEvent {
 	content: string;
 }
 
-/**
- * Structured `render_artifact` payload — emitted as a sibling of the
- * matching `tool_use` so the frontend can render an inline preview card
- * without round-tripping the spec back through the LLM. The catalog of
- * allowed component `type` strings is enforced inside the renderer
- * (see {@link ./artifacts/components}); unknown names render a
- * fallback placeholder rather than the model's free text.
- */
-export interface ChatArtifactPayload {
-	/** Server-minted id, e.g. `art_3f9b2e1a8c01`. */
-	id: string;
-	/** Short label shown on the preview card and dialog header. */
-	title: string;
-	/** json-render flat-spec object — `{ root, elements }`. */
-	spec: {
-		root: string;
-		elements: Record<
-			string,
-			{
-				type: string;
-				props?: Record<string, unknown>;
-				children?: string[];
-			}
-		>;
-	};
-	/** The originating tool_use_id; useful for correlating with chain-of-thought. */
-	tool_use_id: string;
-}
-
 /** Sibling event emitted whenever the agent calls `render_artifact`. */
 export interface ChatArtifactEvent {
 	type: 'artifact';
@@ -103,27 +90,15 @@ export type ChatStreamEvent =
 	| ChatErrorEvent
 	| ChatAgentTerminatedEvent;
 
-/** Lifecycle of a single tool invocation as observed from the SSE stream. */
-export type ChatToolCallStatus = 'pending' | 'completed' | 'failed';
-
 /**
- * A tool invocation captured during streaming.
+ * A tool invocation captured during streaming, enriched with pre-parsed
+ * source chips so the renderer doesn't reparse `result` on every frame.
  *
- * Starts as `pending` when the assistant emits a `tool_use` event and flips
- * to `completed` once the matching `tool_result` arrives. Carries pre-parsed
- * source chips so the renderer doesn't reparse on every frame.
+ * Extends the transport-level {@link ChatToolCallBase} from `@/lib/types`
+ * — assignable into `AgnoMessage.tool_calls` (which uses the base type)
+ * while the chat reducer and renderer keep using the richer fields.
  */
-export interface ChatToolCall {
-	/** Stable id supplied by the backend (`tool_use.id`) — used to match results. */
-	id: string;
-	/** Tool name as declared by the assistant. */
-	name: string;
-	/** Input arguments the assistant passed to the tool. */
-	input: Record<string, unknown>;
-	/** Tool result text (only present once the tool has finished). */
-	result?: string;
-	/** Whether the result has arrived yet. */
-	status: ChatToolCallStatus;
+export interface ChatToolCall extends ChatToolCallBase {
 	/** Web result chips parsed from `result` for `web_search`. */
 	webSources?: WebSourceInfo[];
 	/** Calendar event chips parsed from `result` for `calendar_search`. */
@@ -131,20 +106,3 @@ export interface ChatToolCall {
 	/** Memory chips parsed from `result` for memory-flavoured tools. */
 	memoryResults?: MemoryResultInfo[];
 }
-
-/**
- * One slot in the chain-of-thought timeline.
- *
- * The container records every thinking burst and tool invocation in arrival
- * order so the chain-of-thought view can render them chronologically instead
- * of bucketing all thinking text above all tool steps.
- */
-export type ChatTimelineEntry =
-	| { kind: 'thinking'; text: string }
-	| { kind: 'tool'; toolCallId: string };
-
-/**
- * Whether an assistant message is currently failed (so the UI can offer a
- * retry button) — separate from `status` on individual tool calls.
- */
-export type AssistantMessageStatus = 'streaming' | 'complete' | 'failed';

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,11 +1,81 @@
 /**
  * Shared TypeScript type definitions for conversations, messages, and sidebar items.
  *
- * @fileoverview Types consumed by both the sidebar and the chat view.
+ * @fileoverview Types consumed by both the sidebar and the chat view. The
+ * message-streaming types below (`ChatToolCallBase`, `ChatTimelineEntry`,
+ * `AssistantMessageStatus`, `ChatArtifactPayload`) live here so that
+ * `ChatMessage` can describe its streaming-only fields without `lib/`
+ * reaching upward into `features/chat/`. Feature-internal extensions —
+ * parsed source chips, json-render specs at runtime — stay in
+ * `features/chat/types.ts` and extend these base types.
  */
 
 /** The role of a message sender: human user, AI assistant, or a plan artifact. */
 export type MessageRole = 'user' | 'assistant' | 'plan';
+
+/** Lifecycle of an assistant turn — drives the failed-state UI. */
+export type AssistantMessageStatus = 'streaming' | 'complete' | 'failed';
+
+/** Lifecycle of a single tool invocation as observed from the SSE stream. */
+export type ChatToolCallStatus = 'pending' | 'completed' | 'failed';
+
+/**
+ * The transport-level shape of a tool invocation, without any parsed-source
+ * denormalisations. `features/chat/types.ts` extends this with `webSources`
+ * etc. for tool-specific chip rendering.
+ */
+export interface ChatToolCallBase {
+	/** Stable id supplied by the backend (`tool_use.id`) — used to match results. */
+	id: string;
+	/** Tool name as declared by the assistant. */
+	name: string;
+	/** Input arguments the assistant passed to the tool. */
+	input: Record<string, unknown>;
+	/** Tool result text (only present once the tool has finished). */
+	result?: string;
+	/** Whether the result has arrived yet. */
+	status: ChatToolCallStatus;
+}
+
+/**
+ * One slot in the chain-of-thought timeline.
+ *
+ * The container records every thinking burst and tool invocation in arrival
+ * order so the chain-of-thought view can render them chronologically instead
+ * of bucketing all thinking text above all tool steps.
+ */
+export type ChatTimelineEntry =
+	| { kind: 'thinking'; text: string }
+	| { kind: 'tool'; toolCallId: string };
+
+/**
+ * Structured `render_artifact` payload — emitted as a sibling of the
+ * matching `tool_use` so the frontend can render an inline preview card
+ * without round-tripping the spec back through the LLM. The catalog of
+ * allowed component `type` strings is enforced inside the chat renderer;
+ * unknown names render a fallback placeholder rather than the model's free
+ * text.
+ */
+export interface ChatArtifactPayload {
+	/** Server-minted id, e.g. `art_3f9b2e1a8c01`. */
+	id: string;
+	/** Short label shown on the preview card and dialog header. */
+	title: string;
+	/** json-render flat-spec object — `{ root, elements }`. */
+	spec: {
+		root: string;
+		elements: Record<
+			string,
+			{
+				type: string;
+				props?: Record<string, unknown>;
+				children?: string[];
+			}
+		>;
+	};
+	/** The originating tool_use_id; useful for correlating with chain-of-thought. */
+	tool_use_id: string;
+}
 
 /** Structured label attached to a conversation (e.g. status tags, categories). */
 export type ConversationLabel = {
@@ -102,7 +172,10 @@ export interface Project {
  * `thinking_started_at`, `thinking_duration_seconds`, `assistant_status`) are
  * optional so that history fetched from the server (which only persists
  * `role` + `content`) hydrates unchanged; they're populated live during
- * streaming by {@link import('@/features/chat/ChatContainer').default}.
+ * streaming by the chat container in `features/chat/`. `tool_calls` is
+ * typed against the transport-level `ChatToolCallBase`; the chat feature
+ * extends this with parsed source chips (`webSources`, etc.) that the
+ * renderer reads from feature-internal context.
  */
 export interface ChatMessage {
 	/** Sender of the message. Excludes `'plan'` from {@link MessageRole}. */
@@ -112,18 +185,18 @@ export interface ChatMessage {
 	/** Accumulated reasoning text from `thinking` SSE events on the assistant turn. */
 	thinking?: string;
 	/** Tool invocations and their results captured during streaming. */
-	tool_calls?: import('@/features/chat/types').ChatToolCall[];
+	tool_calls?: ChatToolCallBase[];
 	/** Arrival-ordered timeline of thinking bursts and tool invocations. */
-	timeline?: import('@/features/chat/types').ChatTimelineEntry[];
+	timeline?: ChatTimelineEntry[];
 	/** Wall-clock millis when the first thinking/tool/delta event landed. */
 	thinking_started_at?: number;
 	/** Total reasoning duration in whole seconds — set when streaming completes. */
 	thinking_duration_seconds?: number;
 	/** Lifecycle of the assistant turn — drives the failed-state UI. */
-	assistant_status?: import('@/features/chat/types').AssistantMessageStatus;
+	assistant_status?: AssistantMessageStatus;
 	/**
 	 * Artifacts the agent rendered during this turn (one per `render_artifact`
 	 * tool call). v0 lives on the in-memory message only — reload drops them.
 	 */
-	artifacts?: import('@/features/chat/types').ChatArtifactPayload[];
+	artifacts?: ChatArtifactPayload[];
 }


### PR DESCRIPTION
**Stack: 3 / 10** — base `claude/sentrux-02-extract-base` (PR #223)

`frontend/lib/types.ts` previously declared `ChatMessage.tool_calls`,
`.timeline`, `.assistant_status`, and `.artifacts` with JSDoc-style
`import('@/features/chat/types').X` references. Those upward edges (lib
order 4 → features order 1) violated the sentrux layer rule in spirit:
the foundational types module reaching into a feature for its own type
definitions. Static SCC analysis surfaced a 16-file tangle around the
chat module rooted in this back-edge.

## What changes

Moves four generic message-shape types DOWN into `lib/types.ts`:

- `AssistantMessageStatus` — `'streaming' | 'complete' | 'failed'`
- `ChatToolCallStatus` — `'pending' | 'completed' | 'failed'`
- `ChatToolCallBase` — transport-level tool-call shape (id, name, input, result, status)
- `ChatTimelineEntry` — `{ kind: 'thinking' | 'tool', ... }`
- `ChatArtifactPayload` — render_artifact spec

`features/chat/types.ts` keeps the parsed-source-rich `ChatToolCall`
(extends `ChatToolCallBase` with `webSources` / `calendarEvents` /
`memoryResults` from `tool-result-parsers.ts`), and re-exports the
moved types so existing importers keep working unchanged.

`ChatMessage.tool_calls` is now typed as `ChatToolCallBase[]`. The chat
reducer stores `ChatToolCall` (the richer subtype) and the assignment
is structurally fine — extra optional fields are allowed.

## Score impact

Sentrux's runtime-only edge counting doesn't see JSDoc / type-position
imports, so the quality_signal stays at 6912. This PR is **architectural
correctness, not a score-mover** — the static SCC my own import-graph
analysis caught is gone, and `lib/` no longer claims a type it can't
actually reach without reaching upward.

## Verification

- `cd frontend && bun run typecheck` — clean.
- `cd frontend && bun run test features/chat/` — 56 / 56 pass.
- `cd frontend && bun run arch:check` — green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGNvy9RyjAuRDDKZU18Ts)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR inverts the dependency direction between `lib/types.ts` and `features/chat/types.ts`: four generic streaming types (`AssistantMessageStatus`, `ChatToolCallStatus`, `ChatToolCallBase`, `ChatTimelineEntry`, `ChatArtifactPayload`) move down into `lib/types.ts`, eliminating the upward JSDoc `import('@/features/chat/types').X` expressions that had `lib/` reaching into a feature layer.

- `ChatMessage.tool_calls` is re-typed from `ChatToolCall[]` to `ChatToolCallBase[]`; the richer `ChatToolCall` (with `webSources`, `calendarEvents`, `memoryResults`) still lives in `features/chat/` and extends the base, keeping assignments structurally sound.
- All four moved types are re-exported from `features/chat/types.ts` so existing importers (`chat-reducer`, `AssistantMessage`, artifact components) require no import-path changes.
- Verified clean: `bun run typecheck`, 56/56 feature tests, `arch:check`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure type-level reorganisation with no runtime behaviour changes, confirmed by typecheck, 56/56 tests, and arch:check all passing.

Both changed files are TypeScript type-declaration files with no runtime code. The moved types are structurally identical to what existed before; ChatToolCall extends ChatToolCallBase is a sound subtype relationship; re-exports preserve all existing import paths; and the verified toolchain output leaves no open correctness concerns.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/lib/types.ts | Adds five base streaming types (AssistantMessageStatus, ChatToolCallStatus, ChatToolCallBase, ChatTimelineEntry, ChatArtifactPayload) that previously lived in features/chat/types.ts; ChatMessage.tool_calls now typed against the transport-level base. JSDoc inline imports removed. |
| frontend/features/chat/types.ts | Removes the four now-moved type definitions; imports them from @/lib/types and re-exports AssistantMessageStatus, ChatArtifactPayload, ChatTimelineEntry, ChatToolCallStatus so existing importers require no path changes. ChatToolCall now extends ChatToolCallBase rather than redeclaring shared fields. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant lib as lib/types.ts
    participant feat as features/chat/types.ts
    participant reducer as chat-reducer
    participant ui as AssistantMessage / Artifact components

    note over lib: Defines base types:<br/>ChatToolCallBase, ChatTimelineEntry,<br/>AssistantMessageStatus, ChatArtifactPayload,<br/>ChatToolCallStatus

    lib-->>feat: "import type { ChatToolCallBase, … }"
    note over feat: Extends base:<br/>ChatToolCall extends ChatToolCallBase<br/>Adds webSources / calendarEvents / memoryResults

    feat-->>feat: "re-export AssistantMessageStatus,<br/>ChatArtifactPayload,<br/>ChatTimelineEntry,<br/>ChatToolCallStatus"

    reducer->>feat: "import { ChatToolCall }"
    reducer->>lib: stores ChatMessage with tool_calls: ChatToolCallBase[]
    note over reducer: Assigns ChatToolCall[] → ChatToolCallBase[]<br/>(structurally safe, extra fields are optional)

    ui->>feat: "import { ChatToolCall, AssistantMessageStatus, … }"
    note over ui: No import path changes needed<br/>due to re-exports
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(frontend): invert lib ↔ feature..."](https://github.com/octaviantocan/pawrrtal-ai/commit/37c02498f1ab1513a0061fb251b86efba325cbf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32421717)</sub>

<!-- /greptile_comment -->