### PR TITLE
refactor(frontend): move app-layout → features/app-shell, split header out

### DIFF
--- a/frontend/app/(app)/knowledge/page.tsx
+++ b/frontend/app/(app)/knowledge/page.tsx
@@ -9,7 +9,7 @@ import { KnowledgeContainer } from '@/features/knowledge/KnowledgeContainer';
  * inside a `Suspense` boundary so `useSearchParams` (which requires Suspense
  * in the App Router) works without a CSR bailout warning.
  *
- * The `(app)` segment layout already wraps this in `AppLayout`, so the
+ * The `(app)` segment layout already wraps this in `AppShell`, so the
  * global sidebar and header are present without any extra plumbing here.
  */
 export default function KnowledgePage(): ReactNode {

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -2,15 +2,15 @@
  * Authenticated app segment layout: sidebar shell and main content region.
  */
 
-import { AppLayout } from '@/components/app-layout';
+import { AppShell } from '@/features/app-shell/AppShell';
 
 /**
- * Wraps `(app)/*` routes with the persistent {@link AppLayout} chrome.
+ * Wraps `(app)/*` routes with the persistent {@link AppShell} chrome.
  */
-export default function AppLayoutWrapper({
+export default function AppShellWrapper({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	return <AppLayout>{children}</AppLayout>;
+	return <AppShell>{children}</AppShell>;
 }

--- a/frontend/app/(app)/tasks/page.tsx
+++ b/frontend/app/(app)/tasks/page.tsx
@@ -2,7 +2,7 @@
  * Tasks route (`/tasks`).
  *
  * Server component that mounts the client {@link TasksContainer} inside the
- * `(app)` route group's existing `AppLayout` chrome. All state, URL parsing,
+ * `(app)` route group's existing `AppShell` chrome. All state, URL parsing,
  * and mock-data lookup happens in the container — this file is purely an
  * entry point so the route has a stable boundary.
  *

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 /**
  * Thin sidebar shell that only mounts the conversations list.
  *
- * @fileoverview Prefer {@link AppLayout} for the full app chrome; this is used by the dashboard demo page.
+ * @fileoverview Prefer {@link AppShell} for the full app chrome; this is used by the dashboard demo page.
  */
 
 'use client';

--- a/frontend/features/app-shell/AppShell.tsx
+++ b/frontend/features/app-shell/AppShell.tsx
@@ -1,63 +1,44 @@
 /**
- * Application layout with resizable sidebar.
+ * Application shell with resizable sidebar.
  *
- * Provides the main app layout structure with a resizable sidebar on desktop and
- * a mobile-friendly sheet overlay. Integrates SidebarProvider, navigation, and
- * content area with proper responsive behavior.
+ * Provides the main app shell with a resizable sidebar on desktop and
+ * a mobile-friendly sheet overlay. Integrates SidebarProvider, navigation,
+ * and content area with proper responsive behavior. Lives under
+ * `features/app-shell/` (fe-features) rather than `components/` because
+ * it composes nav-chats, onboarding, and chat-activity context providers;
+ * keeping it in fe-shell forced same-order edges into 5 separate features.
  *
- * @fileoverview Main app layout with resizable sidebar support
+ * The header (workspace selector, help menu, history controls) is split
+ * out into `AppShellHeader.tsx` to keep this file under the 500-LOC budget.
+ *
+ * @fileoverview Main app shell composition.
  */
 
 'use client';
 
-import {
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownPanelMenu,
-} from '@octavian-tocan/react-dropdown';
-import {
-	ArrowLeftIcon,
-	ArrowRightIcon,
-	BookOpenIcon,
-	CheckIcon,
-	ChevronDownIcon,
-	CircleHelpIcon,
-	DatabaseIcon,
-	ExternalLinkIcon,
-	FolderPlusIcon,
-	MessageSquareIcon,
-	SettingsIcon,
-	ShieldCheckIcon,
-	WorkflowIcon,
-	ZapIcon,
-} from 'lucide-react';
 import React from 'react';
-import { ChatActivityProvider } from '@/features/nav-chats/context/chat-activity-context';
-import { SidebarFocusProvider, useFocusZone } from '@/features/nav-chats/context/sidebar-focus';
-import { NavChats } from '@/features/nav-chats/NavChats';
-import { useOnboardingReadiness } from '@/features/onboarding/hooks/use-onboarding-readiness';
-import { OnboardingModal, OPEN_ONBOARDING_EVENT } from '@/features/onboarding/OnboardingModal';
-import {
-	OnboardingFlow,
-	OPEN_ONBOARDING_FLOW_EVENT,
-	OPEN_ONBOARDING_SERVER_STEP_EVENT,
-} from '@/features/onboarding/v2/OnboardingFlow';
-import { useIsMacDesktop } from '@/hooks/use-is-mac-desktop';
-import { cn } from '@/lib/utils';
-import { KeyboardShortcutsDialog } from './keyboard-shortcuts-dialog';
-import { NavUser, type NavUserIdentity } from './nav-user';
-import { NewSessionButton } from './new-session-button';
-import { Button } from './ui/button';
-import { Separator } from './ui/separator';
+import { NavUser, type NavUserIdentity } from '@/components/nav-user';
+import { NewSessionButton } from '@/components/new-session-button';
 import {
 	Sidebar,
 	SidebarContent,
 	SidebarHeader,
 	SidebarInset,
 	SidebarProvider,
-	SidebarTrigger,
 	useSidebar,
-} from './ui/sidebar';
+} from '@/components/ui/sidebar';
+import { ChatActivityProvider } from '@/features/nav-chats/context/chat-activity-context';
+import { SidebarFocusProvider, useFocusZone } from '@/features/nav-chats/context/sidebar-focus';
+import { NavChats } from '@/features/nav-chats/NavChats';
+import { useOnboardingReadiness } from '@/features/onboarding/hooks/use-onboarding-readiness';
+import { OnboardingModal } from '@/features/onboarding/OnboardingModal';
+import {
+	OnboardingFlow,
+	OPEN_ONBOARDING_FLOW_EVENT,
+	OPEN_ONBOARDING_SERVER_STEP_EVENT,
+} from '@/features/onboarding/v2/OnboardingFlow';
+import { cn } from '@/lib/utils';
+import { AppShellHeader } from './AppShellHeader';
 
 /**
  * Placeholder identity rendered in the sidebar footer.
@@ -71,248 +52,6 @@ const SIDEBAR_USER: NavUserIdentity = {
 	email: 'tocanoctavian@gmail.com',
 	plan: 'Studio plan',
 };
-
-const HELP_LINKS = [
-	{ label: 'Sources', icon: DatabaseIcon },
-	{ label: 'Skills', icon: ZapIcon },
-	{ label: 'Statuses', icon: CheckIcon },
-	{ label: 'Permissions', icon: ShieldCheckIcon },
-	{ label: 'Automations', icon: WorkflowIcon },
-	{ label: 'Messaging', icon: MessageSquareIcon },
-] as const;
-
-/**
- * Fired by the workspace dropdown's "Add Workspace..." item. Opens the
- * three-step **workspace** onboarding modal (Welcome → Create workspace →
- * Local workspace) — NOT the home-page personalization wizard. The two
- * are distinct surfaces: workspace lives behind this dropdown, while
- * personalization fires on every fresh page load.
- */
-function handleOpenOnboarding(): void {
-	window.dispatchEvent(new Event(OPEN_ONBOARDING_EVENT));
-}
-
-/**
- * Back / Forward buttons that drive the browser history stack so the user can
- * step between previously-visited routes (chat → settings → another chat,
- * etc.). Wired through `window.history` directly because Next.js's
- * `router.back()` lacks a corresponding `forward()` and we want both
- * directions to behave identically.
- */
-function AppHistoryControls(): React.JSX.Element {
-	const handleBack = React.useCallback(() => {
-		if (typeof window !== 'undefined') {
-			window.history.back();
-		}
-	}, []);
-
-	const handleForward = React.useCallback(() => {
-		if (typeof window !== 'undefined') {
-			window.history.forward();
-		}
-	}, []);
-
-	return (
-		<div className="flex items-center gap-0.5">
-			<Button
-				aria-label="Back"
-				className="size-7 cursor-pointer rounded-[7px] text-muted-foreground transition-[background-color,color] duration-150 hover:bg-foreground/[0.055] hover:text-foreground"
-				onClick={handleBack}
-				size="icon-xs"
-				title="Back"
-				type="button"
-				variant="ghost"
-			>
-				<ArrowLeftIcon aria-hidden="true" className="size-4" />
-			</Button>
-			<Button
-				aria-label="Forward"
-				className="size-7 cursor-pointer rounded-[7px] text-muted-foreground transition-[background-color,color] duration-150 hover:bg-foreground/[0.055] hover:text-foreground"
-				onClick={handleForward}
-				size="icon-xs"
-				title="Forward"
-				type="button"
-				variant="ghost"
-			>
-				<ArrowRightIcon aria-hidden="true" className="size-4" />
-			</Button>
-		</div>
-	);
-}
-
-function WorkspaceSelector(): React.JSX.Element {
-	return (
-		<DropdownPanelMenu
-			asChild
-			usePortal
-			align="start"
-			contentClassName="popover-styled p-1 min-w-56"
-			trigger={
-				<Button
-					aria-label="Select workspace"
-					className="h-7 gap-2 rounded-[7px] border border-foreground/10 bg-foreground/[0.03] px-2.5 text-[13px] font-normal text-foreground hover:bg-foreground/[0.06] aria-expanded:bg-foreground/[0.06]"
-					type="button"
-					variant="ghost"
-				>
-					<span className="flex size-4.5 items-center justify-center rounded-full bg-foreground/10 text-[10px] font-medium">
-						A
-					</span>
-					<span>Pawrrtal</span>
-					<ChevronDownIcon
-						aria-hidden="true"
-						className="size-3.5 text-muted-foreground"
-					/>
-				</Button>
-			}
-		>
-			<DropdownMenuItem className="justify-between">
-				<span className="flex items-center gap-2">
-					<span className="flex size-5 items-center justify-center rounded-full bg-foreground/10 text-[11px] font-medium">
-						A
-					</span>
-					Pawrrtal
-				</span>
-				<CheckIcon aria-hidden="true" className="size-3.5 text-foreground" />
-			</DropdownMenuItem>
-			<DropdownMenuSeparator />
-			<DropdownMenuItem onSelect={handleOpenOnboarding}>
-				<FolderPlusIcon aria-hidden="true" className="size-3.5" />
-				Add Workspace&hellip;
-			</DropdownMenuItem>
-		</DropdownPanelMenu>
-	);
-}
-
-function HelpMenu(): React.JSX.Element {
-	const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
-	const [isAppleLike, setIsAppleLike] = React.useState(false);
-
-	React.useEffect(() => {
-		if (typeof navigator === 'undefined') return;
-		setIsAppleLike(/Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
-	}, []);
-
-	return (
-		<>
-			<KeyboardShortcutsDialog
-				isMac={isAppleLike}
-				onOpenChange={setShortcutsOpen}
-				open={shortcutsOpen}
-			/>
-			<DropdownPanelMenu
-				asChild
-				usePortal
-				align="end"
-				contentClassName="popover-styled p-1 min-w-56"
-				trigger={
-					<Button
-						aria-label="Open documentation menu"
-						className="size-7 rounded-[7px] text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground aria-expanded:bg-foreground/[0.05]"
-						size="icon-xs"
-						type="button"
-						variant="ghost"
-					>
-						<CircleHelpIcon aria-hidden="true" className="size-4" />
-					</Button>
-				}
-			>
-				{HELP_LINKS.map((link) => {
-					const Icon = link.icon;
-
-					return (
-						<DropdownMenuItem className="justify-between" key={link.label}>
-							<span className="flex items-center gap-2">
-								<Icon aria-hidden="true" className="size-3.5" />
-								{link.label}
-							</span>
-							<ExternalLinkIcon
-								aria-hidden="true"
-								className="size-3.5 text-muted-foreground"
-							/>
-						</DropdownMenuItem>
-					);
-				})}
-				<DropdownMenuSeparator />
-				<DropdownMenuItem>
-					<BookOpenIcon aria-hidden="true" className="size-3.5" />
-					All Documentation
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onSelect={() => {
-						setShortcutsOpen(true);
-					}}
-				>
-					<SettingsIcon aria-hidden="true" className="size-3.5" />
-					Keyboard Shortcuts
-				</DropdownMenuItem>
-			</DropdownPanelMenu>
-		</>
-	);
-}
-
-/**
- * Top-bar chrome rendered as a full-width overlay above the sidebar and content.
- * Lives outside the sidebar so its controls (sidebar trigger, history, workspace
- * selector) stay in their original screen positions even when the sidebar is
- * hidden — the sidebar visually extends underneath this header.
- *
- * macOS Electron uses the **native title bar** (`titleBarStyle: 'default'` in
- * `electron/src/window-chrome.ts`): full-size traffic lights live in the system
- * strip above the web view, so this row does not need extra left inset. If you
- * switch to `hidden` / `hiddenInset`, pad this header in the layout yourself.
- */
-function AppHeader(): React.JSX.Element {
-	const isMacDesktop = useIsMacDesktop();
-	const { isMobile, state } = useSidebar();
-	const showHeaderNewSession = !isMobile && state === 'collapsed';
-
-	return (
-		<header
-			className={cn(
-				'absolute inset-x-0 top-0 z-20 flex h-10 shrink-0 items-center border-0 py-0 pr-3 pl-3 outline-none focus:outline-none focus-visible:outline-none',
-				// On macOS Electron the custom header remains a drag surface for
-				// window moves (native bar is also draggable).
-				isMacDesktop && '[-webkit-app-region:drag]'
-			)}
-		>
-			{/* Left control cluster — `no-drag` so clicks land on the
-			    individual buttons instead of being intercepted as window
-			    drags. Sized to its content (no `flex-1`) so the middle
-			    space is left as a draggable gutter. */}
-			<div
-				className={cn(
-					'flex items-center gap-2',
-					isMacDesktop && '[-webkit-app-region:no-drag]'
-				)}
-			>
-				<SidebarTrigger className="size-7 cursor-pointer" />
-				<AppHistoryControls />
-				<Separator
-					orientation="vertical"
-					className="ml-1 data-vertical:h-4 data-vertical:self-auto"
-				/>
-				<WorkspaceSelector />
-				{showHeaderNewSession ? <NewSessionButton layout="headerCompact" /> : null}
-			</div>
-
-			{/* Spacer that consumes the leftover width and stays inside
-			    the header's drag region — this is the user-facing handle
-			    they can grab to move the window. */}
-			<div className="min-w-0 flex-1" />
-
-			{/* Right control cluster — also `no-drag` so the +/help
-			    buttons keep working. */}
-			<div
-				className={cn(
-					'flex items-center gap-1',
-					isMacDesktop && '[-webkit-app-region:no-drag]'
-				)}
-			>
-				<HelpMenu />
-			</div>
-		</header>
-	);
-}
 
 /**
  * Wraps sidebar content in a focus zone so keyboard navigation (Tab/Shift+Tab)
@@ -532,7 +271,7 @@ function ResizableSidebarContent({ children }: { children: React.ReactNode }): R
  * Provides full-page structure with sidebar navigation and responsive behavior.
  * Wraps everything in focus-zone and chat-activity providers.
  */
-export function AppLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
+export function AppShell({ children }: { children: React.ReactNode }): React.JSX.Element {
 	const onboardingReadiness = useOnboardingReadiness();
 	const isAppReady =
 		!onboardingReadiness.isLoading &&
@@ -589,7 +328,7 @@ export function AppLayout({ children }: { children: React.ReactNode }): React.JS
 										<div className="min-h-0 min-w-0 flex-1">{children}</div>
 									</SidebarInset>
 								</ResizableSidebarContent>
-								<AppHeader />
+								<AppShellHeader />
 							</>
 						) : null}
 					</div>

--- a/frontend/features/app-shell/AppShellHeader.tsx
+++ b/frontend/features/app-shell/AppShellHeader.tsx
@@ -1,0 +1,286 @@
+/**
+ * Top-bar chrome for the app shell.
+ *
+ * Split out of `AppShell.tsx` to keep that file under the 500-LOC budget.
+ * Owns the workspace selector, help menu, history controls, and the
+ * outer header strip that composes them. `AppShell` is the only consumer.
+ *
+ * @fileoverview Header strip rendered above the sidebar + content.
+ */
+
+'use client';
+
+import {
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownPanelMenu,
+} from '@octavian-tocan/react-dropdown';
+import {
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	BookOpenIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	CircleHelpIcon,
+	DatabaseIcon,
+	ExternalLinkIcon,
+	FolderPlusIcon,
+	MessageSquareIcon,
+	SettingsIcon,
+	ShieldCheckIcon,
+	WorkflowIcon,
+	ZapIcon,
+} from 'lucide-react';
+import React from 'react';
+import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog';
+import { NewSessionButton } from '@/components/new-session-button';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
+import { OPEN_ONBOARDING_EVENT } from '@/features/onboarding/OnboardingModal';
+import { useIsMacDesktop } from '@/hooks/use-is-mac-desktop';
+import { cn } from '@/lib/utils';
+
+const HELP_LINKS = [
+	{ label: 'Sources', icon: DatabaseIcon },
+	{ label: 'Skills', icon: ZapIcon },
+	{ label: 'Statuses', icon: CheckIcon },
+	{ label: 'Permissions', icon: ShieldCheckIcon },
+	{ label: 'Automations', icon: WorkflowIcon },
+	{ label: 'Messaging', icon: MessageSquareIcon },
+] as const;
+
+/**
+ * Fired by the workspace dropdown's "Add Workspace..." item. Opens the
+ * three-step **workspace** onboarding modal (Welcome → Create workspace →
+ * Local workspace) — NOT the home-page personalization wizard. The two
+ * are distinct surfaces: workspace lives behind this dropdown, while
+ * personalization fires on every fresh page load.
+ */
+function handleOpenOnboarding(): void {
+	window.dispatchEvent(new Event(OPEN_ONBOARDING_EVENT));
+}
+
+/**
+ * Back / Forward buttons that drive the browser history stack so the user can
+ * step between previously-visited routes (chat → settings → another chat,
+ * etc.). Wired through `window.history` directly because Next.js's
+ * `router.back()` lacks a corresponding `forward()` and we want both
+ * directions to behave identically.
+ */
+function AppHistoryControls(): React.JSX.Element {
+	const handleBack = React.useCallback(() => {
+		if (typeof window !== 'undefined') {
+			window.history.back();
+		}
+	}, []);
+
+	const handleForward = React.useCallback(() => {
+		if (typeof window !== 'undefined') {
+			window.history.forward();
+		}
+	}, []);
+
+	return (
+		<div className="flex items-center gap-0.5">
+			<Button
+				aria-label="Back"
+				className="size-7 cursor-pointer rounded-[7px] text-muted-foreground transition-[background-color,color] duration-150 hover:bg-foreground/[0.055] hover:text-foreground"
+				onClick={handleBack}
+				size="icon-xs"
+				title="Back"
+				type="button"
+				variant="ghost"
+			>
+				<ArrowLeftIcon aria-hidden="true" className="size-4" />
+			</Button>
+			<Button
+				aria-label="Forward"
+				className="size-7 cursor-pointer rounded-[7px] text-muted-foreground transition-[background-color,color] duration-150 hover:bg-foreground/[0.055] hover:text-foreground"
+				onClick={handleForward}
+				size="icon-xs"
+				title="Forward"
+				type="button"
+				variant="ghost"
+			>
+				<ArrowRightIcon aria-hidden="true" className="size-4" />
+			</Button>
+		</div>
+	);
+}
+
+function WorkspaceSelector(): React.JSX.Element {
+	return (
+		<DropdownPanelMenu
+			asChild
+			usePortal
+			align="start"
+			contentClassName="popover-styled p-1 min-w-56"
+			trigger={
+				<Button
+					aria-label="Select workspace"
+					className="h-7 gap-2 rounded-[7px] border border-foreground/10 bg-foreground/[0.03] px-2.5 text-[13px] font-normal text-foreground hover:bg-foreground/[0.06] aria-expanded:bg-foreground/[0.06]"
+					type="button"
+					variant="ghost"
+				>
+					<span className="flex size-4.5 items-center justify-center rounded-full bg-foreground/10 text-[10px] font-medium">
+						A
+					</span>
+					<span>Pawrrtal</span>
+					<ChevronDownIcon
+						aria-hidden="true"
+						className="size-3.5 text-muted-foreground"
+					/>
+				</Button>
+			}
+		>
+			<DropdownMenuItem className="justify-between">
+				<span className="flex items-center gap-2">
+					<span className="flex size-5 items-center justify-center rounded-full bg-foreground/10 text-[11px] font-medium">
+						A
+					</span>
+					Pawrrtal
+				</span>
+				<CheckIcon aria-hidden="true" className="size-3.5 text-foreground" />
+			</DropdownMenuItem>
+			<DropdownMenuSeparator />
+			<DropdownMenuItem onSelect={handleOpenOnboarding}>
+				<FolderPlusIcon aria-hidden="true" className="size-3.5" />
+				Add Workspace&hellip;
+			</DropdownMenuItem>
+		</DropdownPanelMenu>
+	);
+}
+
+function HelpMenu(): React.JSX.Element {
+	const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
+	const [isAppleLike, setIsAppleLike] = React.useState(false);
+
+	React.useEffect(() => {
+		if (typeof navigator === 'undefined') return;
+		setIsAppleLike(/Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
+	}, []);
+
+	return (
+		<>
+			<KeyboardShortcutsDialog
+				isMac={isAppleLike}
+				onOpenChange={setShortcutsOpen}
+				open={shortcutsOpen}
+			/>
+			<DropdownPanelMenu
+				asChild
+				usePortal
+				align="end"
+				contentClassName="popover-styled p-1 min-w-56"
+				trigger={
+					<Button
+						aria-label="Open documentation menu"
+						className="size-7 rounded-[7px] text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground aria-expanded:bg-foreground/[0.05]"
+						size="icon-xs"
+						type="button"
+						variant="ghost"
+					>
+						<CircleHelpIcon aria-hidden="true" className="size-4" />
+					</Button>
+				}
+			>
+				{HELP_LINKS.map((link) => {
+					const Icon = link.icon;
+
+					return (
+						<DropdownMenuItem className="justify-between" key={link.label}>
+							<span className="flex items-center gap-2">
+								<Icon aria-hidden="true" className="size-3.5" />
+								{link.label}
+							</span>
+							<ExternalLinkIcon
+								aria-hidden="true"
+								className="size-3.5 text-muted-foreground"
+							/>
+						</DropdownMenuItem>
+					);
+				})}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem>
+					<BookOpenIcon aria-hidden="true" className="size-3.5" />
+					All Documentation
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onSelect={() => {
+						setShortcutsOpen(true);
+					}}
+				>
+					<SettingsIcon aria-hidden="true" className="size-3.5" />
+					Keyboard Shortcuts
+				</DropdownMenuItem>
+			</DropdownPanelMenu>
+		</>
+	);
+}
+
+/**
+ * Top-bar chrome rendered as a full-width overlay above the sidebar and
+ * content. Lives outside the sidebar so its controls (sidebar trigger,
+ * history, workspace selector) stay in their original screen positions
+ * even when the sidebar is hidden — the sidebar visually extends
+ * underneath this header.
+ *
+ * macOS Electron uses the **native title bar** (`titleBarStyle: 'default'`
+ * in `electron/src/window-chrome.ts`): full-size traffic lights live in
+ * the system strip above the web view, so this row does not need extra
+ * left inset. If you switch to `hidden` / `hiddenInset`, pad this header
+ * in the layout yourself.
+ */
+export function AppShellHeader(): React.JSX.Element {
+	const isMacDesktop = useIsMacDesktop();
+	const { isMobile, state } = useSidebar();
+	const showHeaderNewSession = !isMobile && state === 'collapsed';
+
+	return (
+		<header
+			className={cn(
+				'absolute inset-x-0 top-0 z-20 flex h-10 shrink-0 items-center border-0 py-0 pr-3 pl-3 outline-none focus:outline-none focus-visible:outline-none',
+				// On macOS Electron the custom header remains a drag surface for
+				// window moves (native bar is also draggable).
+				isMacDesktop && '[-webkit-app-region:drag]'
+			)}
+		>
+			{/* Left control cluster — `no-drag` so clicks land on the
+			    individual buttons instead of being intercepted as window
+			    drags. Sized to its content (no `flex-1`) so the middle
+			    space is left as a draggable gutter. */}
+			<div
+				className={cn(
+					'flex items-center gap-2',
+					isMacDesktop && '[-webkit-app-region:no-drag]'
+				)}
+			>
+				<SidebarTrigger className="size-7 cursor-pointer" />
+				<AppHistoryControls />
+				<Separator
+					orientation="vertical"
+					className="ml-1 data-vertical:h-4 data-vertical:self-auto"
+				/>
+				<WorkspaceSelector />
+				{showHeaderNewSession ? <NewSessionButton layout="headerCompact" /> : null}
+			</div>
+
+			{/* Spacer that consumes the leftover width and stays inside
+			    the header's drag region — this is the user-facing handle
+			    they can grab to move the window. */}
+			<div className="min-w-0 flex-1" />
+
+			{/* Right control cluster — also `no-drag` so the +/help
+			    buttons keep working. */}
+			<div
+				className={cn(
+					'flex items-center gap-1',
+					isMacDesktop && '[-webkit-app-region:no-drag]'
+				)}
+			>
+				<HelpMenu />
+			</div>
+		</header>
+	);
+}

--- a/frontend/features/knowledge/KnowledgeView.tsx
+++ b/frontend/features/knowledge/KnowledgeView.tsx
@@ -245,7 +245,7 @@ function KnowledgeContent(props: KnowledgeViewProps): ReactNode {
  * TWO separate elevated panels with a small gap between them.
  *
  * The outer wrapper has no background AND no `overflow-hidden` — the page
- * background (`bg-sidebar` from `AppLayout`) supplies the warm surround,
+ * background (`bg-sidebar` from `AppShell`) supplies the warm surround,
  * and we deliberately let the panels' drop shadows paint outside this
  * wrapper. The earlier `overflow-hidden` clipped the elevated-panel
  * shadows flush against the wrapper's edges, making the cards read as

--- a/frontend/features/tasks/TasksView.tsx
+++ b/frontend/features/tasks/TasksView.tsx
@@ -75,7 +75,7 @@ export interface TasksViewProps {
 /**
  * Pure presentation entry point. The outer wrapper is the elevated panel
  * (`rounded-[14px]`, `shadow-minimal`) that sits inside the chat-inset slot
- * provided by `AppLayout`.
+ * provided by `AppShell`.
  */
 export function TasksView(props: TasksViewProps): ReactNode {
 	const {


### PR DESCRIPTION
**Stack: 7 / 10** — base `claude/sentrux-06-whimsy-card` (PR #228)

Bean `pawrrtal-y2tt` (line-budget exemption) + the same-order edges
analysis: `frontend/components/app-layout.tsx` was 569 LOC (over the
500-LOC budget) AND reached into 5 different features
(`ChatActivityProvider`, `SidebarFocusProvider` + `useFocusZone`,
`NavChats`, `OnboardingModal`, `OnboardingFlow`). It was nominally in
`fe-shell` (components/app-*) but composed `fe-features` — 6 same-order
edges.

## What changes

```
frontend/components/app-layout.tsx
  → frontend/features/app-shell/AppShell.tsx           (~307 LOC)
  + frontend/features/app-shell/AppShellHeader.tsx     (~280 LOC)
```

- `AppLayout` → `AppShell` rename. `app/(app)/layout.tsx` imports
  `AppShell` from `@/features/app-shell/AppShell` — clean fe-app →
  fe-features edge (downward, allowed).
- The 6 cross-feature imports inside the file (nav-chats + onboarding)
  are now feature → same-level-feature siblings, which sentrux's layer
  rule treats as OK.
- `AppShellHeader.tsx` owns workspace selector + history controls +
  help menu + the top-bar strip.
- Doc comments referencing the old `AppLayout` name in `app-sidebar.tsx`,
  `tasks/page.tsx`, `knowledge/page.tsx`, `TasksView.tsx`, and
  `KnowledgeView.tsx` are updated to `AppShell`.

## Verification

- file-lines budget: `AppShell.tsx` 307 + `AppShellHeader.tsx` ~280
  — both well under 500.
- `cd frontend && bun run typecheck` — clean.
- `cd frontend && bun run arch:check` — clean (361 modules, 1249
  deps).
- `vitest features/` — 45 files / 212 tests pass.
- `just sentrux` — still green; quality_signal 6911 → 6909 (noise).

## Open follow-up

PR-7 needs a visual smoke (`just dev` → sidebar slide, onboarding
modal, chat-activity context propagation) before merge. Changes are
pure file relocations + rename — risk is low.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGNvy9RyjAuRDDKZU18Ts)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors `frontend/components/app-layout.tsx` (569 LOC) into two purpose-built files under `features/app-shell/`: `AppShell.tsx` (~307 LOC) holding the sidebar shell and provider hierarchy, and `AppShellHeader.tsx` (~280 LOC) holding the workspace selector, history controls, and help menu.

- `AppShell` is a direct rename with the header logic excised; the provider nesting, mobile/desktop sidebar split, and onboarding-readiness gate are all unchanged from the original.
- `AppShellHeader` cleanly extracts `AppHistoryControls`, `WorkspaceSelector`, `HelpMenu`, and the outer header strip with no behavioral changes.
- Seven additional files still carry stale `components/app-layout.tsx` or \"app-layout level\" references in doc comments that weren't updated alongside the six that were.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — pure file relocation and rename with no logic changes; the provider hierarchy, responsive behavior, and onboarding flow are structurally identical to the original.

All functional code is a verbatim move; the only net-new content is the import path in layout.tsx and the AppShellHeader export boundary. Outstanding items are stale doc-comment references in several untouched files and the namespace React import pattern in both new files.

The two new features/app-shell/ files carry namespace React imports against project conventions; a follow-up pass should also update stale app-layout references in the E2E specs, OnboardingFlow.tsx, and NavChatsView.tsx.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/features/app-shell/AppShell.tsx | Rename of AppLayout to AppShell with header logic excised; provider hierarchy unchanged. Uses namespace React import pattern against project conventions. |
| frontend/features/app-shell/AppShellHeader.tsx | New file extracting WorkspaceSelector, HelpMenu, AppHistoryControls from the old app-layout. Clean extraction; namespace React import pattern against project conventions. |
| frontend/app/(app)/layout.tsx | Import and wrapper renamed from AppLayout to AppShell at new feature-level path. No functional change. |
| frontend/components/app-sidebar.tsx | Doc-comment fileoverview updated from AppLayout to AppShell; no code changes. |
| frontend/features/knowledge/KnowledgeView.tsx | Single inline comment updated from AppLayout to AppShell; no functional change. |
| frontend/features/tasks/TasksView.tsx | Single inline comment updated from AppLayout to AppShell; no functional change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["app/(app)/layout.tsx\nAppShellWrapper"] --> B["features/app-shell/AppShell.tsx\nAppShell"]
    B --> C["SidebarProvider"]
    C --> D["SidebarFocusProvider"]
    D --> E["ChatActivityProvider"]
    E --> F["OnboardingFlow"]
    E --> G["OnboardingModal"]
    E --> H{isAppReady?}
    H -->|yes| I["ResizableSidebarContent"]
    H -->|yes| J["features/app-shell/AppShellHeader.tsx\nAppShellHeader"]
    I --> K{isMobile?}
    K -->|yes| L["Sidebar + NavChats\n(Sheet overlay)"]
    K -->|no| M["Custom sidebar\n(translate-X animation)"]
    I --> N["SidebarInset\n{children}"]
    J --> O["SidebarTrigger"]
    J --> P["AppHistoryControls"]
    J --> Q["WorkspaceSelector"]
    J --> R["HelpMenu"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fapp-shell%2FAppShell.tsx%3A19-20%0ABoth%20new%20files%20use%20%60import%20React%20from%20'react'%60%20with%20namespace-style%20access%20%28%60React.useState%60%2C%20%60React.JSX.Element%60%2C%20%60React.useCallback%60%2C%20etc.%29%2C%20which%20violates%20the%20project's%20%60use-direct-named-imports-not-namespace%60%20rule.%20Direct%20named%20imports%20should%20be%20used%20instead.%20The%20same%20pattern%20applies%20to%20%60AppShellHeader.tsx%60.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20useCallback%2C%20useEffect%2C%20useLayoutEffect%2C%20type%20JSX%2C%20type%20ReactNode%20%7D%20from%20'react'%3B%0Aimport%20%7B%20NavUser%2C%20type%20NavUserIdentity%20%7D%20from%20'%40%2Fcomponents%2Fnav-user'%3B%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=229&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-07-app-shell%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-07-app-shell%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fapp-shell%2FAppShell.tsx%3A19-20%0ABoth%20new%20files%20use%20%60import%20React%20from%20'react'%60%20with%20namespace-style%20access%20%28%60React.useState%60%2C%20%60React.JSX.Element%60%2C%20%60React.useCallback%60%2C%20etc.%29%2C%20which%20violates%20the%20project's%20%60use-direct-named-imports-not-namespace%60%20rule.%20Direct%20named%20imports%20should%20be%20used%20instead.%20The%20same%20pattern%20applies%20to%20%60AppShellHeader.tsx%60.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20useCallback%2C%20useEffect%2C%20useLayoutEffect%2C%20type%20JSX%2C%20type%20ReactNode%20%7D%20from%20'react'%3B%0Aimport%20%7B%20NavUser%2C%20type%20NavUserIdentity%20%7D%20from%20'%40%2Fcomponents%2Fnav-user'%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-07-app-shell%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-07-app-shell%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fapp-shell%2FAppShell.tsx%3A19-20%0ABoth%20new%20files%20use%20%60import%20React%20from%20'react'%60%20with%20namespace-style%20access%20%28%60React.useState%60%2C%20%60React.JSX.Element%60%2C%20%60React.useCallback%60%2C%20etc.%29%2C%20which%20violates%20the%20project's%20%60use-direct-named-imports-not-namespace%60%20rule.%20Direct%20named%20imports%20should%20be%20used%20instead.%20The%20same%20pattern%20applies%20to%20%60AppShellHeader.tsx%60.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20useCallback%2C%20useEffect%2C%20useLayoutEffect%2C%20type%20JSX%2C%20type%20ReactNode%20%7D%20from%20'react'%3B%0Aimport%20%7B%20NavUser%2C%20type%20NavUserIdentity%20%7D%20from%20'%40%2Fcomponents%2Fnav-user'%3B%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(frontend): move app-layout → fe..."](https://github.com/octaviantocan/pawrrtal-ai/commit/e79187c94f7e5722828d229ebc6c8a7eae74c68f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32425751)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->