### PR TITLE
refactor(backend): drop CRUD _service suffix; rename Response→Read (#238, #239, #240)

### DIFF
--- a/backend/app/api/appearance.py
+++ b/backend/app/api/appearance.py
@@ -3,11 +3,7 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.crud.appearance import (
-    get_appearance_service,
-    reset_appearance_service,
-    upsert_appearance_service,
-)
+from app.crud import appearance as crud
 from app.db import User, get_async_session
 from app.models import UserAppearance
 from app.schemas import (
@@ -52,7 +48,7 @@ def get_appearance_router() -> APIRouter:
         The frontend layers these on top of the Mistral defaults from
         ``frontend/features/appearance/defaults.ts``.
         """
-        row = await get_appearance_service(user.id, session)
+        row = await crud.get_appearance(user.id, session)
         return _to_settings(row)
 
     @router.put("", response_model=AppearanceSettings)
@@ -62,7 +58,7 @@ def get_appearance_router() -> APIRouter:
         session: AsyncSession = Depends(get_async_session),
     ) -> AppearanceSettings:
         """Create or replace the authenticated user's appearance settings."""
-        row = await upsert_appearance_service(user_id=user.id, payload=payload, session=session)
+        row = await crud.upsert_appearance(user_id=user.id, payload=payload, session=session)
         return _to_settings(row)
 
     @router.delete("", status_code=status.HTTP_204_NO_CONTENT)
@@ -75,6 +71,6 @@ def get_appearance_router() -> APIRouter:
         Idempotent — deletes the persisted row so subsequent GETs return
         an empty settings object that the frontend resolves to defaults.
         """
-        await reset_appearance_service(user.id, session)
+        await crud.reset_appearance(user.id, session)
 
     return router

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -29,8 +29,8 @@ from app.core.tools.artifact_agent import (
     build_artifact,
 )
 from app.crud.conversation import (
-    get_conversation_service,
-    update_conversation_model_service,
+    get_conversation,
+    update_conversation_model,
 )
 from app.crud.workspace import get_default_workspace
 from app.db import User, get_async_session
@@ -197,7 +197,7 @@ def get_chat_router() -> APIRouter:
             len(request.question),
         )
 
-        conversation = await get_conversation_service(user.id, session, request.conversation_id)
+        conversation = await get_conversation(user.id, session, request.conversation_id)
         if conversation is None:
             logger.warning(
                 "CHAT_404 rid=%s user_id=%s conversation_id=%s",
@@ -215,7 +215,7 @@ def get_chat_router() -> APIRouter:
 
         # Persist model change if it differs from what is stored
         if model_id != conversation.model_id:
-            await update_conversation_model_service(
+            await update_conversation_model(
                 model_id=model_id,
                 user_id=user.id,
                 conversation_id=request.conversation_id,

--- a/backend/app/api/conversations.py
+++ b/backend/app/api/conversations.py
@@ -8,21 +8,14 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.gemini_utils import generate_text_once
+from app.crud import conversation as crud
 from app.crud.chat_message import get_messages_for_conversation
-from app.crud.conversation import (
-    create_conversation_service,
-    delete_conversation_service,
-    get_conversation_service,
-    get_conversations_for_user_service,
-    update_conversation_service,
-    update_conversation_title_service,
-)
 from app.db import User, get_async_session
 from app.models import ChatMessage, Conversation
 from app.schemas import (
     ChatMessageRead,
     ConversationCreate,
-    ConversationResponse,
+    ConversationRead,
     ConversationUpdate,
 )
 from app.users import get_allowed_user
@@ -99,7 +92,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         state (thinking, tool calls, timeline, duration), so a hard reload
         rehydrates the chat exactly as the user last saw it.
         """
-        conversation = await get_conversation_service(user.id, session, conversation_id)
+        conversation = await crud.get_conversation(user.id, session, conversation_id)
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
@@ -111,13 +104,13 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         conversation_id: uuid.UUID,
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ConversationResponse | None:
+    ) -> ConversationRead | None:
         """Return metadata for a single conversation."""
-        conversation: Conversation | None = await get_conversation_service(
+        conversation: Conversation | None = await crud.get_conversation(
             user.id, session, conversation_id
         )
         if conversation:
-            return ConversationResponse(
+            return ConversationRead(
                 title=conversation.title,
                 id=conversation.id,
                 user_id=conversation.user_id,
@@ -163,7 +156,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
             )
             return ""
 
-        await update_conversation_title_service(
+        await crud.update_conversation_title(
             title=generated_title,
             user_id=user.id,
             conversation_id=conversation_id,
@@ -171,13 +164,13 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         )
         return generated_title
 
-    @router.patch("/{conversation_id}", response_model=ConversationResponse)
+    @router.patch("/{conversation_id}", response_model=ConversationRead)
     async def update_conversation(
         conversation_id: uuid.UUID,
         payload: ConversationUpdate,
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ConversationResponse:
+    ) -> ConversationRead:
         """Update mutable conversation metadata for the authenticated user.
 
         Accepts any combination of: title, is_archived, is_flagged, is_unread,
@@ -186,7 +179,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         if payload.title is not None and not payload.title.strip():
             raise HTTPException(status_code=422, detail="Conversation title cannot be empty")
 
-        conversation = await update_conversation_service(
+        conversation = await crud.update_conversation(
             payload=payload,
             user_id=user.id,
             conversation_id=conversation_id,
@@ -195,7 +188,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         if conversation is None:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
-        return ConversationResponse(
+        return ConversationRead(
             title=conversation.title,
             id=conversation.id,
             user_id=conversation.user_id,
@@ -217,7 +210,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         session: AsyncSession = Depends(get_async_session),
     ) -> None:
         """Delete a conversation owned by the authenticated user."""
-        deleted = await delete_conversation_service(user.id, session, conversation_id)
+        deleted = await crud.delete_conversation(user.id, session, conversation_id)
         if not deleted:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
@@ -225,13 +218,11 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
     async def list_conversations(
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> list[ConversationResponse]:
+    ) -> list[ConversationRead]:
         """List all conversations for the authenticated user, most recent first."""
-        conversations: list[Conversation] = await get_conversations_for_user_service(
-            user.id, session
-        )
+        conversations: list[Conversation] = await crud.list_conversations_for_user(user.id, session)
         return [
-            ConversationResponse(
+            ConversationRead(
                 title=conversation.title,
                 id=conversation.id,
                 user_id=conversation.user_id,
@@ -254,7 +245,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         payload: ConversationCreate | None = Body(default=None),
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ConversationResponse:
+    ) -> ConversationRead:
         """Create a new conversation with an immediate initial title.
 
         Frontend generates the UUID first; this endpoint persists metadata before
@@ -262,7 +253,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         """
         creation_payload = payload or ConversationCreate()
         try:
-            new_conversation: Conversation = await create_conversation_service(
+            new_conversation: Conversation = await crud.create_conversation(
                 user.id,
                 session,
                 ConversationCreate(id=conversation_id, title=creation_payload.title),
@@ -270,7 +261,7 @@ def get_conversations_router() -> APIRouter:  # noqa: C901 — FastAPI router bu
         except ValueError as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
 
-        return ConversationResponse(
+        return ConversationRead(
             title=new_conversation.title,
             id=new_conversation.id,
             user_id=new_conversation.user_id,

--- a/backend/app/api/exports.py
+++ b/backend/app/api/exports.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exporters import render_html, render_json, render_markdown
 from app.crud.chat_message import get_messages_for_conversation
-from app.crud.conversation import get_conversation_service
+from app.crud.conversation import get_conversation
 from app.db import User, get_async_session
 from app.users import get_allowed_user
 
@@ -56,7 +56,7 @@ def get_exports_router() -> APIRouter:
         conversations; anything else returns 404 (not 403, so we
         don't leak existence).
         """
-        conversation = await get_conversation_service(
+        conversation = await get_conversation(
             user_id=user.id,
             session=session,
             conversation_id=conversation_id,

--- a/backend/app/api/personalization.py
+++ b/backend/app/api/personalization.py
@@ -5,10 +5,7 @@ import logging
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.crud.personalization import (
-    get_personalization_service,
-    upsert_personalization_service,
-)
+from app.crud import personalization as crud
 from app.crud.workspace import ensure_default_workspace
 from app.db import User, get_async_session
 from app.models import UserPersonalization
@@ -49,7 +46,7 @@ def get_personalization_router() -> APIRouter:
         session: AsyncSession = Depends(get_async_session),
     ) -> PersonalizationProfile:
         """Return the authenticated user's personalization profile."""
-        row = await get_personalization_service(user.id, session)
+        row = await crud.get_personalization(user.id, session)
         return _to_profile(row)
 
     @router.put("", response_model=PersonalizationProfile)
@@ -63,9 +60,7 @@ def get_personalization_router() -> APIRouter:
         Also seeds the user's default workspace the first time this endpoint
         is called (idempotent — subsequent calls are a no-op for the workspace).
         """
-        row = await upsert_personalization_service(
-            user_id=user.id, payload=payload, session=session
-        )
+        row = await crud.upsert_personalization(user_id=user.id, payload=payload, session=session)
 
         # Seed the default workspace on first personalization save.  This is
         # the natural trigger for "onboarding complete" since the wizard writes

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -5,21 +5,16 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.crud.project import (
-    create_project_service,
-    delete_project_service,
-    list_projects_service,
-    update_project_service,
-)
+from app.crud import project as crud
 from app.db import User, get_async_session
 from app.models import Project
-from app.schemas import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.schemas import ProjectCreate, ProjectRead, ProjectUpdate
 from app.users import get_allowed_user
 
 
-def _serialize(project: Project) -> ProjectResponse:
-    """Build a {@link ProjectResponse} from a Project ORM row."""
-    return ProjectResponse(
+def _serialize(project: Project) -> ProjectRead:
+    """Build a {@link ProjectRead} from a Project ORM row."""
+    return ProjectRead(
         id=project.id,
         user_id=project.user_id,
         name=project.name,
@@ -32,34 +27,34 @@ def get_projects_router() -> APIRouter:
     """Build the projects router."""
     router = APIRouter(prefix="/api/v1/projects", tags=["projects"])
 
-    @router.get("", response_model=list[ProjectResponse])
+    @router.get("", response_model=list[ProjectRead])
     async def list_projects(
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> list[ProjectResponse]:
+    ) -> list[ProjectRead]:
         """List every project owned by the authenticated user."""
-        projects = await list_projects_service(user.id, session)
+        projects = await crud.list_projects(user.id, session)
         return [_serialize(project) for project in projects]
 
-    @router.post("", response_model=ProjectResponse, status_code=201)
+    @router.post("", response_model=ProjectRead, status_code=201)
     async def create_project(
         payload: ProjectCreate,
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ProjectResponse:
+    ) -> ProjectRead:
         """Create a new project owned by the authenticated user."""
-        project = await create_project_service(user.id, session, payload)
+        project = await crud.create_project(user.id, session, payload)
         return _serialize(project)
 
-    @router.patch("/{project_id}", response_model=ProjectResponse)
+    @router.patch("/{project_id}", response_model=ProjectRead)
     async def update_project(
         project_id: uuid.UUID,
         payload: ProjectUpdate,
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ProjectResponse:
+    ) -> ProjectRead:
         """Rename a project (currently the only mutable field)."""
-        project = await update_project_service(
+        project = await crud.update_project(
             payload=payload,
             user_id=user.id,
             project_id=project_id,
@@ -76,7 +71,7 @@ def get_projects_router() -> APIRouter:
         session: AsyncSession = Depends(get_async_session),
     ) -> None:
         """Delete a project. Linked conversations are unlinked, not deleted."""
-        deleted = await delete_project_service(user.id, session, project_id)
+        deleted = await crud.delete_project(user.id, session, project_id)
         if not deleted:
             raise HTTPException(status_code=404, detail="Project not found")
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -167,7 +167,7 @@ class Settings(BaseSettings):
     # token budget divided by expected request count.
     chat_rate_limit_per_minute: int = 0
 
-    # When True, ConversationResponse 422s on a non-canonical stored
+    # When True, ConversationRead 422s on a non-canonical stored
     # model_id. When False (operator escape hatch), the bad value falls
     # back to ``catalog.default_model().id`` and the row is logged.
     strict_conversation_read_validation: bool = True

--- a/backend/app/crud/appearance.py
+++ b/backend/app/crud/appearance.py
@@ -17,9 +17,7 @@ from app.models import UserAppearance
 from app.schemas import AppearanceSettings
 
 
-async def get_appearance_service(
-    user_id: uuid.UUID, session: AsyncSession
-) -> UserAppearance | None:
+async def get_appearance(user_id: uuid.UUID, session: AsyncSession) -> UserAppearance | None:
     """Fetch the appearance row for the given user.
 
     Returns ``None`` when the user has never customized their appearance —
@@ -30,7 +28,7 @@ async def get_appearance_service(
     return result.scalar_one_or_none()
 
 
-async def upsert_appearance_service(
+async def upsert_appearance(
     user_id: uuid.UUID,
     payload: AppearanceSettings,
     session: AsyncSession,
@@ -42,7 +40,7 @@ async def upsert_appearance_service(
     plain dict. ``mode="json"`` keeps `Literal` / nested-model fields
     serializable directly to the database column.
     """
-    existing = await get_appearance_service(user_id, session)
+    existing = await get_appearance(user_id, session)
     now = datetime.now()
 
     light = payload.light.model_dump(mode="json")
@@ -75,13 +73,13 @@ async def upsert_appearance_service(
     return existing
 
 
-async def reset_appearance_service(user_id: uuid.UUID, session: AsyncSession) -> None:
+async def reset_appearance(user_id: uuid.UUID, session: AsyncSession) -> None:
     """Delete the appearance row so the user falls back to defaults.
 
     Used by the "Reset to defaults" button in the Appearance panel.
     Idempotent — no-ops cleanly when there's no row.
     """
-    existing = await get_appearance_service(user_id, session)
+    existing = await get_appearance(user_id, session)
     if existing is None:
         return
     await session.delete(existing)

--- a/backend/app/crud/conversation.py
+++ b/backend/app/crud/conversation.py
@@ -14,7 +14,7 @@ from app.models import Conversation
 from app.schemas import ConversationCreate, ConversationUpdate
 
 
-async def create_conversation_service(
+async def create_conversation(
     user_id: uuid.UUID, session: AsyncSession, schema_data: ConversationCreate
 ) -> Conversation:
     """Create a new conversation with an initial title.
@@ -55,7 +55,7 @@ async def create_conversation_service(
     return new_conversation
 
 
-async def get_conversation_service(
+async def get_conversation(
     user_id: uuid.UUID, session: AsyncSession, conversation_id: uuid.UUID
 ) -> Conversation | None:
     """Retrieve a single conversation by ID, scoped to the given user.
@@ -77,7 +77,7 @@ async def get_conversation_service(
     return result.scalar_one_or_none()
 
 
-async def get_conversations_for_user_service(
+async def list_conversations_for_user(
     user_id: uuid.UUID, session: AsyncSession
 ) -> list[Conversation]:
     """Retrieve all conversations for a user, most-recent first.
@@ -98,7 +98,7 @@ async def get_conversations_for_user_service(
     return list(result.scalars().all())
 
 
-async def update_conversation_title_service(
+async def update_conversation_title(
     title: str, user_id: uuid.UUID, conversation_id: uuid.UUID, session: AsyncSession
 ) -> Conversation | None:
     """Update the title of an existing conversation.
@@ -131,7 +131,7 @@ async def update_conversation_title_service(
     return conversation
 
 
-async def update_conversation_service(
+async def update_conversation(
     payload: ConversationUpdate,
     user_id: uuid.UUID,
     conversation_id: uuid.UUID,
@@ -193,7 +193,7 @@ async def update_conversation_service(
     return conversation
 
 
-async def update_conversation_model_service(
+async def update_conversation_model(
     model_id: str,
     user_id: uuid.UUID,
     conversation_id: uuid.UUID,
@@ -229,7 +229,7 @@ async def update_conversation_model_service(
     return conversation
 
 
-async def delete_conversation_service(
+async def delete_conversation(
     user_id: uuid.UUID, session: AsyncSession, conversation_id: uuid.UUID
 ) -> bool:
     """Delete an existing conversation owned by the given user.

--- a/backend/app/crud/personalization.py
+++ b/backend/app/crud/personalization.py
@@ -15,7 +15,7 @@ from app.models import UserPersonalization
 from app.schemas import PersonalizationProfile
 
 
-async def get_personalization_service(
+async def get_personalization(
     user_id: uuid.UUID, session: AsyncSession
 ) -> UserPersonalization | None:
     """Fetch the personalization row for the given user.
@@ -27,7 +27,7 @@ async def get_personalization_service(
     return result.scalar_one_or_none()
 
 
-async def upsert_personalization_service(
+async def upsert_personalization(
     user_id: uuid.UUID,
     payload: PersonalizationProfile,
     session: AsyncSession,
@@ -40,7 +40,7 @@ async def upsert_personalization_service(
     on every step transition, so partial progress round-trips correctly
     without tracking dirty fields.
     """
-    existing = await get_personalization_service(user_id, session)
+    existing = await get_personalization(user_id, session)
     now = datetime.now()
 
     if existing is None:

--- a/backend/app/crud/project.py
+++ b/backend/app/crud/project.py
@@ -14,7 +14,7 @@ from app.models import Project
 from app.schemas import ProjectCreate, ProjectUpdate
 
 
-async def create_project_service(
+async def create_project(
     user_id: uuid.UUID, session: AsyncSession, payload: ProjectCreate
 ) -> Project:
     """Create a new project owned by the given user.
@@ -40,7 +40,7 @@ async def create_project_service(
     return new_project
 
 
-async def list_projects_service(user_id: uuid.UUID, session: AsyncSession) -> list[Project]:
+async def list_projects(user_id: uuid.UUID, session: AsyncSession) -> list[Project]:
     """List every project owned by the given user, oldest-first.
 
     Args:
@@ -55,7 +55,7 @@ async def list_projects_service(user_id: uuid.UUID, session: AsyncSession) -> li
     return list(result.scalars().all())
 
 
-async def get_project_service(
+async def get_project(
     user_id: uuid.UUID, session: AsyncSession, project_id: uuid.UUID
 ) -> Project | None:
     """Retrieve a single project by ID, scoped to the given user.
@@ -73,7 +73,7 @@ async def get_project_service(
     return result.scalar_one_or_none()
 
 
-async def update_project_service(
+async def update_project(
     payload: ProjectUpdate,
     user_id: uuid.UUID,
     project_id: uuid.UUID,
@@ -90,7 +90,7 @@ async def update_project_service(
     Returns:
         The updated ``Project``, or ``None`` if not found / not owned.
     """
-    project = await get_project_service(user_id, session, project_id)
+    project = await get_project(user_id, session, project_id)
     if project is None:
         return None
 
@@ -106,9 +106,7 @@ async def update_project_service(
     return project
 
 
-async def delete_project_service(
-    user_id: uuid.UUID, session: AsyncSession, project_id: uuid.UUID
-) -> bool:
+async def delete_project(user_id: uuid.UUID, session: AsyncSession, project_id: uuid.UUID) -> bool:
     """Delete an existing project owned by the given user.
 
     Linked conversations have their ``project_id`` cleared by the FK's
@@ -117,7 +115,7 @@ async def delete_project_service(
     Returns:
         ``True`` when a project was deleted, otherwise ``False``.
     """
-    project = await get_project_service(user_id, session, project_id)
+    project = await get_project(user_id, session, project_id)
     if project is None:
         return False
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -39,7 +39,7 @@ def _canonicalise_model_id(raw: str | None) -> str | None:
 
 
 def _canonicalise_model_id_for_read(raw: str | None) -> str | None:
-    """Output validator for ``ConversationResponse.model_id``.
+    """Output validator for ``ConversationRead.model_id``.
 
     Defaults to strict (matches the input contract). When
     ``settings.strict_conversation_read_validation`` is ``False``,
@@ -107,7 +107,7 @@ class ConversationCreate(BaseModel):
     title: ConversationTitle | None = None
 
 
-class ConversationResponse(BaseModel):
+class ConversationRead(BaseModel):
     """Response schema returned for conversation endpoints."""
 
     id: uuid.UUID
@@ -154,7 +154,7 @@ class ConversationUpdate(BaseModel):
     project_id_set: bool = False
 
 
-class ProjectResponse(BaseModel):
+class ProjectRead(BaseModel):
     """Response schema returned for project endpoints."""
 
     id: uuid.UUID

--- a/backend/tests/test_appearance_crud.py
+++ b/backend/tests/test_appearance_crud.py
@@ -6,9 +6,9 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.appearance import (
-    get_appearance_service,
-    reset_appearance_service,
-    upsert_appearance_service,
+    get_appearance,
+    reset_appearance,
+    upsert_appearance,
 )
 from app.db import User
 from app.schemas import (
@@ -24,7 +24,7 @@ async def test_get_returns_none_when_no_row_exists(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """A user who has never customized appearance returns None (not a stub row)."""
-    result = await get_appearance_service(test_user.id, db_session)
+    result = await get_appearance(test_user.id, db_session)
     assert result is None
 
 
@@ -38,7 +38,7 @@ async def test_upsert_inserts_a_new_row(db_session: AsyncSession, test_user: Use
         options=AppearanceOptions(theme_mode="dark", contrast=72),
     )
 
-    row = await upsert_appearance_service(test_user.id, payload, db_session)
+    row = await upsert_appearance(test_user.id, payload, db_session)
 
     assert row.user_id == test_user.id
     assert row.light == {
@@ -59,7 +59,7 @@ async def test_upsert_inserts_a_new_row(db_session: AsyncSession, test_user: Use
 @pytest.mark.anyio
 async def test_upsert_replaces_existing_row(db_session: AsyncSession, test_user: User) -> None:
     """Second upsert is a full replacement: omitted sub-fields revert to None."""
-    await upsert_appearance_service(
+    await upsert_appearance(
         test_user.id,
         AppearanceSettings(
             light=ThemeColors(accent="#AAA111"),
@@ -68,7 +68,7 @@ async def test_upsert_replaces_existing_row(db_session: AsyncSession, test_user:
         db_session,
     )
 
-    updated = await upsert_appearance_service(
+    updated = await upsert_appearance(
         test_user.id,
         AppearanceSettings(light=ThemeColors(background="#FAF3DF")),
         db_session,
@@ -83,16 +83,16 @@ async def test_upsert_replaces_existing_row(db_session: AsyncSession, test_user:
 @pytest.mark.anyio
 async def test_reset_deletes_persisted_row(db_session: AsyncSession, test_user: User) -> None:
     """Reset removes the row so subsequent gets fall back to defaults."""
-    await upsert_appearance_service(
+    await upsert_appearance(
         test_user.id,
         AppearanceSettings(light=ThemeColors(accent="#FF0000")),
         db_session,
     )
-    assert await get_appearance_service(test_user.id, db_session) is not None
+    assert await get_appearance(test_user.id, db_session) is not None
 
-    await reset_appearance_service(test_user.id, db_session)
+    await reset_appearance(test_user.id, db_session)
 
-    assert await get_appearance_service(test_user.id, db_session) is None
+    assert await get_appearance(test_user.id, db_session) is None
 
 
 @pytest.mark.anyio
@@ -100,5 +100,5 @@ async def test_reset_is_idempotent_when_no_row_exists(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Reset on a user who never customized appearance is a no-op (no error)."""
-    await reset_appearance_service(test_user.id, db_session)
-    assert await get_appearance_service(test_user.id, db_session) is None
+    await reset_appearance(test_user.id, db_session)
+    assert await get_appearance(test_user.id, db_session) is None

--- a/backend/tests/test_conversation_crud.py
+++ b/backend/tests/test_conversation_crud.py
@@ -6,13 +6,13 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.conversation import (
-    create_conversation_service,
-    delete_conversation_service,
-    get_conversation_service,
-    get_conversations_for_user_service,
-    update_conversation_model_service,
-    update_conversation_service,
-    update_conversation_title_service,
+    create_conversation,
+    delete_conversation,
+    get_conversation,
+    list_conversations_for_user,
+    update_conversation,
+    update_conversation_model,
+    update_conversation_title,
 )
 from app.db import User
 from app.schemas import ConversationCreate, ConversationUpdate
@@ -25,7 +25,7 @@ async def test_create_conversation_uses_client_supplied_id(
     """Conversation creation preserves a frontend-generated UUID."""
     conversation_id = uuid4()
 
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(id=conversation_id, title="Hello"),
@@ -41,7 +41,7 @@ async def test_create_conversation_defaults_title(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Conversation creation falls back to the default title."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(),
@@ -56,13 +56,13 @@ async def test_create_conversation_is_idempotent_for_same_owner(
 ) -> None:
     """Retrying create with an existing owned UUID returns the existing row."""
     conversation_id = uuid4()
-    first = await create_conversation_service(
+    first = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(id=conversation_id, title="Original"),
     )
 
-    second = await create_conversation_service(
+    second = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(id=conversation_id, title="Retry title"),
@@ -88,14 +88,14 @@ async def test_create_conversation_rejects_cross_user_uuid_collision(
     db_session.add(other_user)
     await db_session.commit()
     conversation_id = uuid4()
-    await create_conversation_service(
+    await create_conversation(
         other_user.id,
         db_session,
         ConversationCreate(id=conversation_id, title="Other"),
     )
 
     with pytest.raises(ValueError, match="already in use"):
-        await create_conversation_service(
+        await create_conversation(
             test_user.id,
             db_session,
             ConversationCreate(id=conversation_id, title="Collision"),
@@ -105,13 +105,13 @@ async def test_create_conversation_rejects_cross_user_uuid_collision(
 @pytest.mark.anyio
 async def test_get_conversation_scopes_to_owner(db_session: AsyncSession, test_user: User) -> None:
     """Conversation lookup returns None for the wrong owner."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Owned"),
     )
 
-    assert await get_conversation_service(uuid4(), db_session, conversation.id) is None
+    assert await get_conversation(uuid4(), db_session, conversation.id) is None
 
 
 @pytest.mark.anyio
@@ -119,18 +119,18 @@ async def test_get_conversations_for_user_orders_newest_first(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Conversation listing is sorted by updated_at descending."""
-    first = await create_conversation_service(
+    first = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="First"),
     )
-    second = await create_conversation_service(
+    second = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Second"),
     )
 
-    conversations = await get_conversations_for_user_service(test_user.id, db_session)
+    conversations = await list_conversations_for_user(test_user.id, db_session)
 
     assert [conversation.id for conversation in conversations] == [second.id, first.id]
 
@@ -140,16 +140,14 @@ async def test_update_conversation_title_updates_title_and_timestamp(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Title updates persist and bump updated_at."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Old"),
     )
     original_updated_at = conversation.updated_at
 
-    updated = await update_conversation_title_service(
-        "New", test_user.id, conversation.id, db_session
-    )
+    updated = await update_conversation_title("New", test_user.id, conversation.id, db_session)
 
     assert updated is not None
     assert updated.title == "New"
@@ -161,13 +159,13 @@ async def test_update_conversation_metadata_updates_only_provided_fields(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Partial metadata updates leave unspecified fields unchanged."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Keep me"),
     )
 
-    updated = await update_conversation_service(
+    updated = await update_conversation(
         ConversationUpdate(is_archived=True, is_flagged=True, status="done"),
         test_user.id,
         conversation.id,
@@ -187,13 +185,13 @@ async def test_update_conversation_model_service_sets_model_id(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Model updates persist the selected model identifier."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Model"),
     )
 
-    updated = await update_conversation_model_service(
+    updated = await update_conversation_model(
         "gemini-3-flash-preview", test_user.id, conversation.id, db_session
     )
 
@@ -206,13 +204,13 @@ async def test_delete_conversation_removes_owned_row(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """Delete returns True and removes an owned conversation."""
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id,
         db_session,
         ConversationCreate(title="Delete"),
     )
 
-    deleted = await delete_conversation_service(test_user.id, db_session, conversation.id)
+    deleted = await delete_conversation(test_user.id, db_session, conversation.id)
 
     assert deleted is True
-    assert await get_conversation_service(test_user.id, db_session, conversation.id) is None
+    assert await get_conversation(test_user.id, db_session, conversation.id) is None

--- a/backend/tests/test_conversation_read.py
+++ b/backend/tests/test_conversation_read.py
@@ -1,4 +1,4 @@
-"""ConversationResponse.model_id validator behaviour with the strict /
+"""ConversationRead.model_id validator behaviour with the strict /
 permissive feature flag."""
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 
 from app.core.config import settings
 from app.core.providers.catalog import default_model
-from app.schemas import ChatRequest, ConversationResponse
+from app.schemas import ChatRequest, ConversationRead
 
 
 def _read_row(model_id: str | None) -> dict[str, object]:
@@ -35,14 +35,14 @@ def _read_row(model_id: str | None) -> dict[str, object]:
 
 def test_canonical_value_passes_through_unchanged() -> None:
     canonical = default_model().id
-    read = ConversationResponse.model_validate(_read_row(canonical))
+    read = ConversationRead.model_validate(_read_row(canonical))
     assert read.model_id == canonical
 
 
 def test_strict_mode_rejects_bare_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "strict_conversation_read_validation", True)
     with pytest.raises(ValidationError):
-        ConversationResponse.model_validate(_read_row("gemini-3-flash-preview"))
+        ConversationRead.model_validate(_read_row("gemini-3-flash-preview"))
 
 
 def test_permissive_mode_falls_back_to_default(
@@ -50,7 +50,7 @@ def test_permissive_mode_falls_back_to_default(
 ) -> None:
     monkeypatch.setattr(settings, "strict_conversation_read_validation", False)
     with caplog.at_level(logging.WARNING, logger="app.schemas"):
-        read = ConversationResponse.model_validate(_read_row("gemini-3-flash-preview"))
+        read = ConversationRead.model_validate(_read_row("gemini-3-flash-preview"))
     assert read.model_id == default_model().id
     assert any("CONVERSATION_READ_FALLBACK" in r.message for r in caplog.records)
 

--- a/backend/tests/test_personalization_crud.py
+++ b/backend/tests/test_personalization_crud.py
@@ -6,8 +6,8 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.personalization import (
-    get_personalization_service,
-    upsert_personalization_service,
+    get_personalization,
+    upsert_personalization,
 )
 from app.db import User
 from app.schemas import PersonalizationProfile
@@ -18,7 +18,7 @@ async def test_get_returns_none_when_no_row_exists(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """A user who has never filled the wizard returns None (not a stub row)."""
-    result = await get_personalization_service(test_user.id, db_session)
+    result = await get_personalization(test_user.id, db_session)
     assert result is None
 
 
@@ -32,7 +32,7 @@ async def test_upsert_inserts_a_new_row(db_session: AsyncSession, test_user: Use
         personality="goose",
     )
 
-    row = await upsert_personalization_service(test_user.id, payload, db_session)
+    row = await upsert_personalization(test_user.id, payload, db_session)
 
     assert row.user_id == test_user.id
     assert row.name == "Octavian"
@@ -45,11 +45,11 @@ async def test_upsert_inserts_a_new_row(db_session: AsyncSession, test_user: Use
 @pytest.mark.anyio
 async def test_upsert_replaces_existing_row(db_session: AsyncSession, test_user: User) -> None:
     """Second upsert is a full replacement: omitted fields go back to None."""
-    await upsert_personalization_service(
+    await upsert_personalization(
         test_user.id, PersonalizationProfile(name="A", role="X"), db_session
     )
 
-    updated = await upsert_personalization_service(
+    updated = await upsert_personalization(
         test_user.id, PersonalizationProfile(name="B"), db_session
     )
 
@@ -62,12 +62,12 @@ async def test_get_returns_persisted_row_after_upsert(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """After upsert the get-side reads the same payload back."""
-    await upsert_personalization_service(
+    await upsert_personalization(
         test_user.id,
         PersonalizationProfile(name="Tavi", custom_instructions="Be terse."),
         db_session,
     )
-    fetched = await get_personalization_service(test_user.id, db_session)
+    fetched = await get_personalization(test_user.id, db_session)
     assert fetched is not None
     assert fetched.name == "Tavi"
     assert fetched.custom_instructions == "Be terse."

--- a/backend/tests/test_project_crud.py
+++ b/backend/tests/test_project_crud.py
@@ -6,16 +6,16 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.conversation import (
-    create_conversation_service,
-    get_conversation_service,
-    update_conversation_service,
+    create_conversation,
+    get_conversation,
+    update_conversation,
 )
 from app.crud.project import (
-    create_project_service,
-    delete_project_service,
-    get_project_service,
-    list_projects_service,
-    update_project_service,
+    create_project,
+    delete_project,
+    get_project,
+    list_projects,
+    update_project,
 )
 from app.db import User
 from app.schemas import (
@@ -31,9 +31,7 @@ async def test_create_project_persists_name_and_owner(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """A new project is created with the supplied name + scoped to the user."""
-    project = await create_project_service(
-        test_user.id, db_session, ProjectCreate(name="portfolio")
-    )
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="portfolio"))
 
     assert project.name == "portfolio"
     assert project.user_id == test_user.id
@@ -44,7 +42,7 @@ async def test_create_project_falls_back_to_default_name(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """An empty name falls back to "Untitled Project" so the row is never blank."""
-    project = await create_project_service(test_user.id, db_session, ProjectCreate(name="   "))
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="   "))
 
     assert project.name == "Untitled Project"
 
@@ -52,9 +50,9 @@ async def test_create_project_falls_back_to_default_name(
 @pytest.mark.anyio
 async def test_list_projects_returns_only_owned(db_session: AsyncSession, test_user: User) -> None:
     """list_projects only returns projects owned by the supplied user."""
-    await create_project_service(test_user.id, db_session, ProjectCreate(name="mine"))
+    await create_project(test_user.id, db_session, ProjectCreate(name="mine"))
 
-    projects = await list_projects_service(test_user.id, db_session)
+    projects = await list_projects(test_user.id, db_session)
     assert [project.name for project in projects] == ["mine"]
     assert all(project.user_id == test_user.id for project in projects)
 
@@ -62,25 +60,23 @@ async def test_list_projects_returns_only_owned(db_session: AsyncSession, test_u
 @pytest.mark.anyio
 async def test_get_project_scoped_to_owner(db_session: AsyncSession, test_user: User) -> None:
     """get_project returns the row when owned, else None for foreign IDs."""
-    project = await create_project_service(test_user.id, db_session, ProjectCreate(name="mine"))
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="mine"))
 
-    found = await get_project_service(test_user.id, db_session, project.id)
+    found = await get_project(test_user.id, db_session, project.id)
     assert found is not None
     assert found.id == project.id
 
-    missing = await get_project_service(test_user.id, db_session, uuid4())
+    missing = await get_project(test_user.id, db_session, uuid4())
     assert missing is None
 
 
 @pytest.mark.anyio
 async def test_update_project_renames_in_place(db_session: AsyncSession, test_user: User) -> None:
     """update_project rewrites the name and bumps updated_at."""
-    project = await create_project_service(test_user.id, db_session, ProjectCreate(name="Old"))
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="Old"))
     original_updated_at = project.updated_at
 
-    renamed = await update_project_service(
-        ProjectUpdate(name="New"), test_user.id, project.id, db_session
-    )
+    renamed = await update_project(ProjectUpdate(name="New"), test_user.id, project.id, db_session)
     assert renamed is not None
     assert renamed.name == "New"
     assert renamed.updated_at >= original_updated_at
@@ -89,11 +85,9 @@ async def test_update_project_renames_in_place(db_session: AsyncSession, test_us
 @pytest.mark.anyio
 async def test_update_project_ignores_blank_name(db_session: AsyncSession, test_user: User) -> None:
     """A whitespace-only rename leaves the existing name untouched."""
-    project = await create_project_service(test_user.id, db_session, ProjectCreate(name="Original"))
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="Original"))
 
-    renamed = await update_project_service(
-        ProjectUpdate(name="   "), test_user.id, project.id, db_session
-    )
+    renamed = await update_project(ProjectUpdate(name="   "), test_user.id, project.id, db_session)
     assert renamed is not None
     assert renamed.name == "Original"
 
@@ -109,26 +103,24 @@ async def test_delete_project_removes_project_row(
     behaviour the test fixtures can reliably provide: the project goes away
     and the previously-linked conversation still exists.
     """
-    project = await create_project_service(
-        test_user.id, db_session, ProjectCreate(name="container")
-    )
-    conversation = await create_conversation_service(
+    project = await create_project(test_user.id, db_session, ProjectCreate(name="container"))
+    conversation = await create_conversation(
         test_user.id, db_session, ConversationCreate(title="Linked")
     )
-    await update_conversation_service(
+    await update_conversation(
         ConversationUpdate(project_id=project.id, project_id_set=True),
         test_user.id,
         conversation.id,
         db_session,
     )
 
-    deleted = await delete_project_service(test_user.id, db_session, project.id)
+    deleted = await delete_project(test_user.id, db_session, project.id)
     assert deleted is True
 
-    gone = await get_project_service(test_user.id, db_session, project.id)
+    gone = await get_project(test_user.id, db_session, project.id)
     assert gone is None
 
-    survivor = await get_conversation_service(test_user.id, db_session, conversation.id)
+    survivor = await get_conversation(test_user.id, db_session, conversation.id)
     assert survivor is not None
 
 
@@ -137,7 +129,7 @@ async def test_delete_project_returns_false_for_unknown_id(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """delete_project signals "no row" instead of raising for foreign IDs."""
-    deleted = await delete_project_service(test_user.id, db_session, uuid4())
+    deleted = await delete_project(test_user.id, db_session, uuid4())
     assert deleted is False
 
 
@@ -146,31 +138,31 @@ async def test_assign_then_unassign_conversation_to_project(
     db_session: AsyncSession, test_user: User
 ) -> None:
     """The PATCH conversation flow can both attach and detach a conversation."""
-    project = await create_project_service(
+    project = await create_project(
         test_user.id, db_session, ProjectCreate(name="assignment-target")
     )
-    conversation = await create_conversation_service(
+    conversation = await create_conversation(
         test_user.id, db_session, ConversationCreate(title="Hi")
     )
 
     # Attach
-    await update_conversation_service(
+    await update_conversation(
         ConversationUpdate(project_id=project.id, project_id_set=True),
         test_user.id,
         conversation.id,
         db_session,
     )
-    attached = await get_conversation_service(test_user.id, db_session, conversation.id)
+    attached = await get_conversation(test_user.id, db_session, conversation.id)
     assert attached is not None
     assert attached.project_id == project.id
 
     # Detach via project_id_set + None
-    await update_conversation_service(
+    await update_conversation(
         ConversationUpdate(project_id=None, project_id_set=True),
         test_user.id,
         conversation.id,
         db_session,
     )
-    detached = await get_conversation_service(test_user.id, db_session, conversation.id)
+    detached = await get_conversation(test_user.id, db_session, conversation.id)
     assert detached is not None
     assert detached.project_id is None


### PR DESCRIPTION
## Summary

Closes #238, #239, #240. All three are mechanical refactors with no
behavior change.

### #238 — CRUD `_service` suffix dropped
17 functions in `backend/app/crud/` renamed (e.g.
`get_conversation_service` → `get_conversation`). The suffix implied a
service layer that doesn't exist — these are single-statement DB ops.

Where the new names would shadow FastAPI route handlers (the original
reason the suffix existed), the four affected files now import the
module under a `crud` alias instead of renaming the handlers:

```python
from app.crud import conversation as crud
...
await crud.get_conversation(...)
```

This is the standard FastAPI convention for that collision and keeps
operation_ids stable. Legitimate non-CRUD `_service` names
(`TelegramService`, `build_telegram_service`, `app.state.telegram_service`)
are untouched — they actually orchestrate a dispatcher.

Also standardised `get_*` (singular) vs `list_*` (plural) — the only
mismatched name was `get_conversations_for_user_service` →
`list_conversations_for_user`.

### #240 — Schema suffix audit
Resource reads → `Read`, action results → `Response`:

- `ConversationResponse` → `ConversationRead`
- `ProjectResponse` → `ProjectRead`

Untouched (action results, not resource reads):
`ChannelLinkCodeResponse`, `WorkspaceTreeResponse`, `ChatResponse`.

### #239 — Modern type annotations
Ran `pyupgrade --py313-plus` across `backend/app/` and `backend/tests/`.
Zero diff: ruff's `UP` family (already enabled) has been keeping the
codebase modern. Closed in this commit for tracking.

## Test plan

- [x] `cd backend && uv run ruff check .` — clean
- [x] `cd backend && uv run ruff format --check .` — clean
- [x] `cd backend && uv run pytest` — 683 passed, 1 skipped
- [x] `cd frontend && bun run typecheck` — clean
- [x] `cd frontend && bun run check` — clean
- [ ] CI: Backend Check, Tests, Sentrux, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a purely mechanical rename across `backend/app/` and `backend/tests/`: 17 CRUD functions lose their `_service` suffix, `get_conversations_for_user_service` is additionally corrected to `list_conversations_for_user`, and `ConversationResponse`/`ProjectResponse` are renamed to `ConversationRead`/`ProjectRead`. No logic, DB schema, or HTTP response shapes are changed.

- Files with a handler-name clash now import the CRUD module under a `crud` alias (standard FastAPI convention); files without a clash keep direct imports — both patterns are applied consistently.
- `ConversationResponse` and `ProjectResponse` are renamed to the `Read` suffix; action-result schemas (`ChatResponse`, `WorkspaceTreeResponse`, `ChannelLinkCodeResponse`) are correctly left untouched.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — every call site, test, and schema reference has been updated; no HTTP response shapes, DB schema, or business logic is touched.

All 17 renamed functions are accounted for across API layers and tests (683 passing). The two import strategies — module alias where handler-name collisions exist, direct imports elsewhere — are applied consistently. The only gap is one test function name that still carries the old suffix, which is cosmetic and has no runtime effect.

backend/tests/test_conversation_crud.py — one test function name still contains the dropped _service suffix.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/app/crud/conversation.py | All seven CRUD functions renamed by dropping _service suffix; list_conversations_for_user replaces the old get_conversations_for_user_service for get/list naming consistency. No logic changes. |
| backend/app/schemas.py | ConversationResponse → ConversationRead, ProjectResponse → ProjectRead; action-result schemas (ChannelLinkCodeResponse, WorkspaceTreeResponse, ChatResponse) correctly left unchanged. One docstring updated to match. |
| backend/app/api/conversations.py | Switched from explicit function imports to module alias (crud) to avoid shadowing route handler names; all ConversationResponse references updated to ConversationRead throughout the router. |
| backend/app/api/chat.py | Retains direct imports from app.crud.conversation (no handler-name clash here); two functions renamed by dropping _service suffix. |
| backend/tests/test_conversation_crud.py | All import names and call sites updated to new CRUD function names; one test function name (test_update_conversation_model_service_sets_model_id) still contains the dropped _service suffix. |
| backend/app/core/config.py | One-line comment update: ConversationResponse → ConversationRead in the strict_conversation_read_validation description. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/tests/test_conversation_crud.py`, line 184 ([link](https://github.com/octaviantocan/pawrrtal-ai/blob/e3589ee36c87ff1c492fde7aa942f671fefb3c8e/backend/tests/test_conversation_crud.py#L184)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The test function name still carries the `_service` suffix that was dropped everywhere else in this PR. It won't cause a test failure but leaves the refactor incomplete in one spot.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_conversation_crud.py%0ALine%3A%20184%0A%0AComment%3A%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22refactor%2Fbackend-naming-and-modern-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackend-naming-and-modern-types%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_conversation_crud.py%0ALine%3A%20184%0A%0AComment%3A%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22refactor%2Fbackend-naming-and-modern-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackend-naming-and-modern-types%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Ftests%2Ftest_conversation_crud.py%0ALine%3A%20184%0A%0AComment%3A%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Ftests%2Ftest_conversation_crud.py%3A184%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22refactor%2Fbackend-naming-and-modern-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackend-naming-and-modern-types%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Ftests%2Ftest_conversation_crud.py%3A184%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22refactor%2Fbackend-naming-and-modern-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackend-naming-and-modern-types%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Ftests%2Ftest_conversation_crud.py%3A184%0AThe%20test%20function%20name%20still%20carries%20the%20%60_service%60%20suffix%20that%20was%20dropped%20everywhere%20else%20in%20this%20PR.%20It%20won't%20cause%20a%20test%20failure%20but%20leaves%20the%20refactor%20incomplete%20in%20one%20spot.%0A%0A%60%60%60suggestion%0Aasync%20def%20test_update_conversation_model_sets_model_id%28%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(backend): drop CRUD \_service su..."](https://github.com/octaviantocan/pawrrtal-ai/commit/e3589ee36c87ff1c492fde7aa942f671fefb3c8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32429768)</sub>

<!-- /greptile_comment -->