### PR TITLE
fix(telegram): wire verbose command surfaces

### DIFF
--- a/.beans/pawrrtal-dw61--research-telegram-startup-commands-duplicate-works.md
+++ b/.beans/pawrrtal-dw61--research-telegram-startup-commands-duplicate-works.md
@@ -1,0 +1,13 @@
+---
+# pawrrtal-dw61
+title: Research Telegram startup commands, duplicate workspaces, and rename agent tool namespace
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-16T18:49:38Z
+updated_at: 2026-05-16T18:53:44Z
+---
+
+Research Telegram command registration and thinking visibility; investigate duplicate default workspace creation; implement the contained ai_nexus -> pawrrtal tool namespace rename requested in this turn.\n\n## Todos\n\n- [x] Trace Telegram bot startup and command dispatch\n- [x] Trace duplicate default workspace creation path\n- [x] Rename agent tool MCP namespace from ai_nexus to pawrrtal\n- [x] Verify focused rename tests\n- [x] Summarize implementation plan without shipping the researched larger changes
+
+## Summary of Changes\n\nResearched Telegram command registration, Telegram thinking visibility, and duplicate workspace creation paths. Implemented the requested contained Claude MCP tool namespace rename from ai_nexus to pawrrtal and verified the focused backend tests.

--- a/.beans/pawrrtal-ebh4--wire-telegram-verbose-rendering-and-startup-comman.md
+++ b/.beans/pawrrtal-ebh4--wire-telegram-verbose-rendering-and-startup-comman.md
@@ -1,0 +1,13 @@
+---
+# pawrrtal-ebh4
+title: Wire Telegram verbose rendering and startup command refresh
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-16T19:06:27Z
+updated_at: 2026-05-16T19:12:58Z
+---
+
+Implement Telegram command-menu refresh on backend startup, fully wire Telegram verbose levels into stream delivery, and explain default vs non-default workspace behavior after tracing fresh onboarding.
+
+## Summary of Changes\n\n- Registered the Telegram slash-command menu on bot startup from one command registry.\n- Wired Telegram verbose levels into the shared turn runner so quiet drops tools/thinking, normal shows tool activity, and detailed allows thinking events through.\n- Rendered thinking chunks in Telegram when detailed verbosity is enabled.\n- Cleaned up orphan workspace directories left by losing concurrent default-workspace inserts.\n- Added focused regression coverage and verified the touched backend paths.

--- a/.beans/pawrrtal-kngb--address-pr-248-review-comments-and-changelog.md
+++ b/.beans/pawrrtal-kngb--address-pr-248-review-comments-and-changelog.md
@@ -1,0 +1,17 @@
+---
+# pawrrtal-kngb
+title: Address PR 248 review comments and changelog
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-16T22:09:12Z
+updated_at: 2026-05-16T22:12:37Z
+---
+
+Read PR #248 review comments, implement requested fixes, update CHANGELOG.md, verify, commit, and push back to the PR branch.
+
+## Summary of Changes
+
+- Addressed PR #248 review feedback by making Telegram command refresh best-effort during bot startup.
+- Moved orphan workspace directory deletion to `asyncio.to_thread` while preserving path safety validation.
+- Added Telegram command-refresh regression coverage and a top-level CHANGELOG.md entry for this PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+- Added startup refresh for Telegram slash commands so the bot menu matches the current server build.
+- Added verbose Telegram delivery for tool activity and thinking events.
+- Fixed default workspace creation races so losing inserts clean up their seeded directory asynchronously.
+- Renamed agent tool labels from `ai_nexus` to `pawrrtal`.

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -162,6 +162,18 @@ class TelegramChannel:
                 )
                 continue
 
+            if etype == "thinking":
+                accumulated, chars_since_edit, last_edit_at = await _handle_thinking(
+                    event=event,
+                    bot=bot,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    accumulated=accumulated,
+                    chars_since_edit=chars_since_edit,
+                    last_edit_at=last_edit_at,
+                )
+                continue
+
             if etype == "delta":
                 chunk: str = event.get("content", "")
                 accumulated += chunk
@@ -262,6 +274,33 @@ async def _handle_tool_use(
 
     tool_name = event.get("name", "tool")
     line = f"\n{tool_icon(tool_name)} {tool_name}…"
+    accumulated += line
+    chars_since_edit += len(line)
+    now = asyncio.get_event_loop().time()
+    elapsed = now - last_edit_at
+    if accumulated and (
+        chars_since_edit >= _EDIT_DEBOUNCE_CHARS or elapsed >= _MAX_EDIT_INTERVAL_S
+    ):
+        await _safe_edit(bot, chat_id, message_id, accumulated)
+        return accumulated, 0, now
+    return accumulated, chars_since_edit, last_edit_at
+
+
+async def _handle_thinking(
+    *,
+    event: StreamEvent,
+    bot: Bot,
+    chat_id: int | str,
+    message_id: int,
+    accumulated: str,
+    chars_since_edit: int,
+    last_edit_at: float,
+) -> tuple[str, int, float]:
+    """Inject a compact thinking line for detailed Telegram verbosity."""
+    chunk = str(event.get("content") or "").strip()
+    if not chunk:
+        return accumulated, chars_since_edit, last_edit_at
+    line = f"\n🧠 Thinking: {chunk}"
     accumulated += line
     chars_since_edit += len(line)
     now = asyncio.get_event_loop().time()

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.chat_aggregator import ChatTurnAggregator
+from app.core.chat_aggregator import ChatTurnAggregator, should_emit_event
 from app.core.config import settings
 from app.core.event_bus import TurnCompletedEvent
 from app.core.event_bus.global_bus import publish_if_available
@@ -71,6 +71,7 @@ class ChatTurnInput:
     history_window: int = 20
     log_tag: str = "TURN"
     log_extras: dict[str, Any] = field(default_factory=dict)
+    verbose_level: int | None = None
 
 
 @dataclass
@@ -118,6 +119,8 @@ async def run_turn(
                 permission_check=turn_input.permission_check,
                 images=turn_input.images,
             ):
+                if not _should_deliver_event(event, turn_input.verbose_level):
+                    continue
                 counter.record(event)
                 aggregator.apply(event)
                 yield event
@@ -161,6 +164,13 @@ def _expand_hook_events(
     """Yield extra events produced by each hook for the upstream event."""
     for hook in hooks:
         yield from hook(event)
+
+
+def _should_deliver_event(event: StreamEvent, verbose_level: int | None) -> bool:
+    """Apply per-channel verbosity filtering when a channel requests it."""
+    if verbose_level is None:
+        return True
+    return should_emit_event(event, verbose_level)
 
 
 async def _load_history_and_persist(

--- a/backend/app/core/providers/_claude_tool_bridge.py
+++ b/backend/app/core/providers/_claude_tool_bridge.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 # ``mcp__<server>__<tool_name>``; both the server name and that prefix
 # are stable so the allowed-tools whitelist is computable from the
 # AgentTool list alone.
-MCP_SERVER_NAME = "ai_nexus"
+MCP_SERVER_NAME = "pawrrtal"
 
 
 def claude_tool_id(name: str) -> str:
@@ -135,7 +135,7 @@ def _strip_namespace(tool_name: str) -> str:
     The cross-provider :class:`PermissionCheckFn` works in terms of
     the unprefixed names every tool factory registers (``Bash``,
     ``workspace_read``, …); the Claude SDK addresses our bridged
-    tools as ``mcp__ai_nexus__<name>``.  Strip the namespace before
+    tools as ``mcp__pawrrtal__<name>``.  Strip the namespace before
     delegating so policy authors don't have to know about Claude's
     addressing scheme.
     """
@@ -174,7 +174,7 @@ async def auto_approve_bridge_tools(
     permission grants on every custom MCP tool call — the integration
     test on PR #131 surfaced this with::
 
-        Claude requested permissions to use mcp__ai_nexus__echo_back,
+        Claude requested permissions to use mcp__pawrrtal__echo_back,
         but you haven't granted it yet.
 
     The ``allowed_tools`` whitelist is necessary but not sufficient:
@@ -209,11 +209,11 @@ def make_can_use_tool(
     When a :class:`PermissionCheckFn` is supplied (PR 03b chat-router
     wire-up), the returned callback:
 
-    1. Rejects anything outside the ``mcp__ai_nexus__*`` namespace
+    1. Rejects anything outside the ``mcp__pawrrtal__*`` namespace
        with the same message the legacy default uses.  Defence in
        depth — even if the gate is misconfigured, an unexpected MCP
        server can't piggy-back on our approval.
-    2. Strips the ``mcp__ai_nexus__`` prefix from the tool name so
+    2. Strips the ``mcp__pawrrtal__`` prefix from the tool name so
        the cross-provider gate sees the bare ``AgentTool.name`` it
        was authored against.
     3. Awaits the gate.  An ``Allow`` decision becomes a Claude SDK

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -380,7 +380,7 @@ class ClaudeLLM:
                 MCP server via
                 :mod:`app.core.providers._claude_tool_bridge` and mounted
                 under ``ClaudeAgentOptions.mcp_servers``; the matching
-                ``mcp__ai_nexus__<name>`` IDs are appended to the
+                ``mcp__pawrrtal__<name>`` IDs are appended to the
                 allowed-tools whitelist so the SDK actually permits
             permission_check: Optional cross-provider permission gate.
                 When supplied, bound into ``ClaudeAgentOptions.can_use_tool``

--- a/backend/app/core/tools/exa_search_claude.py
+++ b/backend/app/core/tools/exa_search_claude.py
@@ -24,7 +24,7 @@ from .exa_search import (
 )
 
 # Identifier used by Claude when invoking the tool: mcp__<server>__<tool>.
-MCP_SERVER_NAME = "ai_nexus"
+MCP_SERVER_NAME = "pawrrtal"
 MCP_TOOL_NAME = "exa_search"
 
 # Public allowed_tools entry. Whitelist this string in ClaudeAgentOptions

--- a/backend/app/crud/workspace.py
+++ b/backend/app/crud/workspace.py
@@ -6,6 +6,7 @@ Filesystem seeding lives in ``app.core.workspace`` (``seed_workspace``).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 import uuid
@@ -132,7 +133,7 @@ async def ensure_default_workspace(
         # Another concurrent request already inserted the default workspace.
         # The savepoint was rolled back automatically; re-fetch the winner.
         if orphaned_path is not None:
-            _remove_orphan_workspace_dir(orphaned_path)
+            await _remove_orphan_workspace_dir(orphaned_path)
         log.warning(
             "ensure_default_workspace: IntegrityError for user %s — "
             "concurrent insert detected, re-fetching existing row.",
@@ -148,22 +149,30 @@ async def ensure_default_workspace(
         return result
 
 
-def _remove_orphan_workspace_dir(path: Path) -> None:
+async def _remove_orphan_workspace_dir(path: Path) -> None:
     """Remove a just-seeded workspace directory after its DB row rolled back."""
+    resolved = _validated_orphan_workspace_dir(path)
+    if resolved is None:
+        return
+
+    try:
+        await asyncio.to_thread(shutil.rmtree, resolved)
+    except FileNotFoundError:
+        return
+    except OSError:
+        log.warning("Failed to remove orphan workspace directory: %s", resolved, exc_info=True)
+
+
+def _validated_orphan_workspace_dir(path: Path) -> Path | None:
+    """Return a safe workspace path to delete, or None when it is unsafe."""
     try:
         workspace_base = Path(settings.workspace_base_dir).resolve()
         resolved = path.resolve()
         resolved.relative_to(workspace_base)
     except ValueError:
         log.warning("Refusing to remove workspace path outside base dir: %s", path)
-        return
+        return None
     except OSError:
         log.warning("Could not resolve orphan workspace path: %s", path, exc_info=True)
-        return
-
-    try:
-        shutil.rmtree(resolved)
-    except FileNotFoundError:
-        return
-    except OSError:
-        log.warning("Failed to remove orphan workspace directory: %s", resolved, exc_info=True)
+        return None
+    return resolved

--- a/backend/app/crud/workspace.py
+++ b/backend/app/crud/workspace.py
@@ -7,14 +7,17 @@ Filesystem seeding lives in ``app.core.workspace`` (``seed_workspace``).
 from __future__ import annotations
 
 import logging
+import shutil
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.workspace import seed_workspace
 
 log = logging.getLogger(__name__)
@@ -110,6 +113,7 @@ async def ensure_default_workspace(
     if existing is not None:
         return existing
 
+    orphaned_path: Path | None = None
     try:
         # Use a savepoint so a constraint violation only rolls back this
         # nested transaction, not the whole outer session.
@@ -122,10 +126,13 @@ async def ensure_default_workspace(
                 is_default=True,
                 personalization=personalization,
             )
+            orphaned_path = Path(ws.path)
         return ws
     except IntegrityError:
         # Another concurrent request already inserted the default workspace.
         # The savepoint was rolled back automatically; re-fetch the winner.
+        if orphaned_path is not None:
+            _remove_orphan_workspace_dir(orphaned_path)
         log.warning(
             "ensure_default_workspace: IntegrityError for user %s — "
             "concurrent insert detected, re-fetching existing row.",
@@ -139,3 +146,24 @@ async def ensure_default_workspace(
                 f"for user {user_id} after IntegrityError"
             ) from None
         return result
+
+
+def _remove_orphan_workspace_dir(path: Path) -> None:
+    """Remove a just-seeded workspace directory after its DB row rolled back."""
+    try:
+        workspace_base = Path(settings.workspace_base_dir).resolve()
+        resolved = path.resolve()
+        resolved.relative_to(workspace_base)
+    except ValueError:
+        log.warning("Refusing to remove workspace path outside base dir: %s", path)
+        return
+    except OSError:
+        log.warning("Could not resolve orphan workspace path: %s", path, exc_info=True)
+        return
+
+    try:
+        shutil.rmtree(resolved)
+    except FileNotFoundError:
+        return
+    except OSError:
+        log.warning("Failed to remove orphan workspace directory: %s", resolved, exc_info=True)

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -57,6 +57,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_TELEGRAM_COMMANDS: tuple[tuple[str, str], ...] = (
+    ("start", "Connect your Pawrrtal account"),
+    ("new", "Start a new conversation"),
+    ("model", "Switch the model for this conversation"),
+    ("verbose", "Set detail level: 0 quiet, 1 tools, 2 thinking"),
+    ("stop", "Stop the active run"),
+)
+
 # Active streaming tasks keyed by Telegram chat_id.  When a new message
 # arrives we cancel any existing task for that chat (preventing two parallel
 # streams into the same placeholder message), then store the new one so
@@ -185,6 +193,11 @@ async def _run_llm_turn(*, message: Message, context: TelegramTurnContext) -> No
         ),
         log_tag="TELEGRAM",
         log_extras={"chat_id": message.chat.id},
+        verbose_level=(
+            context.verbose_level
+            if context.verbose_level is not None
+            else settings.telegram_verbose_default
+        ),
     )
 
     async def _do_stream() -> None:
@@ -346,6 +359,21 @@ def build_telegram_service() -> TelegramService:  # noqa: PLR0915 — single dis
     return TelegramService(bot=bot, dispatcher=dispatcher)
 
 
+async def refresh_telegram_commands(bot: Bot) -> None:
+    """Publish the current slash-command menu to Telegram."""
+    from aiogram.types import BotCommand  # noqa: PLC0415
+
+    commands = [
+        BotCommand(command=command, description=description)
+        for command, description in _TELEGRAM_COMMANDS
+    ]
+    await bot.set_my_commands(commands)
+    logger.info(
+        "TELEGRAM_COMMANDS_REFRESHED commands=%s",
+        ",".join(command for command, _ in _TELEGRAM_COMMANDS),
+    )
+
+
 def _sender_from_message(message: Message) -> TelegramSender:
     """Project an aiogram ``Message`` onto our framework-free dataclass."""
     user = message.from_user
@@ -484,6 +512,7 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
         return
 
     service = build_telegram_service()
+    await refresh_telegram_commands(service.bot)
 
     if settings.telegram_mode == "polling":
         # Drop any leftover webhook so polling actually receives updates;

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -374,6 +374,14 @@ async def refresh_telegram_commands(bot: Bot) -> None:
     )
 
 
+async def _refresh_telegram_commands_best_effort(bot: Bot) -> None:
+    """Refresh command menu without turning Telegram startup into a hard dependency."""
+    try:
+        await refresh_telegram_commands(bot)
+    except Exception:
+        logger.warning("TELEGRAM_COMMANDS_REFRESH_FAILED", exc_info=True)
+
+
 def _sender_from_message(message: Message) -> TelegramSender:
     """Project an aiogram ``Message`` onto our framework-free dataclass."""
     user = message.from_user
@@ -512,7 +520,7 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
         return
 
     service = build_telegram_service()
-    await refresh_telegram_commands(service.bot)
+    await _refresh_telegram_commands_best_effort(service.bot)
 
     if settings.telegram_mode == "polling":
         # Drop any leftover webhook so polling actually receives updates;

--- a/backend/app/integrations/telegram/tool_icons.py
+++ b/backend/app/integrations/telegram/tool_icons.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 _DEFAULT_GLYPH = "\U0001f527"
 
 # Map keyed on the bare tool name (without the Claude SDK
-# ``mcp__ai_nexus__`` prefix — the bridge strips that before our
+# ``mcp__pawrrtal__`` prefix — the bridge strips that before our
 # permission gate sees the name, and the channel layer matches the
 # same convention).  Mostly Claude-SDK names + the Pawrrtal-native
 # tool factories that ship in the chat router.

--- a/backend/tests/test_claude_provider_pr05.py
+++ b/backend/tests/test_claude_provider_pr05.py
@@ -36,7 +36,7 @@ class TestRetryClassifier:
         "message",
         [
             "MCP server failed to start",
-            "mcp__ai_nexus__echo_back not registered",
+            "mcp__pawrrtal__echo_back not registered",
             "MCP transport closed",
         ],
     )

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -24,6 +24,7 @@ from app.channels.base import ChannelMessage
 from app.channels.telegram import SURFACE_TELEGRAM, TelegramChannel
 from app.core.providers.base import StreamEvent
 from app.core.providers.catalog import default_model
+from app.integrations.telegram.bot import refresh_telegram_commands
 from app.integrations.telegram.bot_provider_resolution import (
     resolve_provider_with_auto_clear as _resolve_provider_with_auto_clear,
 )
@@ -91,6 +92,24 @@ class TestTelegramRegistry:
 
     def test_registered_surface_included(self) -> None:
         assert "telegram" in registered_surfaces()
+
+
+# ---------------------------------------------------------------------------
+# Bot command publishing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_refresh_telegram_commands_sets_current_command_menu() -> None:
+    bot = AsyncMock()
+
+    await refresh_telegram_commands(bot)
+
+    bot.set_my_commands.assert_awaited_once()
+    commands = bot.set_my_commands.await_args.args[0]
+    names = [command.command for command in commands]
+    assert names == ["start", "new", "model", "verbose", "stop"]
+    assert all(command.description for command in commands)
 
 
 # ---------------------------------------------------------------------------
@@ -164,14 +183,13 @@ class TestTelegramChannelDeliver:
         last_call = calls[-1]
         assert last_call.kwargs["text"] == "Hello, world"
 
-    async def test_non_delta_events_ignored(self) -> None:
-        """``type: thinking`` is skipped; ``tool_use`` injects an inline glyph (PR 07)."""
+    async def test_tool_use_injects_inline_glyph(self) -> None:
+        """``tool_use`` injects an inline glyph when verbose filtering lets it through."""
         bot = _make_bot()
         msg = _make_channel_message(bot)
         channel = TelegramChannel()
 
         events: list[StreamEvent] = [
-            {"type": "thinking", "content": "reasoning..."},
             {"type": "delta", "content": "answer"},
             {"type": "tool_use", "name": "search", "input": {}},
         ]
@@ -180,11 +198,27 @@ class TestTelegramChannelDeliver:
 
         last_call = bot.edit_message_text.call_args_list[-1]
         # PR 07: tool_use surfaces a one-line glyph + tool name so the
-        # user can see what the agent is doing in real time. Thinking
-        # is still silenced.
+        # user can see what the agent is doing in real time.
         assert last_call.kwargs["text"].startswith("answer")
         assert "search" in last_call.kwargs["text"]
-        assert "reasoning..." not in last_call.kwargs["text"]
+
+    async def test_thinking_event_renders_when_verbose_filter_allows_it(self) -> None:
+        """Detailed Telegram verbosity surfaces thinking chunks inline."""
+        bot = _make_bot()
+        msg = _make_channel_message(bot)
+        channel = TelegramChannel()
+
+        events: list[StreamEvent] = [
+            {"type": "thinking", "content": "checking the workspace"},
+            {"type": "delta", "content": "answer"},
+        ]
+        async for _ in channel.deliver(_stream(*events), msg):
+            pass
+
+        last_text = bot.edit_message_text.call_args_list[-1].kwargs["text"]
+        assert "Thinking:" in last_text
+        assert "checking the workspace" in last_text
+        assert "answer" in last_text
 
     async def test_agent_terminated_replaces_placeholder(self) -> None:
         """``agent_terminated`` without any text must show the warning to the user."""

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -24,7 +24,10 @@ from app.channels.base import ChannelMessage
 from app.channels.telegram import SURFACE_TELEGRAM, TelegramChannel
 from app.core.providers.base import StreamEvent
 from app.core.providers.catalog import default_model
-from app.integrations.telegram.bot import refresh_telegram_commands
+from app.integrations.telegram.bot import (
+    _refresh_telegram_commands_best_effort,
+    refresh_telegram_commands,
+)
 from app.integrations.telegram.bot_provider_resolution import (
     resolve_provider_with_auto_clear as _resolve_provider_with_auto_clear,
 )
@@ -110,6 +113,19 @@ async def test_refresh_telegram_commands_sets_current_command_menu() -> None:
     names = [command.command for command in commands]
     assert names == ["start", "new", "model", "verbose", "stop"]
     assert all(command.description for command in commands)
+
+
+@pytest.mark.anyio
+async def test_refresh_telegram_commands_best_effort_logs_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bot = AsyncMock()
+    bot.set_my_commands.side_effect = RuntimeError("telegram unavailable")
+
+    await _refresh_telegram_commands_best_effort(bot)
+
+    bot.set_my_commands.assert_awaited_once()
+    assert "TELEGRAM_COMMANDS_REFRESH_FAILED" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_verbose_filter.py
+++ b/backend/tests/test_verbose_filter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.channels.turn_runner import _should_deliver_event
 from app.core.chat_aggregator import (
     VERBOSE_DETAILED,
     VERBOSE_NORMAL,
@@ -85,3 +86,16 @@ class TestDetailed:
     )
     def test_kept(self, ev: StreamEvent) -> None:
         assert should_emit_event(ev, VERBOSE_DETAILED) is True
+
+
+class TestTurnRunnerVerboseBridge:
+    """ChatTurnInput.verbose_level is the seam that applies the filter."""
+
+    def test_none_keeps_everything_for_web_chat(self) -> None:
+        assert _should_deliver_event(_ev("thinking", content="thoughts"), None) is True
+
+    def test_quiet_drops_tool_events_for_telegram(self) -> None:
+        assert _should_deliver_event(_ev("tool_use", name="workspace_read"), VERBOSE_QUIET) is False
+
+    def test_detailed_keeps_thinking_for_telegram(self) -> None:
+        assert _should_deliver_event(_ev("thinking", content="thoughts"), VERBOSE_DETAILED) is True

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -489,6 +490,48 @@ class TestWorkspaceService:
             recovered_ws = await ensure_default_workspace(test_user.id, db_session)
 
         assert recovered_ws.id == real_ws.id
+
+    @pytest.mark.anyio
+    async def test_ensure_default_workspace_removes_orphan_dir_after_integrity_error(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The losing concurrent insert must not leave a seeded directory behind."""
+        from sqlalchemy.exc import IntegrityError as SAIntegrityError
+
+        class FailingSavepoint:
+            async def __aenter__(self) -> None:
+                return None
+
+            async def __aexit__(self, *_args: object) -> None:
+                raise SAIntegrityError("mock", {}, Exception())
+
+        user_id = uuid.uuid4()
+        orphan = tmp_path / str(uuid.uuid4())
+        orphan.mkdir()
+        winner = SimpleNamespace(id=uuid.uuid4())
+
+        def begin_nested() -> FailingSavepoint:
+            return FailingSavepoint()
+
+        fake_session = SimpleNamespace(begin_nested=begin_nested)
+
+        with (
+            patch("app.crud.workspace.settings") as mock_settings,
+            patch(
+                "app.crud.workspace.get_default_workspace",
+                new=AsyncMock(side_effect=[None, winner]),
+            ),
+            patch(
+                "app.crud.workspace.create_workspace",
+                new=AsyncMock(return_value=SimpleNamespace(path=str(orphan))),
+            ),
+        ):
+            mock_settings.workspace_base_dir = str(tmp_path)
+            recovered_ws = await ensure_default_workspace(user_id, fake_session)
+
+        assert recovered_ws is winner
+        assert not orphan.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refresh the Telegram bot command menu on backend startup from one command registry
- wire Telegram verbose levels into turn delivery so /verbose 0/1/2 affects streamed events
- render thinking chunks in Telegram at detailed verbosity and clean orphan workspace directories after duplicate default-workspace races
- rename the Claude MCP tool namespace from ai_nexus to pawrrtal

## Testing
- env AUTH_SECRET=test-secret GOOGLE_API_KEY=test-key WORKSPACE_ENCRYPTION_KEY=4adY4WrJUWzdTjEIclUJRtEmh34SzmiFndMZ1NVYw7A= CORS_ORIGINS='["http://localhost:3001"]' uv run pytest tests/test_telegram_channel.py tests/test_verbose_filter.py tests/test_workspace.py tests/test_claude_tool_bridge.py tests/test_claude_provider_pr05.py\n- bun run typecheck\n- git push pre-push hook: check + typecheck passed\n\n## Notes\n- Branch is one commit over origin/development.\n- Default workspace remains the single DB workspace used for chat/tool execution; this also cleans up orphan filesystem directories left by losing concurrent inserts.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires verbose-level filtering end-to-end for Telegram, registers the bot command menu from a single registry on startup, renders thinking chunks at detailed verbosity, and cleans up orphan workspace directories created by losing concurrent `IntegrityError` inserts. It also renames the Claude MCP tool namespace from `ai_nexus` to `pawrrtal` across the bridge and provider layers.

- **Verbose pipeline**: `verbose_level` is plumbed from `TelegramTurnContext` through `ChatTurnInput` into `run_turn`, where `_should_deliver_event` gates each streamed event before it reaches `TelegramChannel.deliver`. Quiet drops tool/thinking, normal passes tool activity, detailed passes everything including a new 🧠 thinking renderer.
- **Startup command menu**: `_TELEGRAM_COMMANDS` is now a single source-of-truth tuple; `_refresh_telegram_commands_best_effort` wraps the Telegram API call and swallows failures so a transient network error never aborts the lifespan (addressing a previous review concern).
- **Orphan cleanup**: `ensure_default_workspace` captures the seeded path before the savepoint exits and, on `IntegrityError`, offloads `shutil.rmtree` to `asyncio.to_thread` with a path-traversal safety check (addressing the previous blocking-IO concern).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three functional changes (verbose filtering, command-menu refresh, orphan cleanup) are well-scoped and the two concerns raised in the previous review round have been addressed.

The verbose pipeline is correctly gated at `run_turn` so non-Telegram callers are unaffected. The best-effort command-refresh wrapper correctly prevents a Telegram API hiccup from aborting the lifespan. The orphan cleanup uses `asyncio.to_thread` with a path-traversal guard, which is the correct async-safe pattern. The one remaining finding — a broad `except Exception` in the best-effort wrapper — is a style violation of the project's exception-narrowing rule but does not affect correctness or safety of the startup path.

No files require special attention; the broad exception catch in `backend/app/integrations/telegram/bot.py` is the only item worth revisiting.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/integrations/telegram/bot.py | Added `_TELEGRAM_COMMANDS` registry, `refresh_telegram_commands`, and `_refresh_telegram_commands_best_effort` helpers; wires `verbose_level` from `TelegramTurnContext` (or `settings.telegram_verbose_default`) into `ChatTurnInput`. The broad `except Exception` in the best-effort wrapper violates the project's exception-narrowing rule. |
| backend/app/channels/telegram.py | Adds `_handle_thinking` helper that mirrors `_handle_tool_use`; routes `thinking` events through debounce logic with a 🧠 prefix. Pattern and guard logic are consistent with the existing tool-use handler. |
| backend/app/channels/turn_runner.py | Adds `verbose_level` field to `ChatTurnInput` and a `_should_deliver_event` filter that passes all events when `None` (web chat) and applies `should_emit_event` otherwise (Telegram). Logic is correct — `None` is the non-Telegram passthrough. |
| backend/app/crud/workspace.py | Adds orphan-directory cleanup on `IntegrityError` in `ensure_default_workspace`. Uses `asyncio.to_thread(shutil.rmtree, …)` (addressing the previous blocking-IO concern) with path-traversal guard and narrow `OSError` / `FileNotFoundError` catches. |
| backend/app/core/providers/_claude_tool_bridge.py | Mechanical rename of `MCP_SERVER_NAME` constant and all comment references from `ai_nexus` to `pawrrtal`. No logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TG as Telegram User
    participant Bot as bot.py (telegram_lifespan)
    participant TR as turn_runner.py (run_turn)
    participant CA as chat_aggregator (should_emit_event)
    participant Ch as TelegramChannel.deliver

    Bot->>Bot: _refresh_telegram_commands_best_effort()
    Note over Bot: sets command menu on startup (best-effort)

    TG->>Bot: /verbose 2  (or any message)
    Bot->>TR: "ChatTurnInput(verbose_level=context.verbose_level or default)"

    loop Provider stream events
        TR->>CA: _should_deliver_event(event, verbose_level)
        alt verbose_level is None (web chat)
            CA-->>TR: True (pass all)
        else "verbose_level = 0 (quiet)"
            CA-->>TR: False for tool_use/thinking
        else "verbose_level = 1 (normal)"
            CA-->>TR: True for tool_use, False for thinking
        else "verbose_level = 2 (detailed)"
            CA-->>TR: True for everything
        end
        TR-->>Ch: yield filtered event
    end

    Ch->>Ch: _handle_tool_use() or _handle_thinking() or delta
    Ch->>TG: edit_message_text (debounced)
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fintegrations%2Ftelegram%2Fbot.py%3A377-382%0ABroad%20exception%20catch%20swallows%20programming%20errors.%20The%20project's%20exception-narrowing%20rule%20%28%60.claude%2Frules%2Fclean-code%2Fpython-logging-exceptions.md%60%29%20requires%20catching%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%20%60except%20Exception%60%20would%20silently%20absorb%20%60TypeError%60%2C%20%60AttributeError%60%2C%20and%20%60ImportError%60%20%E2%80%94%20bugs%20that%20should%20surface%20immediately.%20The%20only%20realistic%20failures%20here%20are%20Telegram%20API%20errors%20and%20network%20I%2FO%20errors%2C%20which%20aiogram%20surfaces%20as%20%60TelegramAPIError%60%20and%20%60aiohttp.ClientError%60.%0A%0A%60%60%60suggestion%0Aasync%20def%20_refresh_telegram_commands_best_effort%28bot%3A%20Bot%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Refresh%20command%20menu%20without%20turning%20Telegram%20startup%20into%20a%20hard%20dependency.%22%22%22%0A%20%20%20%20from%20aiogram.exceptions%20import%20TelegramAPIError%20%20%23%20noqa%3A%20PLC0415%0A%20%20%20%20import%20aiohttp%20%20%23%20noqa%3A%20PLC0415%0A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20refresh_telegram_commands%28bot%29%0A%20%20%20%20except%20%28TelegramAPIError%2C%20aiohttp.ClientError%2C%20OSError%29%3A%0A%20%20%20%20%20%20%20%20logger.warning%28%22TELEGRAM_COMMANDS_REFRESH_FAILED%22%2C%20exc_info%3DTrue%29%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22octavian%2Ftelegram-verbose-commands%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22octavian%2Ftelegram-verbose-commands%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fintegrations%2Ftelegram%2Fbot.py%3A377-382%0ABroad%20exception%20catch%20swallows%20programming%20errors.%20The%20project's%20exception-narrowing%20rule%20%28%60.claude%2Frules%2Fclean-code%2Fpython-logging-exceptions.md%60%29%20requires%20catching%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%20%60except%20Exception%60%20would%20silently%20absorb%20%60TypeError%60%2C%20%60AttributeError%60%2C%20and%20%60ImportError%60%20%E2%80%94%20bugs%20that%20should%20surface%20immediately.%20The%20only%20realistic%20failures%20here%20are%20Telegram%20API%20errors%20and%20network%20I%2FO%20errors%2C%20which%20aiogram%20surfaces%20as%20%60TelegramAPIError%60%20and%20%60aiohttp.ClientError%60.%0A%0A%60%60%60suggestion%0Aasync%20def%20_refresh_telegram_commands_best_effort%28bot%3A%20Bot%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Refresh%20command%20menu%20without%20turning%20Telegram%20startup%20into%20a%20hard%20dependency.%22%22%22%0A%20%20%20%20from%20aiogram.exceptions%20import%20TelegramAPIError%20%20%23%20noqa%3A%20PLC0415%0A%20%20%20%20import%20aiohttp%20%20%23%20noqa%3A%20PLC0415%0A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20refresh_telegram_commands%28bot%29%0A%20%20%20%20except%20%28TelegramAPIError%2C%20aiohttp.ClientError%2C%20OSError%29%3A%0A%20%20%20%20%20%20%20%20logger.warning%28%22TELEGRAM_COMMANDS_REFRESH_FAILED%22%2C%20exc_info%3DTrue%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22octavian%2Ftelegram-verbose-commands%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22octavian%2Ftelegram-verbose-commands%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapp%2Fintegrations%2Ftelegram%2Fbot.py%3A377-382%0ABroad%20exception%20catch%20swallows%20programming%20errors.%20The%20project's%20exception-narrowing%20rule%20%28%60.claude%2Frules%2Fclean-code%2Fpython-logging-exceptions.md%60%29%20requires%20catching%20the%20narrowest%20type%20that%20covers%20the%20failure%20mode.%20%60except%20Exception%60%20would%20silently%20absorb%20%60TypeError%60%2C%20%60AttributeError%60%2C%20and%20%60ImportError%60%20%E2%80%94%20bugs%20that%20should%20surface%20immediately.%20The%20only%20realistic%20failures%20here%20are%20Telegram%20API%20errors%20and%20network%20I%2FO%20errors%2C%20which%20aiogram%20surfaces%20as%20%60TelegramAPIError%60%20and%20%60aiohttp.ClientError%60.%0A%0A%60%60%60suggestion%0Aasync%20def%20_refresh_telegram_commands_best_effort%28bot%3A%20Bot%29%20-%3E%20None%3A%0A%20%20%20%20%22%22%22Refresh%20command%20menu%20without%20turning%20Telegram%20startup%20into%20a%20hard%20dependency.%22%22%22%0A%20%20%20%20from%20aiogram.exceptions%20import%20TelegramAPIError%20%20%23%20noqa%3A%20PLC0415%0A%20%20%20%20import%20aiohttp%20%20%23%20noqa%3A%20PLC0415%0A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20await%20refresh_telegram_commands%28bot%29%0A%20%20%20%20except%20%28TelegramAPIError%2C%20aiohttp.ClientError%2C%20OSError%29%3A%0A%20%20%20%20%20%20%20%20logger.warning%28%22TELEGRAM_COMMANDS_REFRESH_FAILED%22%2C%20exc_info%3DTrue%29%0A%60%60%60%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(telegram): address PR feedback"](https://github.com/octaviantocan/pawrrtal-ai/commit/efa8d6f5a7327a5a8bb24b4c415573d2d05ad61a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32457723)</sub>

<!-- /greptile_comment -->