### PR TITLE
test(frontend): cover use-chat-turns + use-chat-background-recovery

### DIFF
--- a/frontend/features/chat/hooks/use-chat-background-recovery.test.ts
+++ b/frontend/features/chat/hooks/use-chat-background-recovery.test.ts
@@ -1,0 +1,183 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '@/lib/types';
+import { useChatBackgroundRecovery } from './use-chat-background-recovery';
+
+const CONVERSATION_ID = 'conv-7';
+const KEY = `chat:in-flight:${CONVERSATION_ID}`;
+
+function lastAssistant(overrides: Partial<ChatMessage> = {}): ChatMessage {
+	return {
+		role: 'assistant',
+		content: 'A reply',
+		assistant_status: 'complete',
+		...overrides,
+	};
+}
+
+describe('useChatBackgroundRecovery', () => {
+	beforeEach(() => {
+		window.sessionStorage.clear();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('beginStream / endStream', () => {
+		it('beginStream writes the prompt under the per-conversation key', () => {
+			const onRecover = vi.fn();
+			const { result } = renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant()],
+					isLoading: false,
+					onRecover,
+				})
+			);
+
+			result.current.beginStream('please continue');
+
+			expect(window.sessionStorage.getItem(KEY)).toBe('please continue');
+		});
+
+		it('endStream clears the breadcrumb', () => {
+			window.sessionStorage.setItem(KEY, 'leftover');
+			const { result } = renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant()],
+					isLoading: false,
+					onRecover: vi.fn(),
+				})
+			);
+
+			result.current.endStream();
+
+			expect(window.sessionStorage.getItem(KEY)).toBeNull();
+		});
+
+		it('beginStream survives sessionStorage throwing (private mode)', () => {
+			vi.spyOn(window.sessionStorage, 'setItem').mockImplementation(() => {
+				throw new Error('QuotaExceededError');
+			});
+			const { result } = renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant()],
+					isLoading: false,
+					onRecover: vi.fn(),
+				})
+			);
+
+			// Should not throw; recovery is best-effort.
+			expect(() => result.current.beginStream('whatever')).not.toThrow();
+		});
+	});
+
+	describe('mount-time recovery', () => {
+		it('calls onRecover when a breadcrumb exists and the last reply is missing', () => {
+			window.sessionStorage.setItem(KEY, 'resume me');
+			const onRecover = vi.fn();
+
+			renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [],
+					isLoading: false,
+					onRecover,
+				})
+			);
+
+			expect(onRecover).toHaveBeenCalledExactlyOnceWith('resume me');
+		});
+
+		it('calls onRecover when a breadcrumb exists and the last reply failed', () => {
+			window.sessionStorage.setItem(KEY, 'try again');
+			const onRecover = vi.fn();
+
+			renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant({ assistant_status: 'failed' })],
+					isLoading: false,
+					onRecover,
+				})
+			);
+
+			expect(onRecover).toHaveBeenCalledExactlyOnceWith('try again');
+		});
+
+		it('does NOT call onRecover when the last reply is complete', () => {
+			window.sessionStorage.setItem(KEY, 'do not run');
+			const onRecover = vi.fn();
+
+			renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant({ content: 'finished reply' })],
+					isLoading: false,
+					onRecover,
+				})
+			);
+
+			expect(onRecover).not.toHaveBeenCalled();
+		});
+
+		it('does NOT call onRecover when a turn is already streaming', () => {
+			window.sessionStorage.setItem(KEY, 'do not run');
+			const onRecover = vi.fn();
+
+			renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [lastAssistant({ content: '' })],
+					// A turn is already in flight — recovery would double-fire.
+					isLoading: true,
+					onRecover,
+				})
+			);
+
+			expect(onRecover).not.toHaveBeenCalled();
+		});
+
+		it('does NOT call onRecover when no breadcrumb exists', () => {
+			const onRecover = vi.fn();
+
+			renderHook(() =>
+				useChatBackgroundRecovery({
+					conversationId: CONVERSATION_ID,
+					chatHistory: [],
+					isLoading: false,
+					onRecover,
+				})
+			);
+
+			expect(onRecover).not.toHaveBeenCalled();
+		});
+
+		it('fires onRecover at most once per mount even if deps change', () => {
+			window.sessionStorage.setItem(KEY, 'only-once');
+			const onRecover = vi.fn();
+
+			const { rerender } = renderHook(
+				({ history }: { history: Array<ChatMessage> }) =>
+					useChatBackgroundRecovery({
+						conversationId: CONVERSATION_ID,
+						chatHistory: history,
+						isLoading: false,
+						onRecover,
+					}),
+				{ initialProps: { history: [] as Array<ChatMessage> } }
+			);
+
+			// Simulate the container responding to onRecover by appending a
+			// pending assistant message — the hook must not re-fire.
+			rerender({ history: [lastAssistant({ content: '', assistant_status: 'streaming' })] });
+			rerender({
+				history: [lastAssistant({ content: 'partial', assistant_status: 'streaming' })],
+			});
+
+			expect(onRecover).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/frontend/features/chat/hooks/use-chat-turns.test.ts
+++ b/frontend/features/chat/hooks/use-chat-turns.test.ts
@@ -1,0 +1,224 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatStreamEvent } from '../types';
+import { useChatTurns } from './use-chat-turns';
+
+/**
+ * Build an async generator that yields the supplied events in order.
+ * Mirrors the shape of `useChat().streamMessage` so the hook can drive
+ * a fake transport without touching `fetch`.
+ */
+function makeStream(
+	events: ChatStreamEvent[]
+): (prompt: string) => AsyncGenerator<ChatStreamEvent> {
+	return async function* gen(_prompt: string): AsyncGenerator<ChatStreamEvent> {
+		for (const e of events) yield e;
+	};
+}
+
+function streamThatThrows(message: string): (prompt: string) => AsyncGenerator<ChatStreamEvent> {
+	return async function* gen(_prompt: string): AsyncGenerator<ChatStreamEvent> {
+		yield { type: 'delta', content: 'partial' };
+		throw new Error(message);
+	};
+}
+
+describe('useChatTurns', () => {
+	describe('send (first turn, empty history)', () => {
+		it('appends user + assistant rows and streams deltas into the assistant slot', async () => {
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [],
+					streamMessage: makeStream([
+						{ type: 'delta', content: 'Hel' },
+						{ type: 'delta', content: 'lo' },
+					]),
+				})
+			);
+
+			await act(async () => {
+				await result.current.send('hi');
+			});
+
+			expect(result.current.chatHistory).toEqual([
+				{ role: 'user', content: 'hi' },
+				expect.objectContaining({
+					role: 'assistant',
+					content: 'Hello',
+					assistant_status: 'complete',
+				}),
+			]);
+		});
+
+		it('calls onFirstSend exactly once when history starts empty', async () => {
+			const onFirstSend = vi.fn().mockResolvedValue(undefined);
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [],
+					streamMessage: makeStream([{ type: 'delta', content: 'ok' }]),
+					onFirstSend,
+				})
+			);
+
+			await act(async () => {
+				await result.current.send('first');
+			});
+			await act(async () => {
+				await result.current.send('second');
+			});
+
+			expect(onFirstSend).toHaveBeenCalledExactlyOnceWith('first');
+		});
+
+		it('skips onFirstSend when initialHistory already has messages', async () => {
+			const onFirstSend = vi.fn().mockResolvedValue(undefined);
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [
+						{ role: 'user', content: 'old' },
+						{ role: 'assistant', content: 'reply' },
+					],
+					streamMessage: makeStream([{ type: 'delta', content: 'new reply' }]),
+					onFirstSend,
+				})
+			);
+
+			await act(async () => {
+				await result.current.send('new');
+			});
+
+			expect(onFirstSend).not.toHaveBeenCalled();
+		});
+
+		it('toggles isLoading around the stream', async () => {
+			let resolveStream: () => void = () => {};
+			const streamMessage = (_prompt: string): AsyncGenerator<ChatStreamEvent> => {
+				return (async function* gen() {
+					await new Promise<void>((resolve) => {
+						resolveStream = resolve;
+					});
+					yield { type: 'delta', content: 'done' };
+				})();
+			};
+
+			const { result } = renderHook(() =>
+				useChatTurns({ initialHistory: [], streamMessage })
+			);
+
+			act(() => {
+				void result.current.send('q');
+			});
+			await waitFor(() => expect(result.current.isLoading).toBe(true));
+			await act(async () => {
+				resolveStream();
+			});
+			await waitFor(() => expect(result.current.isLoading).toBe(false));
+		});
+	});
+
+	describe('send (error path)', () => {
+		it('collapses thrown errors into a failed assistant message', async () => {
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [],
+					streamMessage: streamThatThrows('upstream 500'),
+				})
+			);
+
+			await act(async () => {
+				await result.current.send('hi');
+			});
+
+			const last = result.current.chatHistory.at(-1);
+			expect(last).toEqual(
+				expect.objectContaining({
+					role: 'assistant',
+					content: 'Error: upstream 500',
+					assistant_status: 'failed',
+				})
+			);
+		});
+
+		it('uses a generic message when the rejection is not an Error instance', async () => {
+			const streamMessage = (_prompt: string): AsyncGenerator<ChatStreamEvent> => {
+				return (async function* gen() {
+					yield { type: 'delta', content: 'x' };
+					// biome-ignore lint/suspicious/useErrorMessage: simulate a non-Error rejection.
+					throw 'just a string';
+				})();
+			};
+
+			const { result } = renderHook(() =>
+				useChatTurns({ initialHistory: [], streamMessage })
+			);
+
+			await act(async () => {
+				await result.current.send('hi');
+			});
+
+			expect(result.current.chatHistory.at(-1)).toEqual(
+				expect.objectContaining({
+					content: 'Error: Chat stream failed.',
+					assistant_status: 'failed',
+				})
+			);
+		});
+	});
+
+	describe('regenerate', () => {
+		it('replaces the assistant slot in place and re-streams the user prompt', async () => {
+			const streamMessage = vi
+				.fn<typeof makeStream extends (...args: never) => infer R ? R : never>()
+				.mockImplementation(makeStream([{ type: 'delta', content: 'fresh' }]));
+
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [
+						{ role: 'user', content: 'what is 2+2' },
+						{ role: 'assistant', content: 'stale answer' },
+					],
+					streamMessage,
+				})
+			);
+
+			await act(async () => {
+				await result.current.regenerate(1);
+			});
+
+			// `streamMessage` is invoked with `(prompt, images)` — `regenerate`
+			// intentionally passes `undefined` for images so the re-stream is text-only.
+			expect(streamMessage).toHaveBeenCalledExactlyOnceWith('what is 2+2', undefined);
+			expect(result.current.chatHistory).toEqual([
+				{ role: 'user', content: 'what is 2+2' },
+				expect.objectContaining({
+					role: 'assistant',
+					content: 'fresh',
+					assistant_status: 'complete',
+				}),
+			]);
+		});
+
+		it('is a no-op when the index does not point at a user→assistant pair', async () => {
+			const streamMessage = vi
+				.fn<typeof makeStream extends (...args: never) => infer R ? R : never>()
+				.mockImplementation(makeStream([{ type: 'delta', content: 'x' }]));
+
+			const { result } = renderHook(() =>
+				useChatTurns({
+					initialHistory: [{ role: 'user', content: 'only-user' }],
+					streamMessage,
+				})
+			);
+
+			// Index 0 isn't an assistant, and there is no message at index 1.
+			await act(async () => {
+				await result.current.regenerate(0);
+			});
+			await act(async () => {
+				await result.current.regenerate(1);
+			});
+
+			expect(streamMessage).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
**Stack: 10 / 10** — base `claude/sentrux-09-be-test-coverage` (PR #231)

Two zero-coverage chat hooks get focused unit tests:

## `use-chat-background-recovery` (9 tests)

- `beginStream` / `endStream` round-trip the per-conversation
  breadcrumb in sessionStorage
- mount-time recovery fires `onRecover` for incomplete / failed last
  replies
- skips when the last reply is complete, when a turn is already
  streaming, or when no breadcrumb exists
- one-shot guard prevents re-firing across dep changes (which would
  otherwise loop after the container responds to `onRecover`)
- private-mode-safe: `setItem` throws are swallowed

## `use-chat-turns` (8 tests)

- `send()` appends user + assistant rows, streams deltas into the
  assistant slot, calls `onFirstSend` exactly once on the first turn
  (and never when `initialHistory` is non-empty), toggles `isLoading`,
  collapses Error and non-Error rejections into a failed assistant
  message with the right content prefix.
- `regenerate()` replaces the assistant slot in place using the prior
  user prompt and is a strict no-op when the index doesn't point at a
  user→assistant pair.

Both files follow the `renderHook` + scripted-stream pattern already
established by `use-chat.test.ts` (the only existing chat-hook test
file). Streams are pure async generators so the suite never touches
`fetch` or the dev server.

## Verification

- `cd frontend && bun run test features/chat/hooks/` — 28 tests / 5
  files.
- `cd frontend && bun run typecheck` + `bun run arch:check` — green.

## End-state of the stack

After all 10 PRs land:

- sentrux quality: **6026 → ~6909** (+883). Big jump in PR-2
  (acyclicity 5000 → 10000); PRs 3-10 are architectural correctness +
  coverage scaffolding.
- All 17 sentrux rules now actually enforced (4 by sentrux OSS, 6 by
  import-linter, 7 by depcruise).
- No file over the 500-LOC budget.
- Bottleneck shifted to modularity (5896), which is the natural next
  lever.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGNvy9RyjAuRDDKZU18Ts)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds focused unit tests for two previously uncovered chat hooks: `useChatBackgroundRecovery` (9 tests) and `useChatTurns` (8 tests). Both files follow the `renderHook` + scripted-async-generator pattern established by `use-chat.test.ts`, keeping the suite transport-free.

- `use-chat-background-recovery.test.ts` covers `beginStream`/`endStream` storage round-trips, mount-time recovery for failed and missing replies, the one-shot guard across re-renders, and private-mode-safe swallowing of `setItem` throws.
- `use-chat-turns.test.ts` covers `send` delta accumulation, `onFirstSend` exactly-once semantics, `isLoading` toggling, error collapse for both `Error` and non-`Error` rejections, `regenerate` in-place replacement, and the index-validation no-op guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are test-only and add no production code paths.

Both files are pure test additions. The only substantive gap found is that the isSendingRef/isLoading concurrency guard in regenerate (and the symmetric guard in send) has no test exercising the blocked path, so a regression there would be silent. Everything else is well covered.

frontend/features/chat/hooks/use-chat-turns.test.ts — the regenerate-while-sending concurrency scenario is the one gap worth a follow-up test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/features/chat/hooks/use-chat-background-recovery.test.ts | 9 tests cover beginStream/endStream round-trips, mount-time recovery, the one-shot guard, and private-mode safety. Tests are synchronous where appropriate (effects flush inside renderHook's act), and the beforeEach/afterEach isolation is correct. No logic bugs found. |
| frontend/features/chat/hooks/use-chat-turns.test.ts | 8 tests cover send, onFirstSend lifecycle, isLoading toggling, error collapsing, regenerate, and the no-op guard. Concurrency guard (isSendingRef) is not exercised by any test — a regression dropping that guard would go undetected. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-turns.test.ts%3A193-224%0A**Concurrency%20guard%20in%20%60regenerate%60%20is%20untested**%0A%0AThe%20%60regenerate%60%20implementation%20opens%20with%20%60if%20%28isSendingRef.current%20%7C%7C%20isLoading%29%20return%3B%60%2C%20but%20no%20test%20calls%20%60regenerate%60%20while%20a%20%60send%60%20is%20in%20progress%20%28or%20vice%20versa%29.%20The%20symmetrical%20guard%20in%20%60send%60%20has%20the%20same%20gap.%20If%20either%20guard%20were%20accidentally%20dropped%2C%20the%20existing%20suite%20would%20not%20catch%20it%20%E2%80%94%20both%20functions%20share%20%60isSendingRef%60%2C%20so%20a%20concurrent%20call%20can%20corrupt%20the%20assistant%20slot%20mid-stream.%20Adding%20a%20test%20that%20fires%20%60regenerate%60%20while%20%60send%60%20is%20still%20streaming%20%28i.e.%2C%20before%20%60resolveStream%28%29%60%29%20and%20asserts%20%60streamMessage%60%20is%20called%20exactly%20once%20would%20close%20this%20gap.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=232&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-10-fe-test-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-10-fe-test-coverage%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-turns.test.ts%3A193-224%0A**Concurrency%20guard%20in%20%60regenerate%60%20is%20untested**%0A%0AThe%20%60regenerate%60%20implementation%20opens%20with%20%60if%20%28isSendingRef.current%20%7C%7C%20isLoading%29%20return%3B%60%2C%20but%20no%20test%20calls%20%60regenerate%60%20while%20a%20%60send%60%20is%20in%20progress%20%28or%20vice%20versa%29.%20The%20symmetrical%20guard%20in%20%60send%60%20has%20the%20same%20gap.%20If%20either%20guard%20were%20accidentally%20dropped%2C%20the%20existing%20suite%20would%20not%20catch%20it%20%E2%80%94%20both%20functions%20share%20%60isSendingRef%60%2C%20so%20a%20concurrent%20call%20can%20corrupt%20the%20assistant%20slot%20mid-stream.%20Adding%20a%20test%20that%20fires%20%60regenerate%60%20while%20%60send%60%20is%20still%20streaming%20%28i.e.%2C%20before%20%60resolveStream%28%29%60%29%20and%20asserts%20%60streamMessage%60%20is%20called%20exactly%20once%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fsentrux-10-fe-test-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fsentrux-10-fe-test-coverage%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Ffeatures%2Fchat%2Fhooks%2Fuse-chat-turns.test.ts%3A193-224%0A**Concurrency%20guard%20in%20%60regenerate%60%20is%20untested**%0A%0AThe%20%60regenerate%60%20implementation%20opens%20with%20%60if%20%28isSendingRef.current%20%7C%7C%20isLoading%29%20return%3B%60%2C%20but%20no%20test%20calls%20%60regenerate%60%20while%20a%20%60send%60%20is%20in%20progress%20%28or%20vice%20versa%29.%20The%20symmetrical%20guard%20in%20%60send%60%20has%20the%20same%20gap.%20If%20either%20guard%20were%20accidentally%20dropped%2C%20the%20existing%20suite%20would%20not%20catch%20it%20%E2%80%94%20both%20functions%20share%20%60isSendingRef%60%2C%20so%20a%20concurrent%20call%20can%20corrupt%20the%20assistant%20slot%20mid-stream.%20Adding%20a%20test%20that%20fires%20%60regenerate%60%20while%20%60send%60%20is%20still%20streaming%20%28i.e.%2C%20before%20%60resolveStream%28%29%60%29%20and%20asserts%20%60streamMessage%60%20is%20called%20exactly%20once%20would%20close%20this%20gap.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["test(frontend): cover use-chat-turns + u..."](https://github.com/octaviantocan/pawrrtal-ai/commit/ca244d4bc449b9e06b925c4ea9af419fb296e557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32426254)</sub>

<!-- /greptile_comment -->