### PR TITLE
feat(lcm): retrieval lab - observability, eval harness, ranked search, packing, hybrid, planner

### DIFF
--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -83,6 +83,15 @@ ignore_imports =
     app.core.tools.lcm_describe -> app.models
     app.core.tools.lcm_grep -> app.models
     app.core.tools.lcm_expand_query -> app.models
+    ; LCM Retrieval Lab (PR #258 / issues #251–#256) extends the same
+    ; substrate — observability, ranked search, eval harness, semantic
+    ; retrieval — and must read the same ORM tables (now plus
+    ; lcm_embeddings).  Grandfathered alongside the older LCM entries
+    ; until the entire LCM stack is flattened in one pass.
+    app.core.lcm.embeddings -> app.models
+    app.core.lcm.evals -> app.models
+    app.core.lcm.observe -> app.models
+    app.core.tools.lcm_search -> app.models
 
 ; --- Contract 2: the legacy db ↔ models cycle is the one cycle sentrux
 ; allows (max_cycles = 1). Pin it explicitly so any *new* cycle fails CI. -

--- a/backend/alembic/versions/016_add_lcm_embeddings.py
+++ b/backend/alembic/versions/016_add_lcm_embeddings.py
@@ -1,0 +1,77 @@
+"""Add LCM embeddings table for semantic retrieval (issue #254).
+
+Adds ``lcm_embeddings``: one row per ``(conversation_id, item_kind,
+item_id, embedding_model)``.  Stores the embedding as a JSON array
+rather than pulling in pgvector so the migration stays portable
+across SQLite (tests) and Postgres (production).  A future migration
+can drop in a real vector column without changing the row layout.
+
+Revision ID: 016_add_lcm_embeddings
+Revises: 015_add_lcm_tables
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "016_add_lcm_embeddings"
+down_revision = "015_add_lcm_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the lcm_embeddings table and its supporting indices."""
+    op.create_table(
+        "lcm_embeddings",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("item_kind", sa.String(length=16), nullable=False),
+        sa.Column("item_id", sa.Uuid(), nullable=False),
+        sa.Column("embedding_model", sa.String(length=128), nullable=False),
+        sa.Column("embedding", sa.JSON(), nullable=False),
+        sa.Column(
+            "content_hash",
+            sa.String(length=64),
+            nullable=False,
+            server_default="",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "conversation_id",
+            "item_kind",
+            "item_id",
+            "embedding_model",
+            name="uq_lcm_embeddings_conv_kind_item_model",
+        ),
+    )
+    op.create_index(
+        "ix_lcm_embeddings_conversation_id",
+        "lcm_embeddings",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_lcm_embeddings_item_id",
+        "lcm_embeddings",
+        ["item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lcm_embeddings_item_id", table_name="lcm_embeddings")
+    op.drop_index("ix_lcm_embeddings_conversation_id", table_name="lcm_embeddings")
+    op.drop_table("lcm_embeddings")

--- a/backend/alembic/versions/018_add_lcm_embeddings.py
+++ b/backend/alembic/versions/018_add_lcm_embeddings.py
@@ -6,8 +6,8 @@ rather than pulling in pgvector so the migration stays portable
 across SQLite (tests) and Postgres (production).  A future migration
 can drop in a real vector column without changing the row layout.
 
-Revision ID: 016_add_lcm_embeddings
-Revises: 015_add_lcm_tables
+Revision ID: 018_add_lcm_embeddings
+Revises: 017_add_mcp_servers
 """
 
 from __future__ import annotations
@@ -15,8 +15,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "016_add_lcm_embeddings"
-down_revision = "015_add_lcm_tables"
+revision = "018_add_lcm_embeddings"
+down_revision = "017_add_mcp_servers"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/019_add_lcm_embeddings.py
+++ b/backend/alembic/versions/019_add_lcm_embeddings.py
@@ -6,8 +6,8 @@ rather than pulling in pgvector so the migration stays portable
 across SQLite (tests) and Postgres (production).  A future migration
 can drop in a real vector column without changing the row layout.
 
-Revision ID: 018_add_lcm_embeddings
-Revises: 017_add_mcp_servers
+Revision ID: 019_add_lcm_embeddings
+Revises: 018_scheduled_jobs_target_conversation_id
 """
 
 from __future__ import annotations
@@ -15,8 +15,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "018_add_lcm_embeddings"
-down_revision = "017_add_mcp_servers"
+revision = "019_add_lcm_embeddings"
+down_revision = "018_scheduled_jobs_target_conversation_id"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/lcm.py
+++ b/backend/app/api/lcm.py
@@ -1,0 +1,68 @@
+"""LCM debug API — inspect assembled context for a conversation turn.
+
+This router exposes the read-only observability surface introduced in
+issue #251.  It does **not** mutate state, does **not** trigger model
+calls, and does **not** alter compaction; it is purely a microscope
+on the existing ``lcm_context_items`` table.
+
+Access is gated on the same per-user conversation-ownership check the
+rest of the API uses (``crud.conversation.get_conversation`` returns
+``None`` when the conversation belongs to another user), so the panel
+cannot leak history across users even if the caller fabricates a
+conversation UUID.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm.observe import (
+    LCMContextDebugResponse,
+    describe_assembled_context,
+)
+from app.crud import conversation as crud
+from app.db import User, get_async_session
+from app.users import get_allowed_user
+
+logger = logging.getLogger(__name__)
+
+
+def get_lcm_router() -> APIRouter:
+    """Return the LCM debug router."""
+    router = APIRouter(prefix="/api/v1/lcm", tags=["lcm"])
+
+    @router.get(
+        "/conversations/{conversation_id}/context",
+        response_model=LCMContextDebugResponse,
+    )
+    async def get_lcm_context(
+        conversation_id: uuid.UUID,
+        fresh_tail_count: int | None = Query(
+            default=None,
+            ge=0,
+            le=1024,
+            description=(
+                "Override the configured fresh-tail window for this inspection. "
+                "Does not change live assembly; only re-applies the cap to the "
+                "stored items for preview."
+            ),
+        ),
+        user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> LCMContextDebugResponse:
+        """Return the assembled LCM context for ``conversation_id``."""
+        conversation = await crud.get_conversation(user.id, session, conversation_id)
+        if conversation is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+
+        return await describe_assembled_context(
+            session,
+            conversation_id=conversation_id,
+            fresh_tail_count=fresh_tail_count,
+        )
+
+    return router

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -44,6 +44,7 @@ from app.core.tools.lcm_agents import (
     make_lcm_grep_tool,
     make_lcm_list_summaries_tool,
 )
+from app.core.tools.lcm_search_agent import make_lcm_search_tool
 from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.now import (
     build_external_mcp_tools,
@@ -244,6 +245,7 @@ def build_agent_tools(
     # and a conversation_id being present.
     if settings.lcm_enabled and conversation_id is not None:
         tools.append(make_lcm_grep_tool(conversation_id=conversation_id))
+        tools.append(make_lcm_search_tool(conversation_id=conversation_id))
         tools.append(make_lcm_list_summaries_tool(conversation_id=conversation_id))
         tools.append(make_lcm_describe_tool(conversation_id=conversation_id))
         if user_id is not None:

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -43,8 +43,8 @@ from app.core.tools.lcm_agents import (
     make_lcm_expand_query_tool,
     make_lcm_grep_tool,
     make_lcm_list_summaries_tool,
+    make_lcm_search_tool,
 )
-from app.core.tools.lcm_search_agent import make_lcm_search_tool
 from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.now import (
     build_external_mcp_tools,

--- a/backend/app/core/lcm/embeddings.py
+++ b/backend/app/core/lcm/embeddings.py
@@ -1,0 +1,539 @@
+"""Semantic retrieval + RRF blending for LCM (issue #254).
+
+Lexical search (``lcm_search``) wins on keyword recall but misses
+when the user paraphrases.  Semantic-only search has the opposite
+failure mode.  This module adds the embedding storage, deterministic
+fake-embedder for CI, semantic search routine, and the Reciprocal
+Rank Fusion blender that combines the two retrieval signals into a
+single ranked list with transparent component scores.
+
+Why a deterministic hash embedder for the default path
+------------------------------------------------------
+Issue #254 explicitly says live embedding providers must not be
+mandatory in CI.  A SHA-256-seeded random vector is enough to:
+
+* return *consistent* embeddings for the same content,
+* surface paraphrase-style similarity when the same tokens appear
+  in different phrasings (because token hashes contribute to the
+  same vector dimensions), and
+* keep the test suite fully offline.
+
+A future iteration can swap the default for a real provider by
+implementing the same :class:`Embedder` protocol and registering it
+behind a config flag - the storage layout, content-hash skip path,
+and RRF blender will not change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+import re
+import uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypedDict
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tools.lcm_search import (
+    LCMSearchResult,
+    _excerpt_around,
+    _tokenize_query,
+    lcm_search,
+)
+from app.models import ChatMessage, LCMEmbedding, LCMSummary
+
+# Embedding dimensionality.  Small enough to keep test payloads
+# trivial; large enough that the cosine-similarity signal is still
+# meaningful.  Real provider embeddings are typically 384-1536d -
+# the storage layer accepts any length, the deterministic embedder
+# uses this constant.
+EMBEDDING_DIM = 64
+
+# Identifier persisted on every ``LCMEmbedding.embedding_model``
+# column for embeddings produced by the deterministic CI embedder.
+# A future provider swap would use its own identifier so historical
+# rows stay traceable.
+FAKE_MODEL_ID = "pawrrtal-fake-hash-64d"
+
+# Reciprocal Rank Fusion's smoothing constant.  The standard
+# literature value is 60; higher values flatten the curve, lower
+# values reward top-ranked items more aggressively.  We surface the
+# constant so the hybrid blender stays inspectable.
+_RRF_SMOOTHING = 60
+
+# Default cap on the number of semantic candidates pulled from the
+# DB before scoring.  Same shape as ``lcm_search``'s candidate fetch
+# cap; protects against pathological conversations.
+_SEMANTIC_CANDIDATE_CAP = 200
+
+# Token tokeniser splits on the same non-alphanumeric boundaries as
+# ``lcm_search``; the resulting tokens seed the deterministic vector.
+_TOKEN_PATTERN = re.compile(r"[a-zA-Z][a-zA-Z0-9\-]+")
+
+# Standard deviation of the per-dimension Gaussian noise added to
+# each embedding.  Small enough that the token-derived skeleton of
+# the vector still dominates similarity.
+_NOISE_STDDEV = 0.1
+
+# Numerical tolerance for "this vector is already unit-length";
+# below this the cosine helper trusts the magnitudes and skips the
+# division by ``mag_a * mag_b``.
+_UNIT_VECTOR_TOLERANCE = 1e-6
+
+SearchMode = Literal["lexical", "semantic", "hybrid"]
+ItemKind = Literal["message", "summary"]
+
+
+class LCMHybridSearchResult(TypedDict):
+    """One ranked hit from hybrid lexical + semantic retrieval.
+
+    Mirrors the shape proposed in issue #254 so a future swap of
+    either retrieval leg is API-stable.
+    """
+
+    item_kind: ItemKind
+    item_id: str
+    final_score: float
+    lexical_rank: int | None
+    lexical_score: float | None
+    semantic_rank: int | None
+    semantic_score: float | None
+    rrf_score: float
+    excerpt: str
+    metadata: dict[str, object]
+
+
+class Embedder(Protocol):
+    """Minimal embedder contract used by ingest + semantic search."""
+
+    @property
+    def model_id(self) -> str:
+        """Identifier persisted on every embedding row."""
+
+    def embed(self, text: str) -> list[float]:
+        """Return a unit-length embedding vector for ``text``."""
+
+
+class DeterministicHashEmbedder:
+    """Hash-seeded embedder used in tests + CI.
+
+    For each query/content text, we tokenise the input the same way
+    :mod:`app.core.tools.lcm_search` does, hash each token into a
+    dimension index, and accumulate a unit vector.  This makes
+    semantically-similar paraphrases produce overlapping vectors
+    without needing a model server in the loop.
+
+    The implementation is deterministic: same input string in,
+    same vector out, every run.
+    """
+
+    def __init__(self, *, dim: int = EMBEDDING_DIM) -> None:
+        self._dim = dim
+        self._model_id = FAKE_MODEL_ID
+
+    @property
+    def model_id(self) -> str:
+        """Persisted identifier of this embedder."""
+        return self._model_id
+
+    def embed(self, text: str) -> list[float]:
+        """Tokenise + hash each token into a dimension; normalise."""
+        if not text:
+            return [0.0] * self._dim
+        vector = [0.0] * self._dim
+        tokens = _TOKEN_PATTERN.findall(text.lower())
+        for token in tokens:
+            dim_index = _hash_to_dim(token, self._dim)
+            # Add a small token-derived value so repeated tokens
+            # reinforce the dimension; using a hash-derived sign so
+            # unrelated tokens that hit the same dimension can
+            # cancel rather than always add.
+            sign = _hash_sign(token)
+            vector[dim_index] += sign
+        # Random component seeded by the full content hash gives
+        # paraphrases that share most tokens a strong similarity
+        # while letting fully-disjoint content stay distant.  The
+        # generator is a deterministic vector source, not a security
+        # primitive, so the bandit ``S311`` flag is intentionally
+        # silenced - swapping in ``secrets`` would defeat the
+        # determinism that makes this embedder CI-safe.
+        rng = random.Random(content_hash(text))  # noqa: S311  # nosec B311 - deterministic vector seeding, not crypto
+        noise = [rng.gauss(0.0, _NOISE_STDDEV) for _ in range(self._dim)]
+        vector = [v + n for v, n in zip(vector, noise, strict=True)]
+        return _normalise(vector)
+
+
+@dataclass(frozen=True)
+class SemanticHit:
+    """Internal hit shape used while assembling search results."""
+
+    item_kind: ItemKind
+    item_id: str
+    score: float
+    excerpt: str
+    metadata: dict[str, object]
+
+
+def content_hash(text: str) -> str:
+    """Stable SHA-256 hash of ``text`` (hex digest)."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def _hash_to_dim(token: str, dim: int) -> int:
+    """Map a token to a dimension index in ``[0, dim)``."""
+    digest = hashlib.sha256(token.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % dim
+
+
+def _hash_sign(token: str) -> float:
+    """Return +1.0 or -1.0 deterministically based on the token hash."""
+    digest = hashlib.sha256(token.encode("utf-8")).digest()
+    return 1.0 if digest[0] % 2 == 0 else -1.0
+
+
+def _normalise(vector: list[float]) -> list[float]:
+    """L2-normalise ``vector`` so cosine similarity == dot product."""
+    magnitude = math.sqrt(sum(v * v for v in vector))
+    if magnitude == 0:
+        return vector
+    return [v / magnitude for v in vector]
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity assuming both vectors are unit-length.
+
+    Falls back to a magnitude division for callers that pass
+    non-normalised vectors so the function stays robust.
+    """
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    mag_a = math.sqrt(sum(x * x for x in a))
+    mag_b = math.sqrt(sum(y * y for y in b))
+    if mag_a == 0 or mag_b == 0:
+        return 0.0
+    if abs(mag_a - 1.0) < _UNIT_VECTOR_TOLERANCE and abs(mag_b - 1.0) < _UNIT_VECTOR_TOLERANCE:
+        return dot
+    return dot / (mag_a * mag_b)
+
+
+async def upsert_embedding(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    item_kind: ItemKind,
+    item_id: uuid.UUID,
+    content: str,
+    embedder: Embedder | None = None,
+) -> LCMEmbedding | None:
+    """Insert or refresh an embedding row for one LCM item.
+
+    Skips empty content (so empty assistant placeholders never get
+    embedded as meaningful memory - one of the explicit acceptance
+    criteria in #254).  Skips re-embedding when the supplied
+    content's hash matches the persisted row's hash.
+
+    Returns the persisted row, or ``None`` when content was empty.
+    """
+    body = (content or "").strip()
+    if not body:
+        return None
+
+    used_embedder = embedder or DeterministicHashEmbedder()
+    new_hash = content_hash(body)
+
+    existing = await _existing_embedding(
+        session,
+        conversation_id=conversation_id,
+        item_kind=item_kind,
+        item_id=item_id,
+        embedding_model=used_embedder.model_id,
+    )
+    if existing is not None and existing.content_hash == new_hash:
+        return existing
+
+    vector = used_embedder.embed(body)
+
+    if existing is None:
+        row = LCMEmbedding(
+            conversation_id=conversation_id,
+            item_kind=item_kind,
+            item_id=item_id,
+            embedding_model=used_embedder.model_id,
+            embedding=vector,
+            content_hash=new_hash,
+        )
+        session.add(row)
+    else:
+        existing.embedding = vector
+        existing.content_hash = new_hash
+        row = existing
+    await session.flush()
+    return row
+
+
+async def _existing_embedding(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    item_kind: str,
+    item_id: uuid.UUID,
+    embedding_model: str,
+) -> LCMEmbedding | None:
+    """Lookup helper for the unique tuple."""
+    result = await session.execute(
+        select(LCMEmbedding).where(
+            LCMEmbedding.conversation_id == conversation_id,
+            LCMEmbedding.item_kind == item_kind,
+            LCMEmbedding.item_id == item_id,
+            LCMEmbedding.embedding_model == embedding_model,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def semantic_search(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int = 8,
+    embedder: Embedder | None = None,
+) -> list[SemanticHit]:
+    """Run cosine-similarity search over stored embeddings.
+
+    Returns ranked hits scoped to one conversation.  Empty queries
+    short-circuit to ``[]`` so callers do not need to pre-filter.
+    """
+    query_body = (query or "").strip()
+    if not query_body:
+        return []
+    used_embedder = embedder or DeterministicHashEmbedder()
+    query_vector = used_embedder.embed(query_body)
+
+    rows = await _fetch_embeddings(
+        session,
+        conversation_id=conversation_id,
+        embedding_model=used_embedder.model_id,
+    )
+    if not rows:
+        return []
+
+    enriched = await _resolve_excerpts(session, rows, query_body)
+    scored: list[SemanticHit] = []
+    for row, excerpt, metadata in enriched:
+        sim = cosine_similarity(query_vector, row.embedding)
+        if sim <= 0.0:
+            continue
+        scored.append(
+            SemanticHit(
+                item_kind=row.item_kind,  # type: ignore[arg-type]
+                item_id=str(row.item_id),
+                score=round(sim, 6),
+                excerpt=excerpt,
+                metadata=metadata,
+            )
+        )
+    scored.sort(key=lambda hit: -hit.score)
+    return scored[:limit]
+
+
+async def _fetch_embeddings(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    embedding_model: str,
+) -> list[LCMEmbedding]:
+    """Pull all stored embeddings for a conversation + model."""
+    result = await session.execute(
+        select(LCMEmbedding)
+        .where(
+            LCMEmbedding.conversation_id == conversation_id,
+            LCMEmbedding.embedding_model == embedding_model,
+        )
+        .limit(_SEMANTIC_CANDIDATE_CAP)
+    )
+    return list(result.scalars().all())
+
+
+async def _resolve_excerpts(
+    session: AsyncSession,
+    rows: Iterable[LCMEmbedding],
+    query: str,
+) -> list[tuple[LCMEmbedding, str, dict[str, object]]]:
+    """Join each embedding row to its source content for excerpting."""
+    rows_list = list(rows)
+    message_ids = [row.item_id for row in rows_list if row.item_kind == "message"]
+    summary_ids = [row.item_id for row in rows_list if row.item_kind == "summary"]
+
+    messages: dict[uuid.UUID, ChatMessage] = {}
+    if message_ids:
+        result = await session.execute(select(ChatMessage).where(ChatMessage.id.in_(message_ids)))
+        messages = {m.id: m for m in result.scalars().all()}
+    summaries: dict[uuid.UUID, LCMSummary] = {}
+    if summary_ids:
+        result = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(summary_ids)))
+        summaries = {s.id: s for s in result.scalars().all()}
+
+    tokens = _tokenize_query(query)
+    out: list[tuple[LCMEmbedding, str, dict[str, object]]] = []
+    for row in rows_list:
+        meta, excerpt = _excerpt_and_meta(row, messages, summaries, tokens)
+        if excerpt is None:
+            continue
+        out.append((row, excerpt, meta))
+    return out
+
+
+def _excerpt_and_meta(
+    row: LCMEmbedding,
+    messages: dict[uuid.UUID, ChatMessage],
+    summaries: dict[uuid.UUID, LCMSummary],
+    tokens: Sequence[str],
+) -> tuple[dict[str, object], str | None]:
+    """Build the per-row metadata + excerpt for semantic_search."""
+    if row.item_kind == "message":
+        msg = messages.get(row.item_id)
+        if msg is None:
+            return {}, None
+        meta: dict[str, object] = {
+            "ordinal": msg.ordinal,
+            "role": msg.role,
+        }
+        return meta, _excerpt_around(msg.content or "", tokens)
+    summary = summaries.get(row.item_id)
+    if summary is None:
+        return {}, None
+    meta = {
+        "summary_depth": summary.depth,
+        "summary_kind": summary.summary_kind,
+    }
+    return meta, _excerpt_around(summary.content or "", tokens)
+
+
+def reciprocal_rank_fusion(
+    *,
+    lexical: Sequence[LCMSearchResult],
+    semantic: Sequence[SemanticHit],
+) -> list[LCMHybridSearchResult]:
+    """Blend lexical + semantic rankings with Reciprocal Rank Fusion.
+
+    Each entry contributes ``1 / (k + rank)`` to its item's final
+    score.  Component ranks and scores are preserved on every result
+    so callers can inspect *why* an item won, not just that it did.
+    """
+    blended: dict[str, LCMHybridSearchResult] = {}
+    for index, lex in enumerate(lexical):
+        item_id = lex["item_id"]
+        rank = index + 1
+        rrf_term = 1.0 / (_RRF_SMOOTHING + rank)
+        blended[item_id] = _start_blend_from_lexical(lex, rank=rank, rrf_term=rrf_term)
+    for index, sem in enumerate(semantic):
+        rank = index + 1
+        rrf_term = 1.0 / (_RRF_SMOOTHING + rank)
+        item_id = sem.item_id
+        if item_id in blended:
+            blended[item_id]["semantic_rank"] = rank
+            blended[item_id]["semantic_score"] = sem.score
+            blended[item_id]["rrf_score"] = blended[item_id]["rrf_score"] + rrf_term
+        else:
+            blended[item_id] = _start_blend_from_semantic(sem, rank=rank, rrf_term=rrf_term)
+    for entry in blended.values():
+        entry["final_score"] = round(entry["rrf_score"], 6)
+    out = list(blended.values())
+    out.sort(key=lambda r: -r["final_score"])
+    return out
+
+
+def _start_blend_from_lexical(
+    result: LCMSearchResult,
+    *,
+    rank: int,
+    rrf_term: float,
+) -> LCMHybridSearchResult:
+    """Build the initial hybrid entry seeded from a lexical hit."""
+    metadata: dict[str, object] = {
+        "ordinal": result["ordinal"],
+        "role": result["role"],
+        "summary_depth": result["summary_depth"],
+        "summary_kind": result["summary_kind"],
+        "source_ids": result["source_ids"],
+    }
+    return LCMHybridSearchResult(
+        item_kind=result["item_kind"],
+        item_id=result["item_id"],
+        final_score=0.0,
+        lexical_rank=rank,
+        lexical_score=result["score"],
+        semantic_rank=None,
+        semantic_score=None,
+        rrf_score=rrf_term,
+        excerpt=result["excerpt"],
+        metadata=metadata,
+    )
+
+
+def _start_blend_from_semantic(
+    hit: SemanticHit,
+    *,
+    rank: int,
+    rrf_term: float,
+) -> LCMHybridSearchResult:
+    """Build the initial hybrid entry seeded from a semantic-only hit."""
+    return LCMHybridSearchResult(
+        item_kind=hit.item_kind,
+        item_id=hit.item_id,
+        final_score=0.0,
+        lexical_rank=None,
+        lexical_score=None,
+        semantic_rank=rank,
+        semantic_score=hit.score,
+        rrf_score=rrf_term,
+        excerpt=hit.excerpt,
+        metadata=hit.metadata,
+    )
+
+
+async def lcm_hybrid_search(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int = 8,
+    mode: SearchMode = "hybrid",
+    embedder: Embedder | None = None,
+) -> list[LCMHybridSearchResult]:
+    """Public retrieval entry point with mode toggle.
+
+    * ``mode="lexical"``  - only the :func:`lcm_search` ranking,
+      semantic legs left null in each result.
+    * ``mode="semantic"`` - only the cosine-similarity ranking,
+      lexical legs left null in each result.
+    * ``mode="hybrid"``   - both, blended with Reciprocal Rank
+      Fusion; final score order respects both signals.
+    """
+    lexical: list[LCMSearchResult] = []
+    semantic: list[SemanticHit] = []
+    if mode in ("lexical", "hybrid"):
+        lexical = list(
+            await lcm_search(
+                session,
+                conversation_id=conversation_id,
+                query=query,
+                limit=limit,
+            )
+        )
+    if mode in ("semantic", "hybrid"):
+        semantic = await semantic_search(
+            session,
+            conversation_id=conversation_id,
+            query=query,
+            limit=limit,
+            embedder=embedder,
+        )
+    blended = reciprocal_rank_fusion(lexical=lexical, semantic=semantic)
+    return blended[:limit]

--- a/backend/app/core/lcm/embeddings.py
+++ b/backend/app/core/lcm/embeddings.py
@@ -33,6 +33,7 @@ import re
 import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Literal, Protocol, TypedDict
 
 from sqlalchemy import select
@@ -271,6 +272,10 @@ async def upsert_embedding(
     else:
         existing.embedding = vector
         existing.content_hash = new_hash
+        # Bump updated_at so downstream auditors can see which rows
+        # were re-embedded - the column would otherwise pin to the
+        # original creation timestamp forever (Greptile P2 review).
+        existing.updated_at = datetime.now(UTC)
         row = existing
     await session.flush()
     return row

--- a/backend/app/core/lcm/evals.py
+++ b/backend/app/core/lcm/evals.py
@@ -56,8 +56,8 @@ from app.core.lcm.embeddings import (
 )
 from app.core.lcm.pack import PackCandidate, pack_context
 from app.core.tools.lcm_grep import lcm_grep
+from app.core.tools.lcm_search import LCM_STOPWORDS, lcm_search
 from app.core.tools.lcm_search import format_results as format_search_results
-from app.core.tools.lcm_search import lcm_search
 from app.models import (
     ChatMessage,
     Conversation,
@@ -623,40 +623,17 @@ async def _retrieve_lcm_search_packed(
 
 
 def _extract_search_terms(question: str) -> list[str]:
-    """Pull a handful of content-bearing words out of a question."""
-    stopwords = {
-        "what",
-        "which",
-        "when",
-        "where",
-        "who",
-        "why",
-        "how",
-        "did",
-        "does",
-        "have",
-        "the",
-        "and",
-        "for",
-        "from",
-        "with",
-        "that",
-        "this",
-        "into",
-        "about",
-        "would",
-        "should",
-        "ever",
-        "still",
-        "decide",
-        "decided",
-        "decision",
-    }
+    """Pull a handful of content-bearing words out of a question.
+
+    Uses the shared :data:`app.core.tools.lcm_search.LCM_STOPWORDS`
+    set so the eval harness tokenises identically to the retrieval
+    scorer it benchmarks.
+    """
     raw_tokens = re.findall(r"[a-zA-Z][a-zA-Z\-]{2,}", question.lower())
     seen: set[str] = set()
     terms: list[str] = []
     for token in raw_tokens:
-        if token in stopwords:
+        if token in LCM_STOPWORDS:
             continue
         if token in seen:
             continue
@@ -682,9 +659,13 @@ async def run_eval(
 ) -> LCMEvalResult:
     """Run one (scenario, mode) pair and return the structured result.
 
-    The function never raises on retrieval failure — the eval is a
-    measurement, so a missing tool or empty context should surface as
-    ``fact_pass=False`` not a test exception.
+    Retrieval failures for *known* modes never raise - the eval is a
+    measurement, so a missing tool or empty context surfaces as
+    ``fact_pass=False`` rather than a test exception.  An unknown
+    ``mode`` (one absent from :data:`_MODE_RETRIEVERS`) raises
+    ``ValueError`` so callers discover missing registrations
+    immediately, rather than silently scoring against an empty
+    context.
     """
     started = time.perf_counter()
     blob, tools_called = await _retrieve_for_mode(

--- a/backend/app/core/lcm/evals.py
+++ b/backend/app/core/lcm/evals.py
@@ -1,0 +1,629 @@
+"""LCM retrieval eval harness — scoreboard for long-conversation recall.
+
+Issue #252 asks: "judge LCM by data, not vibes".  This module is the
+scoreboard.  It seeds deterministic long-conversation fixtures, runs
+a candidate retrieval mode (baseline tail, LCM-assembled context,
+``lcm_grep``, ``lcm_expand_query``, future ``lcm_search`` /
+semantic / hybrid), and records pass/fail + cost/latency metrics.
+
+The harness is **deterministic by default** so it can run in CI
+without live LLM keys:
+
+* "Answers" are produced by a small, transparent answerer
+  (:func:`deterministic_answer`) that simply walks the retrieved
+  context and quotes the spans that match the scenario's expected
+  fact patterns.  This is intentionally weak — strong enough to tell
+  whether the retrieval path surfaced the right text, no stronger.
+  Real LLM scoring can sit behind a `LCM_EVAL_LIVE=1` env flag in a
+  future iteration without changing the public shape here.
+
+* Seeded conversations write into the same SQLAlchemy tables the
+  production code uses (``chat_messages`` / ``lcm_summaries`` /
+  ``lcm_context_items``) so retrieval/assembly hits the real code
+  path, not a parallel fake.
+
+Public API
+----------
+``LCMEvalScenario``     - dataclass describing one eval case.
+``LCMEvalMode``         - which retrieval mode is under test.
+``LCMEvalResult``       - outcome + metrics for a (scenario, mode) run.
+``seed_scenario``       - bulk-insert a scenario's turns + summaries.
+``run_eval``            - run one (scenario, mode) and return the result.
+``run_eval_matrix``     - run every scenario x mode pair.
+``deterministic_answer``- CI-safe answerer used by every mode by default.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm import assemble_context
+from app.core.tools.lcm_grep import lcm_grep
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+# Same 4-chars-per-token approximation used everywhere else in LCM.
+_CHARS_PER_TOKEN = 4
+
+# Hard cap on retrieved-context characters surfaced to the answerer.
+# Keeps CI runtime stable when a scenario seeds a huge transcript.
+_MAX_CONTEXT_CHARS = 64_000
+
+# Default lcm_grep result cap when the mode-specific runner does not
+# pass one through.  Matches the production tool's default so the
+# harness measures realistic behaviour.
+_GREP_RESULT_CAP = 10
+
+# Phrases the deterministic answerer uses when no expected fact is
+# present in the retrieved context — distinct strings so eval output
+# is greppable and unambiguous.
+_ANSWER_NO_EVIDENCE = "[no evidence in retrieved context]"
+_ANSWER_NEGATIVE = "[history does not contain this]"
+
+ScenarioIntent = Literal[
+    "pinpoint",
+    "broad",
+    "multi_hop",
+    "contradiction",
+    "source",
+    "negative",
+]
+
+
+class LCMEvalMode(StrEnum):
+    """Retrieval modes the harness can compare.
+
+    Future modes (``lcm_search`` lexical/semantic/hybrid) will be
+    appended here as the corresponding issues land.  The value of the
+    enum is what shows up in :class:`LCMEvalResult.mode`, so add new
+    members rather than renaming existing ones once the harness is
+    persisted in any rollout report.
+    """
+
+    BASELINE = "baseline"
+    LCM_ASSEMBLED = "lcm_assembled"
+    LCM_GREP = "lcm_grep"
+
+
+@dataclass(frozen=True)
+class SeedSummary:
+    """One pre-compacted summary inserted in place of raw turns.
+
+    Attributes:
+        content: The summary prose to store in ``lcm_summaries.content``.
+        replaces_turn_indexes: Indexes into the scenario's
+            ``seed_turns`` whose context items will be replaced by
+            this summary's single context item.  Indexes must be
+            contiguous; the summary takes the lowest replaced
+            ordinal, mirroring the in-place rewrite in
+            :func:`app.core.lcm.compact_leaf_if_needed`.
+        depth: ``0`` for leaf summaries, ``1+`` for condensed.
+        kind: ``"normal"`` / ``"aggressive"`` / ``"fallback"``.
+    """
+
+    content: str
+    replaces_turn_indexes: list[int]
+    depth: int = 0
+    kind: str = "normal"
+
+
+@dataclass(frozen=True)
+class LCMEvalScenario:
+    """One eval case - seeded conversation + question + expected facts.
+
+    Attributes:
+        id: Stable identifier used in result reporting (snake-case).
+        intent: Which scenario *type* this case represents.  Mirrors
+            issue #252's six required categories.
+        question: The user's question for this turn.
+        seed_turns: ``[{"role", "content"}]`` list inserted as
+            ``ChatMessage`` rows in order.  Every entry becomes a
+            ``LCMContextItem`` so the assembly path sees them.
+        seed_summaries: Optional pre-compacted summaries to insert in
+            place of the oldest turns; useful for scenarios where the
+            target fact lives in a summary rather than a raw turn.
+            Each entry replaces the raw context items at the indexes
+            in ``replaces_turn_indexes`` with a single summary item.
+        expected_fact_patterns: Regexes (case-insensitive) that must
+            appear in the deterministic answer for ``fact_pass`` to
+            be True.  For negative scenarios this list is empty.
+        expected_source_substrings: Strings that must appear in the
+            retrieved context for ``source_pass`` to be True.  Empty
+            list means no source check (e.g. negative scenarios).
+        expects_unanswerable: When True the scenario is in the
+            "should refuse to answer" category - passing means the
+            answerer emits :data:`_ANSWER_NEGATIVE` and ``fact_pass``
+            tracks that decision, not pattern hits.
+        notes: Free-text rationale shown next to results.
+    """
+
+    id: str
+    intent: ScenarioIntent
+    question: str
+    seed_turns: list[dict[str, str]]
+    seed_summaries: list[SeedSummary] = field(default_factory=list)
+    expected_fact_patterns: list[str] = field(default_factory=list)
+    expected_source_substrings: list[str] = field(default_factory=list)
+    expects_unanswerable: bool = False
+    notes: str = ""
+
+
+@dataclass
+class LCMEvalResult:
+    """Outcome + metrics for one (scenario, mode) run."""
+
+    scenario_id: str
+    mode: str
+    question: str
+    answer: str
+    fact_pass: bool
+    source_pass: bool
+    context_chars: int
+    context_tokens: int
+    output_tokens: int
+    latency_ms: float
+    tools_called: list[str]
+    notes: str = ""
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token estimate; mirrors :mod:`app.core.lcm.__init__`."""
+    return max(0, len(text or "") // _CHARS_PER_TOKEN)
+
+
+def _utcnow() -> datetime:
+    """Timezone-aware UTC now."""
+    return datetime.now(UTC)
+
+
+async def seed_scenario(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    conversation_id: uuid.UUID | None = None,
+) -> Conversation:
+    """Insert one scenario's conversation, turns, and summaries.
+
+    Writes through the production ORM so retrieval paths exercise the
+    real schema.  Caller commits the session (this function only
+    flushes) so the test harness can wrap multiple scenarios in
+    one transaction when desired.
+
+    Args:
+        session: Open async session.
+        user_id: Owning user UUID.
+        scenario: Scenario fixture to seed.
+        conversation_id: Optional pre-allocated UUID so the caller can
+            assert on it without round-tripping.  A fresh UUID is
+            generated when omitted.
+
+    Returns:
+        The persisted :class:`Conversation` row.
+    """
+    conv_id = conversation_id or uuid.uuid4()
+    now = _utcnow()
+    conv = Conversation(
+        id=conv_id,
+        user_id=user_id,
+        title=f"eval/{scenario.id}",
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(conv)
+    await session.flush()
+
+    inserted_message_ids = await _seed_turns(session, conv=conv, user_id=user_id, scenario=scenario)
+    await _seed_summaries(session, conv=conv, scenario=scenario, message_ids=inserted_message_ids)
+    await session.flush()
+    return conv
+
+
+async def _seed_turns(
+    session: AsyncSession,
+    *,
+    conv: Conversation,
+    user_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+) -> list[uuid.UUID]:
+    """Insert every raw turn for a scenario.  Returns inserted IDs in order."""
+    inserted: list[uuid.UUID] = []
+    for ordinal, turn in enumerate(scenario.seed_turns):
+        msg = ChatMessage(
+            id=uuid.uuid4(),
+            conversation_id=conv.id,
+            user_id=user_id,
+            ordinal=ordinal,
+            role=turn["role"],
+            content=turn["content"],
+            created_at=_utcnow(),
+            updated_at=_utcnow(),
+        )
+        session.add(msg)
+        await session.flush()
+        inserted.append(msg.id)
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=ordinal,
+                item_kind="message",
+                item_id=msg.id,
+            )
+        )
+    return inserted
+
+
+async def _seed_summaries(
+    session: AsyncSession,
+    *,
+    conv: Conversation,
+    scenario: LCMEvalScenario,
+    message_ids: list[uuid.UUID],
+) -> None:
+    """Insert pre-compacted summaries, rewriting context items in place."""
+    for seed in scenario.seed_summaries:
+        summary = LCMSummary(
+            conversation_id=conv.id,
+            depth=seed.depth,
+            content=seed.content,
+            token_count=_approx_tokens(seed.content),
+            summary_kind=seed.kind,
+        )
+        session.add(summary)
+        await session.flush()
+
+        replaced_indexes = sorted(seed.replaces_turn_indexes)
+        for src_ordinal, turn_index in enumerate(replaced_indexes):
+            session.add(
+                LCMSummarySource(
+                    summary_id=summary.id,
+                    source_kind="message",
+                    source_id=message_ids[turn_index],
+                    source_ordinal=src_ordinal,
+                )
+            )
+
+        # Replace the context-item rows that previously pointed at the
+        # raw turns with a single summary row at the lowest ordinal.
+        slot_ordinal = replaced_indexes[0]
+        ids_to_remove = [message_ids[i] for i in replaced_indexes if i < len(message_ids)]
+        existing = await session.execute(
+            select(LCMContextItem).where(
+                LCMContextItem.conversation_id == conv.id,
+                LCMContextItem.item_id.in_(ids_to_remove),
+            )
+        )
+        for row in existing.scalars().all():
+            await session.delete(row)
+        await session.flush()
+        session.add(
+            LCMContextItem(
+                conversation_id=conv.id,
+                ordinal=slot_ordinal,
+                item_kind="summary",
+                item_id=summary.id,
+            )
+        )
+
+
+def _flatten_assembled(context: list[dict[str, object]]) -> str:
+    """Concatenate an assembled-context list into a single text blob."""
+    parts: list[str] = []
+    for turn in context:
+        role = str(turn.get("role") or "")
+        content = str(turn.get("content") or "")
+        if content:
+            parts.append(f"{role.upper()}: {content}")
+    blob = "\n\n".join(parts)
+    return blob[:_MAX_CONTEXT_CHARS]
+
+
+def deterministic_answer(
+    question: str,
+    retrieved_context: str,
+    *,
+    scenario: LCMEvalScenario,
+) -> str:
+    """Build a CI-safe "answer" by quoting matches from retrieved context.
+
+    For positive scenarios the answerer scans ``retrieved_context`` for
+    each ``expected_fact_patterns`` regex (case-insensitive).  Every
+    match is quoted into the answer text exactly once; if no patterns
+    hit, the answerer emits :data:`_ANSWER_NO_EVIDENCE`.
+
+    For negative scenarios (``expects_unanswerable=True``) the answer
+    is :data:`_ANSWER_NEGATIVE` whenever none of the optional
+    "false-positive" patterns appear — modelling a well-behaved agent
+    that refuses to invent facts.
+
+    The point of this answerer is to make eval results reflect the
+    retrieval/assembly layer, not a downstream LLM's prose style.
+    """
+    blob = retrieved_context or ""
+    if scenario.expects_unanswerable:
+        return _negative_answer(scenario, blob)
+
+    quotes = _collect_pattern_quotes(scenario.expected_fact_patterns, blob)
+    if not quotes:
+        return _ANSWER_NO_EVIDENCE
+    return " | ".join(quotes)
+
+
+def _negative_answer(scenario: LCMEvalScenario, blob: str) -> str:
+    """Return the answer for a negative-recall scenario.
+
+    A "false positive" pattern is any regex listed in
+    ``expected_fact_patterns`` — those phrases are the things the
+    scenario asserts must *not* be invented.  When none of them
+    appear in the retrieved context the agent should refuse, so the
+    answerer emits :data:`_ANSWER_NEGATIVE`.  When any do appear, the
+    answerer echoes them so ``fact_pass`` flips False and the
+    failure is visible.
+    """
+    quotes = _collect_pattern_quotes(scenario.expected_fact_patterns, blob)
+    if not quotes:
+        return _ANSWER_NEGATIVE
+    return " | ".join(quotes)
+
+
+def _collect_pattern_quotes(patterns: Sequence[str], blob: str) -> list[str]:
+    """Return one quote per pattern that matches inside ``blob``."""
+    quotes: list[str] = []
+    for raw in patterns:
+        try:
+            compiled = re.compile(raw, flags=re.IGNORECASE | re.DOTALL)
+        except re.error:
+            continue
+        hit = compiled.search(blob)
+        if hit is not None:
+            quotes.append(hit.group(0).strip())
+    return quotes
+
+
+def _fact_pass(answer: str, scenario: LCMEvalScenario) -> bool:
+    """Decide whether the answer satisfies the scenario's fact rule."""
+    if scenario.expects_unanswerable:
+        return answer == _ANSWER_NEGATIVE
+    if not scenario.expected_fact_patterns:
+        return True
+    return all(
+        re.search(pat, answer, flags=re.IGNORECASE | re.DOTALL) is not None
+        for pat in scenario.expected_fact_patterns
+    )
+
+
+def _source_pass(retrieved_context: str, scenario: LCMEvalScenario) -> bool:
+    """Decide whether the retrieved context contained every expected source span."""
+    if not scenario.expected_source_substrings:
+        return True
+    blob_lower = (retrieved_context or "").lower()
+    return all(snippet.lower() in blob_lower for snippet in scenario.expected_source_substrings)
+
+
+async def _retrieve_baseline(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Baseline: the old ``LIMIT 20``-style raw-tail slice — no LCM machinery."""
+    result = await session.execute(
+        select(ChatMessage)
+        .where(
+            ChatMessage.conversation_id == conversation_id,
+            ChatMessage.role.in_(["user", "assistant"]),
+        )
+        .order_by(ChatMessage.ordinal.desc())
+        .limit(fresh_tail_count)
+    )
+    rows = list(result.scalars().all())
+    rows.reverse()
+    blob = "\n\n".join(f"{m.role.upper()}: {m.content or ''}" for m in rows)
+    return blob[:_MAX_CONTEXT_CHARS], []
+
+
+async def _retrieve_lcm_assembled(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """LCM mode: protected fresh tail + every summary, via :func:`assemble_context`."""
+    context = await assemble_context(
+        session,
+        conversation_id=conversation_id,
+        fresh_tail_count=fresh_tail_count,
+    )
+    return _flatten_assembled(context), []
+
+
+async def _retrieve_lcm_grep(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    question: str,
+) -> tuple[str, list[str]]:
+    """Grep-assisted recall: synthesise short queries, union the matches.
+
+    Picks the longest few content words from ``question`` and runs them
+    through :func:`lcm_grep`.  The deterministic answerer then quotes
+    matching spans.  We do not stitch grep output into a chat call
+    because the harness's answerer is intentionally retrieval-only.
+    """
+    queries = _extract_search_terms(question)
+    blob_parts: list[str] = []
+    for term in queries:
+        snippet = await lcm_grep(
+            session,
+            conversation_id=conversation_id,
+            query=term,
+            limit=_GREP_RESULT_CAP,
+        )
+        blob_parts.append(snippet)
+    blob = "\n\n".join(blob_parts)
+    return blob[:_MAX_CONTEXT_CHARS], ["lcm_grep"]
+
+
+def _extract_search_terms(question: str) -> list[str]:
+    """Pull a handful of content-bearing words out of a question."""
+    stopwords = {
+        "what",
+        "which",
+        "when",
+        "where",
+        "who",
+        "why",
+        "how",
+        "did",
+        "does",
+        "have",
+        "the",
+        "and",
+        "for",
+        "from",
+        "with",
+        "that",
+        "this",
+        "into",
+        "about",
+        "would",
+        "should",
+        "ever",
+        "still",
+        "decide",
+        "decided",
+        "decision",
+    }
+    raw_tokens = re.findall(r"[a-zA-Z][a-zA-Z\-]{2,}", question.lower())
+    seen: set[str] = set()
+    terms: list[str] = []
+    for token in raw_tokens:
+        if token in stopwords:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        terms.append(token)
+    return terms[:5]
+
+
+_MODE_DISPATCH = {
+    LCMEvalMode.BASELINE: ("baseline tail", []),
+    LCMEvalMode.LCM_ASSEMBLED: ("assemble_context", []),
+    LCMEvalMode.LCM_GREP: ("lcm_grep-assisted", ["lcm_grep"]),
+}
+
+
+async def run_eval(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    mode: LCMEvalMode,
+    fresh_tail_count: int = 4,
+) -> LCMEvalResult:
+    """Run one (scenario, mode) pair and return the structured result.
+
+    The function never raises on retrieval failure — the eval is a
+    measurement, so a missing tool or empty context should surface as
+    ``fact_pass=False`` not a test exception.
+    """
+    started = time.perf_counter()
+    blob, tools_called = await _retrieve_for_mode(
+        session,
+        conversation_id=conversation_id,
+        scenario=scenario,
+        mode=mode,
+        fresh_tail_count=fresh_tail_count,
+    )
+    answer = deterministic_answer(scenario.question, blob, scenario=scenario)
+    latency_ms = (time.perf_counter() - started) * 1000.0
+
+    return LCMEvalResult(
+        scenario_id=scenario.id,
+        mode=mode.value,
+        question=scenario.question,
+        answer=answer,
+        fact_pass=_fact_pass(answer, scenario),
+        source_pass=_source_pass(blob, scenario),
+        context_chars=len(blob),
+        context_tokens=_approx_tokens(blob),
+        output_tokens=_approx_tokens(answer),
+        latency_ms=latency_ms,
+        tools_called=tools_called,
+        notes=scenario.notes,
+    )
+
+
+async def _retrieve_for_mode(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    mode: LCMEvalMode,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Dispatch table for retrieval modes — keeps :func:`run_eval` flat."""
+    if mode is LCMEvalMode.BASELINE:
+        return await _retrieve_baseline(
+            session,
+            conversation_id=conversation_id,
+            fresh_tail_count=fresh_tail_count,
+        )
+    if mode is LCMEvalMode.LCM_ASSEMBLED:
+        return await _retrieve_lcm_assembled(
+            session,
+            conversation_id=conversation_id,
+            fresh_tail_count=fresh_tail_count,
+        )
+    if mode is LCMEvalMode.LCM_GREP:
+        return await _retrieve_lcm_grep(
+            session,
+            conversation_id=conversation_id,
+            question=scenario.question,
+        )
+    raise ValueError(f"unsupported eval mode: {mode!r}")
+
+
+async def run_eval_matrix(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    scenarios: Sequence[LCMEvalScenario],
+    modes: Sequence[LCMEvalMode],
+    fresh_tail_count: int = 4,
+) -> list[LCMEvalResult]:
+    """Seed every scenario and run every mode against each one.
+
+    Returns a flat list of :class:`LCMEvalResult` in
+    ``(scenario, mode)`` order so callers can pivot however they
+    like.
+    """
+    results: list[LCMEvalResult] = []
+    for scenario in scenarios:
+        conv = await seed_scenario(session, user_id=user_id, scenario=scenario)
+        for mode in modes:
+            result = await run_eval(
+                session,
+                conversation_id=conv.id,
+                scenario=scenario,
+                mode=mode,
+                fresh_tail_count=fresh_tail_count,
+            )
+            results.append(result)
+    return results

--- a/backend/app/core/lcm/evals.py
+++ b/backend/app/core/lcm/evals.py
@@ -48,6 +48,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.lcm import assemble_context
+from app.core.lcm.embeddings import (
+    DeterministicHashEmbedder,
+    Embedder,
+    lcm_hybrid_search,
+    upsert_embedding,
+)
 from app.core.lcm.pack import PackCandidate, pack_context
 from app.core.tools.lcm_grep import lcm_grep
 from app.core.tools.lcm_search import format_results as format_search_results
@@ -103,6 +109,8 @@ class LCMEvalMode(StrEnum):
     LCM_GREP = "lcm_grep"
     LCM_SEARCH = "lcm_search"
     LCM_SEARCH_PACKED = "lcm_search_packed"
+    LCM_SEMANTIC = "lcm_semantic"
+    LCM_HYBRID = "lcm_hybrid"
 
 
 @dataclass(frozen=True)
@@ -194,6 +202,52 @@ def _approx_tokens(text: str) -> int:
 def _utcnow() -> datetime:
     """Timezone-aware UTC now."""
     return datetime.now(UTC)
+
+
+async def seed_embeddings_for_conversation(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    embedder: Embedder | None = None,
+) -> int:
+    """Embed every persisted message + summary for one conversation.
+
+    Used by tests that want to exercise the semantic / hybrid
+    retrieval paths after :func:`seed_scenario` has written raw
+    rows.  Returns the number of embeddings written or refreshed
+    so callers can assert on the count.
+    """
+    used_embedder = embedder or DeterministicHashEmbedder()
+    count = 0
+    msg_result = await session.execute(
+        select(ChatMessage).where(ChatMessage.conversation_id == conversation_id)
+    )
+    for msg in msg_result.scalars().all():
+        row = await upsert_embedding(
+            session,
+            conversation_id=conversation_id,
+            item_kind="message",
+            item_id=msg.id,
+            content=msg.content or "",
+            embedder=used_embedder,
+        )
+        if row is not None:
+            count += 1
+    sum_result = await session.execute(
+        select(LCMSummary).where(LCMSummary.conversation_id == conversation_id)
+    )
+    for summary in sum_result.scalars().all():
+        row = await upsert_embedding(
+            session,
+            conversation_id=conversation_id,
+            item_kind="summary",
+            item_id=summary.id,
+            content=summary.content or "",
+            embedder=used_embedder,
+        )
+        if row is not None:
+            count += 1
+    return count
 
 
 async def seed_scenario(
@@ -500,6 +554,36 @@ async def _retrieve_lcm_search(
     return blob[:_MAX_CONTEXT_CHARS], ["lcm_search"]
 
 
+async def _retrieve_hybrid(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    question: str,
+    mode: str,
+    embedder: Embedder | None = None,
+) -> tuple[str, list[str]]:
+    """Hybrid (or one-leg) retrieval via :func:`lcm_hybrid_search`."""
+    used_embedder = embedder or DeterministicHashEmbedder()
+    rows = await lcm_hybrid_search(
+        session,
+        conversation_id=conversation_id,
+        query=question,
+        mode=mode,  # type: ignore[arg-type]
+        embedder=used_embedder,
+    )
+    parts = [
+        f"[{row['item_kind'].upper()} score={row['final_score']:.3f}] {row['excerpt']}"
+        for row in rows
+    ]
+    blob = "\n\n".join(parts)
+    tools = (
+        ["lcm_search", "semantic_search"]
+        if mode == "hybrid"
+        else (["lcm_search"] if mode == "lexical" else ["semantic_search"])
+    )
+    return blob[:_MAX_CONTEXT_CHARS], tools
+
+
 async def _retrieve_lcm_search_packed(
     session: AsyncSession,
     *,
@@ -637,38 +721,146 @@ async def _retrieve_for_mode(
     mode: LCMEvalMode,
     fresh_tail_count: int,
 ) -> tuple[str, list[str]]:
-    """Dispatch table for retrieval modes — keeps :func:`run_eval` flat."""
-    if mode is LCMEvalMode.BASELINE:
-        return await _retrieve_baseline(
-            session,
-            conversation_id=conversation_id,
-            fresh_tail_count=fresh_tail_count,
-        )
-    if mode is LCMEvalMode.LCM_ASSEMBLED:
-        return await _retrieve_lcm_assembled(
-            session,
-            conversation_id=conversation_id,
-            fresh_tail_count=fresh_tail_count,
-        )
-    if mode is LCMEvalMode.LCM_GREP:
-        return await _retrieve_lcm_grep(
-            session,
-            conversation_id=conversation_id,
-            question=scenario.question,
-        )
-    if mode is LCMEvalMode.LCM_SEARCH:
-        return await _retrieve_lcm_search(
-            session,
-            conversation_id=conversation_id,
-            question=scenario.question,
-        )
-    if mode is LCMEvalMode.LCM_SEARCH_PACKED:
-        return await _retrieve_lcm_search_packed(
-            session,
-            conversation_id=conversation_id,
-            question=scenario.question,
-        )
-    raise ValueError(f"unsupported eval mode: {mode!r}")
+    """Dispatch table for retrieval modes — keeps :func:`run_eval` flat.
+
+    The function is intentionally a flat lookup over the supported
+    modes; adding a new mode means appending another ``async def
+    _retrieve_*`` and a single line in :data:`_MODE_RETRIEVERS`.
+    """
+    retriever = _MODE_RETRIEVERS.get(mode)
+    if retriever is None:
+        raise ValueError(f"unsupported eval mode: {mode!r}")
+    return await retriever(
+        session,
+        conversation_id=conversation_id,
+        scenario=scenario,
+        fresh_tail_count=fresh_tail_count,
+    )
+
+
+async def _adapt_baseline(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap the baseline retriever in the dispatch signature."""
+    del scenario  # unused
+    return await _retrieve_baseline(
+        session,
+        conversation_id=conversation_id,
+        fresh_tail_count=fresh_tail_count,
+    )
+
+
+async def _adapt_lcm_assembled(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap the LCM-assembled retriever in the dispatch signature."""
+    del scenario
+    return await _retrieve_lcm_assembled(
+        session,
+        conversation_id=conversation_id,
+        fresh_tail_count=fresh_tail_count,
+    )
+
+
+async def _adapt_lcm_grep(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap the lcm_grep retriever in the dispatch signature."""
+    del fresh_tail_count
+    return await _retrieve_lcm_grep(
+        session,
+        conversation_id=conversation_id,
+        question=scenario.question,
+    )
+
+
+async def _adapt_lcm_search(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap the ranked lcm_search retriever in the dispatch signature."""
+    del fresh_tail_count
+    return await _retrieve_lcm_search(
+        session,
+        conversation_id=conversation_id,
+        question=scenario.question,
+    )
+
+
+async def _adapt_lcm_search_packed(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap the packed-search retriever in the dispatch signature."""
+    del fresh_tail_count
+    return await _retrieve_lcm_search_packed(
+        session,
+        conversation_id=conversation_id,
+        question=scenario.question,
+    )
+
+
+async def _adapt_semantic(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap semantic-only hybrid_search in the dispatch signature."""
+    del fresh_tail_count
+    return await _retrieve_hybrid(
+        session,
+        conversation_id=conversation_id,
+        question=scenario.question,
+        mode="semantic",
+    )
+
+
+async def _adapt_hybrid(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    scenario: LCMEvalScenario,
+    fresh_tail_count: int,
+) -> tuple[str, list[str]]:
+    """Wrap full hybrid_search in the dispatch signature."""
+    del fresh_tail_count
+    return await _retrieve_hybrid(
+        session,
+        conversation_id=conversation_id,
+        question=scenario.question,
+        mode="hybrid",
+    )
+
+
+_MODE_RETRIEVERS = {
+    LCMEvalMode.BASELINE: _adapt_baseline,
+    LCMEvalMode.LCM_ASSEMBLED: _adapt_lcm_assembled,
+    LCMEvalMode.LCM_GREP: _adapt_lcm_grep,
+    LCMEvalMode.LCM_SEARCH: _adapt_lcm_search,
+    LCMEvalMode.LCM_SEARCH_PACKED: _adapt_lcm_search_packed,
+    LCMEvalMode.LCM_SEMANTIC: _adapt_semantic,
+    LCMEvalMode.LCM_HYBRID: _adapt_hybrid,
+}
 
 
 async def run_eval_matrix(

--- a/backend/app/core/lcm/evals.py
+++ b/backend/app/core/lcm/evals.py
@@ -48,6 +48,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.lcm import assemble_context
+from app.core.lcm.pack import PackCandidate, pack_context
 from app.core.tools.lcm_grep import lcm_grep
 from app.core.tools.lcm_search import format_results as format_search_results
 from app.core.tools.lcm_search import lcm_search
@@ -101,6 +102,7 @@ class LCMEvalMode(StrEnum):
     LCM_ASSEMBLED = "lcm_assembled"
     LCM_GREP = "lcm_grep"
     LCM_SEARCH = "lcm_search"
+    LCM_SEARCH_PACKED = "lcm_search_packed"
 
 
 @dataclass(frozen=True)
@@ -498,6 +500,44 @@ async def _retrieve_lcm_search(
     return blob[:_MAX_CONTEXT_CHARS], ["lcm_search"]
 
 
+async def _retrieve_lcm_search_packed(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    question: str,
+) -> tuple[str, list[str]]:
+    """Ranked search routed through the issue-#255 context packer."""
+    raw_results = await lcm_search(
+        session,
+        conversation_id=conversation_id,
+        query=question,
+    )
+    candidates: list[PackCandidate] = [
+        PackCandidate(
+            item_kind=row["item_kind"],
+            item_id=row["item_id"],
+            ordinal=row.get("ordinal"),
+            role=row.get("role"),
+            summary_depth=row.get("summary_depth"),
+            summary_kind=row.get("summary_kind"),
+            source_ids=list(row.get("source_ids") or []),
+            lexical_score=row.get("score"),
+            final_score=row.get("score"),
+            excerpt=row.get("excerpt", ""),
+            content=row.get("excerpt", ""),
+            token_count=max(1, len(row.get("excerpt", "")) // _CHARS_PER_TOKEN),
+        )
+        for row in raw_results
+    ]
+    packed = pack_context(candidates, query=question)
+    rendered_parts = [
+        f"[{item['item_kind'].upper()} reason={item['packed_reason']}]\n{item['content']}"
+        for item in packed["kept"]
+    ]
+    blob = "\n\n".join(rendered_parts)
+    return blob[:_MAX_CONTEXT_CHARS], ["lcm_search", "pack_context"]
+
+
 def _extract_search_terms(question: str) -> list[str]:
     """Pull a handful of content-bearing words out of a question."""
     stopwords = {
@@ -618,6 +658,12 @@ async def _retrieve_for_mode(
         )
     if mode is LCMEvalMode.LCM_SEARCH:
         return await _retrieve_lcm_search(
+            session,
+            conversation_id=conversation_id,
+            question=scenario.question,
+        )
+    if mode is LCMEvalMode.LCM_SEARCH_PACKED:
+        return await _retrieve_lcm_search_packed(
             session,
             conversation_id=conversation_id,
             question=scenario.question,

--- a/backend/app/core/lcm/evals.py
+++ b/backend/app/core/lcm/evals.py
@@ -49,6 +49,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.lcm import assemble_context
 from app.core.tools.lcm_grep import lcm_grep
+from app.core.tools.lcm_search import format_results as format_search_results
+from app.core.tools.lcm_search import lcm_search
 from app.models import (
     ChatMessage,
     Conversation,
@@ -98,6 +100,7 @@ class LCMEvalMode(StrEnum):
     BASELINE = "baseline"
     LCM_ASSEMBLED = "lcm_assembled"
     LCM_GREP = "lcm_grep"
+    LCM_SEARCH = "lcm_search"
 
 
 @dataclass(frozen=True)
@@ -479,6 +482,22 @@ async def _retrieve_lcm_grep(
     return blob[:_MAX_CONTEXT_CHARS], ["lcm_grep"]
 
 
+async def _retrieve_lcm_search(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    question: str,
+) -> tuple[str, list[str]]:
+    """Ranked lexical retrieval via :func:`lcm_search`."""
+    results = await lcm_search(
+        session,
+        conversation_id=conversation_id,
+        query=question,
+    )
+    blob = format_search_results(question, results)
+    return blob[:_MAX_CONTEXT_CHARS], ["lcm_search"]
+
+
 def _extract_search_terms(question: str) -> list[str]:
     """Pull a handful of content-bearing words out of a question."""
     stopwords = {
@@ -593,6 +612,12 @@ async def _retrieve_for_mode(
         )
     if mode is LCMEvalMode.LCM_GREP:
         return await _retrieve_lcm_grep(
+            session,
+            conversation_id=conversation_id,
+            question=scenario.question,
+        )
+    if mode is LCMEvalMode.LCM_SEARCH:
+        return await _retrieve_lcm_search(
             session,
             conversation_id=conversation_id,
             question=scenario.question,

--- a/backend/app/core/lcm/observe.py
+++ b/backend/app/core/lcm/observe.py
@@ -1,0 +1,298 @@
+"""LCM retrieval observability — explain one turn's assembled memory context.
+
+This module is the read-only microscope on top of the LCM substrate
+(``lcm_context_items`` → resolved ``chat_messages`` / ``lcm_summaries``).
+It answers the question "what did the agent actually see for this
+turn, and how was that produced?" without firing a model call or
+mutating any compaction state.
+
+Public API
+----------
+``describe_assembled_context`` — resolve the assembled context for a
+                                 conversation into a structured
+                                 :class:`LCMContextDebugResponse`.
+
+The schema lives next to the resolver so the API layer (
+``app.api.lcm``) and the eval harness (``backend/tests/evals``) can
+both consume the same Pydantic types without crossing the
+``app.schemas`` boundary, which is already at the 500-line cap.
+
+See issue #251.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings as _settings
+from app.models import ChatMessage, LCMContextItem, LCMSummary, LCMSummarySource
+
+# Length of the preview snippet recorded for each item in the debug
+# response.  Wide enough for the first sentence; narrow enough to keep
+# the JSON payload compact even for large conversations.
+_DEBUG_PREVIEW_CHARS = 240
+
+# Same 4-chars-per-token approximation the rest of LCM uses (see
+# ``app.core.lcm.__init__._approx_tokens``).  Duplicated here rather
+# than imported so this module does not pull in the compaction-pass
+# side of the package just to read.
+_CHARS_PER_TOKEN = 4
+
+ItemKind = Literal["message", "summary"]
+
+
+class LCMContextDebugItem(BaseModel):
+    """One row of the assembled context, in resolved + preview-friendly form."""
+
+    ordinal: int
+    item_kind: ItemKind
+    item_id: uuid.UUID
+    role: str | None = None
+    preview: str
+    token_count: int | None = None
+    summary_depth: int | None = None
+    summary_kind: str | None = None
+    source_count: int | None = None
+
+
+class LCMSettingsSnapshot(BaseModel):
+    """The LCM tuning knobs that shaped this assembly call.
+
+    Snapshotted at request time so the debug response stays useful even
+    after settings change — the panel answers "what produced this
+    context" not "what is configured right now."
+    """
+
+    lcm_enabled: bool
+    fresh_tail_count: int
+    leaf_chunk_tokens: int
+    incremental_max_depth: int
+
+
+class LCMContextDebugResponse(BaseModel):
+    """Full debug payload for one conversation's assembled context."""
+
+    conversation_id: uuid.UUID
+    lcm_enabled: bool
+    fresh_tail_count: int
+    item_count: int
+    message_count: int
+    summary_count: int
+    estimated_tokens: int
+    items: list[LCMContextDebugItem]
+    settings: LCMSettingsSnapshot
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token estimate; mirrors :mod:`app.core.lcm.__init__`."""
+    return max(1, len(text or "") // _CHARS_PER_TOKEN)
+
+
+def _preview(text: str) -> str:
+    """Trim text to the debug preview length, ellipsising overflow."""
+    body = (text or "").strip().replace("\n", " ")
+    if len(body) <= _DEBUG_PREVIEW_CHARS:
+        return body
+    return body[: _DEBUG_PREVIEW_CHARS - 1] + "…"
+
+
+def _resolve_fresh_tail_count(override: int | None) -> int:
+    """Resolve the fresh-tail count from the override or live settings."""
+    if override is not None:
+        return max(0, override)
+    return max(0, _settings.lcm_fresh_tail_count)
+
+
+def _settings_snapshot(fresh_tail_count: int) -> LCMSettingsSnapshot:
+    """Materialise the relevant LCM settings into a Pydantic snapshot."""
+    return LCMSettingsSnapshot(
+        lcm_enabled=_settings.lcm_enabled,
+        fresh_tail_count=fresh_tail_count,
+        leaf_chunk_tokens=_settings.lcm_leaf_chunk_tokens,
+        incremental_max_depth=_settings.lcm_incremental_max_depth,
+    )
+
+
+def _empty_response(
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int,
+) -> LCMContextDebugResponse:
+    """Return the empty payload when no LCM context exists yet."""
+    return LCMContextDebugResponse(
+        conversation_id=conversation_id,
+        lcm_enabled=_settings.lcm_enabled,
+        fresh_tail_count=fresh_tail_count,
+        item_count=0,
+        message_count=0,
+        summary_count=0,
+        estimated_tokens=0,
+        items=[],
+        settings=_settings_snapshot(fresh_tail_count),
+    )
+
+
+async def _load_messages(
+    session: AsyncSession,
+    ids: list[uuid.UUID],
+) -> dict[uuid.UUID, ChatMessage]:
+    """Bulk-load ChatMessages by id."""
+    if not ids:
+        return {}
+    result = await session.execute(select(ChatMessage).where(ChatMessage.id.in_(ids)))
+    return {m.id: m for m in result.scalars().all()}
+
+
+async def _load_summaries(
+    session: AsyncSession,
+    ids: list[uuid.UUID],
+) -> dict[uuid.UUID, LCMSummary]:
+    """Bulk-load LCMSummaries by id."""
+    if not ids:
+        return {}
+    result = await session.execute(select(LCMSummary).where(LCMSummary.id.in_(ids)))
+    return {s.id: s for s in result.scalars().all()}
+
+
+async def _summary_source_counts(
+    session: AsyncSession,
+    summary_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """Return ``{summary_id: source_count}`` for the supplied IDs."""
+    if not summary_ids:
+        return {}
+    result = await session.execute(
+        select(LCMSummarySource.summary_id, func.count(LCMSummarySource.id))
+        .where(LCMSummarySource.summary_id.in_(summary_ids))
+        .group_by(LCMSummarySource.summary_id)
+    )
+    return {row[0]: int(row[1]) for row in result.all()}
+
+
+def _build_message_item(
+    item: LCMContextItem,
+    msg: ChatMessage | None,
+) -> LCMContextDebugItem | None:
+    """Resolve a ``message`` context item to a debug row, or drop it."""
+    if msg is None:
+        return None
+    content = msg.content or ""
+    return LCMContextDebugItem(
+        ordinal=item.ordinal,
+        item_kind="message",
+        item_id=item.item_id,
+        role=msg.role,
+        preview=_preview(content),
+        token_count=_approx_tokens(content),
+    )
+
+
+def _build_summary_item(
+    item: LCMContextItem,
+    summary: LCMSummary | None,
+    source_count: int | None,
+) -> LCMContextDebugItem | None:
+    """Resolve a ``summary`` context item to a debug row, or drop it."""
+    if summary is None:
+        return None
+    return LCMContextDebugItem(
+        ordinal=item.ordinal,
+        item_kind="summary",
+        item_id=item.item_id,
+        role=None,
+        preview=_preview(summary.content or ""),
+        token_count=summary.token_count or _approx_tokens(summary.content or ""),
+        summary_depth=summary.depth,
+        summary_kind=summary.summary_kind,
+        source_count=source_count,
+    )
+
+
+async def describe_assembled_context(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    fresh_tail_count: int | None = None,
+) -> LCMContextDebugResponse:
+    """Resolve the assembled LCM context for one conversation into a debug payload.
+
+    This mirrors the read path of :func:`app.core.lcm.assemble_context`
+    (fresh-tail cap on raw messages, all summaries preserved) but
+    surfaces structural metadata — ordinal, role, summary depth/kind,
+    source count, token estimate — instead of the ``[{role, content}]``
+    shape the provider receives.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation to inspect.
+        fresh_tail_count: Optional override of ``settings.lcm_fresh_tail_count``.
+            Used by tests and by callers that want to preview a
+            different fresh-tail window without flipping the global
+            setting.
+
+    Returns:
+        A structured :class:`LCMContextDebugResponse`.  Empty when no
+        ``LCMContextItem`` rows exist for the conversation.
+    """
+    resolved_tail = _resolve_fresh_tail_count(fresh_tail_count)
+
+    items_result = await session.execute(
+        select(LCMContextItem)
+        .where(LCMContextItem.conversation_id == conversation_id)
+        .order_by(LCMContextItem.ordinal.asc())
+    )
+    all_items = list(items_result.scalars().all())
+    if not all_items:
+        return _empty_response(conversation_id, resolved_tail)
+
+    # Same selection rule as ``assemble_context``: keep every summary,
+    # cap raw messages to the most-recent ``resolved_tail`` entries.
+    message_quota = resolved_tail
+    keep: list[LCMContextItem] = []
+    for item in reversed(all_items):
+        if item.item_kind == "message":
+            if message_quota <= 0:
+                continue
+            message_quota -= 1
+        keep.append(item)
+    keep.reverse()
+
+    message_ids = [i.item_id for i in keep if i.item_kind == "message"]
+    summary_ids = [i.item_id for i in keep if i.item_kind == "summary"]
+
+    messages_by_id = await _load_messages(session, message_ids)
+    summaries_by_id = await _load_summaries(session, summary_ids)
+    source_counts = await _summary_source_counts(session, summary_ids)
+
+    debug_items: list[LCMContextDebugItem] = []
+    for item in keep:
+        if item.item_kind == "message":
+            row = _build_message_item(item, messages_by_id.get(item.item_id))
+        else:
+            row = _build_summary_item(
+                item,
+                summaries_by_id.get(item.item_id),
+                source_counts.get(item.item_id),
+            )
+        if row is not None:
+            debug_items.append(row)
+
+    message_count = sum(1 for r in debug_items if r.item_kind == "message")
+    summary_count = sum(1 for r in debug_items if r.item_kind == "summary")
+    estimated_tokens = sum(r.token_count or 0 for r in debug_items)
+
+    return LCMContextDebugResponse(
+        conversation_id=conversation_id,
+        lcm_enabled=_settings.lcm_enabled,
+        fresh_tail_count=resolved_tail,
+        item_count=len(debug_items),
+        message_count=message_count,
+        summary_count=summary_count,
+        estimated_tokens=estimated_tokens,
+        items=debug_items,
+        settings=_settings_snapshot(resolved_tail),
+    )

--- a/backend/app/core/lcm/pack.py
+++ b/backend/app/core/lcm/pack.py
@@ -1,0 +1,472 @@
+"""LCM context packing - turn ranked candidates into a budgeted packet (issue #255).
+
+Retrieval is half the problem.  Once ``lcm_search`` (or any other
+candidate source) returns a ranked set of plausible items, the agent
+still needs to decide *what to put in the model context*.  This
+module is the packer: it takes structured candidates and produces a
+token-bounded :class:`LCMPackedContext` along with explanation of
+why each candidate was kept or dropped.
+
+Design goals
+------------
+* **Deterministic.**  Same candidates + same budget produce the same
+  packet, every run, so evals and diagnostics are reproducible.
+* **Inspectable.**  Every kept item carries a ``packed_reason``;
+  every rejected item carries a ``rejected_reason``.  The whole
+  point of pruning is to make it auditable.
+* **Composable.**  The packer is a pure function over candidates,
+  not a database call.  Callers (``lcm_search``, future hybrid
+  retrieval, eval harness, ``lcm_expand_query``) shape candidates
+  however they want and let the packer apply the budget.
+
+The rules (deliberately small + explainable):
+
+1. Sort candidates by final score descending, with a kind-aware
+   bias (``prefer_kind``) so callers can request raw-message-first
+   or summary-first packing without re-scoring.
+2. Drop summaries that are entirely subsumed by already-kept raw
+   sources (``source_ids`` covered).  Symmetrically, drop raw
+   messages whose only contribution is also in a kept summary's
+   sources - except when the user signalled exact-fact preference.
+3. Enforce the token budget; over-budget items are rejected with
+   ``budget_exceeded`` rather than silently truncated.
+4. Re-order kept items chronologically (ordinal ascending, with
+   summaries floated to the top of their bucket so condensed
+   history precedes raw turns).
+
+The packer never silently changes assembly behaviour - it returns
+a packet.  Routing the packet into a chat turn is a separate
+decision (callers may compare unpruned candidates vs packed context
+in evals before promoting the packer into the default path).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal, TypedDict
+
+# Reasons surfaced on kept / rejected items.  Kept as module
+# constants so callers can switch on them programmatically without
+# string-fishing.
+REASON_TOP_SCORE = "top_score"
+REASON_EXACT_FACT_PREFERENCE = "preferred_for_exact_fact"
+REASON_BROAD_SUMMARY_PREFERENCE = "preferred_for_broad_query"
+REASON_BUDGET_EXCEEDED = "budget_exceeded"
+REASON_DUPLICATE_SOURCE_CHAIN = "source_chain_duplicate"
+REASON_LOWER_RANKED_OVERLAP = "lower_ranked_overlap"
+
+# Default token budget if the caller does not supply one.  Matches
+# the ``lcm_leaf_chunk_tokens`` default in ``app.core.config`` so a
+# typical leaf-summary's worth of context is the unit of packing.
+_DEFAULT_TOKEN_BUDGET = 4_000
+
+# Hard maximum on the number of kept items, regardless of budget.
+# Prevents pathological inputs (1000 tiny excerpts) from packing
+# into a single mega-context.
+_MAX_KEPT_ITEMS = 32
+
+# Multiplier applied to a candidate's effective score when the
+# caller asks for a kind-biased pack.  Small enough that a strong
+# score for the disfavoured kind still wins, large enough to break
+# near-ties in favour of the requested kind.
+_KIND_BIAS = 1.15
+
+# When the query looks like an exact-fact lookup (model IDs, file
+# paths, commands, error text), raw messages get a stronger lift
+# because a raw turn contains the source phrasing while a summary
+# would paraphrase.  This is independent of ``prefer_kind`` so the
+# auto path still has guardrails.
+_EXACT_FACT_RAW_BONUS = 1.25
+
+# Fraction of a summary's source items that must already be in the
+# kept set before we drop the summary as redundant.  The packer
+# treats a summary as "covered" when more than half of its raw
+# sources are already in the packet - any lower and the summary
+# might still add cohesive prose the raw turns lack.
+_SUMMARY_OVERLAP_DROP_THRESHOLD = 0.5
+
+# Regex hints for "this is an exact-fact-style query".  Conservative
+# - false positives would mis-prefer raw turns over summaries, which
+# is the *less* harmful failure mode for an inspectable packer.
+_EXACT_FACT_PATTERNS = (
+    re.compile(r"\b(?:exact|exactly|filename|model id|command)\b", re.IGNORECASE),
+    re.compile(r"\b\w+\.[a-zA-Z]{2,4}\b"),  # e.g. ``foo.py``, ``bar.md``
+    re.compile(r"\b[a-z]+-[a-z0-9]+(?:-[a-z0-9]+)+\b"),  # kebab IDs / model names
+    re.compile(r"\b(?:error|exception|stack trace)\b", re.IGNORECASE),
+)
+
+
+PackingHint = Literal["fresh_tail", "summary_first", "source_first", "timeline"]
+PreferKind = Literal["auto", "messages", "summaries"]
+ItemKind = Literal["message", "summary"]
+
+
+class PackCandidate(TypedDict, total=False):
+    """One retrieval candidate handed to the packer.
+
+    Only ``item_kind``, ``item_id``, ``content``, and ``token_count``
+    are required - the rest are optional metadata used for ordering
+    and dedup.
+    """
+
+    item_kind: ItemKind
+    item_id: str
+    conversation_id: str
+    ordinal: int | None
+    role: str | None
+    summary_depth: int | None
+    summary_kind: str | None
+    source_ids: list[str]
+    lexical_score: float | None
+    semantic_score: float | None
+    final_score: float | None
+    excerpt: str
+    content: str
+    token_count: int
+
+
+class LCMPackedContextItem(TypedDict):
+    """One item that survived packing."""
+
+    item_kind: ItemKind
+    item_id: str
+    content: str
+    token_count: int
+    source_ids: list[str]
+    packed_reason: str
+    score: float
+    ordinal: int | None
+    summary_depth: int | None
+
+
+class LCMPackingRejectedItem(TypedDict):
+    """One item the packer dropped, with the reason."""
+
+    item_kind: ItemKind
+    item_id: str
+    token_count: int
+    rejected_reason: str
+    score: float
+
+
+class LCMPackedContext(TypedDict):
+    """Full packing result - kept items + rejected items + diagnostics."""
+
+    query: str
+    token_budget: int
+    token_count: int
+    kept: list[LCMPackedContextItem]
+    rejected: list[LCMPackingRejectedItem]
+    diagnostics: dict[str, Any]
+
+
+def _candidate_score(candidate: PackCandidate) -> float:
+    """Pick the best available score from a candidate.
+
+    Resolution order: ``final_score`` (set by hybrid blending) >
+    ``lexical_score`` (set by :func:`lcm_search`) > ``semantic_score``
+    (set by future semantic retrieval) > ``0.0``.
+    """
+    final = candidate.get("final_score")
+    if final is not None:
+        return float(final)
+    lex = candidate.get("lexical_score")
+    if lex is not None:
+        return float(lex)
+    sem = candidate.get("semantic_score")
+    if sem is not None:
+        return float(sem)
+    return 0.0
+
+
+def _effective_score(
+    candidate: PackCandidate,
+    *,
+    prefer_kind: PreferKind,
+    exact_fact: bool,
+) -> float:
+    """Apply kind-bias + exact-fact bonus to the raw candidate score."""
+    base = _candidate_score(candidate)
+    kind = candidate.get("item_kind")
+    if (prefer_kind == "messages" and kind == "message") or (
+        prefer_kind == "summaries" and kind == "summary"
+    ):
+        base *= _KIND_BIAS
+    if exact_fact and kind == "message":
+        base *= _EXACT_FACT_RAW_BONUS
+    return base
+
+
+def _looks_like_exact_fact_query(query: str) -> bool:
+    """Heuristic: does the query look like an exact-fact lookup?"""
+    if not query:
+        return False
+    return any(pattern.search(query) for pattern in _EXACT_FACT_PATTERNS)
+
+
+def _approx_tokens(text: str) -> int:
+    """Same 4-chars-per-token approximation used across LCM."""
+    return max(1, math.ceil(len(text or "") / 4))
+
+
+def _candidate_tokens(candidate: PackCandidate) -> int:
+    """Resolve a candidate's token cost, preferring the supplied count."""
+    raw = candidate.get("token_count")
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return _approx_tokens(candidate.get("content") or candidate.get("excerpt") or "")
+
+
+def _ordinal_for_sort(candidate: PackCandidate) -> int:
+    """Chronological sort key. Summaries float to the top of their bucket."""
+    ordinal = candidate.get("ordinal")
+    if ordinal is not None:
+        # Floats summaries above messages at the same ordinal slot.
+        return int(ordinal) * 2
+    # Summaries without explicit ordinal sort to the very front.
+    return -1
+
+
+def _initial_reason(
+    candidate: PackCandidate,
+    *,
+    prefer_kind: PreferKind,
+    exact_fact: bool,
+) -> str:
+    """Pick the keep-reason that applies to a candidate before dedup."""
+    kind = candidate.get("item_kind")
+    if exact_fact and kind == "message":
+        return REASON_EXACT_FACT_PREFERENCE
+    if prefer_kind == "summaries" and kind == "summary":
+        return REASON_BROAD_SUMMARY_PREFERENCE
+    if prefer_kind == "messages" and kind == "message":
+        return REASON_EXACT_FACT_PREFERENCE
+    return REASON_TOP_SCORE
+
+
+def _is_subsumed_by_kept_summary(
+    candidate: PackCandidate,
+    kept_summary_source_ids: set[str],
+) -> bool:
+    """Is this raw message already covered by a kept summary's sources?"""
+    if candidate.get("item_kind") != "message":
+        return False
+    return candidate.get("item_id", "") in kept_summary_source_ids
+
+
+def _summary_overlap_ratio(candidate: PackCandidate, kept_message_ids: set[str]) -> float:
+    """Fraction of a summary's sources already kept as raw messages."""
+    if candidate.get("item_kind") != "summary":
+        return 0.0
+    sources = candidate.get("source_ids") or []
+    if not sources:
+        return 0.0
+    overlap = sum(1 for sid in sources if sid in kept_message_ids)
+    return overlap / len(sources)
+
+
+class _PackState:
+    """Mutable accumulator used by :func:`pack_context`.
+
+    Defined ahead of the helper that consumes it so the helper can
+    reference the type without a forward-string annotation.
+    """
+
+    def __init__(self, budget: int) -> None:
+        self.budget = budget
+        self.token_count = 0
+        self.kept: list[LCMPackedContextItem] = []
+        self.rejected: list[LCMPackingRejectedItem] = []
+        self.kept_summary_source_ids: set[str] = set()
+        self.kept_message_ids: set[str] = set()
+        self.reject_counts: dict[str, int] = {}
+
+    def would_overflow(self, tokens: int) -> bool:
+        return (self.token_count + tokens) > self.budget
+
+    def keep(
+        self,
+        candidate: PackCandidate,
+        *,
+        reason: str,
+        score: float,
+        tokens: int,
+    ) -> None:
+        """Record a kept candidate and update bookkeeping sets."""
+        item_id = candidate.get("item_id", "")
+        item_kind = candidate.get("item_kind")
+        if item_kind not in ("message", "summary"):
+            return
+        content = candidate.get("content") or candidate.get("excerpt") or ""
+        source_ids = list(candidate.get("source_ids") or [])
+        self.kept.append(
+            LCMPackedContextItem(
+                item_kind=item_kind,
+                item_id=item_id,
+                content=content,
+                token_count=tokens,
+                source_ids=source_ids,
+                packed_reason=reason,
+                score=round(score, 6),
+                ordinal=candidate.get("ordinal"),
+                summary_depth=candidate.get("summary_depth"),
+            )
+        )
+        self.token_count += tokens
+        if item_kind == "summary":
+            self.kept_summary_source_ids.update(source_ids)
+        else:
+            self.kept_message_ids.add(item_id)
+
+    def reject(self, candidate: PackCandidate, reason: str, score: float) -> None:
+        item_kind = candidate.get("item_kind")
+        if item_kind not in ("message", "summary"):
+            return
+        tokens = _candidate_tokens(candidate)
+        self.rejected.append(
+            LCMPackingRejectedItem(
+                item_kind=item_kind,
+                item_id=candidate.get("item_id", ""),
+                token_count=tokens,
+                rejected_reason=reason,
+                score=round(score, 6),
+            )
+        )
+        self.reject_counts[reason] = self.reject_counts.get(reason, 0) + 1
+
+
+def _try_pack_candidate(
+    candidate: PackCandidate,
+    *,
+    state: _PackState,
+    prefer_kind: PreferKind,
+    exact_fact: bool,
+) -> None:
+    """Decide whether to keep, reject, or skip one candidate.
+
+    Mutates ``state`` in place.  Keeps :func:`pack_context` flat
+    enough to fit the project's 3-level nesting budget.
+    """
+    kind = candidate.get("item_kind")
+    if kind not in ("message", "summary"):
+        return
+
+    score = _effective_score(candidate, prefer_kind=prefer_kind, exact_fact=exact_fact)
+    tokens = _candidate_tokens(candidate)
+
+    if _is_subsumed_by_kept_summary(candidate, state.kept_summary_source_ids):
+        state.reject(candidate, REASON_DUPLICATE_SOURCE_CHAIN, score)
+        return
+
+    if (
+        not exact_fact
+        and _summary_overlap_ratio(candidate, state.kept_message_ids)
+        > _SUMMARY_OVERLAP_DROP_THRESHOLD
+    ):
+        # We already have most of this summary's raw sources in the
+        # packet; the summary now adds little.
+        state.reject(candidate, REASON_LOWER_RANKED_OVERLAP, score)
+        return
+
+    if state.would_overflow(tokens):
+        state.reject(candidate, REASON_BUDGET_EXCEEDED, score)
+        return
+    if len(state.kept) >= _MAX_KEPT_ITEMS:
+        state.reject(candidate, REASON_BUDGET_EXCEEDED, score)
+        return
+
+    reason = _initial_reason(candidate, prefer_kind=prefer_kind, exact_fact=exact_fact)
+    state.keep(candidate, reason=reason, score=score, tokens=tokens)
+
+
+def pack_context(
+    candidates: Iterable[PackCandidate],
+    *,
+    query: str = "",
+    token_budget: int = _DEFAULT_TOKEN_BUDGET,
+    prefer_kind: PreferKind = "auto",
+    chronological: bool = True,
+) -> LCMPackedContext:
+    """Pack ranked candidates into a token-bounded :class:`LCMPackedContext`.
+
+    Args:
+        candidates: Ranked-or-not candidate iterable.  The packer
+            re-orders by effective score before walking.
+        query: The user's question; used for the exact-fact heuristic
+            and surfaced in diagnostics.
+        token_budget: Hard token cap on the final packet.
+        prefer_kind: ``"auto"`` (default) defers to score; ``"messages"``
+            and ``"summaries"`` apply a small bias to break near-ties.
+        chronological: When True (default) the kept list is re-sorted
+            chronologically before return; otherwise it stays in
+            score order.  Useful for consumers that want score-first
+            ranking (e.g. the eval harness's diagnostic output).
+
+    Returns:
+        :class:`LCMPackedContext` with ``kept``, ``rejected``, and
+        ``diagnostics``.
+    """
+    ordered = _order_candidates_for_packing(list(candidates), query=query, prefer_kind=prefer_kind)
+    exact_fact = _looks_like_exact_fact_query(query)
+    state = _PackState(budget=max(0, int(token_budget)))
+
+    for candidate in ordered:
+        _try_pack_candidate(
+            candidate,
+            state=state,
+            prefer_kind=prefer_kind,
+            exact_fact=exact_fact,
+        )
+
+    if chronological:
+        state.kept.sort(
+            key=lambda item: (
+                item.get("ordinal") if item.get("ordinal") is not None else -1,
+                item.get("summary_depth") or 0,
+            )
+        )
+
+    diagnostics = _build_diagnostics(state, ordered, exact_fact)
+    return LCMPackedContext(
+        query=query,
+        token_budget=state.budget,
+        token_count=state.token_count,
+        kept=state.kept,
+        rejected=state.rejected,
+        diagnostics=diagnostics,
+    )
+
+
+def _order_candidates_for_packing(
+    candidates: list[PackCandidate],
+    *,
+    query: str,
+    prefer_kind: PreferKind,
+) -> list[PackCandidate]:
+    """Sort candidates by effective score descending; stable for diagnostics."""
+    exact_fact = _looks_like_exact_fact_query(query)
+    return sorted(
+        candidates,
+        key=lambda c: (
+            -_effective_score(c, prefer_kind=prefer_kind, exact_fact=exact_fact),
+            _ordinal_for_sort(c),
+        ),
+    )
+
+
+def _build_diagnostics(
+    state: _PackState,
+    ordered: Sequence[PackCandidate],
+    exact_fact: bool,
+) -> dict[str, Any]:
+    """Materialise the diagnostics payload required by issue #255."""
+    return {
+        "candidates_considered": len(ordered),
+        "kept_count": len(state.kept),
+        "rejected_count": len(state.rejected),
+        "rejection_breakdown": dict(state.reject_counts),
+        "exact_fact_query": exact_fact,
+        "final_order": [item["item_id"] for item in state.kept],
+    }

--- a/backend/app/core/lcm/pack.py
+++ b/backend/app/core/lcm/pack.py
@@ -220,11 +220,19 @@ def _candidate_tokens(candidate: PackCandidate) -> int:
 
 
 def _ordinal_for_sort(candidate: PackCandidate) -> int:
-    """Chronological sort key. Summaries float to the top of their bucket."""
+    """Chronological sort key.  Summaries float to the top of their bucket.
+
+    Summaries get an even slot (``ordinal * 2``); raw messages get the
+    odd slot (``ordinal * 2 + 1``) so when both share the same ordinal
+    the summary always sorts first.  This is the behaviour the
+    surrounding docstring describes; without the kind offset both kinds
+    landed on the same key and the documented ordering never fired
+    (Greptile P2 review).
+    """
     ordinal = candidate.get("ordinal")
     if ordinal is not None:
-        # Floats summaries above messages at the same ordinal slot.
-        return int(ordinal) * 2
+        kind_offset = 0 if candidate.get("item_kind") == "summary" else 1
+        return int(ordinal) * 2 + kind_offset
     # Summaries without explicit ordinal sort to the very front.
     return -1
 

--- a/backend/app/core/lcm/planner.py
+++ b/backend/app/core/lcm/planner.py
@@ -1,0 +1,365 @@
+"""LCM query planner - classify recall intent before retrieval (issue #256).
+
+The retrieval stack now has lexical, semantic, hybrid, and packed
+modes.  What it does *not* have is a planning layer that can tell a
+"what exact model did we pick?" question apart from a "what did we
+change our mind about?" question - and pick the right tool, subqueries,
+and packing hint up front.
+
+This module is that planning layer.  It accepts a user question (and
+optional context such as prior assistant turns) and returns a
+structured :class:`LCMQueryPlan` describing:
+
+* intent classification (``exact_fact`` / ``source_lookup`` /
+  ``broad_timeline`` / ``decision_trace`` / ``multi_hop`` /
+  ``contradiction_check`` / ``unknown_or_unanswerable``),
+* normalised question text,
+* bounded subquery list (so broad plans cannot fan out unbounded),
+* recommended retrieval modes,
+* time + entity hints extracted from the question,
+* packing hint surfacing the right item kind to prefer,
+* citation requirement.
+
+The default planner is **heuristic**: simple keyword rules picked to
+cover the categories with high precision on a small fixture set.  A
+model-based planner can plug in behind the same API in a future
+iteration without changing the call sites.  The whole point of
+issue #256 is that this layer is *inspectable* - keeping the
+heuristic version deterministic preserves that.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+Intent = Literal[
+    "exact_fact",
+    "source_lookup",
+    "broad_timeline",
+    "decision_trace",
+    "multi_hop",
+    "contradiction_check",
+    "unknown_or_unanswerable",
+]
+
+RetrievalMode = Literal[
+    "grep",
+    "lexical",
+    "semantic",
+    "hybrid",
+    "summary_walk",
+]
+
+PackingHint = Literal[
+    "fresh_tail",
+    "summary_first",
+    "source_first",
+    "timeline",
+]
+
+CitationRequirement = Literal["none", "preferred", "required"]
+
+
+class LCMQueryPlan(BaseModel):
+    """Structured plan for one user recall query.
+
+    Mirrors the shape proposed in issue #256 so the agent loop, eval
+    harness, and observability panel can all consume the same
+    Pydantic type.
+    """
+
+    intent: Intent
+    normalized_question: str
+    subqueries: list[str] = Field(default_factory=list)
+    retrieval_modes: list[RetrievalMode] = Field(default_factory=list)
+    time_hints: list[str] = Field(default_factory=list)
+    entity_hints: list[str] = Field(default_factory=list)
+    packing_hint: PackingHint = "summary_first"
+    citation_requirement: CitationRequirement = "preferred"
+    max_budget_tokens: int | None = None
+    diagnostics: dict[str, object] = Field(default_factory=dict)
+
+
+# Subquery cap - hard ceiling so broad-query plans cannot fan out
+# into unbounded retrieval calls (one of the explicit acceptance
+# criteria in issue #256).
+_MAX_SUBQUERIES = 4
+
+# Default token budget hint surfaced on every plan.  Matches the
+# packer's default so plan-aware code paths receive a value that
+# pack_context can use without falling back.
+_DEFAULT_BUDGET_TOKENS = 4_000
+
+# Cue phrases used by the intent classifier.  Keeping them as module
+# constants makes the heuristic auditable; tuning a single rule
+# means editing one tuple, not chasing branches.
+_INTENT_CUES: tuple[tuple[Intent, tuple[str, ...]], ...] = (
+    # Contradictions / change of mind - check first so a query that
+    # also says "decision" still routes to contradiction_check.
+    (
+        "contradiction_check",
+        (
+            "change our mind",
+            "changed our mind",
+            "contradict",
+            "still true",
+            "rule out",
+            "did we ever rule",
+            "was it ever true",
+            "did we reverse",
+        ),
+    ),
+    # Multi-hop - "earlier X caused later Y" shape.  Checked before
+    # decision_trace because the question superficially matches
+    # "caused" but its real shape is multi-hop reasoning.
+    (
+        "multi_hop",
+        (
+            "earlier decision",
+            "what caused later",
+            "which earlier",
+            "which decision caused",
+            "follow from",
+        ),
+    ),
+    # Decision trace - explanatory queries about reversals or causes.
+    (
+        "decision_trace",
+        (
+            "why did",
+            "what caused",
+            "what led to",
+            "ended up",
+            "decision",
+            "decided",
+        ),
+    ),
+    # Source / citation lookup.
+    (
+        "source_lookup",
+        (
+            "where did",
+            "where does",
+            "source",
+            "citation",
+            "cite",
+            "evidence for",
+        ),
+    ),
+    # Broad timeline.
+    (
+        "broad_timeline",
+        (
+            "last week",
+            "this week",
+            "this month",
+            "last month",
+            "yesterday",
+            "today",
+            "earlier",
+            "when did",
+            "timeline",
+            "history",
+        ),
+    ),
+    # Exact-fact cues are the catch-all for pinpoint phrasing.
+    (
+        "exact_fact",
+        (
+            "what exact",
+            "exact",
+            "exactly",
+            "model id",
+            "filename",
+            "command",
+            "error",
+            "stack trace",
+        ),
+    ),
+)
+
+# Per-intent retrieval-mode recipes.  ``hybrid`` is the default
+# leg for broad/multi-hop intents; ``grep`` + ``lexical`` cover
+# pinpoint asks; ``summary_walk`` is reserved for decision-trace
+# style questions that need to walk every leaf summary.
+_INTENT_MODES: dict[Intent, list[RetrievalMode]] = {
+    "exact_fact": ["grep", "lexical"],
+    "source_lookup": ["lexical", "hybrid"],
+    "broad_timeline": ["summary_walk", "hybrid"],
+    "decision_trace": ["summary_walk", "hybrid"],
+    "multi_hop": ["hybrid", "summary_walk"],
+    "contradiction_check": ["hybrid", "summary_walk"],
+    "unknown_or_unanswerable": ["lexical"],
+}
+
+_INTENT_PACKING: dict[Intent, PackingHint] = {
+    "exact_fact": "source_first",
+    "source_lookup": "source_first",
+    "broad_timeline": "timeline",
+    "decision_trace": "summary_first",
+    "multi_hop": "summary_first",
+    "contradiction_check": "summary_first",
+    "unknown_or_unanswerable": "fresh_tail",
+}
+
+_INTENT_CITATION: dict[Intent, CitationRequirement] = {
+    "exact_fact": "preferred",
+    "source_lookup": "required",
+    "broad_timeline": "preferred",
+    "decision_trace": "required",
+    "multi_hop": "required",
+    "contradiction_check": "preferred",
+    "unknown_or_unanswerable": "none",
+}
+
+_TIME_HINT_PATTERNS = (
+    "today",
+    "yesterday",
+    "this week",
+    "last week",
+    "this month",
+    "last month",
+    "earlier",
+    "later",
+    "before",
+    "after",
+)
+
+_STOPWORDS = frozenset(
+    {
+        "what",
+        "which",
+        "when",
+        "where",
+        "who",
+        "why",
+        "how",
+        "did",
+        "does",
+        "have",
+        "had",
+        "the",
+        "and",
+        "for",
+        "from",
+        "with",
+        "that",
+        "this",
+        "into",
+        "about",
+        "would",
+        "should",
+        "could",
+        "ever",
+        "still",
+    }
+)
+
+
+def _normalise(text: str) -> str:
+    """Trim + collapse whitespace + drop trailing punctuation."""
+    body = " ".join((text or "").split()).strip()
+    return body.rstrip("?.,!")
+
+
+def _classify_intent(question: str) -> Intent:
+    """Walk the cue table and pick the first matching intent."""
+    lowered = question.lower()
+    for intent, cues in _INTENT_CUES:
+        if any(cue in lowered for cue in cues):
+            return intent
+    return "exact_fact"
+
+
+def _extract_time_hints(question: str) -> list[str]:
+    """Pull any of the recognised relative time phrases out of the question."""
+    lowered = question.lower()
+    return [phrase for phrase in _TIME_HINT_PATTERNS if phrase in lowered]
+
+
+def _extract_entity_hints(question: str) -> list[str]:
+    """Pull capitalised tokens + hyphenated identifiers as entity-style hints."""
+    pascal = re.findall(r"\b[A-Z][a-zA-Z0-9]+\b", question)
+    hyphenated = re.findall(r"\b[a-z]+(?:-[a-z0-9]+)+\b", question)
+    seen: set[str] = set()
+    out: list[str] = []
+    for hint in (*pascal, *hyphenated):
+        if hint.lower() in _STOPWORDS:
+            continue
+        if hint not in seen:
+            seen.add(hint)
+            out.append(hint)
+    return out
+
+
+def _split_subqueries(question: str, intent: Intent) -> list[str]:
+    """Bounded subquery list for the planner output.
+
+    For pinpoint intents we keep the question as-is so retrieval
+    hits the exact phrase.  Broad / decision-trace intents split on
+    conjunctions so the agent can fan out to bounded sub-questions.
+    """
+    base = _normalise(question)
+    if not base:
+        return []
+    if intent in ("exact_fact", "source_lookup"):
+        return [base][:_MAX_SUBQUERIES]
+    parts = [p.strip() for p in re.split(r"\s+(?:and|or)\s+|;|,|/", base) if p.strip()]
+    if not parts:
+        return [base][:_MAX_SUBQUERIES]
+    return parts[:_MAX_SUBQUERIES]
+
+
+def _looks_unanswerable(question: str, intent: Intent) -> bool:
+    """Catch obvious "we never discussed this" framings."""
+    lowered = question.lower()
+    refusal_cues = (
+        "did we ever discuss",
+        "did we mention",
+        "was there ever",
+        "anything about",
+    )
+    if intent == "contradiction_check":
+        return False
+    return any(cue in lowered for cue in refusal_cues)
+
+
+def plan_query(question: str, *, context: str | None = None) -> LCMQueryPlan:
+    """Classify the user's recall query and return a structured plan.
+
+    Args:
+        question: The user's raw question.
+        context: Optional adjacent context (recent assistant prose,
+            current draft, etc.).  Surfaced in diagnostics; future
+            iterations may use it for entity hint enrichment.
+
+    Returns:
+        A populated :class:`LCMQueryPlan`.
+    """
+    normalised = _normalise(question)
+    intent = _classify_intent(question)
+    if _looks_unanswerable(question, intent):
+        intent = "unknown_or_unanswerable"
+    subqueries = _split_subqueries(question, intent)
+    time_hints = _extract_time_hints(question)
+    entity_hints = _extract_entity_hints(question)
+    diagnostics: dict[str, object] = {
+        "raw_question_length": len(question or ""),
+        "context_provided": context is not None,
+        "subqueries_capped_at": _MAX_SUBQUERIES,
+    }
+    return LCMQueryPlan(
+        intent=intent,
+        normalized_question=normalised,
+        subqueries=subqueries,
+        retrieval_modes=list(_INTENT_MODES.get(intent, ["lexical"])),
+        time_hints=time_hints,
+        entity_hints=entity_hints,
+        packing_hint=_INTENT_PACKING.get(intent, "summary_first"),
+        citation_requirement=_INTENT_CITATION.get(intent, "preferred"),
+        max_budget_tokens=_DEFAULT_BUDGET_TOKENS,
+        diagnostics=diagnostics,
+    )

--- a/backend/app/core/lcm/planner.py
+++ b/backend/app/core/lcm/planner.py
@@ -35,6 +35,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.core.tools.lcm_search import LCM_STOPWORDS
+
 Intent = Literal[
     "exact_fact",
     "source_lookup",
@@ -228,35 +230,11 @@ _TIME_HINT_PATTERNS = (
     "after",
 )
 
-_STOPWORDS = frozenset(
-    {
-        "what",
-        "which",
-        "when",
-        "where",
-        "who",
-        "why",
-        "how",
-        "did",
-        "does",
-        "have",
-        "had",
-        "the",
-        "and",
-        "for",
-        "from",
-        "with",
-        "that",
-        "this",
-        "into",
-        "about",
-        "would",
-        "should",
-        "could",
-        "ever",
-        "still",
-    }
-)
+# Reuse the retrieval-stack stopword set so the planner tokenises
+# identically to ``lcm_search`` and the eval harness.  Diverging
+# lists caused inconsistent extraction between layers (Greptile P2
+# review).
+_STOPWORDS = LCM_STOPWORDS
 
 
 def _normalise(text: str) -> str:

--- a/backend/app/core/tools/lcm_agents.py
+++ b/backend/app/core/tools/lcm_agents.py
@@ -1,6 +1,6 @@
 """Aggregator for LCM-history agent tool factories.
 
-The four LCM tool factories live in their own modules so each one is
+The five LCM tool factories live in their own modules so each one is
 small and individually testable. The composer in ``agent_tools.py``
 imports them through this single module to keep its fan-out under
 sentrux's ``no_god_files`` threshold (15) — without this aggregator,
@@ -15,10 +15,12 @@ from app.core.tools.lcm_describe_agent import (
 )
 from app.core.tools.lcm_expand_query_agent import make_lcm_expand_query_tool
 from app.core.tools.lcm_grep_agent import make_lcm_grep_tool
+from app.core.tools.lcm_search_agent import make_lcm_search_tool
 
 __all__ = [
     "make_lcm_describe_tool",
     "make_lcm_expand_query_tool",
     "make_lcm_grep_tool",
     "make_lcm_list_summaries_tool",
+    "make_lcm_search_tool",
 ]

--- a/backend/app/core/tools/lcm_search.py
+++ b/backend/app/core/tools/lcm_search.py
@@ -88,10 +88,15 @@ _COVERAGE_BONUS_PER_EXTRA_TOKEN = 0.25
 # to read; the saturation effect we want shows up by ~3 hits.
 _TF_SATURATION = 3
 
-# Stopwords intentionally narrow.  Removing common English filler
-# words keeps the scorer signal high; keeping the list small avoids
-# stripping useful domain terms that happen to be everyday English.
-_STOPWORDS = frozenset(
+# Stopwords shared across the LCM retrieval stack
+# (``lcm_search``, ``planner``, ``evals``).  Removing common English
+# filler keeps the scorer signal high; keeping the list narrow avoids
+# stripping useful domain terms.  Exported as ``LCM_STOPWORDS`` so
+# the planner + eval harness use the *same* set as the retrieval
+# scorer - otherwise the modules tokenise inconsistently and the
+# eval harness measures a different surface than retrieval sees
+# (Greptile P2 review).
+LCM_STOPWORDS: frozenset[str] = frozenset(
     {
         "the",
         "and",
@@ -137,8 +142,14 @@ _STOPWORDS = frozenset(
         "not",
         "yes",
         "yet",
+        "ever",
+        "still",
+        "decide",
+        "decided",
+        "decision",
     }
 )
+_STOPWORDS = LCM_STOPWORDS  # module-local alias retained for clarity
 
 
 SearchItemKind = Literal["message", "summary"]

--- a/backend/app/core/tools/lcm_search.py
+++ b/backend/app/core/tools/lcm_search.py
@@ -1,0 +1,447 @@
+"""LCM ranked lexical search (issue #253).
+
+``lcm_grep`` is a faithful substring tracer-bullet.  It misses any
+recall where the source text and the user's question share *meaning*
+but not exact tokens.  This module adds the second layer: a ranked
+lexical retrieval primitive that returns scored candidates spanning
+raw messages and summary nodes.
+
+Why pure-Python scoring rather than Postgres FTS:
+
+* The test suite uses SQLite-in-memory and there is no portable
+  ``ts_vector`` story across SQLite + Postgres; we keep production +
+  test parity by computing the ranking in application code over a
+  coarse ``ILIKE`` candidate slice.  The ranking is explicit,
+  inspectable, and easy to evolve toward a real FTS index later —
+  the public ``LCMSearchResult`` shape will not change when that
+  upgrade lands.
+* The scorer is deterministic.  That matters for evals (issue #252):
+  result ordering is reproducible without seeding randomness.
+
+The scorer is a small term-frequency + coverage formula:
+
+* Drop short tokens and a tight English stopword list from the query.
+* Fetch every row that contains at least one query token (single
+  ``ILIKE`` per token, union semantics).
+* For each candidate, count how many tokens hit and how often.
+* Score = ``(total_term_hits / sqrt(content_len)) * (1 + coverage_bonus) * source_weight``
+* Summaries get a small source-weight bump because a hit inside a
+  compacted summary covers more original conversation surface than
+  one inside a raw turn.
+* Recency / ordinal is a stable tie-breaker.
+
+This is not BM25 — it is BM25's older cousin.  It is enough to beat
+substring grep at paraphrased recall while staying explainable in a
+single read.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import uuid
+from collections.abc import Iterable, Sequence
+from typing import Literal, TypedDict
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChatMessage, LCMSummary
+
+# Limits exposed via the tool schema.  Keep the defaults tight so a
+# greedy agent does not blow context.  ``_MAX_LIMIT`` matches the
+# upper bound in the JSON-schema parameter declaration.
+_DEFAULT_LIMIT = 8
+_MAX_LIMIT = 20
+
+# Hard cap on the number of rows we score per source kind.  A coarse
+# substring filter is cheap, but scoring is O(rows * tokens) — this
+# guards against pathological queries on huge conversations.
+_CANDIDATE_FETCH_CAP = 200
+
+# Excerpt window in characters surrounding the highest-scoring token
+# hit.  Wide enough to make the result actionable, narrow enough to
+# keep the tool response token-efficient.
+_EXCERPT_CHARS = 320
+
+# Minimum token length the scorer considers.  One- and two-letter
+# tokens hit too much noise (``a``, ``of``, ``is`` etc.).
+_MIN_TOKEN_LEN = 3
+
+# Multiplicative weight applied to summary scores so an equivalent
+# token hit in a summary edges out one in a raw turn — summaries
+# concentrate compacted history that grep would miss entirely.
+_SUMMARY_SOURCE_WEIGHT = 1.2
+_MESSAGE_SOURCE_WEIGHT = 1.0
+
+# Coverage bonus added per *additional* unique query token that hits
+# a candidate (the first hit gets no bonus).  Mild on purpose: we
+# want multi-term matches to win over single-term spam but not so
+# heavily that a partial paraphrase loses to a single-token plant.
+_COVERAGE_BONUS_PER_EXTRA_TOKEN = 0.25
+
+# Per-token TF saturation cap.  Without this, a row that repeats a
+# single token N times can outrank a row that hits every term in
+# the query once - that is the failure mode that motivated BM25's
+# tf-saturation curve.  We use a hard cap rather than the BM25
+# saturation formula because the scorer is deliberately small + easy
+# to read; the saturation effect we want shows up by ~3 hits.
+_TF_SATURATION = 3
+
+# Stopwords intentionally narrow.  Removing common English filler
+# words keeps the scorer signal high; keeping the list small avoids
+# stripping useful domain terms that happen to be everyday English.
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "from",
+        "with",
+        "that",
+        "this",
+        "into",
+        "about",
+        "would",
+        "should",
+        "could",
+        "have",
+        "has",
+        "had",
+        "does",
+        "did",
+        "what",
+        "which",
+        "when",
+        "where",
+        "who",
+        "why",
+        "how",
+        "are",
+        "was",
+        "were",
+        "been",
+        "you",
+        "your",
+        "our",
+        "their",
+        "his",
+        "her",
+        "its",
+        "they",
+        "them",
+        "any",
+        "all",
+        "some",
+        "but",
+        "not",
+        "yes",
+        "yet",
+    }
+)
+
+
+SearchItemKind = Literal["message", "summary"]
+
+
+class LCMSearchResult(TypedDict):
+    """One scored hit from :func:`lcm_search`."""
+
+    item_kind: SearchItemKind
+    item_id: str
+    ordinal: int | None
+    role: str | None
+    summary_depth: int | None
+    summary_kind: str | None
+    score: float
+    excerpt: str
+    source_ids: list[str]
+
+
+def _tokenize_query(query: str) -> list[str]:
+    """Lowercase, drop stopwords, dedupe — yields the query terms used for scoring."""
+    raw = re.findall(r"[a-zA-Z][a-zA-Z0-9\-]+", query.lower())
+    seen: set[str] = set()
+    out: list[str] = []
+    for token in raw:
+        if len(token) < _MIN_TOKEN_LEN:
+            continue
+        if token in _STOPWORDS:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out
+
+
+def _excerpt_around(text: str, tokens: Sequence[str]) -> str:
+    """Return a substring of ``text`` around the first token hit."""
+    body = text or ""
+    if not body:
+        return ""
+    lowered = body.lower()
+    earliest = len(body)
+    for token in tokens:
+        pos = lowered.find(token)
+        if pos != -1 and pos < earliest:
+            earliest = pos
+    if earliest == len(body):
+        return body[:_EXCERPT_CHARS] + ("…" if len(body) > _EXCERPT_CHARS else "")
+    half = _EXCERPT_CHARS // 2
+    start = max(0, earliest - half)
+    end = min(len(body), earliest + half)
+    if start == 0:
+        end = min(len(body), _EXCERPT_CHARS)
+    if end == len(body):
+        start = max(0, len(body) - _EXCERPT_CHARS)
+    snippet = body[start:end]
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(body):
+        snippet = snippet + "…"
+    return snippet
+
+
+def _score(
+    content: str,
+    tokens: Sequence[str],
+    *,
+    source_weight: float,
+) -> tuple[float, int]:
+    """Score one candidate.  Returns ``(score, hit_count)``.
+
+    The TF contribution per token is saturated at ``_TF_SATURATION``
+    so a row that repeats a single query token cannot drown a row
+    that hits multiple distinct tokens once each (which is the
+    motivating failure for issue #253 - paraphrased multi-term
+    recall must beat a single-token plant).
+    """
+    body = (content or "").lower()
+    if not body:
+        return 0.0, 0
+    contribution_total = 0.0
+    distinct_hits = 0
+    total_hits = 0
+    for token in tokens:
+        if not token:
+            continue
+        # ``str.count`` returns non-overlapping count, which is what
+        # we want for term-frequency-style scoring.
+        hits = body.count(token)
+        if hits == 0:
+            continue
+        distinct_hits += 1
+        total_hits += hits
+        contribution_total += min(hits, _TF_SATURATION)
+    if contribution_total == 0.0:
+        return 0.0, 0
+    coverage_bonus = max(0, distinct_hits - 1) * _COVERAGE_BONUS_PER_EXTRA_TOKEN
+    length_norm = math.sqrt(max(len(body), 1))
+    raw = contribution_total / length_norm
+    return raw * (1.0 + coverage_bonus) * source_weight, total_hits
+
+
+def _normalise_limit(limit: int | None) -> int:
+    """Clamp ``limit`` to the safe range; falls back to the default when missing."""
+    if limit is None:
+        return _DEFAULT_LIMIT
+    return max(1, min(_MAX_LIMIT, int(limit)))
+
+
+async def _fetch_message_candidates(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    tokens: Sequence[str],
+) -> list[ChatMessage]:
+    """Coarse ILIKE-OR filter: rows that contain *at least one* query token."""
+    if not tokens:
+        return []
+    clauses = [ChatMessage.content.ilike(f"%{token}%") for token in tokens]
+    result = await session.execute(
+        select(ChatMessage)
+        .where(
+            ChatMessage.conversation_id == conversation_id,
+            ChatMessage.role.in_(["user", "assistant"]),
+            or_(*clauses),
+        )
+        .order_by(ChatMessage.ordinal.desc())
+        .limit(_CANDIDATE_FETCH_CAP)
+    )
+    return list(result.scalars().all())
+
+
+async def _fetch_summary_candidates(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    tokens: Sequence[str],
+) -> list[LCMSummary]:
+    """Coarse ILIKE-OR filter for summary rows."""
+    if not tokens:
+        return []
+    clauses = [LCMSummary.content.ilike(f"%{token}%") for token in tokens]
+    result = await session.execute(
+        select(LCMSummary)
+        .where(
+            LCMSummary.conversation_id == conversation_id,
+            or_(*clauses),
+        )
+        .order_by(LCMSummary.created_at.desc())
+        .limit(_CANDIDATE_FETCH_CAP)
+    )
+    return list(result.scalars().all())
+
+
+def _build_message_result(
+    msg: ChatMessage,
+    *,
+    tokens: Sequence[str],
+    score: float,
+) -> LCMSearchResult:
+    """Wrap a scored message row as the public result shape."""
+    return LCMSearchResult(
+        item_kind="message",
+        item_id=str(msg.id),
+        ordinal=msg.ordinal,
+        role=msg.role,
+        summary_depth=None,
+        summary_kind=None,
+        score=round(score, 6),
+        excerpt=_excerpt_around(msg.content or "", tokens),
+        source_ids=[str(msg.id)],
+    )
+
+
+def _build_summary_result(
+    summary: LCMSummary,
+    *,
+    tokens: Sequence[str],
+    score: float,
+) -> LCMSearchResult:
+    """Wrap a scored summary row as the public result shape."""
+    return LCMSearchResult(
+        item_kind="summary",
+        item_id=str(summary.id),
+        ordinal=None,
+        role=None,
+        summary_depth=summary.depth,
+        summary_kind=summary.summary_kind,
+        score=round(score, 6),
+        excerpt=_excerpt_around(summary.content or "", tokens),
+        source_ids=[str(summary.id)],
+    )
+
+
+def _ranked_messages(
+    rows: Iterable[ChatMessage],
+    *,
+    tokens: Sequence[str],
+) -> list[LCMSearchResult]:
+    """Score every message candidate and return the ones with non-zero hits."""
+    results: list[LCMSearchResult] = []
+    for row in rows:
+        score, hits = _score(row.content or "", tokens, source_weight=_MESSAGE_SOURCE_WEIGHT)
+        if hits == 0:
+            continue
+        results.append(_build_message_result(row, tokens=tokens, score=score))
+    return results
+
+
+def _ranked_summaries(
+    rows: Iterable[LCMSummary],
+    *,
+    tokens: Sequence[str],
+) -> list[LCMSearchResult]:
+    """Score every summary candidate and return the ones with non-zero hits."""
+    results: list[LCMSearchResult] = []
+    for row in rows:
+        score, hits = _score(row.content or "", tokens, source_weight=_SUMMARY_SOURCE_WEIGHT)
+        if hits == 0:
+            continue
+        results.append(_build_summary_result(row, tokens=tokens, score=score))
+    return results
+
+
+async def lcm_search(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    query: str,
+    limit: int | None = None,
+    include_messages: bool = True,
+    include_summaries: bool = True,
+) -> list[LCMSearchResult]:
+    """Run ranked lexical search over a conversation's messages + summaries.
+
+    Args:
+        session: Open async database session.
+        conversation_id: Conversation whose history is in scope.
+        query: User-supplied query string.
+        limit: Cap on the number of results returned.  Clamped to
+            ``_MAX_LIMIT``; falls back to ``_DEFAULT_LIMIT`` when
+            unset or non-positive.
+        include_messages: Include scored raw messages in the result.
+        include_summaries: Include scored summary nodes in the result.
+
+    Returns:
+        A list of :class:`LCMSearchResult` ordered by score descending.
+        Empty when the query is empty, when no tokens survive
+        normalisation, or when nothing scored above zero.
+    """
+    tokens = _tokenize_query(query)
+    if not tokens:
+        return []
+
+    capped = _normalise_limit(limit)
+
+    messages: list[ChatMessage] = []
+    if include_messages:
+        messages = await _fetch_message_candidates(
+            session, conversation_id=conversation_id, tokens=tokens
+        )
+    summaries: list[LCMSummary] = []
+    if include_summaries:
+        summaries = await _fetch_summary_candidates(
+            session, conversation_id=conversation_id, tokens=tokens
+        )
+
+    scored: list[LCMSearchResult] = _ranked_messages(messages, tokens=tokens)
+    scored.extend(_ranked_summaries(summaries, tokens=tokens))
+
+    # Recency / ordinal tie-breaker: higher score first, then most
+    # recent ordinal/depth first (depth ascending — leaves first).
+    scored.sort(
+        key=lambda r: (
+            -r["score"],
+            -(r["ordinal"] or 0),
+            r["summary_depth"] or 0,
+        )
+    )
+    return scored[:capped]
+
+
+def format_results(query: str, results: Sequence[LCMSearchResult]) -> str:
+    """Render search results as the compact text block the agent receives."""
+    if not results:
+        return f"lcm_search: no ranked matches for {query!r}"
+    lines: list[str] = [
+        f"lcm_search: {len(results)} result(s) for {query!r}",
+    ]
+    for index, result in enumerate(results, start=1):
+        meta = _format_result_metadata(result)
+        lines.append(f"\n[{index}] score={result['score']:.3f} {meta}\n{result['excerpt']}")
+    return "\n".join(lines)
+
+
+def _format_result_metadata(result: LCMSearchResult) -> str:
+    """One-liner metadata header for a scored result."""
+    if result["item_kind"] == "message":
+        return (
+            f"kind=message role={result['role']} ordinal={result['ordinal']} id={result['item_id']}"
+        )
+    return (
+        f"kind=summary depth={result['summary_depth']} "
+        f"summary_kind={result['summary_kind']} id={result['item_id']}"
+    )

--- a/backend/app/core/tools/lcm_search_agent.py
+++ b/backend/app/core/tools/lcm_search_agent.py
@@ -1,0 +1,107 @@
+"""Agent-loop adapter for the ranked LCM search tool (issue #253).
+
+Mirrors the lcm_grep adapter shape so the chat router can wire both
+tools the same way.  The backing search lives in
+:mod:`app.core.tools.lcm_search`; this module only owns the JSON
+schema and the thin async wrapper the agent loop calls.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.lcm_search import (
+    _DEFAULT_LIMIT,
+    _MAX_LIMIT,
+    format_results,
+    lcm_search,
+)
+from app.db import async_session_maker
+
+_TOOL_NAME = "lcm_search"
+
+_TOOL_DESCRIPTION = (
+    "Run ranked lexical search over this conversation's full history,"
+    " including compacted summaries.  Returns scored excerpts with"
+    " item kind (message vs summary), ordinal/role for raw messages,"
+    " summary depth/kind for summary nodes, and a stable score so"
+    " callers can rank further.  Use this when lcm_grep's substring"
+    " match would miss relevant context because the user's wording"
+    " does not match the original phrasing exactly.  Results are"
+    " ordered by score descending."
+)
+
+_PARAMETERS: dict = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Question or keyword phrase.  The scorer tokenises this,"
+                " drops stopwords + tokens shorter than 3 characters,"
+                " then ranks candidates by term frequency, multi-token"
+                " coverage, and length-normalisation."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"Maximum number of ranked results to return."
+                f"  Defaults to {_DEFAULT_LIMIT}, capped at {_MAX_LIMIT}."
+            ),
+            "default": _DEFAULT_LIMIT,
+            "minimum": 1,
+            "maximum": _MAX_LIMIT,
+        },
+        "include_messages": {
+            "type": "boolean",
+            "description": "Include raw chat messages in the ranked set.",
+            "default": True,
+        },
+        "include_summaries": {
+            "type": "boolean",
+            "description": "Include LCM summary nodes in the ranked set.",
+            "default": True,
+        },
+    },
+    "required": ["query"],
+}
+
+
+def make_lcm_search_tool(*, conversation_id: uuid.UUID) -> AgentTool:
+    """Return an :class:`AgentTool` wrapping the ranked LCM search.
+
+    The tool opens its own database session per call so it is
+    independent of the request-scoped session.  ``conversation_id``
+    is baked into the closure at construction so the agent cannot
+    search across other users' conversations.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        query = str(kwargs.get("query") or "")
+        limit_raw = kwargs.get("limit")
+        try:
+            limit_val: int | None = int(limit_raw) if limit_raw is not None else None
+        except (TypeError, ValueError):
+            limit_val = None
+        include_messages = bool(kwargs.get("include_messages", True))
+        include_summaries = bool(kwargs.get("include_summaries", True))
+
+        async with async_session_maker() as session:
+            results = await lcm_search(
+                session,
+                conversation_id=conversation_id,
+                query=query,
+                limit=limit_val,
+                include_messages=include_messages,
+                include_summaries=include_summaries,
+            )
+        return format_results(query, results)
+
+    return AgentTool(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        parameters=_PARAMETERS,
+        execute=_execute,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -397,6 +397,57 @@ class LCMContextItem(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
 
 
+class LCMEmbedding(Base):
+    """Vector index entry for a single LCM-searchable item.
+
+    Issue #254 (hybrid retrieval) needs a place to store one embedding
+    per ``ChatMessage`` or ``LCMSummary`` so semantic search can run
+    alongside the lexical scorer.  We keep the vectors as JSON arrays
+    rather than introducing a pgvector dependency; that decision is
+    documented in the issue and revisitable if production workloads
+    demand it.  The ``content_hash`` column lets ingest skip
+    re-embedding unchanged content; the ``UniqueConstraint`` ensures
+    we only ever have one embedding per ``(conversation_id, item_kind,
+    item_id, embedding_model)`` tuple.
+    """
+
+    __tablename__ = "lcm_embeddings"
+    __table_args__ = (
+        UniqueConstraint(
+            "conversation_id",
+            "item_kind",
+            "item_id",
+            "embedding_model",
+            name="uq_lcm_embeddings_conv_kind_item_model",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # "message" | "summary" - mirrors LCMContextItem.item_kind so a
+    # search hit can be joined back to either source table.
+    item_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    item_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    # Identifier of the embedding provider that produced this vector.
+    # Stored so a future migration to a stronger model can re-embed
+    # in place without dropping the table.
+    embedding_model: Mapped[str] = mapped_column(String(128), nullable=False)
+    # The embedding itself - stored as a JSON array of floats.  Length
+    # is fixed per ``embedding_model`` but the database does not
+    # enforce that; the ingest pipeline checks it.
+    embedding: Mapped[list[float]] = mapped_column(JSON, nullable=False, default=list)
+    # Content hash used to skip re-embedding when the underlying text
+    # has not changed.  SHA-256 hex digest of the embedded text.
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
 # ---------------------------------------------------------------------------
 # Governance + ops platform (PRs 01-12)
 #
@@ -471,6 +522,7 @@ __all__ = [
     "Conversation",
     "CostLedger",
     "LCMContextItem",
+    "LCMEmbedding",
     "LCMSummary",
     "LCMSummarySource",
     "McpServer",

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from app.api.cost import get_cost_router
 from app.api.exports import get_exports_router
 from app.api.health import get_health_router
 from app.api.heartbeat import get_heartbeat_router
+from app.api.lcm import get_lcm_router
 from app.api.mcp_servers import get_mcp_servers_router
 from app.api.models import get_models_router
 from app.api.oauth import get_oauth_router
@@ -215,6 +216,9 @@ def create_app() -> FastAPI:
     )
     fastapi_app.include_router(
         get_health_router(),
+    )
+    fastapi_app.include_router(
+        get_lcm_router(),
     )
 
     return fastapi_app

--- a/backend/tests/evals/__init__.py
+++ b/backend/tests/evals/__init__.py
@@ -1,0 +1,7 @@
+"""LCM retrieval eval fixtures + tests.
+
+This package is the home of the deterministic eval harness wired up
+by issue #252.  The scenarios live in :mod:`tests.evals.scenarios`,
+and :mod:`tests.evals.test_lcm_retrieval_eval` drives them via
+:mod:`app.core.lcm.evals`.
+"""

--- a/backend/tests/evals/scenarios.py
+++ b/backend/tests/evals/scenarios.py
@@ -1,0 +1,231 @@
+"""Seeded long-conversation eval scenarios for the LCM retrieval harness.
+
+Issue #252 requires at least six scenario *shapes* — pinpoint, broad,
+multi-hop, contradiction/change, source recall, and negative recall.
+Each scenario seeds enough turns to push the relevant fact *outside*
+the default fresh-tail window so the eval actually measures the
+retrieval/assembly layer rather than the trivial tail.
+
+These fixtures are intentionally small and prose-flat: the harness
+answerer is deterministic and only needs the target spans to be
+present somewhere in the seeded turns or summaries.  We are not
+training a model; we are measuring whether the right text reached
+the model's input.
+"""
+
+from __future__ import annotations
+
+from app.core.lcm.evals import LCMEvalScenario, SeedSummary
+
+# Padding turns are reused everywhere we need to push the target fact
+# beyond the fresh-tail window.  Distinct content per index keeps the
+# baseline mode from accidentally surfacing the target via collision.
+_PADDING_TOPICS = (
+    "discussed the colour of the homepage button",
+    "talked about adding a new copy edit pass to the marketing site",
+    "argued about whether dark mode should default on for new accounts",
+    "scoped the migration of the analytics pipeline to ClickHouse",
+    "estimated effort for the i18n string scrape across the dashboard",
+    "compared two competing icons for the workspace switcher",
+    "noted the latency regression on the documents tab last Tuesday",
+    "rehashed the SSO debate from the partnerships meeting",
+    "swept the dependabot PR queue in the mobile repo",
+    "tabled the question of whether to rename the Inbox screen",
+)
+
+
+def _padding(
+    count: int, *, role_cycle: tuple[str, ...] = ("user", "assistant")
+) -> list[dict[str, str]]:
+    """Return ``count`` padding turns alternating roles."""
+    turns: list[dict[str, str]] = []
+    for i in range(count):
+        role = role_cycle[i % len(role_cycle)]
+        topic = _PADDING_TOPICS[i % len(_PADDING_TOPICS)]
+        turns.append({"role": role, "content": f"Padding turn {i}: {topic}."})
+    return turns
+
+
+def _pinpoint_summary_model_scenario() -> LCMEvalScenario:
+    """Pinpoint: which exact model did we pick for summaries?"""
+    target_fact = (
+        "We decided that summary generation will use the "
+        "gemini-2.5-flash-preview-05-20 model for cost reasons."
+    )
+    turns: list[dict[str, str]] = [
+        {"role": "user", "content": "Pick a model for the summary compaction job."},
+        {"role": "assistant", "content": target_fact},
+        *_padding(10),
+        {"role": "user", "content": "Quick aside — should the inbox auto-archive?"},
+        {"role": "assistant", "content": "Let's defer that to next week."},
+    ]
+    return LCMEvalScenario(
+        id="pinpoint_summary_model",
+        intent="pinpoint",
+        question="What exact model did we decide to use for summaries?",
+        seed_turns=turns,
+        expected_fact_patterns=[r"gemini-2\.5-flash-preview-05-20"],
+        expected_source_substrings=["gemini-2.5-flash-preview-05-20"],
+        notes="Target fact is at ordinal 1; padding pushes it beyond a fresh-tail of 4.",
+    )
+
+
+def _broad_telegram_blockers_scenario() -> LCMEvalScenario:
+    """Broad: what did we decide about Telegram demo blockers?"""
+    target_fact = (
+        "Demo blocker list: (a) skip the login wall for demo mode, "
+        "(b) bypass the workspace-connect onboarding step, "
+        "(c) suppress the API-key banner."
+    )
+    turns: list[dict[str, str]] = [
+        {"role": "user", "content": "Let's pin down the Telegram demo blockers."},
+        {"role": "assistant", "content": target_fact},
+        *_padding(8),
+        {"role": "user", "content": "Switching topics — got the new pricing sheet?"},
+        {"role": "assistant", "content": "I'll send it over today."},
+    ]
+    return LCMEvalScenario(
+        id="broad_telegram_demo_blockers",
+        intent="broad",
+        question="What did we decide about the Telegram demo blockers?",
+        seed_turns=turns,
+        expected_fact_patterns=[r"workspace-connect", r"login wall"],
+        expected_source_substrings=["workspace-connect onboarding"],
+        notes=(
+            "Broad query — the target spans multiple sub-decisions in one assistant turn"
+            " outside the fresh tail."
+        ),
+    )
+
+
+def _multi_hop_onboarding_regression_scenario() -> LCMEvalScenario:
+    """Multi-hop: which earlier decision caused the later regression?"""
+    summary_prose = (
+        "Earlier in the discussion the team agreed to remove the workspace-connect"
+        " step from the onboarding flow so the Telegram demo would skip straight"
+        " into the chat surface."
+    )
+    turns: list[dict[str, str]] = [
+        {"role": "user", "content": "Quick recap on onboarding decisions."},
+        {"role": "assistant", "content": "Earlier we agreed to drop the workspace-connect step."},
+        {"role": "user", "content": "Cool, anything else?"},
+        {"role": "assistant", "content": "Padding-style note about copy edits."},
+        *_padding(6),
+        {
+            "role": "user",
+            "content": "Bug: new accounts have no default workspace after onboarding.",
+        },
+        {
+            "role": "assistant",
+            "content": ("Right — that follows from dropping the workspace-connect step earlier."),
+        },
+    ]
+    summary = SeedSummary(
+        content=summary_prose,
+        replaces_turn_indexes=[0, 1, 2, 3],
+    )
+    return LCMEvalScenario(
+        id="multi_hop_onboarding_regression",
+        intent="multi_hop",
+        question="Which earlier decision caused the missing-default-workspace bug?",
+        seed_turns=turns,
+        seed_summaries=[summary],
+        expected_fact_patterns=[r"workspace-connect", r"onboarding"],
+        expected_source_substrings=["workspace-connect step"],
+        notes=(
+            "The cause sits in a summary node and the symptom sits in a recent raw turn;"
+            " mode under test must surface both."
+        ),
+    )
+
+
+def _contradiction_inbox_archive_scenario() -> LCMEvalScenario:
+    """Contradiction/change: what did we change our mind about?"""
+    summary_prose = "Original position: inbox auto-archives messages older than seven days."
+    turns: list[dict[str, str]] = [
+        {"role": "user", "content": "Inbox archiving cadence?"},
+        {"role": "assistant", "content": "Auto-archive everything older than seven days."},
+        {"role": "user", "content": "Sticking with that?"},
+        {"role": "assistant", "content": "Yes, agreed for now."},
+        *_padding(6),
+        {"role": "user", "content": "Rethinking: enterprise users hate auto-archive."},
+        {
+            "role": "assistant",
+            "content": (
+                "Updated plan: disable auto-archive by default; users opt-in per workspace."
+            ),
+        },
+    ]
+    summary = SeedSummary(
+        content=summary_prose,
+        replaces_turn_indexes=[0, 1, 2, 3],
+    )
+    return LCMEvalScenario(
+        id="contradiction_inbox_archive",
+        intent="contradiction",
+        question="What did we change our mind about regarding inbox archiving?",
+        seed_turns=turns,
+        seed_summaries=[summary],
+        expected_fact_patterns=[
+            r"auto-archive",
+            r"disable auto-archive by default",
+        ],
+        expected_source_substrings=["auto-archive"],
+        notes=(
+            "Original stance lives in a summary; revised stance lives in the fresh tail."
+            " Mode under test must surface both for a complete contradiction trace."
+        ),
+    )
+
+
+def _source_recall_pricing_scenario() -> LCMEvalScenario:
+    """Source recall: where did this claim come from?"""
+    cited_fact = (
+        "Pricing tier breakpoint set at 25 active workspaces per team. "
+        "Source: workspaces-pricing-2026-Q2.md, section 'Tier ceilings'."
+    )
+    turns: list[dict[str, str]] = [
+        {"role": "user", "content": "Did we cite a doc for the 25-workspace breakpoint?"},
+        {"role": "assistant", "content": cited_fact},
+        *_padding(8),
+    ]
+    return LCMEvalScenario(
+        id="source_recall_pricing_breakpoint",
+        intent="source",
+        question="Where did the 25-workspace pricing breakpoint claim come from?",
+        seed_turns=turns,
+        expected_fact_patterns=[r"workspaces-pricing-2026-Q2\.md"],
+        expected_source_substrings=["workspaces-pricing-2026-Q2.md"],
+        notes="Citation lives in the assistant turn outside the fresh tail.",
+    )
+
+
+def _negative_recall_dns_scenario() -> LCMEvalScenario:
+    """Negative recall: a topic we never discussed."""
+    turns: list[dict[str, str]] = [
+        *_padding(10),
+        {"role": "user", "content": "Catch up complete; anything else for this week?"},
+        {"role": "assistant", "content": "Nothing else from my side."},
+    ]
+    return LCMEvalScenario(
+        id="negative_recall_dns_migration",
+        intent="negative",
+        question="What did we decide about migrating our DNS provider?",
+        seed_turns=turns,
+        expected_fact_patterns=[r"DNS provider"],  # absence-of-match is the pass.
+        expected_source_substrings=[],
+        expects_unanswerable=True,
+        notes="No turn discusses DNS — the agent must refuse rather than invent.",
+    )
+
+
+def all_scenarios() -> list[LCMEvalScenario]:
+    """Return every required scenario in stable order."""
+    return [
+        _pinpoint_summary_model_scenario(),
+        _broad_telegram_blockers_scenario(),
+        _multi_hop_onboarding_regression_scenario(),
+        _contradiction_inbox_archive_scenario(),
+        _source_recall_pricing_scenario(),
+        _negative_recall_dns_scenario(),
+    ]

--- a/backend/tests/evals/test_lcm_retrieval_eval.py
+++ b/backend/tests/evals/test_lcm_retrieval_eval.py
@@ -210,6 +210,27 @@ async def test_eval_matrix_runs_every_scenario_for_every_mode(
 
 
 @pytest.mark.anyio
+async def test_search_packed_mode_carries_pack_tool_in_trace(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """LCM_SEARCH_PACKED routes lcm_search results through the issue-#255 packer."""
+    scenario = next(s for s in all_scenarios() if s.id == "pinpoint_summary_model")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_SEARCH_PACKED,
+        fresh_tail_count=4,
+    )
+    assert "lcm_search" in result.tools_called
+    assert "pack_context" in result.tools_called
+    assert result.fact_pass is True
+
+
+@pytest.mark.anyio
 async def test_result_records_cost_and_latency_fields(
     db_session: AsyncSession, test_user: User
 ) -> None:

--- a/backend/tests/evals/test_lcm_retrieval_eval.py
+++ b/backend/tests/evals/test_lcm_retrieval_eval.py
@@ -1,0 +1,231 @@
+"""End-to-end tests for the LCM retrieval eval harness (issue #252).
+
+Drives :mod:`app.core.lcm.evals` over the seeded scenarios from
+:mod:`tests.evals.scenarios` in baseline / LCM-assembled / LCM-grep
+modes and asserts the harness reports the expected pass/fail
+distribution.
+
+These are *eval* tests rather than unit tests — they exercise the
+real retrieval/assembly code path through the production ORM.  They
+deliberately do not call any live LLM provider; the harness's
+deterministic answerer makes the suite CI-safe.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm.evals import (
+    LCMEvalMode,
+    LCMEvalResult,
+    run_eval,
+    run_eval_matrix,
+    seed_scenario,
+)
+from app.db import User
+from tests.evals.scenarios import all_scenarios
+
+
+def _result_for(
+    results: list[LCMEvalResult],
+    *,
+    scenario_id: str,
+    mode: LCMEvalMode,
+) -> LCMEvalResult:
+    """Pick one result out of a matrix run by ``(scenario, mode)``."""
+    for item in results:
+        if item.scenario_id == scenario_id and item.mode == mode.value:
+            return item
+    raise AssertionError(f"no result for {scenario_id} / {mode.value}")
+
+
+@pytest.mark.anyio
+async def test_at_least_six_scenarios_cover_required_intents() -> None:
+    scenarios = all_scenarios()
+    intents = {s.intent for s in scenarios}
+    assert len(scenarios) >= 6
+    assert intents == {
+        "pinpoint",
+        "broad",
+        "multi_hop",
+        "contradiction",
+        "source",
+        "negative",
+    }
+
+
+@pytest.mark.anyio
+async def test_seed_scenario_persists_turns_and_summaries(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "multi_hop_onboarding_regression")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    from sqlalchemy import select
+
+    from app.models import ChatMessage, LCMContextItem, LCMSummary
+
+    message_count = (
+        (
+            await db_session.execute(
+                select(ChatMessage).where(ChatMessage.conversation_id == conv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summary_count = (
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
+    item_count = (
+        (
+            await db_session.execute(
+                select(LCMContextItem).where(LCMContextItem.conversation_id == conv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(message_count) == len(scenario.seed_turns)
+    assert len(summary_count) == 1
+    # One context item per turn, minus the 4 collapsed into the summary, plus
+    # the one summary item itself.
+    assert len(item_count) == len(scenario.seed_turns) - 4 + 1
+
+
+@pytest.mark.anyio
+async def test_baseline_misses_facts_outside_fresh_tail(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The whole point: baseline tail mode loses facts outside the recent window."""
+    scenario = next(s for s in all_scenarios() if s.id == "pinpoint_summary_model")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.BASELINE,
+        fresh_tail_count=4,
+    )
+    assert result.fact_pass is False
+    assert result.source_pass is False
+    assert result.context_tokens > 0
+
+
+@pytest.mark.anyio
+async def test_lcm_assembled_surfaces_summary_node(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "multi_hop_onboarding_regression")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_ASSEMBLED,
+        fresh_tail_count=4,
+    )
+    # The summary preserves the workspace-connect decision so the
+    # multi-hop scenario is answerable under LCM_ASSEMBLED.
+    assert result.fact_pass is True
+    assert result.source_pass is True
+
+
+@pytest.mark.anyio
+async def test_lcm_grep_recovers_pinpoint_fact(db_session: AsyncSession, test_user: User) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "pinpoint_summary_model")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_GREP,
+        fresh_tail_count=4,
+    )
+    assert result.fact_pass is True
+    assert "lcm_grep" in result.tools_called
+
+
+@pytest.mark.anyio
+async def test_negative_scenario_refuses_to_answer(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "negative_recall_dns_migration")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_ASSEMBLED,
+        fresh_tail_count=4,
+    )
+    assert result.fact_pass is True  # well-behaved refusal
+    assert "history does not contain this" in result.answer
+
+
+@pytest.mark.anyio
+async def test_eval_matrix_runs_every_scenario_for_every_mode(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenarios = all_scenarios()
+    modes = [
+        LCMEvalMode.BASELINE,
+        LCMEvalMode.LCM_ASSEMBLED,
+        LCMEvalMode.LCM_GREP,
+    ]
+    results = await run_eval_matrix(
+        db_session,
+        user_id=test_user.id,
+        scenarios=scenarios,
+        modes=modes,
+        fresh_tail_count=4,
+    )
+    await db_session.commit()
+
+    assert len(results) == len(scenarios) * len(modes)
+    assert {r.scenario_id for r in results} == {s.id for s in scenarios}
+    assert {r.mode for r in results} == {m.value for m in modes}
+
+    # The headline claim of issue #252 — LCM-assembled mode wins on
+    # at least one scenario where baseline fails.  Concrete check:
+    # pinpoint summary model is unanswerable from the tail alone but
+    # answerable from any LCM-backed mode.
+    baseline = _result_for(results, scenario_id="pinpoint_summary_model", mode=LCMEvalMode.BASELINE)
+    grep = _result_for(results, scenario_id="pinpoint_summary_model", mode=LCMEvalMode.LCM_GREP)
+    assert baseline.fact_pass is False
+    assert grep.fact_pass is True
+
+
+@pytest.mark.anyio
+async def test_result_records_cost_and_latency_fields(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "source_recall_pricing_breakpoint")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_ASSEMBLED,
+        fresh_tail_count=4,
+    )
+
+    assert result.context_tokens > 0
+    assert result.context_chars > 0
+    assert result.latency_ms >= 0.0
+    assert result.output_tokens >= 0

--- a/backend/tests/test_lcm_embeddings.py
+++ b/backend/tests/test_lcm_embeddings.py
@@ -1,0 +1,414 @@
+"""Issue #254 - semantic retrieval + RRF blending tests.
+
+Covers ``app.core.lcm.embeddings``:
+
+- Deterministic hash embedder is stable across runs and gives
+  paraphrases similar (non-zero, > 0) cosine.
+- ``upsert_embedding`` skips empty content (acceptance criterion:
+  empty assistant placeholders are not embedded).
+- Content-hash skip path: re-embedding unchanged content does not
+  rewrite the row.
+- ``semantic_search`` returns ranked hits scoped to one conversation
+  with no cross-conversation leak.
+- ``reciprocal_rank_fusion`` blends lexical + semantic with explainable
+  component ranks/scores.
+- ``lcm_hybrid_search`` respects mode: lexical-only returns
+  ``lexical_rank`` populated and ``semantic_rank`` None; semantic-only
+  inverts it; hybrid surfaces both.
+- Eval harness mode comparison: a paraphrased query that lexical
+  alone misses is recoverable under hybrid retrieval on a seeded
+  scenario.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm.embeddings import (
+    EMBEDDING_DIM,
+    DeterministicHashEmbedder,
+    SemanticHit,
+    content_hash,
+    cosine_similarity,
+    lcm_hybrid_search,
+    reciprocal_rank_fusion,
+    semantic_search,
+    upsert_embedding,
+)
+from app.core.lcm.evals import (
+    LCMEvalMode,
+    run_eval,
+    seed_embeddings_for_conversation,
+    seed_scenario,
+)
+from app.core.tools.lcm_search import LCMSearchResult
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMEmbedding,
+    LCMSummary,
+)
+from tests.evals.scenarios import all_scenarios
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    """Insert a fresh conversation owned by ``user``."""
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="embeddings test",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    *,
+    content: str,
+    ordinal: int = 0,
+    role: str = "user",
+) -> ChatMessage:
+    """Insert one raw chat message at ``ordinal``."""
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+def test_deterministic_embedder_is_stable_across_runs() -> None:
+    e = DeterministicHashEmbedder()
+    text = "workspace-connect was dropped from onboarding"
+    a = e.embed(text)
+    b = e.embed(text)
+    assert a == b
+    assert len(a) == EMBEDDING_DIM
+
+
+def test_deterministic_embedder_similar_text_has_positive_similarity() -> None:
+    e = DeterministicHashEmbedder()
+    a = e.embed("workspace-connect was dropped from onboarding")
+    b = e.embed("we removed workspace-connect from the onboarding flow")
+    c = e.embed("entirely unrelated text about pricing and tiers")
+
+    sim_close = cosine_similarity(a, b)
+    sim_far = cosine_similarity(a, c)
+    assert sim_close > 0
+    assert sim_close > sim_far
+
+
+def test_content_hash_is_stable() -> None:
+    assert content_hash("hello world") == content_hash("hello world")
+    assert content_hash("hello world") != content_hash("hello world!")
+
+
+@pytest.mark.anyio
+async def test_upsert_embedding_skips_empty_content(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(db_session, test_user, conv, content="")
+    await db_session.commit()
+    row = await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content="",
+    )
+    assert row is None
+
+
+@pytest.mark.anyio
+async def test_upsert_embedding_skips_when_content_hash_unchanged(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(db_session, test_user, conv, content="hash skip path", ordinal=0)
+    await db_session.commit()
+
+    first = await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content="hash skip path",
+    )
+    assert first is not None
+    first_created = first.created_at
+    first_hash = first.content_hash
+
+    second = await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content="hash skip path",
+    )
+    assert second is not None
+    assert second.id == first.id
+    assert second.created_at == first_created
+    assert second.content_hash == first_hash
+
+
+@pytest.mark.anyio
+async def test_upsert_embedding_refreshes_when_content_changes(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(db_session, test_user, conv, content="first content")
+    await db_session.commit()
+
+    first = await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content="first content",
+    )
+    assert first is not None
+    first_hash = first.content_hash
+
+    second = await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content="second content - different now",
+    )
+    assert second is not None
+    assert second.id == first.id
+    assert second.content_hash != first_hash
+
+
+@pytest.mark.anyio
+async def test_semantic_search_returns_ranked_hits(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    target = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        content="we removed workspace-connect from onboarding to demo faster",
+        ordinal=0,
+    )
+    decoy = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        content="pricing tiers and active workspace caps for enterprise",
+        ordinal=1,
+    )
+    await db_session.commit()
+
+    for msg in (target, decoy):
+        await upsert_embedding(
+            db_session,
+            conversation_id=conv.id,
+            item_kind="message",
+            item_id=msg.id,
+            content=msg.content or "",
+        )
+    await db_session.commit()
+
+    hits = await semantic_search(
+        db_session,
+        conversation_id=conv.id,
+        query="dropped workspace-connect from the demo flow",
+        limit=5,
+    )
+    assert hits
+    assert hits[0].item_id == str(target.id)
+    assert all(hit.score > 0 for hit in hits)
+
+
+@pytest.mark.anyio
+async def test_semantic_search_isolates_conversations(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    target = await _make_message(
+        db_session, test_user, conv_b, content="leak target text", ordinal=0
+    )
+    await db_session.commit()
+    await upsert_embedding(
+        db_session,
+        conversation_id=conv_b.id,
+        item_kind="message",
+        item_id=target.id,
+        content=target.content or "",
+    )
+    await db_session.commit()
+
+    hits = await semantic_search(db_session, conversation_id=conv_a.id, query="leak target text")
+    assert hits == []
+
+
+def test_reciprocal_rank_fusion_blends_components() -> None:
+    lex: list[LCMSearchResult] = [
+        {
+            "item_kind": "message",
+            "item_id": "m1",
+            "ordinal": 0,
+            "role": "user",
+            "summary_depth": None,
+            "summary_kind": None,
+            "score": 0.5,
+            "excerpt": "lex hit",
+            "source_ids": ["m1"],
+        },
+        {
+            "item_kind": "summary",
+            "item_id": "s1",
+            "ordinal": None,
+            "role": None,
+            "summary_depth": 0,
+            "summary_kind": "normal",
+            "score": 0.4,
+            "excerpt": "summary hit",
+            "source_ids": ["s1"],
+        },
+    ]
+    sem: list[SemanticHit] = [
+        SemanticHit(item_kind="summary", item_id="s1", score=0.9, excerpt="summary", metadata={}),
+        SemanticHit(item_kind="message", item_id="m2", score=0.7, excerpt="m2", metadata={}),
+    ]
+    blended = reciprocal_rank_fusion(lexical=lex, semantic=sem)
+    by_id = {item["item_id"]: item for item in blended}
+
+    # s1 appears in both - higher final_score than m1 (lex only) or m2 (sem only).
+    assert by_id["s1"]["lexical_rank"] == 2
+    assert by_id["s1"]["semantic_rank"] == 1
+    assert by_id["s1"]["final_score"] > by_id["m1"]["final_score"]
+    assert by_id["s1"]["final_score"] > by_id["m2"]["final_score"]
+    # Items hit by only one leg keep the other component null.
+    assert by_id["m1"]["semantic_rank"] is None
+    assert by_id["m2"]["lexical_rank"] is None
+
+
+@pytest.mark.anyio
+async def test_hybrid_search_modes_select_component_legs(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(
+        db_session, test_user, conv, content="workspace-connect onboarding flow"
+    )
+    await db_session.commit()
+    await upsert_embedding(
+        db_session,
+        conversation_id=conv.id,
+        item_kind="message",
+        item_id=msg.id,
+        content=msg.content or "",
+    )
+    await db_session.commit()
+
+    lex_only = await lcm_hybrid_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+        mode="lexical",
+    )
+    sem_only = await lcm_hybrid_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+        mode="semantic",
+    )
+    hybrid = await lcm_hybrid_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+        mode="hybrid",
+    )
+
+    assert lex_only and lex_only[0]["semantic_rank"] is None
+    assert sem_only and sem_only[0]["lexical_rank"] is None
+    assert hybrid
+    # Hybrid result for this single-item conversation should have
+    # both legs populated.
+    assert hybrid[0]["lexical_rank"] is not None
+    assert hybrid[0]["semantic_rank"] is not None
+
+
+@pytest.mark.anyio
+async def test_seed_embeddings_writes_one_row_per_item(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    scenario = next(s for s in all_scenarios() if s.id == "pinpoint_summary_model")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await db_session.commit()
+
+    count = await seed_embeddings_for_conversation(db_session, conversation_id=conv.id)
+    await db_session.commit()
+    stored = (
+        (
+            await db_session.execute(
+                select(LCMEmbedding).where(LCMEmbedding.conversation_id == conv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    msg_count = len(
+        (
+            await db_session.execute(
+                select(ChatMessage).where(ChatMessage.conversation_id == conv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    summary_count = len(
+        (await db_session.execute(select(LCMSummary).where(LCMSummary.conversation_id == conv.id)))
+        .scalars()
+        .all()
+    )
+    assert count == msg_count + summary_count
+    assert len(stored) == msg_count + summary_count
+
+
+@pytest.mark.anyio
+async def test_hybrid_mode_recovers_pinpoint_fact_via_eval_harness(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Hybrid retrieval surfaces the pinpoint fact a paraphrased query would miss lexically."""
+    scenario = next(s for s in all_scenarios() if s.id == "pinpoint_summary_model")
+    conv = await seed_scenario(db_session, user_id=test_user.id, scenario=scenario)
+    await seed_embeddings_for_conversation(db_session, conversation_id=conv.id)
+    await db_session.commit()
+
+    result = await run_eval(
+        db_session,
+        conversation_id=conv.id,
+        scenario=scenario,
+        mode=LCMEvalMode.LCM_HYBRID,
+        fresh_tail_count=4,
+    )
+    assert result.fact_pass is True
+    assert {"lcm_search", "semantic_search"}.issubset(set(result.tools_called))

--- a/backend/tests/test_lcm_observe.py
+++ b/backend/tests/test_lcm_observe.py
@@ -1,0 +1,324 @@
+"""Issue #251 — LCM retrieval observability panel tests.
+
+Covers ``app.core.lcm.observe.describe_assembled_context`` and the
+``GET /api/v1/lcm/conversations/{id}/context`` route registered in
+``app.api.lcm``.  The behaviours nailed down here:
+
+- Empty conversation produces an empty, well-typed response.
+- Message-only context resolves each row with role + token estimate.
+- Mixed message + summary context distinguishes the two kinds and
+  surfaces summary depth/kind/source count.
+- Fresh-tail cap is applied to raw messages while every summary
+  survives — matching ``assemble_context()``'s read contract so the
+  panel cannot diverge from what the provider actually saw.
+- Conversation isolation: a different user / different conversation
+  cannot read this one's context.
+- Settings snapshot reflects ``settings.lcm_enabled``,
+  ``lcm_fresh_tail_count``, ``lcm_leaf_chunk_tokens``,
+  ``lcm_incremental_max_depth``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.lcm.observe import describe_assembled_context
+from app.db import User
+from app.models import (
+    ChatMessage,
+    Conversation,
+    LCMContextItem,
+    LCMSummary,
+    LCMSummarySource,
+)
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    """Insert a fresh conversation owned by ``user``."""
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="observe test",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    *,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    """Insert one raw chat message at ``ordinal``."""
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    *,
+    content: str,
+    depth: int = 0,
+    kind: str = "normal",
+) -> LCMSummary:
+    """Insert one LCM summary row."""
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=max(1, len(content) // 4),
+        summary_kind=kind,
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+async def _make_context_item(
+    session: AsyncSession,
+    conv: Conversation,
+    *,
+    ordinal: int,
+    item_kind: str,
+    item_id: uuid.UUID,
+) -> LCMContextItem:
+    """Insert one assembled-context row."""
+    row = LCMContextItem(
+        conversation_id=conv.id,
+        ordinal=ordinal,
+        item_kind=item_kind,
+        item_id=item_id,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+@pytest.mark.anyio
+async def test_describe_empty_returns_empty_payload(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+
+    response = await describe_assembled_context(
+        db_session,
+        conversation_id=conv.id,
+        fresh_tail_count=10,
+    )
+
+    assert response.conversation_id == conv.id
+    assert response.item_count == 0
+    assert response.message_count == 0
+    assert response.summary_count == 0
+    assert response.estimated_tokens == 0
+    assert response.items == []
+    assert response.settings.fresh_tail_count == 10
+
+
+@pytest.mark.anyio
+async def test_describe_message_only_context(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg_a = await _make_message(
+        db_session, test_user, conv, role="user", content="hello", ordinal=0
+    )
+    msg_b = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content="hi there",
+        ordinal=1,
+    )
+    await _make_context_item(db_session, conv, ordinal=0, item_kind="message", item_id=msg_a.id)
+    await _make_context_item(db_session, conv, ordinal=1, item_kind="message", item_id=msg_b.id)
+    await db_session.commit()
+
+    response = await describe_assembled_context(
+        db_session,
+        conversation_id=conv.id,
+        fresh_tail_count=10,
+    )
+
+    assert response.item_count == 2
+    assert response.message_count == 2
+    assert response.summary_count == 0
+    assert [r.item_kind for r in response.items] == ["message", "message"]
+    assert [r.role for r in response.items] == ["user", "assistant"]
+    assert response.items[0].preview == "hello"
+
+
+@pytest.mark.anyio
+async def test_describe_mixes_messages_and_summaries(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+
+    summary = await _make_summary(
+        db_session,
+        conv,
+        content="earlier discussion about deploys",
+        depth=0,
+        kind="normal",
+    )
+    # Two synthetic source edges so the panel can report source_count=2.
+    db_session.add(
+        LCMSummarySource(
+            summary_id=summary.id,
+            source_kind="message",
+            source_id=uuid.uuid4(),
+            source_ordinal=0,
+        )
+    )
+    db_session.add(
+        LCMSummarySource(
+            summary_id=summary.id,
+            source_kind="message",
+            source_id=uuid.uuid4(),
+            source_ordinal=1,
+        )
+    )
+    msg = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="user",
+        content="and then we picked the new region",
+        ordinal=5,
+    )
+
+    await _make_context_item(db_session, conv, ordinal=0, item_kind="summary", item_id=summary.id)
+    await _make_context_item(db_session, conv, ordinal=1, item_kind="message", item_id=msg.id)
+    await db_session.commit()
+
+    response = await describe_assembled_context(
+        db_session,
+        conversation_id=conv.id,
+        fresh_tail_count=10,
+    )
+
+    assert response.item_count == 2
+    assert response.message_count == 1
+    assert response.summary_count == 1
+    summary_row = response.items[0]
+    assert summary_row.item_kind == "summary"
+    assert summary_row.summary_depth == 0
+    assert summary_row.summary_kind == "normal"
+    assert summary_row.source_count == 2
+    assert summary_row.token_count is not None and summary_row.token_count > 0
+
+
+@pytest.mark.anyio
+async def test_describe_caps_raw_messages_but_keeps_summaries(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The fresh-tail cap drops oldest raw messages but every summary survives."""
+    conv = await _make_conversation(db_session, test_user)
+    summary = await _make_summary(db_session, conv, content="condensed window")
+    await _make_context_item(db_session, conv, ordinal=0, item_kind="summary", item_id=summary.id)
+    msg_ids: list[uuid.UUID] = []
+    for ordinal in range(1, 6):
+        m = await _make_message(
+            db_session,
+            test_user,
+            conv,
+            role="user",
+            content=f"msg {ordinal}",
+            ordinal=ordinal,
+        )
+        msg_ids.append(m.id)
+        await _make_context_item(
+            db_session, conv, ordinal=ordinal, item_kind="message", item_id=m.id
+        )
+    await db_session.commit()
+
+    response = await describe_assembled_context(
+        db_session,
+        conversation_id=conv.id,
+        fresh_tail_count=2,
+    )
+
+    assert response.summary_count == 1
+    assert response.message_count == 2  # capped by fresh-tail
+    kept_message_previews = [r.preview for r in response.items if r.item_kind == "message"]
+    # The two most recent messages survive ("msg 4", "msg 5").
+    assert kept_message_previews == ["msg 4", "msg 5"]
+
+
+@pytest.mark.anyio
+async def test_describe_isolates_conversations(db_session: AsyncSession, test_user: User) -> None:
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    msg = await _make_message(
+        db_session,
+        test_user,
+        conv_b,
+        role="user",
+        content="other conversation",
+        ordinal=0,
+    )
+    await _make_context_item(db_session, conv_b, ordinal=0, item_kind="message", item_id=msg.id)
+    await db_session.commit()
+
+    response = await describe_assembled_context(
+        db_session,
+        conversation_id=conv_a.id,
+    )
+
+    assert response.item_count == 0
+
+
+@pytest.mark.anyio
+async def test_route_returns_404_for_unknown_conversation(client: AsyncClient) -> None:
+    response = await client.get(f"/api/v1/lcm/conversations/{uuid.uuid4()}/context")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_route_returns_payload_for_owned_conversation(
+    db_session: AsyncSession, test_user: User, client: AsyncClient
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="user",
+        content="route hello",
+        ordinal=0,
+    )
+    await _make_context_item(db_session, conv, ordinal=0, item_kind="message", item_id=msg.id)
+    await db_session.commit()
+
+    response = await client.get(f"/api/v1/lcm/conversations/{conv.id}/context")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["conversation_id"] == str(conv.id)
+    assert payload["item_count"] == 1
+    assert payload["items"][0]["preview"] == "route hello"
+    assert "settings" in payload

--- a/backend/tests/test_lcm_pack.py
+++ b/backend/tests/test_lcm_pack.py
@@ -1,0 +1,237 @@
+"""Issue #255 - LCM context packing tests.
+
+Covers ``app.core.lcm.pack.pack_context``.
+
+Behaviour we pin down:
+
+- Empty candidates produce an empty packet with diagnostics zeroed.
+- Budget overflow rejects oversized items with ``budget_exceeded``,
+  not silent truncation.
+- Duplicate source chains: a raw message subsumed by a kept summary
+  is rejected with ``source_chain_duplicate``; symmetrically a
+  summary whose sources are already in the kept set is rejected
+  with ``lower_ranked_overlap`` when not in exact-fact mode.
+- ``prefer_kind="summaries"`` floats summaries above near-tied
+  raw messages.
+- ``prefer_kind="messages"`` does the inverse, and the exact-fact
+  heuristic auto-prefers raw messages when the query looks like a
+  pinpoint lookup (filename, model id, error text).
+- Kept items appear in chronological order by default.
+- Every kept item carries a packed_reason; every rejected item
+  carries a rejected_reason.  Diagnostics surface counts +
+  rejection breakdown.
+"""
+
+from __future__ import annotations
+
+from app.core.lcm.pack import (
+    REASON_BROAD_SUMMARY_PREFERENCE,
+    REASON_BUDGET_EXCEEDED,
+    REASON_DUPLICATE_SOURCE_CHAIN,
+    REASON_EXACT_FACT_PREFERENCE,
+    REASON_LOWER_RANKED_OVERLAP,
+    REASON_TOP_SCORE,
+    PackCandidate,
+    pack_context,
+)
+
+
+def _msg(
+    *,
+    item_id: str,
+    content: str,
+    ordinal: int,
+    score: float,
+    tokens: int | None = None,
+) -> PackCandidate:
+    return PackCandidate(
+        item_kind="message",
+        item_id=item_id,
+        ordinal=ordinal,
+        role="user",
+        final_score=score,
+        excerpt=content,
+        content=content,
+        token_count=tokens if tokens is not None else max(1, len(content) // 4),
+        source_ids=[item_id],
+    )
+
+
+def _summary(
+    *,
+    item_id: str,
+    content: str,
+    score: float,
+    source_ids: list[str] | None = None,
+    tokens: int | None = None,
+    depth: int = 0,
+) -> PackCandidate:
+    return PackCandidate(
+        item_kind="summary",
+        item_id=item_id,
+        summary_depth=depth,
+        summary_kind="normal",
+        final_score=score,
+        excerpt=content,
+        content=content,
+        token_count=tokens if tokens is not None else max(1, len(content) // 4),
+        source_ids=list(source_ids or []),
+    )
+
+
+def test_pack_empty_candidates_returns_empty_packet() -> None:
+    packed = pack_context([], query="anything", token_budget=1000)
+    assert packed["kept"] == []
+    assert packed["rejected"] == []
+    assert packed["token_count"] == 0
+    assert packed["diagnostics"]["candidates_considered"] == 0
+
+
+def test_pack_respects_budget_and_rejects_overflow() -> None:
+    a = _msg(item_id="m1", content="alpha " * 20, ordinal=0, score=0.9, tokens=40)
+    b = _msg(item_id="m2", content="bravo " * 20, ordinal=1, score=0.8, tokens=40)
+    c = _msg(item_id="m3", content="charlie " * 20, ordinal=2, score=0.7, tokens=40)
+
+    packed = pack_context([a, b, c], query="alpha", token_budget=80)
+
+    kept_ids = [item["item_id"] for item in packed["kept"]]
+    rejected_ids = [item["item_id"] for item in packed["rejected"]]
+    assert kept_ids == ["m1", "m2"]  # chronological
+    assert rejected_ids == ["m3"]
+    assert all(item["packed_reason"] for item in packed["kept"])
+    assert packed["rejected"][0]["rejected_reason"] == REASON_BUDGET_EXCEEDED
+    assert packed["token_count"] <= 80
+
+
+def test_pack_drops_message_subsumed_by_kept_summary() -> None:
+    summary = _summary(
+        item_id="s1",
+        content="summary covers m1 and m2",
+        score=0.9,
+        source_ids=["m1", "m2"],
+        tokens=30,
+    )
+    msg_in = _msg(item_id="m1", content="raw m1", ordinal=0, score=0.5, tokens=10)
+    msg_out = _msg(item_id="m_other", content="raw other", ordinal=2, score=0.8, tokens=10)
+
+    packed = pack_context(
+        [summary, msg_in, msg_out],
+        token_budget=200,
+        prefer_kind="summaries",
+    )
+
+    kept_ids = {item["item_id"] for item in packed["kept"]}
+    rejected = {item["item_id"]: item for item in packed["rejected"]}
+    assert "s1" in kept_ids
+    assert "m_other" in kept_ids
+    assert "m1" in rejected
+    assert rejected["m1"]["rejected_reason"] == REASON_DUPLICATE_SOURCE_CHAIN
+
+
+def test_pack_drops_summary_whose_sources_are_already_kept() -> None:
+    msg_a = _msg(item_id="m1", content="raw m1 fact", ordinal=0, score=0.9, tokens=10)
+    msg_b = _msg(item_id="m2", content="raw m2 fact", ordinal=1, score=0.85, tokens=10)
+    summary = _summary(
+        item_id="s1",
+        content="summary of m1 and m2",
+        score=0.6,
+        source_ids=["m1", "m2"],
+        tokens=30,
+    )
+
+    packed = pack_context(
+        [msg_a, msg_b, summary],
+        token_budget=200,
+        prefer_kind="messages",
+    )
+
+    rejected = {item["item_id"]: item for item in packed["rejected"]}
+    assert "s1" in rejected
+    assert rejected["s1"]["rejected_reason"] == REASON_LOWER_RANKED_OVERLAP
+
+
+def test_pack_summary_preference_floats_summaries_in_tie() -> None:
+    msg = _msg(item_id="m1", content="raw discussion", ordinal=5, score=0.5, tokens=15)
+    summary = _summary(item_id="s1", content="summary discussion", score=0.5, tokens=15)
+
+    packed = pack_context(
+        [msg, summary],
+        query="broad question",
+        token_budget=200,
+        prefer_kind="summaries",
+        chronological=False,
+    )
+
+    kept_ids = [item["item_id"] for item in packed["kept"]]
+    assert kept_ids[0] == "s1"
+    assert packed["kept"][0]["packed_reason"] == REASON_BROAD_SUMMARY_PREFERENCE
+
+
+def test_pack_exact_fact_query_lifts_raw_messages() -> None:
+    msg = _msg(
+        item_id="m1",
+        content="we picked gemini-2.5-flash-preview-05-20",
+        ordinal=4,
+        score=0.5,
+        tokens=15,
+    )
+    summary = _summary(
+        item_id="s1",
+        content="model decision summary",
+        score=0.5,
+        tokens=15,
+    )
+
+    packed = pack_context(
+        [summary, msg],
+        query="exact model id we picked: gemini-2.5-flash-preview-05-20",
+        token_budget=200,
+        chronological=False,
+    )
+
+    kept_ids = [item["item_id"] for item in packed["kept"]]
+    assert kept_ids[0] == "m1"
+    assert packed["kept"][0]["packed_reason"] == REASON_EXACT_FACT_PREFERENCE
+    assert packed["diagnostics"]["exact_fact_query"] is True
+
+
+def test_pack_keeps_chronological_order_in_kept_list() -> None:
+    msg0 = _msg(item_id="m0", content="oldest", ordinal=0, score=0.1, tokens=5)
+    msg5 = _msg(item_id="m5", content="middle", ordinal=5, score=0.9, tokens=5)
+    msg10 = _msg(item_id="m10", content="newest", ordinal=10, score=0.5, tokens=5)
+
+    packed = pack_context([msg5, msg10, msg0], token_budget=200)
+
+    ordinals = [item["ordinal"] for item in packed["kept"]]
+    assert ordinals == [0, 5, 10]
+
+
+def test_pack_every_kept_item_has_packed_reason() -> None:
+    msgs = [
+        _msg(item_id=f"m{i}", content=f"content {i}", ordinal=i, score=0.5, tokens=5)
+        for i in range(4)
+    ]
+    packed = pack_context(msgs, token_budget=200)
+    assert all(item["packed_reason"] for item in packed["kept"])
+    assert all(item["score"] is not None for item in packed["kept"])
+    assert {item["packed_reason"] for item in packed["kept"]} == {REASON_TOP_SCORE}
+
+
+def test_pack_diagnostics_count_rejections_by_reason() -> None:
+    big = _msg(item_id="big", content="x" * 4000, ordinal=0, score=0.9, tokens=1000)
+    summary = _summary(
+        item_id="s1",
+        content="summary",
+        score=0.8,
+        source_ids=["m1"],
+        tokens=10,
+    )
+    sub = _msg(item_id="m1", content="raw m1", ordinal=1, score=0.7, tokens=5)
+
+    packed = pack_context([big, summary, sub], token_budget=50, prefer_kind="summaries")
+
+    breakdown = packed["diagnostics"]["rejection_breakdown"]
+    assert breakdown.get(REASON_BUDGET_EXCEEDED, 0) >= 1
+    assert breakdown.get(REASON_DUPLICATE_SOURCE_CHAIN, 0) >= 1
+    assert packed["diagnostics"]["kept_count"] == len(packed["kept"])
+    assert packed["diagnostics"]["candidates_considered"] == 3

--- a/backend/tests/test_lcm_planner.py
+++ b/backend/tests/test_lcm_planner.py
@@ -1,0 +1,100 @@
+"""Issue #256 - LCM query planner tests.
+
+Covers ``app.core.lcm.planner.plan_query``.
+
+Behaviour we pin down:
+
+- Each supported intent has at least one representative phrasing in
+  the test suite (acceptance criterion: planner distinguishes the
+  five primary intents listed in #256).
+- ``unknown_or_unanswerable`` is reached for "did we ever discuss X"
+  style questions.
+- Subquery list is bounded by the documented cap (broad plans
+  cannot fan out into unbounded retrieval loops).
+- Retrieval modes and packing hint are intent-appropriate (exact
+  fact → grep/lexical + source_first; broad timeline → summary_walk
+  + timeline; decision trace → required citations).
+- Time + entity hints are extracted from typical phrasings.
+- The plan returns a JSON-serialisable Pydantic model so it can be
+  surfaced in the issue-#251 observability panel.
+"""
+
+from __future__ import annotations
+
+from app.core.lcm.planner import LCMQueryPlan, plan_query
+
+
+def test_plan_exact_fact_intent_for_pinpoint_question() -> None:
+    plan = plan_query("What exact model did we decide to use for summaries?")
+    assert plan.intent == "exact_fact"
+    assert plan.packing_hint == "source_first"
+    assert "grep" in plan.retrieval_modes
+    assert "lexical" in plan.retrieval_modes
+
+
+def test_plan_source_lookup_intent_for_citation_question() -> None:
+    plan = plan_query("Where did the 25-workspace pricing breakpoint claim come from?")
+    assert plan.intent == "source_lookup"
+    assert plan.citation_requirement == "required"
+    assert plan.packing_hint == "source_first"
+
+
+def test_plan_broad_timeline_intent_for_window_question() -> None:
+    plan = plan_query("What did we decide last week about the demo flow?")
+    assert plan.intent in ("broad_timeline", "decision_trace")
+    assert plan.time_hints  # at least "last week" surfaces
+    assert "summary_walk" in plan.retrieval_modes
+
+
+def test_plan_decision_trace_intent_for_why_question() -> None:
+    plan = plan_query("Why did we end up disabling auto-archive by default?")
+    assert plan.intent in ("decision_trace", "broad_timeline")
+    assert plan.citation_requirement == "required"
+
+
+def test_plan_multi_hop_intent_for_causal_chain() -> None:
+    plan = plan_query("Which earlier decision caused the missing-default-workspace bug?")
+    assert plan.intent == "multi_hop"
+    assert "hybrid" in plan.retrieval_modes
+    assert plan.packing_hint == "summary_first"
+
+
+def test_plan_contradiction_check_intent() -> None:
+    plan = plan_query("What did we change our mind about regarding inbox archiving?")
+    assert plan.intent == "contradiction_check"
+
+
+def test_plan_unanswerable_intent_for_negative_recall() -> None:
+    plan = plan_query("Did we ever discuss migrating our DNS provider?")
+    assert plan.intent == "unknown_or_unanswerable"
+    assert plan.retrieval_modes == ["lexical"]
+    assert plan.citation_requirement == "none"
+
+
+def test_plan_subqueries_bounded() -> None:
+    plan = plan_query(
+        "Last week we discussed pricing and onboarding and SSO and analytics and "
+        "deploys and notifications and inbox archiving and theme switching"
+    )
+    assert len(plan.subqueries) <= 4
+
+
+def test_plan_extracts_entity_hints_from_pascal_and_hyphenated_tokens() -> None:
+    plan = plan_query("Earlier we removed workspace-connect from the Telegram demo")
+    assert "Telegram" in plan.entity_hints
+    assert any(h.startswith("workspace-connect") for h in plan.entity_hints)
+
+
+def test_plan_returns_pydantic_model_serialisable() -> None:
+    plan = plan_query("What exact model did we pick?")
+    assert isinstance(plan, LCMQueryPlan)
+    # Pydantic v2 dump should produce a plain dict.
+    payload = plan.model_dump()
+    assert payload["intent"] == "exact_fact"
+    assert "subqueries" in payload
+    assert "diagnostics" in payload
+
+
+def test_plan_diagnostics_track_subquery_cap() -> None:
+    plan = plan_query("What did we decide about pricing and onboarding?")
+    assert plan.diagnostics["subqueries_capped_at"] == 4

--- a/backend/tests/test_lcm_search.py
+++ b/backend/tests/test_lcm_search.py
@@ -1,0 +1,349 @@
+"""Issue #253 — ranked lcm_search tests.
+
+Covers ``app.core.tools.lcm_search.lcm_search`` and the AgentTool
+factory in ``app.core.tools.lcm_search_agent``.
+
+What we nail down:
+
+- Empty / stopword-only query returns no results without crashing.
+- Token tokenisation + length normalisation rank a focused short
+  match above a noisy long match.
+- Multi-token coverage bonus elevates results that hit *every* query
+  term over results that hit only one.
+- Mixed message + summary candidates appear in the same ranked list
+  and each carry their item-kind-specific metadata.
+- Summaries get a small source-weight bump (equal token frequency
+  in a summary outranks a message).
+- Conversation isolation: rows from another conversation never
+  appear.
+- The agent tool is registered when ``settings.lcm_enabled`` and a
+  conversation_id are present, and not otherwise.
+- The agent tool's wrapper formats results as a readable text block.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_tools import build_agent_tools
+from app.core.config import settings
+from app.core.tools.lcm_search import (
+    LCMSearchResult,
+    _tokenize_query,
+    format_results,
+    lcm_search,
+)
+from app.core.tools.lcm_search_agent import make_lcm_search_tool
+from app.db import User
+from app.models import ChatMessage, Conversation, LCMSummary
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    """Insert a fresh conversation owned by ``user``."""
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="search test",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+async def _make_message(
+    session: AsyncSession,
+    user: User,
+    conv: Conversation,
+    *,
+    role: str,
+    content: str,
+    ordinal: int,
+) -> ChatMessage:
+    """Insert one raw chat message at ``ordinal``."""
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        conversation_id=conv.id,
+        user_id=user.id,
+        ordinal=ordinal,
+        role=role,
+        content=content,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(msg)
+    await session.flush()
+    return msg
+
+
+async def _make_summary(
+    session: AsyncSession,
+    conv: Conversation,
+    *,
+    content: str,
+    depth: int = 0,
+    kind: str = "normal",
+) -> LCMSummary:
+    """Insert one LCM summary row."""
+    s = LCMSummary(
+        conversation_id=conv.id,
+        depth=depth,
+        content=content,
+        token_count=max(1, len(content) // 4),
+        summary_kind=kind,
+    )
+    session.add(s)
+    await session.flush()
+    return s
+
+
+def test_tokenize_drops_stopwords_and_short_tokens() -> None:
+    tokens = _tokenize_query("What did we decide about the Telegram demo blockers?")
+    assert "telegram" in tokens
+    assert "demo" in tokens
+    assert "blockers" in tokens
+    # Stopwords and short noise drop out.
+    assert "the" not in tokens
+    assert "we" not in tokens
+    assert "did" not in tokens
+
+
+def test_tokenize_dedupes_and_lowercases() -> None:
+    assert _tokenize_query("Telegram telegram Telegram demo") == ["telegram", "demo"]
+
+
+@pytest.mark.anyio
+async def test_search_empty_query_returns_no_results(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    assert (await lcm_search(db_session, conversation_id=conv.id, query="   ")) == []
+    assert (await lcm_search(db_session, conversation_id=conv.id, query="the and from")) == []
+
+
+@pytest.mark.anyio
+async def test_search_ranks_focused_match_above_noisy_match(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Short, focused content with the query term outranks a long noisy hit."""
+    conv = await _make_conversation(db_session, test_user)
+    focused = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content="Hetzner deploy plan finalised.",
+        ordinal=0,
+    )
+    # Noisy long content: contains the term once amidst lots of unrelated text.
+    noisy_content = "padding " * 200 + "Hetzner mention buried in noise."
+    await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content=noisy_content,
+        ordinal=1,
+    )
+    await db_session.commit()
+
+    results = await lcm_search(db_session, conversation_id=conv.id, query="hetzner deploy")
+    assert results
+    # Focused match should win on coverage + length-normalisation.
+    assert results[0]["item_id"] == str(focused.id)
+
+
+@pytest.mark.anyio
+async def test_search_coverage_bonus_favours_multi_token_hits(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    # Hits BOTH tokens, even though the single-token row has more total hits.
+    both = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content="onboarding workspace-connect plan",
+        ordinal=0,
+    )
+    # Repeats one token many times but never the other.
+    repeat = "onboarding " * 12
+    await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content=repeat,
+        ordinal=1,
+    )
+    await db_session.commit()
+
+    results = await lcm_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+    )
+    assert results
+    assert results[0]["item_id"] == str(both.id)
+
+
+@pytest.mark.anyio
+async def test_search_returns_mixed_messages_and_summaries(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    msg = await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content="Earlier we discussed pricing.",
+        ordinal=0,
+    )
+    summary = await _make_summary(
+        db_session, conv, content="Pricing tiers: 25 active workspaces per team."
+    )
+    await db_session.commit()
+
+    results = await lcm_search(db_session, conversation_id=conv.id, query="pricing workspaces")
+
+    item_ids = {r["item_id"] for r in results}
+    item_kinds = {r["item_kind"] for r in results}
+    assert str(msg.id) in item_ids
+    assert str(summary.id) in item_ids
+    assert item_kinds == {"message", "summary"}
+
+
+@pytest.mark.anyio
+async def test_search_isolates_conversations(db_session: AsyncSession, test_user: User) -> None:
+    conv_a = await _make_conversation(db_session, test_user)
+    conv_b = await _make_conversation(db_session, test_user)
+    await _make_message(
+        db_session,
+        test_user,
+        conv_b,
+        role="assistant",
+        content="secret banana memo",
+        ordinal=0,
+    )
+    await db_session.commit()
+
+    results = await lcm_search(db_session, conversation_id=conv_a.id, query="banana")
+    assert results == []
+
+
+@pytest.mark.anyio
+async def test_search_filters_can_disable_messages_or_summaries(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    await _make_message(
+        db_session,
+        test_user,
+        conv,
+        role="assistant",
+        content="onboarding workspace-connect",
+        ordinal=0,
+    )
+    await _make_summary(db_session, conv, content="Summary about onboarding workspace-connect")
+    await db_session.commit()
+
+    only_messages = await lcm_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+        include_summaries=False,
+    )
+    only_summaries = await lcm_search(
+        db_session,
+        conversation_id=conv.id,
+        query="workspace-connect onboarding",
+        include_messages=False,
+    )
+
+    assert only_messages and all(r["item_kind"] == "message" for r in only_messages)
+    assert only_summaries and all(r["item_kind"] == "summary" for r in only_summaries)
+
+
+@pytest.mark.anyio
+async def test_search_respects_limit(db_session: AsyncSession, test_user: User) -> None:
+    conv = await _make_conversation(db_session, test_user)
+    for i in range(6):
+        await _make_message(
+            db_session,
+            test_user,
+            conv,
+            role="assistant",
+            content=f"workspace-connect mention {i}",
+            ordinal=i,
+        )
+    await db_session.commit()
+
+    results = await lcm_search(
+        db_session, conversation_id=conv.id, query="workspace-connect", limit=3
+    )
+    assert len(results) == 3
+
+
+def test_format_results_produces_readable_block() -> None:
+    rows: list[LCMSearchResult] = [
+        {
+            "item_kind": "message",
+            "item_id": "00000000-0000-0000-0000-000000000001",
+            "ordinal": 7,
+            "role": "user",
+            "summary_depth": None,
+            "summary_kind": None,
+            "score": 0.42,
+            "excerpt": "workspace-connect was dropped",
+            "source_ids": ["00000000-0000-0000-0000-000000000001"],
+        }
+    ]
+    text = format_results("workspace-connect", rows)
+    assert "lcm_search: 1 result(s) for 'workspace-connect'" in text
+    assert "kind=message" in text
+    assert "score=0.420" in text
+
+
+def test_build_agent_tools_includes_lcm_search_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(settings, "lcm_enabled", True)
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        user_id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+    )
+    assert any(tool.name == "lcm_search" for tool in tools)
+
+
+def test_build_agent_tools_omits_lcm_search_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(settings, "lcm_enabled", False)
+    tools = build_agent_tools(
+        workspace_root=tmp_path,
+        user_id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+    )
+    assert not any(tool.name == "lcm_search" for tool in tools)
+
+
+def test_make_lcm_search_tool_exposes_expected_schema() -> None:
+    tool = make_lcm_search_tool(conversation_id=uuid.uuid4())
+    assert tool.name == "lcm_search"
+    props = tool.parameters["properties"]
+    assert set(props.keys()) >= {
+        "query",
+        "limit",
+        "include_messages",
+        "include_summaries",
+    }


### PR DESCRIPTION
## Summary

Implements all six open LCM "Retrieval Lab" issues as one stacked feature
branch off `origin/development`. Each commit closes one issue and builds on
the previous one - the stack reads top-to-bottom as the agent-memory story
the issues describe.

| Commit | Closes | What lands |
|--------|--------|------------|
| `63abaec` | #251 | Read-only debug endpoint `GET /api/v1/lcm/conversations/{id}/context` + resolver that surfaces the assembled context for any turn without altering compaction or provider input |
| `649c579` | #252 | Eval harness in `app.core.lcm.evals` with seeded long-conversation fixtures covering pinpoint / broad / multi-hop / contradiction / source / negative recall; CI-safe deterministic answerer; pass-fail + cost + latency metrics |
| `fccee39` | #253 | Ranked `lcm_search` with multi-term coverage + TF-saturation scoring; new agent tool registered in `build_agent_tools`; `LCMSearchResult` typed dict for stable downstream contract |
| `7030c09` | #255 | Deterministic context packer that takes structured candidates and emits a token-bounded packet with per-item kept/rejected reasons, dedup, and diagnostics |
| `83f5f21` | #254 | Semantic retrieval (deterministic CI-safe hash embedder, `LCMEmbedding` table + Alembic migration `016`); cosine-similarity search; Reciprocal Rank Fusion blender; `lcm_hybrid_search` mode toggle (lexical / semantic / hybrid) |
| `524f75f` | #256 | `plan_query` heuristic classifier returning a structured `LCMQueryPlan` (intent / subqueries / retrieval modes / packing hint / citation requirement / budget) |

## Tests

All new code ships with tests in the same commit. The full LCM suite
(existing + new) is now **125 tests** and passes locally:

```
tests/test_lcm_observe.py        7 passed
tests/test_lcm_search.py        13 passed
tests/test_lcm_pack.py           9 passed
tests/test_lcm_embeddings.py    12 passed
tests/test_lcm_planner.py       11 passed
tests/evals/                     9 passed
+ pre-existing lcm_grep / lcm_describe / lcm_ingest / lcm_compaction /
  lcm_condensation / lcm_expand_query / lcm_agent_tools / lcm_schema /
  lcm_settings: 64 passed, no regressions
```

`just check` is clean (ruff lint + ruff format + biome). The repo-wide
nesting-depth and file-line gates pass.

## Design highlights

- **No retrieval mode is wired into the default chat path silently.** The
  packer, planner, semantic search, and hybrid blender are all behind
  explicit calls or eval modes. Promoting any of them into
  `assemble_context` happens after evals demonstrate a win - that contract
  is the whole point of #251 + #252 landing first.
- **CI stays offline.** The deterministic hash embedder produces stable,
  paraphrase-aware vectors with no model server. A real provider can plug
  in behind the same `Embedder` Protocol without changing storage,
  content-hash skip, or RRF blending.
- **Everything is inspectable.** Plans, packed contexts, and eval results
  all carry diagnostics so a future failure can be triaged to a specific
  layer (planner mis-classified vs retrieval missed vs packer dropped vs
  answerer refused).

## Test plan

- [x] Backend pytest suite green for every LCM module (125 tests).
- [x] `just check` (ruff + biome) clean.
- [x] `scripts/check-nesting.py` clean.
- [x] No file exceeds the 500 LOC ceiling.
- [x] Alembic migration `016_add_lcm_embeddings` declares both upgrade + downgrade paths.
- [ ] CI suite green on the self-hosted runner (will be visible once the PR opens).

Closes #251, #252, #253, #254, #255, #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements all six open LCM \"Retrieval Lab\" issues as a stacked feature branch, adding observability (debug context endpoint), an eval harness, ranked lexical search, context packing, hybrid semantic retrieval with RRF blending, and a query planner. Each feature is cleanly isolated behind explicit calls and is not wired into the default chat path, which aligns with the \"eval-gated promotion\" design.

- **New modules**: `observe.py`, `evals.py`, `pack.py`, `planner.py`, and `embeddings.py` each close one issue; `lcm_search.py` + `lcm_search_agent.py` deliver ranked lexical retrieval; an Alembic migration (`016`) adds the `lcm_embeddings` table.
- **Testing**: 125 LCM tests ship in the same commits; the deterministic hash-embedder keeps the suite fully offline. The eval harness seeds real ORM rows, so retrieval exercises the actual code path.
- **Architecture**: The packer and planner are pure functions over typed dicts; database access is isolated to dedicated fetch helpers; the `Embedder` protocol allows a real provider to replace the CI embedder without storage or RRF changes.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — no retrieval mode is wired into the default chat path, so no production behaviour changes until a follow-up explicitly promotes one of these modes.

The new retrieval stack is entirely behind explicit calls or eval flags and cannot affect live chat turns. The Alembic migration is clean with both upgrade and downgrade paths. Two logic gaps worth fixing before the packer and embedding refresh paths are relied upon in production: `_ordinal_for_sort` doesn't implement its documented summary-floating behaviour, and `upsert_embedding` leaves `updated_at` stale on content refreshes. Both are isolated to new code with no current callers outside tests.

`backend/app/core/lcm/pack.py` (ordinal sort tie-breaking) and `backend/app/core/lcm/embeddings.py` (`updated_at` on re-embed) are worth a second look before the packer and semantic retrieval are promoted into the default assembly path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/app/core/lcm/embeddings.py | Adds semantic search, cosine similarity, RRF blending, and deterministic CI embedder. `upsert_embedding` doesn't refresh `updated_at` when content changes, leaving audit timestamps stale on re-embeds. |
| backend/app/core/lcm/pack.py | Token-bounded context packer with dedup, kind-bias, and chronological reorder. `_ordinal_for_sort` multiplies ordinal by 2 but never checks item_kind, so the "float summaries to top of their bucket" behaviour described in the comment doesn't actually happen. |
| backend/app/core/lcm/evals.py | Eval harness with seeded fixtures, deterministic answerer, and per-mode dispatch table. `run_eval` docstring claims it never raises on failure, but it propagates ValueError from `_retrieve_for_mode` for unknown modes. |
| backend/app/core/lcm/planner.py | Heuristic intent classifier returning LCMQueryPlan. Clean cue-table design; fallthrough to "exact_fact" default is intentional and documented. |
| backend/app/core/lcm/observe.py | Read-only debug context resolver. Correctly mirrors the assemble_context fresh-tail cap without touching compaction state. |
| backend/app/core/tools/lcm_search.py | Ranked lexical search with TF-saturation scoring. Coarse ILIKE candidate fetch + in-process scoring pattern matches the stated design rationale for SQLite/Postgres parity. |
| backend/alembic/versions/016_add_lcm_embeddings.py | Adds lcm_embeddings table with CASCADE FK, unique constraint on (conversation_id, item_kind, item_id, embedding_model), and both upgrade/downgrade paths. Migration is clean. |
| backend/app/api/lcm.py | Read-only debug endpoint with proper per-user conversation-ownership gate. No mutation risk. |
| backend/app/core/agent_tools.py | Registers the new lcm_search tool alongside existing LCM tools, gated on the lcm_enabled flag and conversation_id presence. No regressions to existing tool registration. |
| backend/app/models.py | Adds LCMEmbedding model matching migration schema. UniqueConstraint, CASCADE FK, and __all__ export are all present. |
| backend/app/core/tools/lcm_search_agent.py | Thin agent-loop adapter for lcm_search. Correctly scopes the conversation_id in the closure and opens its own DB session per call. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fembeddings.py%3A261-274%0AStale%20%60updated_at%60%20on%20embedding%20refresh%3A%20when%20%60upsert_embedding%60%20finds%20an%20existing%20row%20whose%20content%20hash%20has%20changed%2C%20it%20updates%20%60embedding%60%20and%20%60content_hash%60%20but%20never%20touches%20%60updated_at%60.%20The%20column%20will%20keep%20its%20original%20creation%20timestamp%2C%20making%20it%20impossible%20to%20tell%20later%20which%20rows%20were%20re-embedded%20and%20when.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20existing%20is%20None%3A%0A%20%20%20%20%20%20%20%20row%20%3D%20LCMEmbedding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_kind%3Ditem_kind%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_id%3Ditem_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding_model%3Dused_embedder.model_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding%3Dvector%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20content_hash%3Dnew_hash%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20session.add%28row%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20from%20datetime%20import%20UTC%2C%20datetime%0A%0A%20%20%20%20%20%20%20%20existing.embedding%20%3D%20vector%0A%20%20%20%20%20%20%20%20existing.content_hash%20%3D%20new_hash%0A%20%20%20%20%20%20%20%20existing.updated_at%20%3D%20datetime.now%28UTC%29%0A%20%20%20%20%20%20%20%20row%20%3D%20existing%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fpack.py%3A222-229%0AThe%20%60*%202%60%20multiplier%20on%20ordinal%20was%20apparently%20designed%20to%20create%20room%20for%20item-kind%20differentiation%20%28summaries%20at%20%60ordinal*2%60%2C%20messages%20at%20%60ordinal*2%2B1%60%29%2C%20but%20the%20code%20never%20checks%20%60item_kind%60%20here.%20Both%20kinds%20return%20the%20same%20value%2C%20so%20the%20documented%20%22float%20summaries%20to%20the%20top%20of%20their%20bucket%22%20behaviour%20never%20fires.%0A%0A%60%60%60suggestion%0Adef%20_ordinal_for_sort%28candidate%3A%20PackCandidate%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Chronological%20sort%20key.%20Summaries%20float%20to%20the%20top%20of%20their%20bucket.%22%22%22%0A%20%20%20%20ordinal%20%3D%20candidate.get%28%22ordinal%22%29%0A%20%20%20%20if%20ordinal%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%23%20Summaries%20get%20an%20even%20slot%20%28ordinal*2%29%3B%20messages%20get%20ordinal*2%2B1%20so%0A%20%20%20%20%20%20%20%20%23%20a%20summary%20always%20sorts%20before%20a%20raw%20message%20at%20the%20same%20ordinal.%0A%20%20%20%20%20%20%20%20kind_offset%20%3D%200%20if%20candidate.get%28%22item_kind%22%29%20%3D%3D%20%22summary%22%20else%201%0A%20%20%20%20%20%20%20%20return%20int%28ordinal%29%20*%202%20%2B%20kind_offset%0A%20%20%20%20%23%20Summaries%20without%20explicit%20ordinal%20sort%20to%20the%20very%20front.%0A%20%20%20%20return%20-1%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fevals.py%3A685-687%0AThe%20docstring%20says%20the%20function%20%22never%20raises%20on%20retrieval%20failure%2C%22%20but%20%60_retrieve_for_mode%60%20raises%20%60ValueError%60%20for%20any%20mode%20not%20present%20in%20%60_MODE_RETRIEVERS%60.%20A%20future%20caller%20adding%20a%20new%20%60LCMEvalMode%60%20variant%20without%20a%20corresponding%20retriever%20entry%20would%20get%20an%20unhandled%20exception%2C%20not%20a%20%60fact_pass%3DFalse%60%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20The%20function%20never%20raises%20on%20retrieval%20failure%20for%20known%20modes%20%E2%80%94%20the%20eval%20is%20a%0A%20%20%20%20measurement%2C%20so%20an%20empty%20context%20or%20tool%20error%20should%20surface%20as%0A%20%20%20%20%60%60fact_pass%3DFalse%60%60%20not%20a%20test%20exception.%20%20An%20unrecognised%20%60%60mode%60%60%20value%0A%20%20%20%20%28i.e.%20one%20absent%20from%20%60%60_MODE_RETRIEVERS%60%60%29%20raises%20%60%60ValueError%60%60%20so%0A%20%20%20%20callers%20discover%20missing%20registrations%20immediately%20rather%20than%20silently%0A%20%20%20%20returning%20empty%20results.%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=octaviantocan%2Fpawrrtal-ai&pr=258&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22octavian%2Flcm-retrieval-lab%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22octavian%2Flcm-retrieval-lab%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fembeddings.py%3A261-274%0AStale%20%60updated_at%60%20on%20embedding%20refresh%3A%20when%20%60upsert_embedding%60%20finds%20an%20existing%20row%20whose%20content%20hash%20has%20changed%2C%20it%20updates%20%60embedding%60%20and%20%60content_hash%60%20but%20never%20touches%20%60updated_at%60.%20The%20column%20will%20keep%20its%20original%20creation%20timestamp%2C%20making%20it%20impossible%20to%20tell%20later%20which%20rows%20were%20re-embedded%20and%20when.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20existing%20is%20None%3A%0A%20%20%20%20%20%20%20%20row%20%3D%20LCMEmbedding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_kind%3Ditem_kind%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_id%3Ditem_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding_model%3Dused_embedder.model_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding%3Dvector%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20content_hash%3Dnew_hash%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20session.add%28row%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20from%20datetime%20import%20UTC%2C%20datetime%0A%0A%20%20%20%20%20%20%20%20existing.embedding%20%3D%20vector%0A%20%20%20%20%20%20%20%20existing.content_hash%20%3D%20new_hash%0A%20%20%20%20%20%20%20%20existing.updated_at%20%3D%20datetime.now%28UTC%29%0A%20%20%20%20%20%20%20%20row%20%3D%20existing%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fpack.py%3A222-229%0AThe%20%60*%202%60%20multiplier%20on%20ordinal%20was%20apparently%20designed%20to%20create%20room%20for%20item-kind%20differentiation%20%28summaries%20at%20%60ordinal*2%60%2C%20messages%20at%20%60ordinal*2%2B1%60%29%2C%20but%20the%20code%20never%20checks%20%60item_kind%60%20here.%20Both%20kinds%20return%20the%20same%20value%2C%20so%20the%20documented%20%22float%20summaries%20to%20the%20top%20of%20their%20bucket%22%20behaviour%20never%20fires.%0A%0A%60%60%60suggestion%0Adef%20_ordinal_for_sort%28candidate%3A%20PackCandidate%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Chronological%20sort%20key.%20Summaries%20float%20to%20the%20top%20of%20their%20bucket.%22%22%22%0A%20%20%20%20ordinal%20%3D%20candidate.get%28%22ordinal%22%29%0A%20%20%20%20if%20ordinal%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%23%20Summaries%20get%20an%20even%20slot%20%28ordinal*2%29%3B%20messages%20get%20ordinal*2%2B1%20so%0A%20%20%20%20%20%20%20%20%23%20a%20summary%20always%20sorts%20before%20a%20raw%20message%20at%20the%20same%20ordinal.%0A%20%20%20%20%20%20%20%20kind_offset%20%3D%200%20if%20candidate.get%28%22item_kind%22%29%20%3D%3D%20%22summary%22%20else%201%0A%20%20%20%20%20%20%20%20return%20int%28ordinal%29%20*%202%20%2B%20kind_offset%0A%20%20%20%20%23%20Summaries%20without%20explicit%20ordinal%20sort%20to%20the%20very%20front.%0A%20%20%20%20return%20-1%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fevals.py%3A685-687%0AThe%20docstring%20says%20the%20function%20%22never%20raises%20on%20retrieval%20failure%2C%22%20but%20%60_retrieve_for_mode%60%20raises%20%60ValueError%60%20for%20any%20mode%20not%20present%20in%20%60_MODE_RETRIEVERS%60.%20A%20future%20caller%20adding%20a%20new%20%60LCMEvalMode%60%20variant%20without%20a%20corresponding%20retriever%20entry%20would%20get%20an%20unhandled%20exception%2C%20not%20a%20%60fact_pass%3DFalse%60%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20The%20function%20never%20raises%20on%20retrieval%20failure%20for%20known%20modes%20%E2%80%94%20the%20eval%20is%20a%0A%20%20%20%20measurement%2C%20so%20an%20empty%20context%20or%20tool%20error%20should%20surface%20as%0A%20%20%20%20%60%60fact_pass%3DFalse%60%60%20not%20a%20test%20exception.%20%20An%20unrecognised%20%60%60mode%60%60%20value%0A%20%20%20%20%28i.e.%20one%20absent%20from%20%60%60_MODE_RETRIEVERS%60%60%29%20raises%20%60%60ValueError%60%60%20so%0A%20%20%20%20callers%20discover%20missing%20registrations%20immediately%20rather%20than%20silently%0A%20%20%20%20returning%20empty%20results.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fevals.py%3A625-665%0A**Duplicated%20stopword%20list%20across%20three%20modules**%0A%0A%60_extract_search_terms%60%20in%20%60evals.py%60%20defines%20its%20own%20stopword%20set%20that%20partially%20diverges%20from%20the%20sets%20in%20%60lcm_search.py%60%20%28%60_STOPWORDS%60%29%20and%20%60planner.py%60%20%28%60_STOPWORDS%60%29.%20For%20example%2C%20%60%22decide%22%60%2C%20%60%22decided%22%60%2C%20%60%22decision%22%60%20appear%20only%20in%20the%20eval%20harness%2C%20while%20%60%22are%22%60%2C%20%60%22was%22%60%2C%20%60%22were%22%60%20appear%20only%20in%20%60lcm_search.py%60.%20Diverging%20lists%20cause%20inconsistent%20tokenisation%20between%20the%20retrieval%20path%20and%20the%20eval%20harness%20meant%20to%20measure%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22octaviantocan%2Fpawrrtal-ai%22%20on%20the%20existing%20branch%20%22octavian%2Flcm-retrieval-lab%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22octavian%2Flcm-retrieval-lab%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fembeddings.py%3A261-274%0AStale%20%60updated_at%60%20on%20embedding%20refresh%3A%20when%20%60upsert_embedding%60%20finds%20an%20existing%20row%20whose%20content%20hash%20has%20changed%2C%20it%20updates%20%60embedding%60%20and%20%60content_hash%60%20but%20never%20touches%20%60updated_at%60.%20The%20column%20will%20keep%20its%20original%20creation%20timestamp%2C%20making%20it%20impossible%20to%20tell%20later%20which%20rows%20were%20re-embedded%20and%20when.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20existing%20is%20None%3A%0A%20%20%20%20%20%20%20%20row%20%3D%20LCMEmbedding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20conversation_id%3Dconversation_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_kind%3Ditem_kind%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20item_id%3Ditem_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding_model%3Dused_embedder.model_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20embedding%3Dvector%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20content_hash%3Dnew_hash%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20session.add%28row%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20from%20datetime%20import%20UTC%2C%20datetime%0A%0A%20%20%20%20%20%20%20%20existing.embedding%20%3D%20vector%0A%20%20%20%20%20%20%20%20existing.content_hash%20%3D%20new_hash%0A%20%20%20%20%20%20%20%20existing.updated_at%20%3D%20datetime.now%28UTC%29%0A%20%20%20%20%20%20%20%20row%20%3D%20existing%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fpack.py%3A222-229%0AThe%20%60*%202%60%20multiplier%20on%20ordinal%20was%20apparently%20designed%20to%20create%20room%20for%20item-kind%20differentiation%20%28summaries%20at%20%60ordinal*2%60%2C%20messages%20at%20%60ordinal*2%2B1%60%29%2C%20but%20the%20code%20never%20checks%20%60item_kind%60%20here.%20Both%20kinds%20return%20the%20same%20value%2C%20so%20the%20documented%20%22float%20summaries%20to%20the%20top%20of%20their%20bucket%22%20behaviour%20never%20fires.%0A%0A%60%60%60suggestion%0Adef%20_ordinal_for_sort%28candidate%3A%20PackCandidate%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Chronological%20sort%20key.%20Summaries%20float%20to%20the%20top%20of%20their%20bucket.%22%22%22%0A%20%20%20%20ordinal%20%3D%20candidate.get%28%22ordinal%22%29%0A%20%20%20%20if%20ordinal%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%23%20Summaries%20get%20an%20even%20slot%20%28ordinal*2%29%3B%20messages%20get%20ordinal*2%2B1%20so%0A%20%20%20%20%20%20%20%20%23%20a%20summary%20always%20sorts%20before%20a%20raw%20message%20at%20the%20same%20ordinal.%0A%20%20%20%20%20%20%20%20kind_offset%20%3D%200%20if%20candidate.get%28%22item_kind%22%29%20%3D%3D%20%22summary%22%20else%201%0A%20%20%20%20%20%20%20%20return%20int%28ordinal%29%20*%202%20%2B%20kind_offset%0A%20%20%20%20%23%20Summaries%20without%20explicit%20ordinal%20sort%20to%20the%20very%20front.%0A%20%20%20%20return%20-1%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fevals.py%3A685-687%0AThe%20docstring%20says%20the%20function%20%22never%20raises%20on%20retrieval%20failure%2C%22%20but%20%60_retrieve_for_mode%60%20raises%20%60ValueError%60%20for%20any%20mode%20not%20present%20in%20%60_MODE_RETRIEVERS%60.%20A%20future%20caller%20adding%20a%20new%20%60LCMEvalMode%60%20variant%20without%20a%20corresponding%20retriever%20entry%20would%20get%20an%20unhandled%20exception%2C%20not%20a%20%60fact_pass%3DFalse%60%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20The%20function%20never%20raises%20on%20retrieval%20failure%20for%20known%20modes%20%E2%80%94%20the%20eval%20is%20a%0A%20%20%20%20measurement%2C%20so%20an%20empty%20context%20or%20tool%20error%20should%20surface%20as%0A%20%20%20%20%60%60fact_pass%3DFalse%60%60%20not%20a%20test%20exception.%20%20An%20unrecognised%20%60%60mode%60%60%20value%0A%20%20%20%20%28i.e.%20one%20absent%20from%20%60%60_MODE_RETRIEVERS%60%60%29%20raises%20%60%60ValueError%60%60%20so%0A%20%20%20%20callers%20discover%20missing%20registrations%20immediately%20rather%20than%20silently%0A%20%20%20%20returning%20empty%20results.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Fapp%2Fcore%2Flcm%2Fevals.py%3A625-665%0A**Duplicated%20stopword%20list%20across%20three%20modules**%0A%0A%60_extract_search_terms%60%20in%20%60evals.py%60%20defines%20its%20own%20stopword%20set%20that%20partially%20diverges%20from%20the%20sets%20in%20%60lcm_search.py%60%20%28%60_STOPWORDS%60%29%20and%20%60planner.py%60%20%28%60_STOPWORDS%60%29.%20For%20example%2C%20%60%22decide%22%60%2C%20%60%22decided%22%60%2C%20%60%22decision%22%60%20appear%20only%20in%20the%20eval%20harness%2C%20while%20%60%22are%22%60%2C%20%60%22was%22%60%2C%20%60%22were%22%60%20appear%20only%20in%20%60lcm_search.py%60.%20Diverging%20lists%20cause%20inconsistent%20tokenisation%20between%20the%20retrieval%20path%20and%20the%20eval%20harness%20meant%20to%20measure%20it.%0A%0A&repo=octaviantocan%2Fpawrrtal-ai"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(lcm): add query planner for broad v..."](https://github.com/octaviantocan/pawrrtal-ai/commit/524f75fa23a5596f3c29dcf65564bdeff951359c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32496247)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->