### PR TITLE
refactor(channels): port practice-branch shape into schemas/models/crud/api

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -24,7 +24,7 @@ from app.crud.channel import (
     list_bindings,
 )
 from app.db import User, get_async_session
-from app.schemas import ChannelBindingRead, ChannelLinkCodeResponse
+from app.schemas import ChannelBindingRead, TelegramLinkCodeRead
 from app.users import get_allowed_user
 
 _TELEGRAM = "telegram"
@@ -62,24 +62,15 @@ def get_channels_router() -> APIRouter:
     ) -> list[ChannelBindingRead]:
         """List every channel the authenticated user has currently bound."""
         rows = await list_bindings(user_id=user.id, session=session)
-        return [
-            ChannelBindingRead(
-                provider=row.provider,
-                external_user_id=row.external_user_id,
-                external_chat_id=row.external_chat_id,
-                display_handle=row.display_handle,
-                created_at=row.created_at,
-            )
-            for row in rows
-        ]
+        return [ChannelBindingRead.model_validate(row) for row in rows]
 
     # --- Telegram ------------------------------------------------------------
 
-    @router.post("/telegram/link", response_model=ChannelLinkCodeResponse)
+    @router.post("/telegram/link", response_model=TelegramLinkCodeRead)
     async def link_telegram(
         user: User = Depends(get_allowed_user),
         session: AsyncSession = Depends(get_async_session),
-    ) -> ChannelLinkCodeResponse:
+    ) -> TelegramLinkCodeRead:
         """Issue a fresh one-time code the user can redeem in the bot.
 
         The plaintext code is returned exactly once. The DB only stores
@@ -100,7 +91,7 @@ def get_channels_router() -> APIRouter:
             provider=_TELEGRAM,
             session=session,
         )
-        return ChannelLinkCodeResponse(
+        return TelegramLinkCodeRead(
             code=code,
             expires_at=expires_at,
             bot_username=settings.telegram_bot_username or None,

--- a/backend/app/crud/channel.py
+++ b/backend/app/crud/channel.py
@@ -167,10 +167,32 @@ async def list_bindings(
     user_id: uuid.UUID,
     session: AsyncSession,
 ) -> list[ChannelBinding]:
-    """Return all channel bindings owned by ``user_id``."""
-    stmt = select(ChannelBinding).where(ChannelBinding.user_id == user_id)
+    """Return all channel bindings owned by ``user_id``, newest first."""
+    stmt = (
+        select(ChannelBinding)
+        .where(ChannelBinding.user_id == user_id)
+        .order_by(ChannelBinding.created_at.desc())
+    )
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+async def get_binding(
+    *,
+    user_id: uuid.UUID,
+    provider: str,
+    session: AsyncSession,
+) -> ChannelBinding | None:
+    """Return the user's binding for ``provider`` if one exists, else ``None``.
+
+    Useful as an exists-check before issuing a fresh link code or for
+    surfacing the connected state in the Settings UI.
+    """
+    stmt = select(ChannelBinding).where(
+        ChannelBinding.user_id == user_id,
+        ChannelBinding.provider == provider,
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
 
 
 async def delete_binding(
@@ -182,14 +204,11 @@ async def delete_binding(
     """Remove the user's binding for ``provider`` if one exists.
 
     Returns ``True`` when a row was deleted, ``False`` when the user
-    had no binding for that provider. Callers translate to 200/404 as
-    needed.
+    had no binding for that provider. The Settings UI calls the
+    matching route unconditionally — translating the ``False`` to a
+    204 keeps the click idempotent.
     """
-    stmt = select(ChannelBinding).where(
-        ChannelBinding.user_id == user_id,
-        ChannelBinding.provider == provider,
-    )
-    row = (await session.execute(stmt)).scalar_one_or_none()
+    row = await get_binding(user_id=user_id, provider=provider, session=session)
     if row is None:
         return False
     await session.delete(row)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -175,66 +175,62 @@ class UserAppearance(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 
 
-class ChannelBinding(Base):
-    """Persistent map from a third-party messaging identity to a Nexus user.
-
-    One row per (provider, external_user_id) — enforced by a unique
-    constraint so a Telegram account can never silently move between
-    Nexus users. Created when a user successfully redeems a one-time
-    code via the bot's `/start <code>` (or manual paste) flow.
-
-    The `provider` column is open-ended on purpose: today only
-    `"telegram"` is wired up, but the same table will host Slack,
-    WhatsApp, iMessage, etc. as those adapters land.
-    """
-
-    __tablename__ = "channel_bindings"
-
-    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
-    )
-    provider: Mapped[str] = mapped_column(String(32))
-    # Provider identities can be ints (Telegram user_id) or strings
-    # (Slack user IDs, WhatsApp phone numbers). Normalize to text so
-    # the column shape stays the same across providers.
-    external_user_id: Mapped[str] = mapped_column(String(128))
-    # Default chat to push to. For Telegram direct chats this matches
-    # external_user_id; for groups it's the chat where the bind happened.
-    external_chat_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    # Display handle captured at bind time. Stored for admin/debug only,
-    # never used for authentication.
-    display_handle: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    # True when this Telegram chat has Bot API 9.3+ Topics enabled.
-    # Drives the routing branch in the inbound message handler.
-    has_topics_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default="false"
-    )
-    created_at: Mapped[datetime] = mapped_column(DateTime)
-
-
 class ChannelLinkCode(Base):
-    """Short-lived one-time-use code that brokers a channel bind.
-
-    The web app issues a code (server-side; user only sees the plaintext
-    once), the user sends it to the bot, and the bot consumes the row to
-    create the matching `ChannelBinding`. We persist an HMAC of the code
-    rather than the plaintext so a DB leak cannot be replayed against
-    the bot. Lookups are always by `code_hash`, which is therefore the
-    primary key.
-    """
+    """A short-lived one-time-use code for linking a Pawrrtal user to a third-party channel."""
 
     __tablename__ = "channel_link_codes"
 
+    # HMAC-SHA-256 hex hash of the user-facing code. PK so lookups are
+    # by hash; the plaintext is never persisted.
     code_hash: Mapped[str] = mapped_column(String(128), primary_key=True)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    provider: Mapped[str] = mapped_column(String(32))
-    created_at: Mapped[datetime] = mapped_column(DateTime)
-    expires_at: Mapped[datetime] = mapped_column(DateTime, index=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     # NULL while the code is unredeemed; populated once the bot consumes it.
     used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
+class ChannelBinding(Base):
+    """A binding between a Pawrrtal user and a third-party channel."""
+
+    __tablename__ = "channel_bindings"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider",
+            "external_user_id",
+            name="uq_channel_bindings_provider_external_user",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    # The Pawrrtal user ID.
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    # Stable identity from the provider (Telegram user_id as text so the
+    # column type is the same across providers).
+    external_user_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    # Default chat to push to. For Telegram direct chats this matches
+    # external_user_id; for groups it's the chat where the bind happened.
+    external_chat_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Display handle captured at bind time. Surfaced in the Settings UI
+    # connected-state ("@<display_handle>"); never trusted for auth.
+    display_handle: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    # Pointer to the currently active conversation for non-topic DMs.
+    # NULL until the first message creates one. Column lives in DB
+    # via migration 011.
+    active_conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
+    # Whether the Telegram chat has Topics (forum threads) enabled.
+    has_topics_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
 
 
 class ChatMessage(Base):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -188,7 +188,9 @@ class ChannelLinkCode(Base):
     )
     provider: Mapped[str] = mapped_column(String(32), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    # Indexed because the cleanup job scans on (expires_at, used_at IS NULL)
+    # to GC unredeemed codes; matches migration 007's ix_channel_link_codes_expires_at.
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
     # NULL while the code is unredeemed; populated once the bot consumes it.
     used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -223,12 +223,6 @@ class ChannelBinding(Base):
     # connected-state ("@<display_handle>"); never trusted for auth.
     display_handle: Mapped[str | None] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    # Pointer to the currently active conversation for non-topic DMs.
-    # NULL until the first message creates one. Column lives in DB
-    # via migration 011.
-    active_conversation_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
-    )
     # Whether the Telegram chat has Topics (forum threads) enabled.
     has_topics_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -340,34 +340,29 @@ class ChatMessageRead(BaseModel):
 
 
 class ChannelBindingRead(BaseModel):
-    """Public view of a third-party messaging binding.
-
-    Returned by ``GET /api/v1/channels`` so the Settings UI can list which
-    services the user has connected. Sensitive provider IDs are exposed only
-    to their owner via the authenticated route.
-    """
+    """Public shape returned by ``GET /api/v1/channels``."""
 
     provider: str
     external_user_id: str
+    # external_chat_id + display_handle remain on the read shape because
+    # the Settings UI renders the handle (``@{display_handle}``) on the
+    # connected-state dialog and the binding hook reads the chat id.
     external_chat_id: str | None = None
     display_handle: str | None = None
     created_at: datetime
 
+    model_config = ConfigDict(from_attributes=True)
 
-class ChannelLinkCodeResponse(BaseModel):
-    """Response shape returned when the web app requests a fresh link code.
 
-    `code` is the plaintext the user types (or the bot reads from a
-    `t.me/<bot>?start=<code>` deep link); the server only persists its
-    HMAC. `expires_at` powers the countdown timer the frontend renders.
-    `bot_username` is included so the frontend can render the deep link
-    without hard-coding the bot identity.
-    """
+class TelegramLinkCodeRead(BaseModel):
+    """Response shape from ``POST /api/v1/channels/telegram/link``."""
 
     code: str
     expires_at: datetime
     bot_username: str | None = None
     deep_link: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 # --- Workspace schemas --------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -355,14 +355,18 @@ class ChannelBindingRead(BaseModel):
 
 
 class TelegramLinkCodeRead(BaseModel):
-    """Response shape from ``POST /api/v1/channels/telegram/link``."""
+    """Response shape from ``POST /api/v1/channels/telegram/link``.
+
+    Always constructed from scalar kwargs by the route — never
+    ``.model_validate(orm_row)``. The closest ORM row (``ChannelLinkCode``)
+    only stores ``code_hash``, never the plaintext ``code`` returned here,
+    so attribute-mode validation would be a bug, not a convenience.
+    """
 
     code: str
     expires_at: datetime
     bot_username: str | None = None
     deep_link: str | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 # --- Workspace schemas --------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings the structural choices from your `octavian/practice-telegram` branch into `development` for the parts you actually wrote, while keeping `development`'s intentional behavior choices in places where they conflict.

This is the "where possible" subset of the substitution map we walked through. Pieces you left as TODO stubs (`channels/telegram.py`, `bot.py`, `handlers.py`, `turn_stream.py`, the link-code HMAC/redeem path, send_message, etc.) are untouched.

## What changed (your shape adopted)

- **schemas** — `ChannelLinkCodeResponse` → `TelegramLinkCodeRead`; added `model_config = ConfigDict(from_attributes=True)` on both, so routes can `.model_validate(orm_row)` directly.
- **models** — adopted your `ChannelBinding` / `ChannelLinkCode` class bodies (including the terser docstrings + explicit `nullable=False`). Added the `active_conversation_id` ORM column you mapped; it lives in the DB via migration 011 but was missing from dev's ORM. Added `__table_args__` with the `(provider, external_user_id)` unique constraint that migration 007 already enforces.
- **crud** — `list_bindings` now orders by `created_at DESC` (newest first), matching your version. New `get_binding(user_id, provider, session)` read helper; `delete_binding` composes it.
- **api** — `list_channels` uses `ChannelBindingRead.model_validate(row)` instead of the manual constructor.

## Deliberate deviations from practice (and why)

- **`ChannelBindingRead` keeps `external_chat_id` + `display_handle`.** Your practice version dropped them, but `frontend/features/channels/TelegramConnectDialog.tsx` renders `@{display_handle}` in the connected-state message and `use-telegram-binding.ts` reads `external_chat_id`. Dropping them silently regresses the Settings UI.
- **CRUD function names kept (`list_bindings`, `delete_binding`, no `_service` suffix).** Practice used the older `*_service` naming; commit `3e5dc5f` (#244) dropped that suffix project-wide.
- **CRUD signatures stay kwarg-only (`*, ...`).** Practice used positional; dev's convention is enforced kwargs.
- **`unlink_telegram` still returns 204 unconditionally.** Practice raised 400 when the binding didn't exist; dev's idempotent 204 is deliberate so the Settings UI can hit Disconnect without a state precheck.
- **`link_telegram` still issues a code even if a binding exists** (no 400 short-circuit). `redeem_link_code` updates the binding in place, supporting the "I want to re-link" flow.

## Pieces from the practice branch *not* ported

- `backend/app/channels/telegram.py` — practice has an empty `deliver()`; dev has the working edit-message + debounce.
- `backend/app/integrations/telegram/{bot,handlers,turn_stream}.py` — practice has stub + echo handler; dev has the full lifecycle.
- `crud.issue_link_code` / `crud.redeem_link_code` — practice's `issue_link_code_service` is a stub that returns an empty row. Dev's HMAC-backed implementation stays.

## Test plan

- [x] `uv run pytest tests/test_channels_api.py` — 9/9 pass
- [x] `uv run pytest tests/ -k 'channel or telegram or binding'` — 90/90 pass (1 skipped)
- [x] `just check` — ruff + ruff format + biome all green
- [x] mypy on the four modified files: clean
- [ ] Manual smoke: link / unlink Telegram in Settings UI; verify `@{display_handle}` still renders in the connected dialog

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This refactor ports the structural choices from the `octavian/practice-telegram` branch into `development` for schemas, models, CRUD, and the channels API, while deliberately preserving `development`'s behavioral decisions (idempotent 204 on unlink, retained `display_handle`/`external_chat_id` fields for the Settings UI).

- **Schemas**: `ChannelLinkCodeResponse` → `TelegramLinkCodeRead`; `ChannelBindingRead` gains `model_config = ConfigDict(from_attributes=True)`, enabling `model_validate(row)` in `list_channels`.
- **Models**: `ChannelBinding` gains `__table_args__` with a `UniqueConstraint` matching the name already created by migration 007, and explicit `nullable=False` on several columns to align the ORM with the live schema; `ChannelLinkCode` moves before `ChannelBinding` in the file.
- **CRUD**: `list_bindings` now orders by `created_at DESC`; a new `get_binding` read helper is introduced and composed into `delete_binding`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are structural renames and alignments with no behavior regressions.

The three concerns raised in earlier review rounds (dropped expires_at index, misleading from_attributes on TelegramLinkCodeRead, and active_conversation_id re-added without a migration) are all resolved in the current HEAD. The UniqueConstraint name added to __table_args__ matches migration 007 exactly, so autogenerate will not diverge. The model_validate call in list_channels is safe because ChannelBindingRead declares from_attributes=True and every field it reads is present on the ORM row.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/models.py | ChannelLinkCode moved before ChannelBinding; explicit nullable=False added throughout; __table_args__ UniqueConstraint added to ChannelBinding with name matching migration 007 exactly; active_conversation_id correctly absent. |
| backend/app/schemas.py | ChannelLinkCodeResponse renamed to TelegramLinkCodeRead with no from_attributes (correct — always built from scalar kwargs); ChannelBindingRead gains from_attributes=True to support model_validate(row). |
| backend/app/crud/channel.py | list_bindings gains ORDER BY created_at DESC; new get_binding helper extracted; delete_binding composes it cleanly. All signatures stay kwarg-only. |
| backend/app/api/channels.py | list_channels switches to ChannelBindingRead.model_validate(row); link_telegram return type updated to TelegramLinkCodeRead. All fields needed by model_validate are present on the ORM row. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /channels/telegram/link] -->|issue_link_code| B[(channel_link_codes\ncode_hash PK)]
    A -->|returns| C[TelegramLinkCodeRead\ncode, expires_at, bot_username, deep_link]
    D[GET /channels] -->|list_bindings\nORDER BY created_at DESC| E[(channel_bindings\nUQ provider+external_user_id)]
    D -->|ChannelBindingRead.model_validate| F[ChannelBindingRead\nfrom_attributes=True]
    G[DELETE /channels/telegram/link] -->|delete_binding| H{get_binding\nuser_id + provider}
    H -->|found| I[session.delete -> 204]
    H -->|not found| J[return False -> 204\nidempotent]
    K[Bot adapter\nredeem_link_code] -->|marks code used| B
    K -->|upsert by provider+external_user_id| E
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(channels): drop active\_conversation\_..."](https://github.com/octaviantocan/pawrrtal-ai/commit/35febf8a52abac19be839459bd0fd0c38e98a36f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32484774)</sub>

<!-- /greptile_comment -->