### PR TITLE
feat(workspace): align with agentic-stack structure

### DIFF
--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -21,11 +21,13 @@ from fastapi.responses import FileResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.tools.skills import read_skill_manifest
 from app.crud.workspace import get_default_workspace, list_workspaces
 from app.db import User, get_async_session
 from app.models import Workspace
 from app.schemas import (
     OnboardingStatus,
+    SkillRead,
     WorkspaceFileContent,
     WorkspaceFileNode,
     WorkspaceFileWrite,
@@ -253,6 +255,39 @@ def get_workspace_router() -> APIRouter:
             )
 
         target.unlink()
+
+    # ------------------------------------------------------------------
+    # List skills
+    # ------------------------------------------------------------------
+
+    @router.get("/{workspace_id}/skills", response_model=list[SkillRead])
+    async def list_workspace_skills(
+        workspace_id: uuid.UUID,
+        user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> list[SkillRead]:
+        """Return the skill list for a workspace.
+
+        Reads ``skills/_manifest.jsonl`` and falls back to directory discovery.
+        Returns an empty list (not 404) when the workspace has no skills yet.
+        """
+        ws = await _get_owned_workspace(workspace_id, user, session)
+        root = Path(ws.path)
+        if not root.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Workspace directory not found on disk",
+            )
+        entries = read_skill_manifest(root)
+        return [
+            SkillRead(
+                name=e.name,
+                trigger=e.trigger,
+                summary=e.summary,
+                has_skill_md=e.has_skill_md,
+            )
+            for e in entries
+        ]
 
     # ------------------------------------------------------------------
     # Serve binary file from the default workspace

--- a/backend/app/core/tools/agents_md.py
+++ b/backend/app/core/tools/agents_md.py
@@ -26,17 +26,19 @@ log = logging.getLogger(__name__)
 
 _AGENTS_MD = "AGENTS.md"
 _SOUL_MD = "SOUL.md"
+_SKILLS_INDEX_MD = "skills/_index.md"
 _MAX_BYTES = 64_000  # 64 KB — generous but keeps the context window sane
+_SKILLS_INDEX_MAX_BYTES = 32_000  # 32 KB — index only, not skill bodies
 
-# Files at the workspace root that the agent must NEVER be able to
-# delete or rename.  Used by the workspace_files write tool — see
-# `app/core/tools/workspace_files.py::is_protected_path`.
+# Files the agent must NEVER be able to delete or rename.  Used by the
+# workspace_files write tool — see `app/core/tools/workspace_files.py::is_protected_path`.
 PROTECTED_FILENAMES: frozenset[str] = frozenset(
     {
         _AGENTS_MD,
         _SOUL_MD,
         "USER.md",
         "IDENTITY.md",
+        _SKILLS_INDEX_MD,
     }
 )
 
@@ -56,21 +58,29 @@ def read_soul_md(workspace_root: Path) -> str | None:
     return read_capped_utf8(workspace_root / _SOUL_MD, max_bytes=_MAX_BYTES)
 
 
-def assemble_workspace_prompt(workspace_root: Path) -> str | None:
-    """Return the concatenated SOUL.md + AGENTS.md, or ``None`` if both missing.
+def read_skills_index(workspace_root: Path) -> str | None:
+    """Return the text of *workspace_root*/skills/_index.md, or ``None`` on failure."""
+    return read_capped_utf8(workspace_root / _SKILLS_INDEX_MD, max_bytes=_SKILLS_INDEX_MAX_BYTES)
 
-    Order: SOUL.md first ("who you are"), then a separator, then
-    AGENTS.md ("how to operate here").  Either may be missing
-    independently; the missing section is omitted with no trace in the
-    output so the agent doesn't see "(file missing)" placeholders.
+
+def assemble_workspace_prompt(workspace_root: Path) -> str | None:
+    """Return SOUL.md + AGENTS.md + skills/_index.md, or ``None`` if all missing.
+
+    Order: SOUL.md ("who you are"), AGENTS.md ("how to operate here"), then
+    skills/_index.md ("what skills are available").  Any section may be absent
+    independently; missing sections are omitted with no placeholder text so the
+    agent doesn't see "(file missing)" noise.
     """
     soul = read_soul_md(workspace_root)
     agents = read_agents_md(workspace_root)
-    if soul is None and agents is None:
+    skills_index = read_skills_index(workspace_root)
+    if soul is None and agents is None and skills_index is None:
         return None
     parts: list[str] = []
     if soul is not None:
         parts.append(soul)
     if agents is not None:
         parts.append(agents)
+    if skills_index is not None:
+        parts.append(skills_index)
     return "\n\n---\n\n".join(parts)

--- a/backend/app/core/tools/skills.py
+++ b/backend/app/core/tools/skills.py
@@ -1,0 +1,118 @@
+"""Skill manifest reader for the workspace API layer.
+
+Reads ``skills/_manifest.jsonl`` for machine-readable skill metadata and
+falls back to directory discovery when the manifest is absent or corrupt.
+
+No database access, no network calls — pure filesystem reads.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_SKILLS_DIR = "skills"
+_MANIFEST_FILE = "skills/_manifest.jsonl"
+_SKILL_MD_NAME = "SKILL.md"
+
+# Hard caps to prevent runaway directory scanning or line parsing.
+_MAX_SKILLS = 200
+_MAX_MANIFEST_LINE_BYTES = 4_000
+
+
+@dataclass
+class SkillEntry:
+    """A single skill discovered in the workspace skills directory."""
+
+    name: str
+    trigger: str
+    summary: str
+    has_skill_md: bool
+    extra: dict = field(default_factory=dict)
+
+
+def read_skill_manifest(workspace_root: Path) -> list[SkillEntry]:
+    """Return all skills found in the workspace skills directory.
+
+    Strategy:
+    1. Parse ``skills/_manifest.jsonl`` line-by-line into a name → dict lookup.
+       Corrupt lines are skipped with a warning; the function never raises.
+    2. Scan ``skills/`` for subdirectories whose names do not start with ``_``.
+    3. Merge each subdirectory with its manifest entry (if any) into a
+       ``SkillEntry``, checking whether ``SKILL.md`` exists.
+    4. Return up to ``_MAX_SKILLS`` entries sorted by name.
+
+    Returns an empty list on any I/O error so the API degrades gracefully.
+    """
+    skills_dir = workspace_root / _SKILLS_DIR
+    if not skills_dir.is_dir():
+        return []
+
+    manifest_lookup = _load_manifest(workspace_root)
+
+    entries: list[SkillEntry] = []
+    try:
+        subdirs = sorted(
+            (p for p in skills_dir.iterdir() if p.is_dir() and not p.name.startswith("_")),
+            key=lambda p: p.name,
+        )
+    except OSError:
+        log.warning("Failed to list skills directory: %s", skills_dir)
+        return []
+
+    for subdir in subdirs[:_MAX_SKILLS]:
+        meta = manifest_lookup.get(subdir.name, {})
+        entries.append(
+            SkillEntry(
+                name=subdir.name,
+                trigger=meta.get("trigger", "—"),
+                summary=meta.get("summary", "—"),
+                has_skill_md=(subdir / _SKILL_MD_NAME).is_file(),
+                extra={k: v for k, v in meta.items() if k not in ("name", "trigger", "summary")},
+            )
+        )
+
+    return entries
+
+
+def _load_manifest(workspace_root: Path) -> dict[str, dict]:
+    """Parse ``skills/_manifest.jsonl`` into a name → metadata dict.
+
+    Skips lines that exceed ``_MAX_MANIFEST_LINE_BYTES`` or fail JSON parsing.
+    Returns an empty dict if the file is absent or unreadable.
+    """
+    manifest_path = workspace_root / _MANIFEST_FILE
+    if not manifest_path.is_file():
+        return {}
+
+    lookup: dict[str, dict] = {}
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        log.warning("Could not read skill manifest: %s", manifest_path)
+        return {}
+
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        if len(line.encode()) > _MAX_MANIFEST_LINE_BYTES:
+            log.warning("Skill manifest line %d exceeds byte limit, skipping", lineno)
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            log.warning("Skill manifest line %d is not valid JSON, skipping", lineno)
+            continue
+        if not isinstance(entry, dict):
+            log.warning("Skill manifest line %d is not a JSON object, skipping", lineno)
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name:
+            lookup[name] = entry
+
+    return lookup

--- a/backend/app/core/workspace.py
+++ b/backend/app/core/workspace.py
@@ -44,11 +44,33 @@ from __future__ import annotations
 import logging
 import uuid
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from app.core.config import settings
-from app.models import UserPersonalization
 
 log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class PersonalizationFields(Protocol):
+    """Subset of ``UserPersonalization`` attributes the workspace seeders read.
+
+    Declared here (in ``app.core``) so the seeder stays in the architectural
+    core layer without importing from ``app.models`` — that import would
+    invert the sentrux layer ordering (``be-core`` must not depend on
+    ``be-models``). Any ORM instance with matching attributes — notably
+    ``UserPersonalization`` — satisfies this protocol via duck typing, so
+    callers in higher layers can keep passing the model directly.
+    """
+
+    name: str | None
+    role: str | None
+    company_website: str | None
+    linkedin: str | None
+    goals: list[str] | None
+    personality: str | None
+    custom_instructions: str | None
+
 
 # ---------------------------------------------------------------------------
 # Directory layout constants
@@ -335,7 +357,7 @@ false confidence.  You are here to be genuinely useful.
 _DEFAULT_SOUL = _PERSONALITY_SOULS["balanced"]
 
 
-def _build_user_md(p: UserPersonalization | None) -> str:
+def _build_user_md(p: PersonalizationFields | None) -> str:
     if p is None:
         return "# USER.md — About You\n\n_(Fill in your details here.)_\n"
 
@@ -365,7 +387,7 @@ def _build_user_md(p: UserPersonalization | None) -> str:
     return "\n".join(lines)
 
 
-def _build_soul_md(p: UserPersonalization | None) -> str:
+def _build_soul_md(p: PersonalizationFields | None) -> str:
     if p is None or not p.personality:
         return _DEFAULT_SOUL
     return _PERSONALITY_SOULS.get(p.personality.lower(), _DEFAULT_SOUL)
@@ -383,7 +405,7 @@ def _workspace_path(workspace_id: uuid.UUID) -> Path:
 
 def seed_workspace(
     workspace_id: uuid.UUID,
-    personalization: UserPersonalization | None = None,
+    personalization: PersonalizationFields | None = None,
 ) -> Path:
     """Create the workspace directory tree and write seed files.
 

--- a/backend/app/core/workspace.py
+++ b/backend/app/core/workspace.py
@@ -1,22 +1,37 @@
 """Workspace management service.
 
-A workspace is an OpenClaw-style agent home directory.  Each user can have
-multiple workspaces; each workspace is a self-contained directory tree that
-holds the agent's identity, memory, skills, and generated artifacts.
+A workspace is an agentic-stack-compatible agent home directory.  Each user
+can have multiple workspaces; each workspace is a self-contained directory
+tree that holds the agent's identity, memory, skills, and generated artifacts.
 
-Standard file layout (inspired by the official OpenClaw workspace structure):
+Standard file layout (aligned with the agentic-stack open standard):
 
     {workspace_root}/
-    ├── AGENTS.md       # Operating instructions / entry point
-    ├── SOUL.md         # Agent persona and tone
-    ├── IDENTITY.md     # Agent name, emoji, vibe
-    ├── USER.md         # Who the human is (from onboarding)
-    ├── TOOLS.md        # Local tool conventions
-    ├── memory/         # Memory files (daily notes, long-term)
-    │   └── .gitkeep
-    ├── skills/         # Workspace-scoped skills
-    │   └── .gitkeep
-    └── artifacts/      # Files the agent has generated
+    ├── AGENTS.md              # Operating instructions / entry point
+    ├── SOUL.md                # Agent persona and tone
+    ├── IDENTITY.md            # Agent name, emoji, vibe
+    ├── USER.md                # Who the human is (from onboarding)
+    ├── TOOLS.md               # Local tool conventions
+    ├── memory/
+    │   ├── personal/
+    │   │   └── PREFERENCES.md    # User conventions (indefinite lifespan)
+    │   ├── working/
+    │   │   ├── WORKSPACE.md      # Current task state (~2-day lifespan)
+    │   │   └── REVIEW_QUEUE.md   # Items awaiting review
+    │   ├── episodic/
+    │   │   └── .gitkeep          # Raw experience log (AGENT_LEARNINGS.jsonl)
+    │   └── semantic/
+    │       ├── LESSONS.md        # Distilled patterns (append-only)
+    │       └── DECISIONS.md      # Key decisions log (append-only)
+    ├── skills/
+    │   ├── _index.md             # Always-in-context skill map
+    │   ├── _manifest.jsonl       # Machine-readable skill metadata
+    │   └── <name>/
+    │       └── SKILL.md          # Fetched on-demand via read_file tool
+    ├── protocols/
+    │   ├── permissions.md        # Allow/deny rules
+    │   └── delegation.md        # Escalation protocol
+    └── artifacts/               # Files the agent generates for the user
         └── .gitkeep
 
 Seeding happens once: when the user completes the onboarding wizard and the
@@ -31,9 +46,24 @@ import uuid
 from pathlib import Path
 
 from app.core.config import settings
+from app.models import UserPersonalization
 
 log = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Directory layout constants
+# ---------------------------------------------------------------------------
+
+_MEMORY_LAYERS: tuple[str, ...] = (
+    "memory/personal",
+    "memory/working",
+    "memory/episodic",
+    "memory/semantic",
+)
+_SKILLS_DIR = "skills"
+_SKILLS_INDEX = "skills/_index.md"
+_SKILLS_MANIFEST = "skills/_manifest.jsonl"
+_PROTOCOLS_DIR = "protocols"
 
 # ---------------------------------------------------------------------------
 # File templates
@@ -56,17 +86,37 @@ This folder is the agent's home for this workspace.
 On every session start, read:
 1. `SOUL.md` — who you are
 2. `USER.md` — who you're helping
-3. `memory/` — recent daily notes for context
+3. `skills/_index.md` — your skill map (already in context; use `read_file`
+   to load full skill bodies on demand when a trigger fires)
+4. `memory/working/WORKSPACE.md` — current task state
 
 ## Memory
 
-Write to `memory/YYYY-MM-DD.md` constantly — every decision, lesson,
-build event, or correction goes in before anything else.
+Memory is split into four layers:
+
+- **personal/** — User conventions and preferences (indefinite lifespan).
+  Edit `memory/personal/PREFERENCES.md` when the user states a standing preference.
+- **working/** — Current task state (~2-day lifespan).
+  Update `memory/working/WORKSPACE.md` at the start and end of every session.
+  Use `memory/working/REVIEW_QUEUE.md` for items needing user approval.
+- **episodic/** — Raw experience log.
+  Append events, corrections, and learnings to `memory/episodic/AGENT_LEARNINGS.jsonl`.
+- **semantic/** — Distilled patterns (append-only).
+  Promoted lessons go in `memory/semantic/LESSONS.md`; key decisions in
+  `memory/semantic/DECISIONS.md`.
 
 ## Skills
 
-Custom skills live in `skills/`.  Each skill is a markdown file describing
-a repeatable workflow.
+Custom skills live in `skills/<name>/SKILL.md`.  The skill map at
+`skills/_index.md` is always in your context.  When a skill's trigger fires,
+call `read_file` with `path: "skills/<name>/SKILL.md"` to load the full
+playbook before acting.  Add new skills by writing a subdirectory.
+
+## Protocols
+
+Operating rules live in `protocols/`:
+- `permissions.md` — what you may do autonomously vs what requires confirmation
+- `delegation.md` — when to escalate to the user
 
 ## Artifacts
 
@@ -102,13 +152,141 @@ The agent has direct read/write access to this workspace directory.
 
 ## Memory
 
-- Daily notes: `memory/YYYY-MM-DD.md`
-- Long-term memory index: `memory/MEMORY.md` _(created automatically)_
+- Personal preferences: `memory/personal/PREFERENCES.md`
+- Current task state: `memory/working/WORKSPACE.md`
+- Review queue: `memory/working/REVIEW_QUEUE.md`
+- Experience log: `memory/episodic/AGENT_LEARNINGS.jsonl`
+- Distilled lessons: `memory/semantic/LESSONS.md`
+- Key decisions: `memory/semantic/DECISIONS.md`
 
 ## Skills
 
-- List available skills with the skill workshop tool.
-- Workspace-scoped skills live in `skills/`.
+- Skill map (always in context): `skills/_index.md`
+- Load a skill body: `read_file` with `path: "skills/<name>/SKILL.md"`
+- Add a skill: write `skills/<name>/SKILL.md` and update `skills/_index.md`
+"""
+
+_MEMORY_PREFERENCES_MD = """\
+# PREFERENCES.md — User Conventions (Indefinite Lifespan)
+
+Record anything about how the user prefers to work: code style, communication
+preferences, recurring patterns, standing decisions.
+
+This file lives in personal/ and is never automatically expired.
+Update it whenever the user states a standing preference.
+
+## Preferences
+
+_(None recorded yet.)_
+"""
+
+_MEMORY_WORKSPACE_MD = """\
+# WORKSPACE.md — Current Task State (~2-Day Lifespan)
+
+Track the current active task: what is in progress, what is blocked, what
+the next concrete action is.
+
+Update this at the start and end of every work session.
+Carry only what is relevant to the next 48 hours; archive to
+`episodic/AGENT_LEARNINGS.jsonl` after.
+
+## Status
+
+_(No active task.)_
+
+## Next Action
+
+_(None.)_
+"""
+
+_MEMORY_REVIEW_QUEUE_MD = """\
+# REVIEW_QUEUE.md — Items Awaiting Review
+
+List items that need the user's attention or approval before the agent
+can proceed.  Clear rows as they are resolved.
+
+| Item | Added | Status |
+|------|-------|--------|
+"""
+
+_MEMORY_LESSONS_MD = """\
+# LESSONS.md — Distilled Patterns (Append-Only)
+
+Patterns and principles that have been proved reliable across multiple
+episodes.  Append new entries; never delete.
+
+Each entry: date · context · lesson · confidence.
+
+## Lessons
+
+_(None recorded yet.)_
+"""
+
+_MEMORY_DECISIONS_MD = """\
+# DECISIONS.md — Architectural & Process Decisions (Append-Only)
+
+Record significant decisions: what was chosen, what was rejected, and why.
+Append only; amendments go below the original entry.
+
+## Decisions
+
+_(None recorded yet.)_
+"""
+
+_SKILLS_INDEX_MD = """\
+# skills/_index.md — Skill Map (Always in Context)
+
+This file is embedded in your system prompt on every turn.  It is your map
+to all available skills.
+
+## How skills work
+
+- This index lists every skill with its **trigger** and a one-line summary.
+- The full skill body lives at `skills/<name>/SKILL.md`.
+- When a trigger fires, call `read_file` with `path: "skills/<name>/SKILL.md"`
+  to load the full playbook before acting.
+- New skills are added by writing a subdirectory here and updating this index.
+
+## Available skills
+
+_(No skills yet.  Add a skill by writing `skills/<name>/SKILL.md` and adding
+an entry in this index.)_
+"""
+
+_PROTOCOLS_PERMISSIONS_MD = """\
+# permissions.md — Agent Permission Model
+
+Defines what the agent may do autonomously vs what requires user confirmation.
+
+## Autonomous (no confirmation needed)
+
+- Read any file in the workspace.
+- Write to `memory/` and `artifacts/`.
+- Create new skill directories under `skills/`.
+
+## Requires confirmation
+
+- Overwrite an existing artifact the user explicitly named.
+- Any action outside the workspace root.
+- Any call to a destructive external API.
+"""
+
+_PROTOCOLS_DELEGATION_MD = """\
+# delegation.md — Delegation & Escalation Protocol
+
+When to escalate to the user vs when to proceed independently.
+
+## Proceed independently
+
+- Gathering information (read_file, list_dir, web search).
+- Writing to memory or working notes.
+- Drafting artifacts in `artifacts/` clearly named as drafts.
+
+## Escalate before acting
+
+- When scope is ambiguous and the wrong choice is hard to reverse.
+- When the user asked for A and you believe B is better — propose, don't substitute.
+- When a tool returns an unexpected error more than twice.
 """
 
 _PERSONALITY_SOULS: dict[str, str] = {
@@ -216,24 +394,40 @@ def seed_workspace(
     """
     root = _workspace_path(workspace_id)
 
-    # Create standard subdirectories.
-    for subdir in ("memory", "skills", "artifacts"):
+    # Create four-layer memory directories, skills, artifacts, and protocols.
+    for subdir in (*_MEMORY_LAYERS, _SKILLS_DIR, "artifacts", _PROTOCOLS_DIR):
         (root / subdir).mkdir(parents=True, exist_ok=True)
-        gitkeep = root / subdir / ".gitkeep"
+
+    # Place .gitkeep in directories that start empty so git can track them.
+    for gitkeep_dir in ("memory/episodic", "artifacts"):
+        gitkeep = root / gitkeep_dir / ".gitkeep"
         if not gitkeep.exists():
             gitkeep.touch()
 
-    # Write seed files — skip if already present so edits aren't clobbered.
+    # Write seed files — skip if already present so edits are not clobbered.
     seed_files: dict[str, str] = {
         "AGENTS.md": _AGENTS_MD,
         "IDENTITY.md": _IDENTITY_MD,
         "TOOLS.md": _TOOLS_MD,
         "SOUL.md": _build_soul_md(personalization),
         "USER.md": _build_user_md(personalization),
+        "memory/personal/PREFERENCES.md": _MEMORY_PREFERENCES_MD,
+        "memory/working/WORKSPACE.md": _MEMORY_WORKSPACE_MD,
+        "memory/working/REVIEW_QUEUE.md": _MEMORY_REVIEW_QUEUE_MD,
+        "memory/semantic/LESSONS.md": _MEMORY_LESSONS_MD,
+        "memory/semantic/DECISIONS.md": _MEMORY_DECISIONS_MD,
+        _SKILLS_INDEX: _SKILLS_INDEX_MD,
+        "protocols/permissions.md": _PROTOCOLS_PERMISSIONS_MD,
+        "protocols/delegation.md": _PROTOCOLS_DELEGATION_MD,
     }
     for filename, content in seed_files.items():
         target = root / filename
         if not target.exists():
             target.write_text(content, encoding="utf-8")
+
+    # Seed an empty manifest; content is machine-generated, not a static template.
+    manifest = root / _SKILLS_MANIFEST
+    if not manifest.exists():
+        manifest.write_text("", encoding="utf-8")
 
     return root

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -422,6 +422,15 @@ class WorkspaceFileWrite(BaseModel):
     content: str
 
 
+class SkillRead(BaseModel):
+    """A single skill entry returned by GET /{workspace_id}/skills."""
+
+    name: str
+    trigger: str
+    summary: str
+    has_skill_md: bool
+
+
 # --- Governance + ops platform schemas ---------------------------------------
 #
 # Implementations live in :mod:`app.governance_schemas` to keep this

--- a/backend/tests/test_agents_md.py
+++ b/backend/tests/test_agents_md.py
@@ -1,0 +1,91 @@
+"""Tests for the agents_md workspace prompt assembler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.tools.agents_md import (
+    PROTECTED_FILENAMES,
+    assemble_workspace_prompt,
+    read_skills_index,
+)
+
+
+class TestAssembleWorkspacePrompt:
+    def test_includes_skills_index_when_present(self, tmp_path: Path) -> None:
+        (tmp_path / "SOUL.md").write_text("# SOUL\n", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_index.md").write_text("# Skill Map\n\nsome skills\n", encoding="utf-8")
+
+        result = assemble_workspace_prompt(tmp_path)
+
+        assert result is not None
+        assert "Skill Map" in result
+        assert "some skills" in result
+
+    def test_omits_skills_index_when_missing(self, tmp_path: Path) -> None:
+        (tmp_path / "SOUL.md").write_text("# SOUL\n", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+
+        result = assemble_workspace_prompt(tmp_path)
+
+        assert result is not None
+        assert "SOUL" in result
+        assert "AGENTS" in result
+
+    def test_returns_none_when_all_three_missing(self, tmp_path: Path) -> None:
+        result = assemble_workspace_prompt(tmp_path)
+        assert result is None
+
+    def test_sections_joined_with_separator(self, tmp_path: Path) -> None:
+        (tmp_path / "SOUL.md").write_text("SOUL_CONTENT", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("AGENTS_CONTENT", encoding="utf-8")
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_index.md").write_text("INDEX_CONTENT", encoding="utf-8")
+
+        result = assemble_workspace_prompt(tmp_path)
+
+        assert result is not None
+        parts = result.split("\n\n---\n\n")
+        assert len(parts) == 3
+        assert parts[0] == "SOUL_CONTENT"
+        assert parts[1] == "AGENTS_CONTENT"
+        assert parts[2] == "INDEX_CONTENT"
+
+    def test_skills_index_only_returns_non_none(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_index.md").write_text("# Index\n", encoding="utf-8")
+
+        result = assemble_workspace_prompt(tmp_path)
+
+        assert result is not None
+        assert "Index" in result
+
+
+class TestReadSkillsIndex:
+    def test_returns_content_when_present(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_index.md").write_text("hello index", encoding="utf-8")
+
+        result = read_skills_index(tmp_path)
+        assert result == "hello index"
+
+    def test_returns_none_when_missing(self, tmp_path: Path) -> None:
+        result = read_skills_index(tmp_path)
+        assert result is None
+
+
+class TestProtectedFilenames:
+    def test_skills_index_is_protected(self) -> None:
+        assert "skills/_index.md" in PROTECTED_FILENAMES
+
+    def test_agents_md_is_protected(self) -> None:
+        assert "AGENTS.md" in PROTECTED_FILENAMES
+
+    def test_soul_md_is_protected(self) -> None:
+        assert "SOUL.md" in PROTECTED_FILENAMES

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1,0 +1,132 @@
+"""Tests for the skills manifest reader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.core.tools.skills import read_skill_manifest
+
+
+def _make_skill_dir(skills_dir: Path, name: str, with_skill_md: bool = True) -> Path:
+    """Create a skill subdirectory, optionally with SKILL.md."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    if with_skill_md:
+        (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    return skill_dir
+
+
+def _write_manifest(skills_dir: Path, entries: list[dict]) -> None:
+    """Write JSONL entries to _manifest.jsonl."""
+    lines = "\n".join(json.dumps(e) for e in entries)
+    (skills_dir / "_manifest.jsonl").write_text(lines, encoding="utf-8")
+
+
+class TestReadSkillManifest:
+    def test_returns_empty_when_skills_dir_absent(self, tmp_path: Path) -> None:
+        result = read_skill_manifest(tmp_path)
+        assert result == []
+
+    def test_empty_manifest_and_no_subdirs_returns_empty(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_manifest.jsonl").write_text("", encoding="utf-8")
+
+        result = read_skill_manifest(tmp_path)
+        assert result == []
+
+    def test_discovers_skill_dirs_without_manifest_entries(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_manifest.jsonl").write_text("", encoding="utf-8")
+        _make_skill_dir(skills_dir, "my-skill")
+
+        result = read_skill_manifest(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].name == "my-skill"
+        assert result[0].trigger == "—"
+        assert result[0].summary == "—"
+        assert result[0].has_skill_md is True
+
+    def test_manifest_entries_populate_trigger_and_summary(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        _make_skill_dir(skills_dir, "tdd")
+        _write_manifest(skills_dir, [
+            {"name": "tdd", "trigger": "when writing tests", "summary": "red-green-refactor loop"},
+        ])
+
+        result = read_skill_manifest(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].trigger == "when writing tests"
+        assert result[0].summary == "red-green-refactor loop"
+
+    def test_ignores_underscore_prefixed_names(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "_index.md").write_text("# index\n", encoding="utf-8")
+        # _internal dir should also be ignored
+        internal = skills_dir / "_internal"
+        internal.mkdir()
+        (internal / "SKILL.md").write_text("hidden\n", encoding="utf-8")
+        _make_skill_dir(skills_dir, "visible-skill")
+
+        result = read_skill_manifest(tmp_path)
+
+        names = [e.name for e in result]
+        assert "visible-skill" in names
+        assert "_internal" not in names
+
+    def test_has_skill_md_false_when_file_missing(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        _make_skill_dir(skills_dir, "no-file", with_skill_md=False)
+
+        result = read_skill_manifest(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].has_skill_md is False
+
+    def test_corrupt_manifest_line_is_skipped(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        _make_skill_dir(skills_dir, "good-skill")
+        _make_skill_dir(skills_dir, "bad-skill")
+        (skills_dir / "_manifest.jsonl").write_text(
+            '{"name": "good-skill", "trigger": "ok"}\nnot json at all\n',
+            encoding="utf-8",
+        )
+
+        result = read_skill_manifest(tmp_path)
+
+        names = [e.name for e in result]
+        assert "good-skill" in names
+        # bad-skill is still discovered via directory scan, just without manifest metadata
+        assert "bad-skill" in names
+        good = next(e for e in result if e.name == "good-skill")
+        assert good.trigger == "ok"
+
+    def test_results_sorted_by_name(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        for name in ("zebra", "alpha", "mango"):
+            _make_skill_dir(skills_dir, name)
+
+        result = read_skill_manifest(tmp_path)
+
+        assert [e.name for e in result] == ["alpha", "mango", "zebra"]
+
+    def test_returns_empty_on_missing_manifest_file(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        _make_skill_dir(skills_dir, "some-skill")
+        # No _manifest.jsonl — should still discover via dir scan
+
+        result = read_skill_manifest(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].name == "some-skill"
+        assert result[0].trigger == "—"

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -82,14 +82,101 @@ class TestSeedWorkspace:
         assert (root / "skills").is_dir()
         assert (root / "artifacts").is_dir()
 
-    def test_creates_gitkeep_in_each_subdir(self, tmp_path: Path) -> None:
+    def test_creates_memory_sublayers(self, tmp_path: Path) -> None:
         ws_id = uuid.uuid4()
         with patch("app.core.workspace.settings") as mock_settings:
             mock_settings.workspace_base_dir = str(tmp_path)
             root = seed_workspace(ws_id)
 
-        for subdir in ("memory", "skills", "artifacts"):
-            assert (root / subdir / ".gitkeep").exists()
+        for layer in ("personal", "working", "episodic", "semantic"):
+            assert (root / "memory" / layer).is_dir()
+
+    def test_creates_protocols_dir(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "protocols").is_dir()
+
+    def test_creates_gitkeep_in_episodic_and_artifacts(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "memory" / "episodic" / ".gitkeep").exists()
+        assert (root / "artifacts" / ".gitkeep").exists()
+
+    def test_seeds_skills_index_md(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        index = (root / "skills" / "_index.md").read_text()
+        assert "Skill Map" in index
+        assert "read_file" in index
+
+    def test_seeds_manifest_as_empty_file(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        manifest = root / "skills" / "_manifest.jsonl"
+        assert manifest.exists()
+        assert manifest.read_text() == ""
+
+    def test_seeds_memory_personal_preferences(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "memory" / "personal" / "PREFERENCES.md").exists()
+
+    def test_seeds_memory_working_workspace(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "memory" / "working" / "WORKSPACE.md").exists()
+        assert (root / "memory" / "working" / "REVIEW_QUEUE.md").exists()
+
+    def test_seeds_semantic_memory_files(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "memory" / "semantic" / "LESSONS.md").exists()
+        assert (root / "memory" / "semantic" / "DECISIONS.md").exists()
+
+    def test_seeds_protocols_files(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        assert (root / "protocols" / "permissions.md").exists()
+        assert (root / "protocols" / "delegation.md").exists()
+
+    def test_does_not_overwrite_existing_skills_index(self, tmp_path: Path) -> None:
+        ws_id = uuid.uuid4()
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            root = seed_workspace(ws_id)
+
+        custom = "# My custom skill index\n"
+        (root / "skills" / "_index.md").write_text(custom)
+
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            seed_workspace(ws_id)
+
+        assert (root / "skills" / "_index.md").read_text() == custom
 
     def test_writes_agents_md(self, tmp_path: Path) -> None:
         ws_id = uuid.uuid4()
@@ -559,3 +646,48 @@ class TestWorkspaceAPI:
         resp = await client.get(f"/api/v1/workspaces/{ws.id}/files/../../../etc/passwd")
         # Either 400 (traversal blocked) or 404 (path normalised to inside workspace).
         assert resp.status_code in (400, 404)
+
+    @pytest.mark.anyio
+    async def test_skills_endpoint_returns_empty_for_fresh_workspace(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        resp = await client.get(f"/api/v1/workspaces/{ws.id}/skills")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.anyio
+    async def test_skills_endpoint_discovers_skill_after_write(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+        tmp_path: Path,
+    ) -> None:
+        with patch("app.core.workspace.settings") as mock_settings:
+            mock_settings.workspace_base_dir = str(tmp_path)
+            ws = await create_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        # Write a skill via the existing file endpoint.
+        skill_content = "---\nname: my-skill\ntrigger: when testing\nsummary: run tests\n---\n\n# My Skill\n"
+        put_resp = await client.put(
+            f"/api/v1/workspaces/{ws.id}/files/skills/my-skill/SKILL.md",
+            json={"content": skill_content},
+        )
+        assert put_resp.status_code == 200
+
+        resp = await client.get(f"/api/v1/workspaces/{ws.id}/skills")
+        assert resp.status_code == 200
+        skills = resp.json()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "my-skill"
+        assert skills[0]["has_skill_md"] is True


### PR DESCRIPTION
## Summary

- Restructures the agent workspace to be compatible with the [agentic-stack](https://github.com/codejunkie99/agentic-stack) open standard, enabling users with an existing agentic-stack brain to bring it directly into Pawrrtal
- Replaces the flat `memory/` dir with a four-layer model (`personal/`, `working/`, `episodic/`, `semantic/`) and seeds all layers with purpose-built starter files
- Adds `skills/_index.md` (always-in-context skill map embedded in every system prompt) + `skills/_manifest.jsonl` (machine-readable metadata) + `protocols/` directory
- Exposes a new `GET /api/v1/workspaces/{id}/skills` endpoint for the skill manifest

## Changes

- **`backend/app/core/workspace.py`** — new `_MEMORY_LAYERS`, `_PROTOCOLS_DIR` constants; 8 new seed-file templates; updated `seed_workspace()` to create the full agentic-stack tree; updated `_AGENTS_MD` template to reference the new layout
- **`backend/app/core/tools/agents_md.py`** — `read_skills_index()` + updated `assemble_workspace_prompt()` to embed `skills/_index.md` as a third system-prompt section; `"skills/_index.md"` added to `PROTECTED_FILENAMES`
- **`backend/app/core/tools/skills.py`** (new) — pure filesystem reader; `SkillEntry` dataclass; `read_skill_manifest()` merges `_manifest.jsonl` + directory scan
- **`backend/app/schemas.py`** — `SkillRead` Pydantic model
- **`backend/app/api/workspace.py`** — `GET /{workspace_id}/skills` endpoint
- **`backend/tests/test_workspace.py`** — 10 new unit tests + 2 new API tests covering the new tree shape and idempotency
- **`backend/tests/test_agents_md.py`** (new) — 9 tests for prompt assembly and protected filenames
- **`backend/tests/test_skills.py`** (new) — 9 tests for manifest parsing, directory discovery, corrupt-line skipping

## Test plan

- [ ] All 482 backend tests pass locally (`uv run pytest`)
- [ ] CI backend pytest job passes
- [ ] `seed_workspace()` is idempotent — existing workspaces are not overwritten
- [ ] Fresh workspace has `memory/personal/PREFERENCES.md`, `memory/working/WORKSPACE.md`, `skills/_index.md`, `protocols/permissions.md`, etc.
- [ ] System prompt for a workspace includes the contents of `skills/_index.md`
- [ ] `GET /api/v1/workspaces/{id}/skills` returns `[]` for a fresh workspace

https://claude.ai/code/session_0166p93G9kaR1XxvYXaESXSm

---
_Generated by [Claude Code](https://claude.ai/code/session_0166p93G9kaR1XxvYXaESXSm)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restructures the agent workspace layout to align with the agentic-stack open standard, replacing the flat `memory/` directory with a four-layer model and adding `skills/` and `protocols/` directories, a new `GET /skills` endpoint, and `skills/_index.md` embedded in every system prompt.

- **Workspace seeding** (`workspace.py`): adds `_MEMORY_LAYERS`, `_PROTOCOLS_DIR` constants and 8 new seed-file templates; `seed_workspace()` is correctly idempotent (skip-if-exists); the new `PersonalizationFields` Protocol cleanly decouples the core layer from `app.models`, though `@runtime_checkable` on a data-only Protocol is a no-op that can mislead callers.
- **Prompt assembly** (`agents_md.py`): `read_skills_index()` and updated `assemble_workspace_prompt()` embed `skills/_index.md` as a third system-prompt section; `skills/_index.md` is added to `PROTECTED_FILENAMES`.
- **Skill manifest reader + API endpoint**: pure filesystem reader with per-line caps and graceful degradation; test coverage across all three new modules is thorough.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive, idempotency is preserved, and no existing behaviour is modified.

The workspace restructuring is purely additive — existing workspaces are not overwritten, the new endpoint degrades gracefully to an empty list, and the system-prompt change only adds a new section when the file exists. All flagged findings are non-blocking quality observations with no effect on correctness.

No files require special attention; the findings in skills.py and workspace.py are minor and do not affect correctness on any current code path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/api/workspace.py | Adds GET /{workspace_id}/skills endpoint; correctly delegates to read_skill_manifest and maps SkillEntry to SkillRead; returns [] (not 404) when skills dir is empty; auth guard and ownership check follow established patterns. |
| backend/app/core/tools/agents_md.py | Adds read_skills_index() and embeds skills/_index.md as third section in assemble_workspace_prompt(); adds skills/_index.md to PROTECTED_FILENAMES; changes are minimal and consistent with the existing soul/agents pattern. |
| backend/app/core/tools/skills.py | New pure-filesystem skill manifest reader; per-line 4 KB cap and error handling are correct; _MAX_SKILLS cap is applied after full iterdir() sort, so a workspace with thousands of skill dirs still enumerates all of them before slicing. |
| backend/app/core/workspace.py | Restructures seed_workspace() to the four-layer memory model and adds protocols/; idempotency (skip-if-exists) is preserved; PersonalizationFields Protocol correctly decouples the core layer from app.models. |
| backend/app/schemas.py | Adds SkillRead Pydantic model with name, trigger, summary, has_skill_md; straightforward addition. |
| backend/tests/test_workspace.py | Ten new unit tests cover all new seed files, memory layers, protocols, and idempotency; two new API tests cover the skills endpoint for fresh workspace and after a skill write. |
| backend/tests/test_agents_md.py | Nine tests covering prompt assembly with all three sections present, each section missing, separator format, and PROTECTED_FILENAMES membership; thorough and correct. |
| backend/tests/test_skills.py | Nine tests covering manifest parsing, directory discovery, underscore exclusion, corrupt-line skipping, and sort order. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A54-55%0A%60%40runtime_checkable%60%20on%20a%20Protocol%20whose%20members%20are%20all%20data%20attributes%20%28not%20methods%29%20means%20%60isinstance%28x%2C%20PersonalizationFields%29%60%20returns%20%60True%60%20for%20**any**%20object%20%E2%80%94%20Python's%20runtime%20check%20only%20verifies%20callable%20members%2C%20not%20attributes.%20So%20the%20decorator%20provides%20no%20protection%20and%20may%20mislead%20future%20callers%20into%20trusting%20%60isinstance%60%20checks.%20Removing%20it%20leaves%20the%20structural-typing%20contract%20intact%20for%20static%20checkers%20%28mypy%2Fpyright%29%20without%20creating%20a%20false%20sense%20of%20runtime%20safety.%0A%0A%60%60%60suggestion%0Aclass%20PersonalizationFields%28Protocol%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A47%0AThe%20%60runtime_checkable%60%20import%20becomes%20unused%20once%20the%20decorator%20is%20removed%3B%20leaving%20it%20will%20trigger%20a%20%60ruff%20F401%60%20unused-import%20error%20during%20%60just%20check%60.%0A%0A%60%60%60suggestion%0Afrom%20typing%20import%20Protocol%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fapp%2Fcore%2Ftools%2Fskills.py%3A59-62%0A**%60sorted%28%29%60%20enumerates%20all%20entries%20before%20the%20%60_MAX_SKILLS%60%20slice**%0A%0A%60sorted%28generator%29%60%20forces%20the%20entire%20generator%20to%20be%20consumed%20into%20a%20list%20before%20slicing%20at%20%60subdirs%5B%3A_MAX_SKILLS%5D%60.%20On%20a%20workspace%20where%20an%20agent%20loop%20has%20created%20thousands%20of%20skill%20subdirectories%2C%20this%20materialises%20all%20%60Path%60%20objects%20and%20stat%20calls%20before%20any%20cap%20takes%20effect.%20Wrapping%20the%20generator%20with%20%60itertools.islice%60%20at%20the%20source%20would%20bound%20the%20work%20to%20%60_MAX_SKILLS%60%20directories.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=233&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fagent-skills-research-qUrFj%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fagent-skills-research-qUrFj%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A54-55%0A%60%40runtime_checkable%60%20on%20a%20Protocol%20whose%20members%20are%20all%20data%20attributes%20%28not%20methods%29%20means%20%60isinstance%28x%2C%20PersonalizationFields%29%60%20returns%20%60True%60%20for%20**any**%20object%20%E2%80%94%20Python's%20runtime%20check%20only%20verifies%20callable%20members%2C%20not%20attributes.%20So%20the%20decorator%20provides%20no%20protection%20and%20may%20mislead%20future%20callers%20into%20trusting%20%60isinstance%60%20checks.%20Removing%20it%20leaves%20the%20structural-typing%20contract%20intact%20for%20static%20checkers%20%28mypy%2Fpyright%29%20without%20creating%20a%20false%20sense%20of%20runtime%20safety.%0A%0A%60%60%60suggestion%0Aclass%20PersonalizationFields%28Protocol%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A47%0AThe%20%60runtime_checkable%60%20import%20becomes%20unused%20once%20the%20decorator%20is%20removed%3B%20leaving%20it%20will%20trigger%20a%20%60ruff%20F401%60%20unused-import%20error%20during%20%60just%20check%60.%0A%0A%60%60%60suggestion%0Afrom%20typing%20import%20Protocol%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fapp%2Fcore%2Ftools%2Fskills.py%3A59-62%0A**%60sorted%28%29%60%20enumerates%20all%20entries%20before%20the%20%60_MAX_SKILLS%60%20slice**%0A%0A%60sorted%28generator%29%60%20forces%20the%20entire%20generator%20to%20be%20consumed%20into%20a%20list%20before%20slicing%20at%20%60subdirs%5B%3A_MAX_SKILLS%5D%60.%20On%20a%20workspace%20where%20an%20agent%20loop%20has%20created%20thousands%20of%20skill%20subdirectories%2C%20this%20materialises%20all%20%60Path%60%20objects%20and%20stat%20calls%20before%20any%20cap%20takes%20effect.%20Wrapping%20the%20generator%20with%20%60itertools.islice%60%20at%20the%20source%20would%20bound%20the%20work%20to%20%60_MAX_SKILLS%60%20directories.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22claude%2Fagent-skills-research-qUrFj%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fagent-skills-research-qUrFj%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A54-55%0A%60%40runtime_checkable%60%20on%20a%20Protocol%20whose%20members%20are%20all%20data%20attributes%20%28not%20methods%29%20means%20%60isinstance%28x%2C%20PersonalizationFields%29%60%20returns%20%60True%60%20for%20**any**%20object%20%E2%80%94%20Python's%20runtime%20check%20only%20verifies%20callable%20members%2C%20not%20attributes.%20So%20the%20decorator%20provides%20no%20protection%20and%20may%20mislead%20future%20callers%20into%20trusting%20%60isinstance%60%20checks.%20Removing%20it%20leaves%20the%20structural-typing%20contract%20intact%20for%20static%20checkers%20%28mypy%2Fpyright%29%20without%20creating%20a%20false%20sense%20of%20runtime%20safety.%0A%0A%60%60%60suggestion%0Aclass%20PersonalizationFields%28Protocol%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fapp%2Fcore%2Fworkspace.py%3A47%0AThe%20%60runtime_checkable%60%20import%20becomes%20unused%20once%20the%20decorator%20is%20removed%3B%20leaving%20it%20will%20trigger%20a%20%60ruff%20F401%60%20unused-import%20error%20during%20%60just%20check%60.%0A%0A%60%60%60suggestion%0Afrom%20typing%20import%20Protocol%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fapp%2Fcore%2Ftools%2Fskills.py%3A59-62%0A**%60sorted%28%29%60%20enumerates%20all%20entries%20before%20the%20%60_MAX_SKILLS%60%20slice**%0A%0A%60sorted%28generator%29%60%20forces%20the%20entire%20generator%20to%20be%20consumed%20into%20a%20list%20before%20slicing%20at%20%60subdirs%5B%3A_MAX_SKILLS%5D%60.%20On%20a%20workspace%20where%20an%20agent%20loop%20has%20created%20thousands%20of%20skill%20subdirectories%2C%20this%20materialises%20all%20%60Path%60%20objects%20and%20stat%20calls%20before%20any%20cap%20takes%20effect.%20Wrapping%20the%20generator%20with%20%60itertools.islice%60%20at%20the%20source%20would%20bound%20the%20work%20to%20%60_MAX_SKILLS%60%20directories.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(workspace): define PersonalizationFi..."](https://github.com/octaviantocan/pawrrtal-ai/commit/124f2459f9d3d84f0f5bcfa3bc021edfecd8fffa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32418668)</sub>

<!-- /greptile_comment -->