### PR TITLE
refactor(channels): SSEChannel explicitly inherits Channel protocol (#241)

### DIFF
--- a/backend/app/channels/sse.py
+++ b/backend/app/channels/sse.py
@@ -28,7 +28,7 @@ from collections.abc import AsyncIterator
 
 from app.core.providers.base import StreamEvent
 
-from .base import ChannelMessage
+from .base import Channel, ChannelMessage
 
 # Sentinel surface names recognized by the registry.
 SURFACE_WEB = "web"
@@ -47,11 +47,13 @@ def _frame(event: StreamEvent) -> bytes:
 _DONE_FRAME = b"data: [DONE]\n\n"
 
 
-class SSEChannel:
+class SSEChannel(Channel):
     """``Channel`` implementation for HTTP SSE (web + Electron).
 
     Instantiated once and shared across requests — it holds no per-request
-    state.
+    state. Explicitly inheriting from ``Channel`` makes mypy/pyright
+    enforce protocol conformance at class-definition time rather than at
+    each call site.
     """
 
     def __init__(self, surface: str = SURFACE_WEB) -> None:


### PR DESCRIPTION
## Summary

Closes #241.

`TelegramChannel` declares `class TelegramChannel(Channel)` and gets
class-definition-time protocol enforcement from mypy/pyright. `SSEChannel`
was relying on silent structural matching, so any contract drift would
only surface at call sites (or not at all).

Switching to explicit inheritance is zero-cost at runtime — Protocol
classes support both nominal and structural matching — and shifts
enforcement to the spot where it's cheapest to fix: the class
definition.

Also adds the missing `r` prefix to the module docstring so the `\n\n`
SSE-frame literals pass ruff's D301 (the new strict backend gate from
#242 catches it).

## Test plan

- [x] `cd backend && uv run pytest tests/test_channels.py` — 17/17 pass
- [x] `cd backend && uv run ruff check app/channels/` — clean
- [ ] CI: Backend Check, Tests, Sentrux, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Switches `SSEChannel` from implicit structural matching against the `Channel` protocol to explicit nominal inheritance (`class SSEChannel(Channel)`), matching the pattern already used by `TelegramChannel`. A companion fix adds the `r` prefix to the module docstring so ruff D301 is satisfied when it encounters the `\n\n` SSE-frame literals in the module docstring.

- `SSEChannel` now declares `class SSEChannel(Channel)` and imports `Channel` from `.base`, giving mypy/pyright class-definition-time enforcement instead of relying on silent structural matching at call sites.
- The module-level docstring was changed from `"""…"""` to `r"""…"""` to prevent ruff from flagging the literal `\n\n` sequences as invalid escape sequences (D301).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely structural, touching only the class declaration and docstring with no modifications to logic or data flow.

The only runtime change is that `SSEChannel` now lists `Channel` in its bases. Since `Channel` is a `Protocol`, this adds no MRO overhead, no new abstract methods, and no new behaviour. The `surface` attribute and `deliver` method were already present and correctly typed, so the explicit inheritance introduces no regression risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/channels/sse.py | Adds explicit `Channel` protocol inheritance to `SSEChannel` and fixes the module docstring raw-string prefix (D301); no functional changes, no logic touched. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class Channel {
        <<Protocol>>
        +str surface
        +deliver(stream: AsyncIterator[StreamEvent], message: ChannelMessage) AsyncIterator[bytes]
    }

    class SSEChannel {
        +str surface
        +__init__(surface: str)
        +deliver(stream: AsyncIterator[StreamEvent], message: ChannelMessage) AsyncIterator[bytes]
    }

    class TelegramChannel {
        +str surface
        +deliver(stream: AsyncIterator[StreamEvent], message: ChannelMessage) AsyncIterator[bytes]
    }

    Channel <|-- SSEChannel : explicit (this PR)
    Channel <|-- TelegramChannel : explicit (existing)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(channels): make SSEChannel expl..."](https://github.com/octaviantocan/pawrrtal-ai/commit/0fd88e08a19c8a036d2c997402f934f1410ab6f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32429489)</sub>

<!-- /greptile_comment -->