### PR TITLE
refactor(frontend): hoist CONVERSATION_DRAG_MIME → lib/conversations/drag

### DIFF
--- a/frontend/features/nav-chats/components/ConversationSidebarItemView.tsx
+++ b/frontend/features/nav-chats/components/ConversationSidebarItemView.tsx
@@ -22,7 +22,7 @@ import { EntityRow } from '@/components/ui/entity-row';
 import { useMenuComponents } from '@/components/ui/menu-context';
 import { SidebarMenuItem } from '@/components/ui/sidebar';
 import { NAV_CHATS_LABELS } from '@/features/nav-chats/constants';
-import { CONVERSATION_DRAG_MIME } from '@/features/projects/constants';
+import { CONVERSATION_DRAG_MIME } from '@/lib/conversations/drag';
 import { TOAST_IDS, toast } from '@/lib/toast';
 import type { ConversationStatus } from '@/lib/types';
 import { ConversationStatusGlyph, STATUS_SUBMENU } from './ConversationStatusGlyph';

--- a/frontend/features/projects/components/ProjectRow.test.tsx
+++ b/frontend/features/projects/components/ProjectRow.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { CONVERSATION_DRAG_MIME } from '../constants';
+import { CONVERSATION_DRAG_MIME } from '@/lib/conversations/drag';
 import { ProjectRow } from './ProjectRow';
 
 describe('ProjectRow', () => {

--- a/frontend/features/projects/components/ProjectRow.tsx
+++ b/frontend/features/projects/components/ProjectRow.tsx
@@ -4,8 +4,8 @@ import { Folder, Pencil } from 'lucide-react';
 import type * as React from 'react';
 import { useState } from 'react';
 import { SidebarNavRow } from '@/components/ui/sidebar-nav-row';
+import { CONVERSATION_DRAG_MIME } from '@/lib/conversations/drag';
 import { cn } from '@/lib/utils';
-import { CONVERSATION_DRAG_MIME } from '../constants';
 
 /** Props for {@link ProjectRow}. */
 export interface ProjectRowProps {

--- a/frontend/features/projects/constants.test.ts
+++ b/frontend/features/projects/constants.test.ts
@@ -1,15 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { CONVERSATION_DRAG_MIME, PROJECTS_STORAGE_KEYS } from './constants';
+import { PROJECTS_STORAGE_KEYS } from './constants';
 
 describe('projects constants', () => {
 	it('uses the project-namespaced collapsed-projects key', () => {
 		expect(PROJECTS_STORAGE_KEYS.collapsedProjects).toBe('projects:collapsed');
-	});
-
-	it('publishes a unique custom MIME type for the chat drag payload', () => {
-		expect(CONVERSATION_DRAG_MIME).toBe('application/x-pawrrtal-conversation');
-		// The MIME type must NOT collide with anything the browser uses by
-		// default for plain text / URI drags — assert the prefix.
-		expect(CONVERSATION_DRAG_MIME.startsWith('application/')).toBe(true);
 	});
 });

--- a/frontend/features/projects/constants.ts
+++ b/frontend/features/projects/constants.ts
@@ -1,8 +1,10 @@
 /**
  * Constants for the projects feature.
  *
- * Keeps the localStorage key namespace + the mime type used by the
- * sidebar drag-and-drop in one place so renames don't drift across files.
+ * The conversation drag MIME used to live here too, but it's consumed by
+ * both `features/nav-chats/` (drag source) and `features/projects/` (drop
+ * target). It now lives at `@/lib/conversations/drag` to avoid a
+ * cross-feature edge.
  */
 
 /** localStorage keys owned by the projects feature. */
@@ -13,10 +15,3 @@ export const PROJECTS_STORAGE_KEYS = {
 
 /** Union of every recognized projects `localStorage` key. */
 export type ProjectsStorageKey = (typeof PROJECTS_STORAGE_KEYS)[keyof typeof PROJECTS_STORAGE_KEYS];
-
-/**
- * MIME type used in the HTML5 drag-and-drop dataTransfer when a chat row
- * is being dragged onto a project. Custom string so the drop target can
- * tell our payload apart from arbitrary text/uri-list drags.
- */
-export const CONVERSATION_DRAG_MIME = 'application/x-pawrrtal-conversation';

--- a/frontend/lib/conversations/drag.test.ts
+++ b/frontend/lib/conversations/drag.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { CONVERSATION_DRAG_MIME } from './drag';
+
+describe('conversation drag MIME', () => {
+	it('publishes a unique custom MIME type for the chat drag payload', () => {
+		expect(CONVERSATION_DRAG_MIME).toBe('application/x-pawrrtal-conversation');
+		// The MIME type must NOT collide with anything the browser uses by
+		// default for plain text / URI drags — assert the prefix.
+		expect(CONVERSATION_DRAG_MIME.startsWith('application/')).toBe(true);
+	});
+});

--- a/frontend/lib/conversations/drag.ts
+++ b/frontend/lib/conversations/drag.ts
@@ -1,0 +1,15 @@
+/**
+ * Conversation drag-and-drop constants.
+ *
+ * @fileoverview Lives in `lib/` (not under any feature) because both
+ * `features/nav-chats/` (drag source) and `features/projects/` (drop
+ * target) need it. Putting it under either feature would create a
+ * cross-feature edge.
+ */
+
+/**
+ * MIME type used in the HTML5 drag-and-drop `dataTransfer` when a chat
+ * row is being dragged onto a project. Custom string so the drop target
+ * can tell our payload apart from arbitrary `text/uri-list` drags.
+ */
+export const CONVERSATION_DRAG_MIME = 'application/x-pawrrtal-conversation';


### PR DESCRIPTION
**Stack: 5 / 10** — base `claude/sentrux-04-promote-personalization` (PR #226)

Bean `pawrrtal-q8p8` Stage A. The drag-and-drop MIME was declared in
`features/projects/constants.ts` but consumed by
`features/nav-chats/components/ConversationSidebarItemView.tsx` (the
drag source). One feature reaching into another for a shared
protocol-level constant.

## What changes

- New: `frontend/lib/conversations/drag.ts` — owns the constant.
- New: `frontend/lib/conversations/drag.test.ts` — moved MIME-specific
  test case.
- `features/projects/constants.ts` — drops the constant (no
  re-export shim, per bean intent).
- `features/projects/constants.test.ts` — drops the MIME test.
- 3 importer sites rewritten to `@/lib/conversations/drag`:
  `features/projects/components/ProjectRow.tsx`, its test, and
  `features/nav-chats/components/ConversationSidebarItemView.tsx`.

Stage B (extract `chat-activity-context` +
`use-conversation-mutations` to `lib/conversations/`) is deferred.

## Verification

- `cd frontend && bun run typecheck` + `bun run arch:check` — clean.
- 13 tests / 4 files across `features/projects`, `features/nav-chats`,
  `lib/conversations` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGNvy9RyjAuRDDKZU18Ts)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized drag-and-drop related definitions to a centralized module for improved code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OctavianTocan/Pawrrtal-AI/pull/227)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hoists `CONVERSATION_DRAG_MIME` from `features/projects/constants.ts` into a new shared module `lib/conversations/drag.ts`, eliminating a cross-feature dependency where `features/nav-chats/` was reaching into `features/projects/` for a protocol-level constant.

- New `lib/conversations/drag.ts` owns the constant with clear ownership rationale; its dedicated test file (`drag.test.ts`) carries over the MIME-validation assertions previously in `features/projects/constants.test.ts`.
- All three consumer import sites (`ProjectRow.tsx`, `ProjectRow.test.tsx`, `ConversationSidebarItemView.tsx`) are updated; no stale references remain, and no re-export shim is left in `constants.ts`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a constant relocation with no runtime behaviour change.

Every consumer import site is updated, no stale reference to `features/projects/constants` remains, and test coverage for the constant travels with it to the new module. The refactoring is mechanical and self-contained.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/lib/conversations/drag.ts | New shared module that owns `CONVERSATION_DRAG_MIME`; well-documented rationale, clean single-export file. |
| frontend/lib/conversations/drag.test.ts | MIME constant test moved from `features/projects/constants.test.ts`; assertions are identical and coverage is preserved. |
| frontend/features/projects/constants.ts | Drops `CONVERSATION_DRAG_MIME` export and updates the file docblock; remaining `PROJECTS_STORAGE_KEYS` constant is untouched. |
| frontend/features/projects/constants.test.ts | MIME test case removed; remaining `PROJECTS_STORAGE_KEYS` test is intact and coverage still lives in `drag.test.ts`. |
| frontend/features/projects/components/ProjectRow.tsx | Import updated from `../constants` to `@/lib/conversations/drag`; no functional change. |
| frontend/features/projects/components/ProjectRow.test.tsx | Import updated to match the new module location; test logic is unchanged. |
| frontend/features/nav-chats/components/ConversationSidebarItemView.tsx | Import corrected from `@/features/projects/constants` to `@/lib/conversations/drag`; removes the cross-feature dependency that motivated this PR. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["features/nav-chats/\nConversationSidebarItemView.tsx\n(drag source)"] -->|"imports CONVERSATION_DRAG_MIME"| C
    B["features/projects/\nProjectRow.tsx\n(drop target)"] -->|"imports CONVERSATION_DRAG_MIME"| C
    C["lib/conversations/drag.ts\n(new shared constant)"]

    style C fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(frontend): hoist CONVERSATION\_D..."](https://github.com/octaviantocan/pawrrtal-ai/commit/f2e52dc764611191c581adc4d125f2105794f598) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32423780)</sub>

<!-- /greptile_comment -->