### PR TITLE
refactor(frontend): move WhimsySettingsCard to settings/sections to kill back-edge

### DIFF
--- a/frontend/features/settings/sections/AppearanceSection.tsx
+++ b/frontend/features/settings/sections/AppearanceSection.tsx
@@ -20,7 +20,6 @@
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { SelectButton, type SelectButtonOption } from '@/components/ui/select-button';
-import { WhimsySettingsCard } from '@/features/whimsy';
 import { cn } from '@/lib/utils';
 import {
 	SettingsCard,
@@ -50,6 +49,7 @@ import {
 	THEME_PRESETS,
 	type ThemeMode,
 } from './appearance-helpers';
+import { WhimsySettingsCard } from './WhimsySettingsCard';
 
 /** Top-of-card theme-mode switcher (visual-only). */
 function ThemeModeToggle({

--- a/frontend/features/settings/sections/WhimsySettingsCard.tsx
+++ b/frontend/features/settings/sections/WhimsySettingsCard.tsx
@@ -23,16 +23,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { SelectButton, type SelectButtonOption } from '@/components/ui/select-button';
 import {
-	SettingsCard,
-	SettingsRow,
-	SettingsSectionHeader,
-	Slider,
-	Switch,
-} from '@/features/settings/primitives';
-import { cn } from '@/lib/utils';
-import { WHIMSY_PRESETS, whimsyPresetUrl } from '@/lib/whimsy-presets';
-import { WHIMSY_THEMES, type WhimsyThemeName } from '@/lib/whimsy-tile';
-import {
 	DEFAULT_WHIMSY_CONFIG,
 	isWhimsyThemeName,
 	OPACITY_SLIDER_DIVISOR,
@@ -42,7 +32,11 @@ import {
 	type WhimsyColor,
 	type WhimsyConfig,
 	type WhimsyMode,
-} from './config';
+} from '@/features/whimsy/config';
+import { cn } from '@/lib/utils';
+import { WHIMSY_PRESETS, whimsyPresetUrl } from '@/lib/whimsy-presets';
+import { WHIMSY_THEMES, type WhimsyThemeName } from '@/lib/whimsy-tile';
+import { SettingsCard, SettingsRow, SettingsSectionHeader, Slider, Switch } from '../primitives';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Module-local labels + options

--- a/frontend/features/whimsy/index.tsx
+++ b/frontend/features/whimsy/index.tsx
@@ -3,27 +3,32 @@
  *
  * Re-exports the public surface of the whimsy feature so callers can
  * import from `@/features/whimsy` without reaching into the internal
- * file layout.  Consumers today:
+ * file layout. Consumers today:
  *
- *   - {@link useWhimsyTile}     — `frontend/features/chat/ChatView.tsx`,
- *                                 `frontend/features/settings/SettingsLayout.tsx`
- *   - {@link WhimsySettingsCard} — `frontend/features/settings/sections/AppearanceSection.tsx`
+ *   - {@link useWhimsyTile}    — `frontend/features/chat/ChatView.tsx`,
+ *                                `frontend/features/settings/SettingsLayout.tsx`
+ *   - {@link useWhimsyConfig}  — `frontend/features/settings/sections/WhimsySettingsCard.tsx`
+ *   - {@link WhimsyConfig}/{@link WhimsyMode}/{@link WhimsyColor} — same
+ *
+ * `WhimsySettingsCard` previously lived here, which created a back-edge
+ * (whimsy importing from settings/primitives + settings importing back
+ * from whimsy). It now lives in `features/settings/sections/` and reads
+ * the whimsy config types from this barrel.
  *
  * Designed to be removable with minimal blast radius. To rip out:
  *
- * 1. Delete `frontend/features/whimsy/`.
- * 2. Revert the `useWhimsyTile()` calls in the three files above (or
- *    remove the texture overlay entirely).
+ * 1. Delete `frontend/features/whimsy/` AND
+ *    `frontend/features/settings/sections/WhimsySettingsCard.tsx`.
+ * 2. Revert the `useWhimsyTile()` calls (or remove the texture overlay
+ *    entirely).
  * 3. Optionally delete `frontend/lib/whimsy-tile.ts` and
  *    `frontend/app/dev/whimsy-tile/`.
  *
- * No new providers, no new contexts, no new query layers.  Storage
- * uses one localStorage key (`whimsy:config`) and re-uses the
- * existing settings primitives.
+ * No new providers, no new contexts, no new query layers. Storage uses
+ * one localStorage key (`whimsy:config`).
  */
 
 export type { WhimsyColor, WhimsyConfig, WhimsyMode } from './config';
 export { useWhimsyConfig } from './config';
 export type { UseWhimsyTileResult } from './use-whimsy-tile';
 export { useWhimsyTile } from './use-whimsy-tile';
-export { WhimsySettingsCard } from './WhimsySettingsCard';


### PR DESCRIPTION
**Stack: 6 / 10** — base `claude/sentrux-05-hoist-drag-mime` (PR #227)

Bean `pawrrtal-yl6q`. `features/whimsy/WhimsySettingsCard.tsx` rendered
the settings UI for whimsy customization, but lived in the whimsy
feature. That forced two back-edges:

- **whimsy → settings**: `WhimsySettingsCard` pulled `SettingsCard`,
  `SettingsRow`, `SettingsSectionHeader`, `Slider`, `Switch` from
  `@/features/settings/primitives`.
- **settings → whimsy**: `AppearanceSection.tsx` pulled
  `WhimsySettingsCard` back from `@/features/whimsy`.

## What changes

Moves the card to `features/settings/sections/WhimsySettingsCard.tsx`:

- Settings primitives import is now `../primitives` (local).
- The whimsy data layer (`useWhimsyConfig`, type defs, bounds, theme
  catalog) is read via `@/features/whimsy/config` — settings is now
  the consumer of whimsy data, not whimsy depending on settings UI.
- `AppearanceSection.tsx` imports the card from
  `./WhimsySettingsCard` (sibling), not `@/features/whimsy`.
- `features/whimsy/index.tsx` drops the `WhimsySettingsCard` export.

The remaining `useWhimsyTile` import in `features/chat/ChatView.tsx`
stays — that's a sibling feature-to-feature edge at the same sentrux
layer (both order 1), which is allowed.

## Verification

- `cd frontend && bun run typecheck` + `bun run arch:check` — clean.
- 35 tests / 10 files across `features/whimsy` + `features/settings` —
  all pass.

Closes bean pawrrtal-yl6q.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGNvy9RyjAuRDDKZU18Ts)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR eliminates a bidirectional dependency between `features/whimsy` and `features/settings` by moving `WhimsySettingsCard` from the whimsy feature directory into `features/settings/sections/`. The change is purely structural — no runtime logic is modified.

- `WhimsySettingsCard.tsx` is renamed/moved to `features/settings/sections/`, its settings-primitives import becomes a local `../primitives` reference, and its whimsy-config import switches from the relative `./config` to the absolute `@/features/whimsy/config`.
- `AppearanceSection.tsx` updates its import of `WhimsySettingsCard` from the whimsy barrel to a sibling `./WhimsySettingsCard` path.
- `features/whimsy/index.tsx` drops the `WhimsySettingsCard` re-export and updates its consumer docs to reflect the new layout.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — purely structural file move with no runtime logic changes.

All three changed files are mechanical: one is a rename with updated import paths, one is a single-line import swap, and one drops a re-export with updated docs. No logic, state, or UI behaviour was modified. The arch:check and typecheck both passed per the PR description.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/features/settings/sections/WhimsySettingsCard.tsx | Moved from features/whimsy/ with updated import paths; primitives now local, whimsy config accessed via @/features/whimsy/config directly (barrel doesn't expose the internal constants needed). |
| frontend/features/settings/sections/AppearanceSection.tsx | Import updated from @/features/whimsy to ./WhimsySettingsCard sibling; inline comment at line 408 still describes the old location. |
| frontend/features/whimsy/index.tsx | Barrel updated: WhimsySettingsCard export removed, consumer docs updated to reflect new WhimsySettingsCard location and direct config imports. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BEFORE["Before (back-edge present)"]
        W1["features/whimsy\nWhimsySettingsCard.tsx"] -->|imports primitives| SP1["features/settings/primitives"]
        AS1["features/settings/sections\nAppearanceSection.tsx"] -->|imports card| W1
        SP1 -.->|same package| AS1
    end

    subgraph AFTER["After (back-edge removed)"]
        WC2["features/settings/sections\nWhimsySettingsCard.tsx"] -->|imports ../primitives| SP2["features/settings/primitives"]
        AS2["features/settings/sections\nAppearanceSection.tsx"] -->|imports ./WhimsySettingsCard| WC2
        WC2 -->|imports config types| WB2["features/whimsy\nconfig.ts / index.tsx"]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/features/settings/sections/AppearanceSection.tsx`, line 407-415 ([link](https://github.com/octaviantocan/pawrrtal-ai/blob/42af72d29fc59a19974de09523affb1c7541f7ed/frontend/features/settings/sections/AppearanceSection.tsx#L407-L415)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Stale inline comment after card move**

   The comment at line 408 still says `Lives in @/features/whimsy as a single self-contained module (hook + storage + settings card)`, but after this PR the settings card now lives in `./WhimsySettingsCard` and the two concerns are no longer co-located. The "(hook + storage + settings card)" wording in particular is now wrong — the card was split out. The removal instruction on the same comment also says "Remove the import + this line" but omits that `WhimsySettingsCard.tsx` itself would also need to be deleted.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Ffeatures%2Fsettings%2Fsections%2FAppearanceSection.tsx%0ALine%3A%20407-415%0A%0AComment%3A%0A**Stale%20inline%20comment%20after%20card%20move**%0A%0AThe%20comment%20at%20line%20408%20still%20says%20%60Lives%20in%20%40%2Ffeatures%2Fwhimsy%20as%20a%20single%20self-contained%20module%20%28hook%20%2B%20storage%20%2B%20settings%20card%29%60%2C%20but%20after%20this%20PR%20the%20settings%20card%20now%20lives%20in%20%60.%2FWhimsySettingsCard%60%20and%20the%20two%20concerns%20are%20no%20longer%20co-located.%20The%20%22%28hook%20%2B%20storage%20%2B%20settings%20card%29%22%20wording%20in%20particular%20is%20now%20wrong%20%E2%80%94%20the%20card%20was%20split%20out.%20The%20removal%20instruction%20on%20the%20same%20comment%20also%20says%20%22Remove%20the%20import%20%2B%20this%20line%22%20but%20omits%20that%20%60WhimsySettingsCard.tsx%60%20itself%20would%20also%20need%20to%20be%20deleted.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-06-whimsy-card%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-06-whimsy-card%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Ffeatures%2Fsettings%2Fsections%2FAppearanceSection.tsx%0ALine%3A%20407-415%0A%0AComment%3A%0A**Stale%20inline%20comment%20after%20card%20move**%0A%0AThe%20comment%20at%20line%20408%20still%20says%20%60Lives%20in%20%40%2Ffeatures%2Fwhimsy%20as%20a%20single%20self-contained%20module%20%28hook%20%2B%20storage%20%2B%20settings%20card%29%60%2C%20but%20after%20this%20PR%20the%20settings%20card%20now%20lives%20in%20%60.%2FWhimsySettingsCard%60%20and%20the%20two%20concerns%20are%20no%20longer%20co-located.%20The%20%22%28hook%20%2B%20storage%20%2B%20settings%20card%29%22%20wording%20in%20particular%20is%20now%20wrong%20%E2%80%94%20the%20card%20was%20split%20out.%20The%20removal%20instruction%20on%20the%20same%20comment%20also%20says%20%22Remove%20the%20import%20%2B%20this%20line%22%20but%20omits%20that%20%60WhimsySettingsCard.tsx%60%20itself%20would%20also%20need%20to%20be%20deleted.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-06-whimsy-card%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-06-whimsy-card%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Ffeatures%2Fsettings%2Fsections%2FAppearanceSection.tsx%0ALine%3A%20407-415%0A%0AComment%3A%0A**Stale%20inline%20comment%20after%20card%20move**%0A%0AThe%20comment%20at%20line%20408%20still%20says%20%60Lives%20in%20%40%2Ffeatures%2Fwhimsy%20as%20a%20single%20self-contained%20module%20%28hook%20%2B%20storage%20%2B%20settings%20card%29%60%2C%20but%20after%20this%20PR%20the%20settings%20card%20now%20lives%20in%20%60.%2FWhimsySettingsCard%60%20and%20the%20two%20concerns%20are%20no%20longer%20co-located.%20The%20%22%28hook%20%2B%20storage%20%2B%20settings%20card%29%22%20wording%20in%20particular%20is%20now%20wrong%20%E2%80%94%20the%20card%20was%20split%20out.%20The%20removal%20instruction%20on%20the%20same%20comment%20also%20says%20%22Remove%20the%20import%20%2B%20this%20line%22%20but%20omits%20that%20%60WhimsySettingsCard.tsx%60%20itself%20would%20also%20need%20to%20be%20deleted.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(frontend): move WhimsySettingsC..."](https://github.com/octaviantocan/pawrrtal-ai/commit/27602b14288210b3ab286c9404abf6da8ed119b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32424610)</sub>

<!-- /greptile_comment -->