### PR TITLE
feat(plugins): plugin system + Notion plugin (18 tools via ntn)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,21 @@ FROM python:3.13-slim AS runtime
 
 WORKDIR /app
 
+# Install the official Notion CLI (``ntn``) used by the Notion plugin.
+# The plugin subprocesses ``ntn`` per tool call with the workspace`s
+# token injected via ``NOTION_API_TOKEN``; see
+# ``app/integrations/notion/ntn_client.py``.  Pinned by date so the
+# install layer is reproducible — bump the env var to refresh.
+ENV NTN_INSTALL_DATE=2026-05-15
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && curl -fsSL https://ntn.dev | bash \
+ && mv /root/.ntn/bin/ntn /usr/local/bin/ntn \
+ && chmod +x /usr/local/bin/ntn \
+ && apt-get purge -y curl \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* /root/.ntn
+
 # Grab the populated venv from the builder stage.
 COPY --from=builder /app/.venv /app/.venv
 

--- a/backend/alembic/versions/013_notion_operation_logs.py
+++ b/backend/alembic/versions/013_notion_operation_logs.py
@@ -1,0 +1,78 @@
+"""Add the notion_operation_logs audit table.
+
+Revision ID: 013_notion_operation_logs
+Revises: 012_canonicalise_conversation_model_ids
+Create Date: 2026-05-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013_notion_operation_logs"
+down_revision: str | None = "012_canonicalise_conversation_model_ids"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the audit-log table used by the Notion plugin."""
+    op.create_table(
+        "notion_operation_logs",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column(
+            "workspace_id",
+            sa.Uuid(),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("tool_name", sa.String(length=64), nullable=False),
+        sa.Column("operation", sa.String(length=32), nullable=False),
+        sa.Column("page_id", sa.String(length=64), nullable=True),
+        sa.Column("database_id", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("duration_ms", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("request_json", sa.JSON(), nullable=True),
+        sa.Column("response_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_notion_operation_logs_workspace_id",
+        "notion_operation_logs",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_notion_operation_logs_tool_name",
+        "notion_operation_logs",
+        ["tool_name"],
+    )
+    op.create_index(
+        "ix_notion_operation_logs_page_id",
+        "notion_operation_logs",
+        ["page_id"],
+    )
+    op.create_index(
+        "ix_notion_operation_logs_database_id",
+        "notion_operation_logs",
+        ["database_id"],
+    )
+    op.create_index(
+        "ix_notion_operation_logs_created_at",
+        "notion_operation_logs",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the audit table and its indexes."""
+    for ix in (
+        "ix_notion_operation_logs_created_at",
+        "ix_notion_operation_logs_database_id",
+        "ix_notion_operation_logs_page_id",
+        "ix_notion_operation_logs_tool_name",
+        "ix_notion_operation_logs_workspace_id",
+    ):
+        op.drop_index(ix, table_name="notion_operation_logs")
+    op.drop_table("notion_operation_logs")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -229,8 +229,6 @@ def get_chat_router() -> APIRouter:
                 session=session,
             )
 
-        provider = resolve_llm(model_id, user_id=user.id)
-
         # Resolve the user's default workspace.  A workspace is created as
         # part of onboarding, so its absence means the user hasn't finished
         # that flow yet — the agent should not run at all in that state.
@@ -253,6 +251,9 @@ def get_chat_router() -> APIRouter:
             rid=rid,
         )
 
+        # Provider construction must happen *after* workspace resolution so
+        # workspace-scoped API-key overrides (Gemini/Claude) take effect.
+        provider = resolve_llm(model_id, workspace_id=workspace_id)
         # Per-turn tool composition lives in `app.core.agent_tools` —
         # the chat router only decides *that* the agent gets tools,
         # not *which* (that's the builder's job, and where future

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -104,13 +105,19 @@ def _maybe_artifact_event(event: StreamEvent) -> StreamEvent | None:
     )
 
 
-async def _require_workspace_root(
+async def _require_workspace(
     *,
     user_id: object,
     session: AsyncSession,
     request_id: str,
-) -> Path:
-    """Return the user's default workspace path or reject the chat turn."""
+) -> tuple[uuid.UUID, Path]:
+    """Return the user's default workspace ``(id, path)`` or reject the chat turn.
+
+    Returns the workspace UUID alongside the directory path so callers
+    can pass both into :func:`app.core.agent_tools.build_agent_tools` —
+    the UUID drives plugin activation (and, post-migration, env-key
+    resolution); the path drives the existing core workspace tools.
+    """
     workspace = await get_default_workspace(user_id, session)
     if workspace is None:
         raise HTTPException(
@@ -129,7 +136,7 @@ async def _require_workspace_root(
             status_code=412,
             detail="Workspace directory is missing on disk.  Re-run onboarding.",
         )
-    return root
+    return workspace.id, root
 
 
 def get_chat_router() -> APIRouter:
@@ -229,7 +236,9 @@ def get_chat_router() -> APIRouter:
         # that flow yet — the agent should not run at all in that state.
         # Refuse with 412 (Precondition Failed) so the frontend can route to
         # onboarding instead of pretending we shipped a degraded reply.
-        root = await _require_workspace_root(user_id=user.id, session=session, request_id=rid)
+        workspace_id, root = await _require_workspace(
+            user_id=user.id, session=session, request_id=rid
+        )
         # Pre-flight per-user cost gate (PR 04).  Refuses with HTTP
         # 402 when the user's rolling-window spend + a small reservation
         # would exceed ``cost_max_per_user_daily_usd``.  This sits
@@ -270,6 +279,7 @@ def get_chat_router() -> APIRouter:
         agent_tools = build_agent_tools(
             workspace_root=root,
             user_id=user.id,
+            workspace_id=workspace_id,
             send_fn=_web_send_fn,
             surface=surface,
             conversation_id=request.conversation_id,

--- a/backend/app/api/stt.py
+++ b/backend/app/api/stt.py
@@ -11,9 +11,11 @@ import logging
 import httpx
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.keys import resolve_api_key
-from app.db import User
+from app.crud.workspace import get_default_workspace
+from app.db import User, get_async_session
 from app.users import get_allowed_user
 
 logger = logging.getLogger(__name__)
@@ -45,6 +47,7 @@ def get_stt_router() -> APIRouter:  # noqa: C901 — single cohesive STT route +
         language: str | None = Form(default=None),
         format: bool = Form(default=True),  # noqa: A002
         user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
     ) -> JSONResponse:
         """Forward an uploaded audio file to xAI and return the transcript JSON.
 
@@ -56,7 +59,6 @@ def get_stt_router() -> APIRouter:  # noqa: C901 — single cohesive STT route +
         Returns the upstream JSON response unmodified so the frontend has
         access to ``text``, ``duration``, and the optional ``words`` array.
         """
-        # `resolve_api_key` already falls back to `settings.xai_api_key`, so
         # PR 14: when the operator selected a non-xAI backend, dispatch
         # to the configured ``Transcriber`` (Mistral / OpenAI / local
         # whisper.cpp).  The xAI proxy below is the historical default
@@ -83,7 +85,13 @@ def get_stt_router() -> APIRouter:  # noqa: C901 — single cohesive STT route +
                 raise HTTPException(status_code=502, detail=str(exc)) from exc
             return JSONResponse(content={"text": text})
 
-        api_key = resolve_api_key(user.id, "XAI_API_KEY")
+        # STT runs against the user's default workspace's configured key —
+        # there's no concept of "STT for workspace X" in the UI yet, so the
+        # default is the only sensible choice.  `resolve_api_key` already
+        # falls back to `settings.xai_api_key`, so the caller doesn't need a
+        # manual `or settings.x` suffix.
+        workspace = await get_default_workspace(user.id, session)
+        api_key = resolve_api_key(workspace.id, "XAI_API_KEY") if workspace is not None else None
         if not api_key:
             raise HTTPException(
                 status_code=503,

--- a/backend/app/api/workspace_env.py
+++ b/backend/app/api/workspace_env.py
@@ -1,16 +1,21 @@
-"""HTTP endpoints for per-user workspace environment variables.
+"""HTTP endpoints for per-workspace environment variables.
 
-Workspace env files live at ``{settings.workspace_base_dir}/{user_id}/.env``
+Workspace env files live at ``{settings.workspace_base_dir}/{workspace_id}/.env``
 (encrypted at rest) and let users override gateway-level settings (e.g.
 their own ``GEMINI_API_KEY``) without modifying the server's global ``.env``.
+Each of a user's workspaces has its own independent ``.env``.
 
-Mounted at: ``/api/v1/workspace``.
+Mounted at: ``/api/v1/workspaces/{workspace_id}/env``.
 """
 
 from __future__ import annotations
 
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.keys import (
     OVERRIDABLE_KEYS,
@@ -18,7 +23,8 @@ from app.core.keys import (
     load_workspace_env,
     save_workspace_env,
 )
-from app.db import User
+from app.db import User, get_async_session
+from app.models import Workspace
 from app.users import get_allowed_user
 
 # Maximum number of distinct keys a single PUT may set/update. Each user can
@@ -58,7 +64,7 @@ class WorkspaceEnvVars(BaseModel):
         The on-disk format is one ``KEY=value`` per line, so a value
         containing a newline would split into a second key=value pair on
         the next read — letting a user with one writable key inject
-        arbitrary other keys (e.g. ``GEMINI_API_KEY=...\\nEXA_API_KEY=hijack``).
+        arbitrary other keys (e.g. ``GEMINI_API_KEY=...\nEXA_API_KEY=hijack``).
         Rejection at validation time is the only safe enforcement boundary
         because the serialiser does no escaping.
         """
@@ -90,34 +96,63 @@ def _all_keys_response(env: dict[str, str]) -> WorkspaceEnvResponse:
     return WorkspaceEnvResponse(vars={k: env.get(k, "") for k in OVERRIDABLE_KEYS})
 
 
-def get_workspace_env_router() -> APIRouter:
-    """Build the per-user workspace env override router.
+async def _get_owned_workspace_id(
+    workspace_id: uuid.UUID,
+    user: User,
+    session: AsyncSession,
+) -> uuid.UUID:
+    """Return ``workspace_id`` after verifying it belongs to ``user``.
 
-    Three endpoints:
-      * ``GET  /env`` — return the user's current overrides (with empty-string
-        defaults for unset keys).
-      * ``PUT  /env`` — merge new overrides on top of existing ones. Empty
-        string values are stored as "absent" (the on-disk file omits them).
-      * ``DELETE /env/{key}`` — remove a single override, falling back to the
-        gateway default for that key.
-
-    All endpoints require an authenticated user.
+    Raises 404 (not 403) when the workspace exists but belongs to someone
+    else — leaking ownership via the status code would let an attacker
+    enumerate workspace IDs.
     """
-    router = APIRouter(prefix="/api/v1/workspace", tags=["workspace-env"])
+    result = await session.execute(
+        select(Workspace.id).where(
+            Workspace.id == workspace_id,
+            Workspace.user_id == user.id,
+        )
+    )
+    owned = result.scalar_one_or_none()
+    if owned is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
+    return owned
 
-    @router.get("/env", response_model=WorkspaceEnvResponse)
+
+def get_workspace_env_router() -> APIRouter:
+    """Build the per-workspace env override router.
+
+    Three endpoints, all scoped to a single workspace owned by the caller:
+      * ``GET  /workspaces/{workspace_id}/env`` — return the workspace's
+        current overrides (with empty-string defaults for unset keys).
+      * ``PUT  /workspaces/{workspace_id}/env`` — merge new overrides on
+        top of existing ones. Empty-string values are stored as "absent"
+        (the on-disk file omits them).
+      * ``DELETE /workspaces/{workspace_id}/env/{key}`` — remove a single
+        override, falling back to the gateway default for that key.
+
+    All endpoints require the authenticated user to own the workspace.
+    """
+    router = APIRouter(prefix="/api/v1/workspaces", tags=["workspace-env"])
+
+    @router.get("/{workspace_id}/env", response_model=WorkspaceEnvResponse)
     async def get_workspace_env(
+        workspace_id: uuid.UUID,
         user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
     ) -> WorkspaceEnvResponse:
-        """Return the current user's workspace env overrides."""
-        return _all_keys_response(load_workspace_env(user.id))
+        """Return the workspace's env overrides."""
+        owned = await _get_owned_workspace_id(workspace_id, user, session)
+        return _all_keys_response(load_workspace_env(owned))
 
-    @router.put("/env", response_model=WorkspaceEnvResponse)
+    @router.put("/{workspace_id}/env", response_model=WorkspaceEnvResponse)
     async def put_workspace_env(
+        workspace_id: uuid.UUID,
         payload: WorkspaceEnvVars,
         user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
     ) -> WorkspaceEnvResponse:
-        """Merge ``payload.vars`` into the user's workspace env file.
+        """Merge ``payload.vars`` into the workspace's env file.
 
         Existing keys not mentioned in ``payload.vars`` are preserved
         (PATCH-like semantics, despite the PUT verb — the field-by-field
@@ -125,6 +160,7 @@ def get_workspace_env_router() -> APIRouter:
         and stored as "absent" so clearing a field in the UI reverts that
         key to the gateway default.
         """
+        owned = await _get_owned_workspace_id(workspace_id, user, session)
         if len(payload.vars) > MAX_KEYS:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -144,27 +180,30 @@ def get_workspace_env_router() -> APIRouter:
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Value for '{k}' exceeds {MAX_VALUE_LENGTH} characters.",
                 )
-        existing = load_workspace_env(user.id)
+        existing = load_workspace_env(owned)
         existing.update(payload.vars)
-        save_workspace_env(user.id, existing)
+        save_workspace_env(owned, existing)
         # Re-load from disk so the response reflects what was actually
         # persisted (empty-string values are stripped during save, so the
         # echoed payload should match what subsequent GETs return).
-        return _all_keys_response(load_workspace_env(user.id))
+        return _all_keys_response(load_workspace_env(owned))
 
-    @router.delete("/env/{key}", status_code=status.HTTP_204_NO_CONTENT)
+    @router.delete("/{workspace_id}/env/{key}", status_code=status.HTTP_204_NO_CONTENT)
     async def delete_workspace_env_key(
+        workspace_id: uuid.UUID,
         key: str,
         user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
     ) -> None:
-        """Remove a single override key for the current user."""
+        """Remove a single override key for the workspace."""
         if key not in OVERRIDABLE_KEYS:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Unknown workspace env key: '{key}'.",
             )
-        existing = load_workspace_env(user.id)
+        owned = await _get_owned_workspace_id(workspace_id, user, session)
+        existing = load_workspace_env(owned)
         existing.pop(key, None)
-        save_workspace_env(user.id, existing)
+        save_workspace_env(owned, existing)
 
     return router

--- a/backend/app/cli/migrate_workspace_env.py
+++ b/backend/app/cli/migrate_workspace_env.py
@@ -1,0 +1,66 @@
+"""One-time migration from user-keyed to workspace-keyed env files.
+
+Before the workspace-keying migration (ADR
+``2026-05-15-plugin-system-and-notion-integration``), encrypted ``.env``
+files lived at ``{workspace_base_dir}/{user_id}/.env``.  The new layout
+keys them by workspace, at ``{workspace_base_dir}/{workspace_id}/.env``,
+so each of a user's workspaces gets its own credentials slate.
+
+This module walks the user table at startup and migrates each user's
+legacy file into their default workspace's path.  Users without a
+default workspace are skipped (they haven't completed onboarding yet,
+so the file shouldn't exist).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from app.core.keys import migrate_user_keyed_env_file
+from app.db import async_session_maker
+from app.models import Workspace
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate_user_keyed_env_files_for_all_users() -> int:
+    """Migrate every user's legacy env file into their default workspace.
+
+    Returns the count of files migrated this run (zero on a clean
+    startup where no legacy files remain).
+
+    The function is idempotent: subsequent calls do nothing because the
+    legacy source files have been renamed with a ``.migrated-<ts>``
+    suffix on the first successful run.
+    """
+    migrated = 0
+    async with async_session_maker() as session:
+        # Pulling the default workspaces directly avoids a separate
+        # "list users, then look up their workspace" two-step. We don't
+        # care about users who never created a workspace — their legacy
+        # files (if any) stay quarantined for manual recovery.
+        result = await session.execute(
+            select(Workspace.id, Workspace.user_id).where(Workspace.is_default.is_(True))
+        )
+        for workspace_id, user_id in result.all():
+            try:
+                if migrate_user_keyed_env_file(user_id=user_id, default_workspace_id=workspace_id):
+                    migrated += 1
+            except OSError as err:
+                # Filesystem failure on one user shouldn't block the rest
+                # of the migration; log and continue.  A repeat startup
+                # will retry whichever users were missed.
+                logger.warning(
+                    "workspace_env_migration: failed for user_id=%s: %s",
+                    user_id,
+                    err,
+                )
+
+    if migrated:
+        logger.info(
+            "workspace_env_migration: migrated %d legacy file(s) this startup",
+            migrated,
+        )
+    return migrated

--- a/backend/app/cli/migrate_workspace_env.py
+++ b/backend/app/cli/migrate_workspace_env.py
@@ -15,14 +15,59 @@ so the file shouldn't exist).
 from __future__ import annotations
 
 import logging
+import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.keys import migrate_user_keyed_env_file
 from app.db import async_session_maker
 from app.models import Workspace
 
 logger = logging.getLogger(__name__)
+
+
+async def _migrate_one_user(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    default_workspace_id: uuid.UUID,
+) -> bool:
+    """Migrate one user's legacy env file; return ``True`` if a file moved.
+
+    Logs and swallows ``OSError`` so a single filesystem failure doesn't
+    abort the migration for everyone else; emits a WARN if the user has
+    more than one workspace so the operator knows the secondary
+    workspaces will start with an empty credentials slate.
+    """
+    try:
+        moved = migrate_user_keyed_env_file(
+            user_id=user_id,
+            default_workspace_id=default_workspace_id,
+        )
+    except OSError as err:
+        # A repeat startup will retry whichever users were missed.
+        logger.warning(
+            "workspace_env_migration: failed for user_id=%s: %s",
+            user_id,
+            err,
+        )
+        return False
+
+    if moved:
+        workspace_count = await session.scalar(
+            select(func.count()).select_from(Workspace).where(Workspace.user_id == user_id)
+        )
+        if workspace_count and workspace_count > 1:
+            logger.warning(
+                "workspace_env_migration: user_id=%s has %d workspaces; "
+                "only default_workspace_id=%s inherited legacy keys "
+                "(secondary workspaces start with an empty .env)",
+                user_id,
+                workspace_count,
+                default_workspace_id,
+            )
+    return moved
 
 
 async def migrate_user_keyed_env_files_for_all_users() -> int:
@@ -45,18 +90,12 @@ async def migrate_user_keyed_env_files_for_all_users() -> int:
             select(Workspace.id, Workspace.user_id).where(Workspace.is_default.is_(True))
         )
         for workspace_id, user_id in result.all():
-            try:
-                if migrate_user_keyed_env_file(user_id=user_id, default_workspace_id=workspace_id):
-                    migrated += 1
-            except OSError as err:
-                # Filesystem failure on one user shouldn't block the rest
-                # of the migration; log and continue.  A repeat startup
-                # will retry whichever users were missed.
-                logger.warning(
-                    "workspace_env_migration: failed for user_id=%s: %s",
-                    user_id,
-                    err,
-                )
+            if await _migrate_one_user(
+                session,
+                user_id=user_id,
+                default_workspace_id=workspace_id,
+            ):
+                migrated += 1
 
     if migrated:
         logger.info(

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -190,21 +190,46 @@ def build_agent_tools(
             )
 
     # Plugin-contributed tools.  Additive only — core tools above are
-    # unaffected.  Skipped entirely when the workspace context isn't
-    # available (legacy callers, background jobs): plugins gate on
-    # workspace-scoped env keys, so they have nothing to resolve without
-    # a workspace_id + user_id pair.
-    if workspace_id is not None and user_id is not None:
-        ctx = ToolContext(
-            workspace_id=workspace_id,
+    # unaffected.  Extracted into a helper so the main composition body
+    # stays under the project's branch-count ceiling.
+    tools.extend(
+        _build_plugin_tools(
             workspace_root=workspace_root,
             user_id=user_id,
+            workspace_id=workspace_id,
             send_fn=send_fn,
         )
-        for plugin in all_plugins():
-            predicate = plugin.is_activated or is_activated_by_env_keys(plugin)
-            if not predicate(ctx):
-                continue
-            tools.extend(factory(ctx) for factory in plugin.tool_factories)
+    )
 
     return tools
+
+
+def _build_plugin_tools(
+    *,
+    workspace_root: Path,
+    user_id: uuid.UUID | None,
+    workspace_id: uuid.UUID | None,
+    send_fn: SendFn | None,
+) -> list[AgentTool]:
+    """Walk the plugin registry and return every activated plugin's tools.
+
+    Skipped entirely when the workspace context isn't available (legacy
+    callers, background jobs): plugins gate on workspace-scoped env keys,
+    so they have nothing to resolve without a ``workspace_id + user_id``
+    pair.
+    """
+    if workspace_id is None or user_id is None:
+        return []
+    ctx = ToolContext(
+        workspace_id=workspace_id,
+        workspace_root=workspace_root,
+        user_id=user_id,
+        send_fn=send_fn,
+    )
+    out: list[AgentTool] = []
+    for plugin in all_plugins():
+        predicate = plugin.is_activated or is_activated_by_env_keys(plugin)
+        if not predicate(ctx):
+            continue
+        out.extend(factory(ctx) for factory in plugin.tool_factories)
+    return out

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -32,8 +32,7 @@ from pathlib import Path
 from app.core.agent_loop.types import AgentTool
 from app.core.config import settings
 from app.core.keys import resolve_api_key
-from app.core.plugins import ToolContext, all_plugins
-from app.core.plugins.registry import is_activated_by_env_keys
+from app.core.plugins import ToolContext, all_plugins, is_activated_by_env_keys
 from app.core.providers.catalog import default_model
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -121,12 +121,12 @@ def build_agent_tools(
     # so a single call is sufficient. The unauthenticated fallback (no
     # `user_id` — e.g. background jobs) reads `settings.exa_api_key`
     # directly.
-    if user_id is not None:
-        exa_key = resolve_api_key(user_id, "EXA_API_KEY")
+    if workspace_id is not None:
+        exa_key = resolve_api_key(workspace_id, "EXA_API_KEY")
     else:
         exa_key = settings.exa_api_key or None
     if exa_key:
-        tools.append(make_exa_search_tool(user_id=user_id))
+        tools.append(make_exa_search_tool(workspace_id=workspace_id))
 
     # Artifact rendering.  Always present — the wire shape is purely
     # structural and the catalog of safe components is enforced on the
@@ -138,12 +138,12 @@ def build_agent_tools(
     # Image generation — pure tool: generates PNG, saves to workspace,
     # returns path.  The agent decides whether to send it via send_message.
     # Capability-gated on OPENAI_CODEX_OAUTH_TOKEN being resolvable.
-    if user_id is not None:
-        codex_token = resolve_api_key(user_id, "OPENAI_CODEX_OAUTH_TOKEN")
+    if workspace_id is not None:
+        codex_token = resolve_api_key(workspace_id, "OPENAI_CODEX_OAUTH_TOKEN")
     else:
         codex_token = None
     if codex_token:
-        tools.append(make_image_gen_tool(workspace_root=workspace_root, user_id=user_id))
+        tools.append(make_image_gen_tool(workspace_root=workspace_root, workspace_id=workspace_id))
 
     # Document-to-Markdown conversion via markitdown.  Always present —
     # no external API key required; all conversion happens locally.

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -32,6 +32,8 @@ from pathlib import Path
 from app.core.agent_loop.types import AgentTool
 from app.core.config import settings
 from app.core.keys import resolve_api_key
+from app.core.plugins import ToolContext, all_plugins
+from app.core.plugins.registry import is_activated_by_env_keys
 from app.core.providers.catalog import default_model
 from app.core.tools.artifact_agent import make_artifact_tool
 from app.core.tools.exa_search_agent import make_exa_search_tool
@@ -51,6 +53,7 @@ def build_agent_tools(
     *,
     workspace_root: Path,
     user_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
     send_fn: SendFn | None = None,
     surface: str | None = None,
     conversation_id: uuid.UUID | None = None,
@@ -72,6 +75,12 @@ def build_agent_tools(
             under prompt pressure.
         user_id: Authenticated user UUID, used to resolve per-workspace
             API key overrides for tools that call external services.
+        workspace_id: Active workspace UUID.  When supplied alongside
+            ``user_id``, plugin tools (additive integrations registered
+            under :mod:`app.core.plugins`) are appended after the core
+            tools.  When ``None`` — including in legacy tests that
+            haven't been updated yet — plugin tools are skipped; core
+            tool composition is unaffected.
         send_fn: Optional channel delivery callback.  When supplied the
             ``send_message`` tool is added to the list so the agent can
             proactively push text and files back to the user.  Both the
@@ -95,9 +104,9 @@ def build_agent_tools(
         A fresh list of :class:`AgentTool` ready to hand to a provider.
         Order is **stable**: workspace tools first (the agent's default
         operating surface), then capability-gated tools (web search,
-        future capabilities).  Stable order matters for the Claude
-        bridge's ``allowed_tools`` whitelist construction and for
-        snapshot-style tests.
+        future capabilities), then any plugin-contributed tools.
+        Stable order matters for the Claude bridge's ``allowed_tools``
+        whitelist construction and for snapshot-style tests.
     """
     tools: list[AgentTool] = []
 
@@ -179,5 +188,23 @@ def build_agent_tools(
                     model_id=expand_model_id,
                 )
             )
+
+    # Plugin-contributed tools.  Additive only — core tools above are
+    # unaffected.  Skipped entirely when the workspace context isn't
+    # available (legacy callers, background jobs): plugins gate on
+    # workspace-scoped env keys, so they have nothing to resolve without
+    # a workspace_id + user_id pair.
+    if workspace_id is not None and user_id is not None:
+        ctx = ToolContext(
+            workspace_id=workspace_id,
+            workspace_root=workspace_root,
+            user_id=user_id,
+            send_fn=send_fn,
+        )
+        for plugin in all_plugins():
+            predicate = plugin.is_activated or is_activated_by_env_keys(plugin)
+            if not predicate(ctx):
+                continue
+            tools.extend(factory(ctx) for factory in plugin.tool_factories)
 
     return tools

--- a/backend/app/core/keys.py
+++ b/backend/app/core/keys.py
@@ -1,13 +1,15 @@
-"""Per-user workspace environment variable resolution.
+"""Per-workspace environment variable resolution.
 
 A workspace `.env` file is encrypted at rest under
-``{settings.workspace_base_dir}/{user_id}/.env``.  Users supply their own
+``{settings.workspace_base_dir}/{workspace_id}/.env``.  Users supply their own
 provider keys (e.g. their own ``GEMINI_API_KEY``) without ever editing the
-server-wide global ``.env``.
+server-wide global ``.env``.  Keying is per-workspace, not per-user — a user
+with multiple workspaces configures each independently.  The settings global
+remains the gateway-level fallback for any key the workspace doesn't override.
 
 Resolution order for any overridable key:
 
-  1. **Workspace override** — read from the per-user encrypted file.
+  1. **Workspace override** — read from the per-workspace encrypted file.
   2. **Gateway global** — fall back to the corresponding ``Settings`` field.
   3. ``None`` — neither is configured.
 
@@ -21,6 +23,13 @@ because it is a cross-cutting helper imported by HTTP routes, tools, and
 agent factories — none of which are providers.  ``providers/`` is
 reserved for SDK-specific bridges (see
 ``.claude/rules/architecture/no-tools-in-providers.md``).
+
+Note on the historical user-keyed layout (prior to the workspace_id
+migration): old ``{workspace_base_dir}/{user_id}/.env`` files are moved to
+``{workspace_base_dir}/{default_workspace_id}/.env`` by
+:func:`migrate_user_keyed_env_files` on application startup.  After
+migration the source file is renamed with a ``.migrated-<timestamp>``
+suffix rather than deleted, so the move is reversible.
 """
 
 from __future__ import annotations
@@ -50,6 +59,10 @@ OVERRIDABLE_KEYS: frozenset[str] = frozenset(
         "EXA_API_KEY",
         "XAI_API_KEY",
         "OPENAI_CODEX_OAUTH_TOKEN",
+        # Notion plugin (see backend/app/integrations/notion/).  The plugin
+        # registry declares the same key via its EnvKeySpec; this central
+        # allowlist remains the source of truth for the HTTP layer.
+        "NOTION_API_KEY",
     }
 )
 
@@ -76,13 +89,20 @@ _SETTINGS_ATTR_MAP: dict[str, str] = {
 VALUE_FORBIDDEN_CHARS = re.compile(r"[\r\n]")
 
 
-def _workspace_env_path(user_id: uuid.UUID) -> Path:
-    """Return the absolute path to a user's encrypted workspace .env file.
+def _workspace_env_path(workspace_id: uuid.UUID) -> Path:
+    """Return the absolute path to a workspace's encrypted ``.env`` file.
 
     Computed on every call so that test code can monkeypatch
     ``settings.workspace_base_dir`` without restarting the import graph.
+
+    The path matches the canonical workspace directory shape produced by
+    :func:`app.core.workspace.seed_workspace` — i.e. the env file is a
+    sibling of ``AGENTS.md`` / ``SOUL.md`` and lives inside the workspace
+    root.  This keeps the per-workspace state self-contained so a single
+    rsync of the workspace directory moves the agent state and its
+    credentials together.
     """
-    return Path(settings.workspace_base_dir) / str(user_id) / ".env"
+    return Path(settings.workspace_base_dir) / str(workspace_id) / ".env"
 
 
 @lru_cache(maxsize=1)
@@ -153,16 +173,16 @@ def _quarantine_corrupt_file(path: Path) -> None:
         )
 
 
-def load_workspace_env(user_id: uuid.UUID) -> dict[str, str]:
-    """Decrypt and parse the user's workspace .env file.
+def load_workspace_env(workspace_id: uuid.UUID) -> dict[str, str]:
+    """Decrypt and parse the workspace's ``.env`` file.
 
     Returns an empty dict when:
-      * No file exists yet (first-time user).
+      * No file exists yet (first-time workspace).
       * The file exists but cannot be decrypted (corrupt or key-rotated);
         in this case the bad file is quarantined to a sibling path and a
         WARNING is logged.
     """
-    path = _workspace_env_path(user_id)
+    path = _workspace_env_path(workspace_id)
     if not path.exists():
         return {}
     try:
@@ -173,18 +193,18 @@ def load_workspace_env(user_id: uuid.UUID) -> dict[str, str]:
     return _parse_env_lines(plaintext)
 
 
-def save_workspace_env(user_id: uuid.UUID, env: dict[str, str]) -> None:
-    """Encrypt and persist the user's workspace .env file.
+def save_workspace_env(workspace_id: uuid.UUID, env: dict[str, str]) -> None:
+    """Encrypt and persist the workspace's ``.env`` file.
 
-    Permissions: the user directory is created with mode 0o700 and the file
-    is chmod'd to 0o600 after write so no other OS user can read it. This
-    is defence-in-depth — the file contents are already encrypted.
+    Permissions: the workspace directory is created with mode 0o700 and
+    the file is chmod'd to 0o600 after write so no other OS user can read
+    it. This is defence-in-depth — the file contents are already encrypted.
 
     Empty-string values are stripped during serialisation; saving an empty
     string for a key is the documented way for a user to "clear" the
     override and fall back to the gateway default.
     """
-    path = _workspace_env_path(user_id)
+    path = _workspace_env_path(workspace_id)
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     plaintext = _serialize_env_lines(env)
     ciphertext = _fernet().encrypt(plaintext.encode())
@@ -192,18 +212,18 @@ def save_workspace_env(user_id: uuid.UUID, env: dict[str, str]) -> None:
     path.chmod(0o600)
 
 
-def resolve_api_key(user_id: uuid.UUID, workspace_key: str) -> str | None:
-    """Resolve an env key for the given user with workspace -> settings fallback.
+def resolve_api_key(workspace_id: uuid.UUID, workspace_key: str) -> str | None:
+    """Resolve an env key for the given workspace with workspace → settings fallback.
 
     Args:
-        user_id: Authenticated user UUID. Used to locate the encrypted
-            .env file.
+        workspace_id: The active workspace UUID. Used to locate the
+            encrypted ``.env`` file.
         workspace_key: One of :data:`OVERRIDABLE_KEYS`, e.g.
             ``"GEMINI_API_KEY"``.
 
     Returns:
         The first non-empty value found, in this order:
-          1. The user's workspace override.
+          1. The workspace's override.
           2. The corresponding ``Settings`` field
              (``_SETTINGS_ATTR_MAP[workspace_key]``).
           3. ``None`` if neither is configured.
@@ -213,7 +233,7 @@ def resolve_api_key(user_id: uuid.UUID, workspace_key: str) -> str | None:
     settings fallback via :data:`_SETTINGS_ATTR_MAP`. A second fallback
     at the call site is dead code that drifts when the map is extended.
     """
-    workspace = load_workspace_env(user_id)
+    workspace = load_workspace_env(workspace_id)
     override = workspace.get(workspace_key)
     if override:
         return override
@@ -222,3 +242,57 @@ def resolve_api_key(user_id: uuid.UUID, workspace_key: str) -> str | None:
         return None
     value = getattr(settings, settings_attr, None)
     return value or None
+
+
+# ---------------------------------------------------------------------------
+# One-time migration: user-keyed → workspace-keyed
+# ---------------------------------------------------------------------------
+
+
+def migrate_user_keyed_env_file(
+    *,
+    user_id: uuid.UUID,
+    default_workspace_id: uuid.UUID,
+) -> bool:
+    """Move a legacy ``{base}/{user_id}/.env`` to ``{base}/{workspace_id}/.env``.
+
+    Returns ``True`` when a file was migrated, ``False`` when there was
+    nothing to do. Idempotent — calling again after a successful run is
+    a no-op (the source no longer exists).
+
+    The migration is non-destructive: after copying the encrypted bytes
+    to the new path the source file is renamed to
+    ``.env.migrated-<timestamp>`` rather than deleted. Operators can
+    recover the original value by renaming the suffix back.
+
+    Args:
+        user_id: The user whose legacy env file we're migrating.
+        default_workspace_id: The workspace that inherits the user's
+            keys.  Only the default workspace is seeded — secondary
+            workspaces start blank, on the principle that "isolated
+            workspace" means a fresh credentials slate.
+    """
+    base = Path(settings.workspace_base_dir)
+    src = base / str(user_id) / ".env"
+    if not src.exists():
+        return False
+
+    dst = base / str(default_workspace_id) / ".env"
+    if dst.exists():
+        # Already-migrated workspace; quarantine the legacy source so a
+        # second run cannot accidentally overwrite the newer file.
+        _quarantine_corrupt_file(src)
+        return False
+
+    dst.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    dst.write_bytes(src.read_bytes())
+    dst.chmod(0o600)
+
+    migrated_suffix = f".migrated-{int(time.time())}"
+    src.rename(src.with_name(src.name + migrated_suffix))
+    logger.info(
+        "workspace_env: migrated user-keyed env file user_id=%s -> workspace_id=%s",
+        user_id,
+        default_workspace_id,
+    )
+    return True

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -1,0 +1,44 @@
+"""Plugin registry — additive integrations that contribute agent tools.
+
+A plugin is a Python package under ``backend/app/integrations/<id>/``
+that exports a :class:`Plugin` object describing one integration.
+Plugins extend the agent's capabilities without modifying core code:
+each plugin contributes one or more tool factories plus a list of
+workspace-scoped env keys it depends on.
+
+Design notes:
+
+* **Additive only.** Core tools (workspace files, web search, image
+  generation, artifact rendering, message delivery) stay hardcoded in
+  :func:`app.core.agent_tools.build_agent_tools`. The registry append
+  happens *after* core tool composition. We avoid a refactor whose only
+  payoff would be uniformity for its own sake.
+* **Tools only, v1.** Plugin-registered channels, providers, hooks, and
+  HTTP routes are out of scope. The seams exist (``Channel`` protocol,
+  ``LLMProvider``) and can grow later without changing this API.
+* **In-process, first-party.** Plugins are imported Python packages,
+  not dynamically-loaded artifacts. Discovery happens through
+  ``app.integrations.__init__`` importing each subpackage, which in
+  turn calls :func:`register_plugin`. No manifest JSON, no hot reload.
+* **Capability gating via ``is_activated``.** A plugin's tools only
+  reach the agent when its prerequisites resolve in the current
+  :class:`ToolContext` — typically "the workspace has a value
+  configured for every env key the plugin declares". The default
+  implementation handles that case; plugins can override for more
+  complex predicates.
+
+See ``frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx``
+for the design rationale.
+"""
+
+from app.core.plugins.registry import all_plugins, register_plugin
+from app.core.plugins.types import EnvKeySpec, Plugin, ToolContext, ToolFactory
+
+__all__ = [
+    "EnvKeySpec",
+    "Plugin",
+    "ToolContext",
+    "ToolFactory",
+    "all_plugins",
+    "register_plugin",
+]

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -31,7 +31,11 @@ See ``frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-noti
 for the design rationale.
 """
 
-from app.core.plugins.registry import all_plugins, register_plugin
+from app.core.plugins.registry import (
+    all_plugins,
+    is_activated_by_env_keys,
+    register_plugin,
+)
 from app.core.plugins.types import EnvKeySpec, Plugin, ToolContext, ToolFactory
 
 __all__ = [
@@ -40,5 +44,6 @@ __all__ = [
     "ToolContext",
     "ToolFactory",
     "all_plugins",
+    "is_activated_by_env_keys",
     "register_plugin",
 ]

--- a/backend/app/core/plugins/registry.py
+++ b/backend/app/core/plugins/registry.py
@@ -1,0 +1,89 @@
+"""Module-level plugin registry.
+
+This is intentionally the simplest mechanism that solves the problem:
+a list of :class:`Plugin` objects populated at import time by each
+integration package, walked once per chat turn by
+``build_agent_tools``.
+
+There is no dynamic loading, no lifecycle, no per-plugin error
+isolation beyond what Python's import system provides. A plugin that
+raises at import surfaces immediately at server start — exactly when
+we want to know.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from app.core.keys import resolve_api_key
+from app.core.plugins.types import Plugin, ToolContext
+
+logger = logging.getLogger(__name__)
+
+# Internal mutable list. The public surface (``all_plugins``,
+# ``register_plugin``) is what callers use; the list is hidden so a
+# future refactor (e.g. plugin disable flags) can change the storage
+# shape without breaking callers.
+_REGISTRY: list[Plugin] = []
+
+
+def register_plugin(plugin: Plugin) -> None:
+    """Add ``plugin`` to the registry.
+
+    Raises:
+        ValueError: If a plugin with the same ``id`` is already
+            registered. We refuse silent overwrites because they would
+            mask real bugs — two integrations claiming the same id is
+            never intentional.
+    """
+    for existing in _REGISTRY:
+        if existing.id == plugin.id:
+            raise ValueError(
+                f"Plugin id '{plugin.id}' is already registered. "
+                f"Each plugin must declare a unique id."
+            )
+    _REGISTRY.append(plugin)
+    logger.info(
+        "plugin_registered id=%s tools=%d env_keys=%d",
+        plugin.id,
+        len(plugin.tool_factories),
+        len(plugin.env_keys),
+    )
+
+
+def all_plugins() -> tuple[Plugin, ...]:
+    """Return every registered plugin in registration order.
+
+    The return type is a tuple so callers can't accidentally mutate
+    the registry. Order is preserved so plugin tools appear in a
+    stable position in the agent's tool list (matters for
+    snapshot-style tests).
+    """
+    return tuple(_REGISTRY)
+
+
+def is_activated_by_env_keys(plugin: Plugin) -> Callable[[ToolContext], bool]:
+    """Build the default activation predicate for ``plugin``.
+
+    A plugin is activated when every ``required=True`` entry in its
+    :attr:`Plugin.env_keys` resolves to a non-empty value for the
+    active workspace. Plugins with no required env keys are always
+    activated (they expose tools unconditionally).
+
+    Plugins that need a more complex predicate override
+    :attr:`Plugin.is_activated` directly; this helper is exposed so
+    they can compose it with extra checks if they want the env-key
+    behaviour as a baseline.
+    """
+    required_keys = tuple(spec.name for spec in plugin.env_keys if spec.required)
+
+    def _predicate(ctx: ToolContext) -> bool:
+        return all(resolve_api_key(ctx.user_id, key_name) for key_name in required_keys)
+
+    return _predicate
+
+
+def reset_for_tests() -> None:
+    """Empty the registry. Exposed only for tests."""
+    _REGISTRY.clear()

--- a/backend/app/core/plugins/registry.py
+++ b/backend/app/core/plugins/registry.py
@@ -79,7 +79,7 @@ def is_activated_by_env_keys(plugin: Plugin) -> Callable[[ToolContext], bool]:
     required_keys = tuple(spec.name for spec in plugin.env_keys if spec.required)
 
     def _predicate(ctx: ToolContext) -> bool:
-        return all(resolve_api_key(ctx.user_id, key_name) for key_name in required_keys)
+        return all(resolve_api_key(ctx.workspace_id, key_name) for key_name in required_keys)
 
     return _predicate
 

--- a/backend/app/core/plugins/types.py
+++ b/backend/app/core/plugins/types.py
@@ -1,0 +1,120 @@
+"""Type definitions for the plugin registry.
+
+A plugin contributes :class:`AgentTool` instances on demand. The host
+hands every tool factory a :class:`ToolContext` carrying the call-time
+fields the factory needs to bind correctly: which workspace is active,
+where on disk it lives, who the authenticated user is, and how the
+agent should deliver messages back if applicable.
+
+This module is deliberately small: the registry is a list of
+:class:`Plugin` objects, ``build_agent_tools`` walks it, and each
+factory is responsible for its own JSON-Schema and execute callable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.agent_loop.types import AgentTool
+    from app.core.tools.send_message import SendFn
+
+
+@dataclass(frozen=True)
+class EnvKeySpec:
+    """One workspace-scoped environment key declared by a plugin.
+
+    Plugins use these to teach the host which keys belong to them —
+    today this is informational (the central ``OVERRIDABLE_KEYS``
+    allowlist in :mod:`app.core.keys` is still the source of truth);
+    once the settings UI auto-renders rows from the registry, the
+    ``label`` and ``help_url`` fields become user-visible.
+
+    Attributes:
+        name: The env-var name as stored in the workspace ``.env``
+            (e.g. ``"NOTION_API_KEY"``). Must match the corresponding
+            entry in :data:`app.core.keys.OVERRIDABLE_KEYS`.
+        label: Short human-readable label for the Settings UI.
+        help_url: Optional link to documentation explaining how to
+            obtain a value for this key (e.g. Notion's integration
+            page). ``None`` if the key is self-explanatory.
+        required: When ``True``, the plugin's default activation
+            predicate refuses to expose tools unless this key resolves
+            to a non-empty value. When ``False``, the plugin handles
+            its own absence (e.g. emits a friendlier error at execute
+            time). Default ``True``.
+    """
+
+    name: str
+    label: str
+    help_url: str | None = None
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ToolContext:
+    """The per-call binding passed into every plugin tool factory.
+
+    Mirrors the keyword arguments the chat router already collects
+    when composing the tool list, so adding a plugin never requires
+    touching the router again.
+
+    Attributes:
+        workspace_id: The active workspace UUID. Plugins resolve env
+            keys via :func:`app.core.keys.resolve_api_key` against this
+            workspace.
+        workspace_root: Absolute filesystem path to the workspace
+            directory (the same path passed to core workspace tools).
+            Plugins may read or write under this root with the same
+            invariants as core tools (no traversal, scoped writes).
+        user_id: Authenticated user UUID. Useful for audit logging
+            and for legacy lookups that still key by user.
+        send_fn: Optional channel delivery callback. When supplied,
+            plugins MAY register tools that proactively push messages
+            back to the user mid-turn. When ``None``, such tools should
+            be omitted from the factory's return value.
+    """
+
+    workspace_id: uuid.UUID
+    workspace_root: Path
+    user_id: uuid.UUID
+    send_fn: SendFn | None = None
+
+
+ToolFactory = Callable[[ToolContext], "AgentTool"]
+"""A function that produces one ``AgentTool`` bound to a ``ToolContext``."""
+
+
+@dataclass(frozen=True)
+class Plugin:
+    """One registered integration.
+
+    Attributes:
+        id: Stable machine-readable identifier (e.g. ``"notion"``).
+            Must be unique across the registry; the loader rejects
+            duplicates.
+        name: Short human-readable label shown in the Settings UI.
+        description: One-sentence summary of what the integration does.
+        env_keys: Tuple of env keys the plugin declares ownership of.
+            By default, the activation predicate requires every
+            ``required=True`` key to resolve in the current workspace
+            before any of this plugin's tools are exposed to the agent.
+        tool_factories: Tuple of factories that produce the plugin's
+            tools when called with a :class:`ToolContext`. Order is
+            preserved in the final tool list (after all core tools).
+        is_activated: Optional override for the activation predicate.
+            Default behaviour returns ``True`` when every required
+            ``env_key`` resolves to a non-empty value for the active
+            workspace.
+    """
+
+    id: str
+    name: str
+    description: str
+    env_keys: tuple[EnvKeySpec, ...] = field(default_factory=tuple)
+    tool_factories: tuple[ToolFactory, ...] = field(default_factory=tuple)
+    is_activated: Callable[[ToolContext], bool] | None = None

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -186,7 +186,7 @@ class ClaudeLLM:
         model_id: str,
         *,
         config: ClaudeLLMConfig | None = None,
-        user_id: uuid.UUID | None = None,
+        workspace_id: uuid.UUID | None = None,
     ) -> None:
         """Construct a Claude provider bound to a specific model slug.
 
@@ -199,12 +199,13 @@ class ClaudeLLM:
             config: Optional Claude-specific config (OAuth token,
                 ``max_turns``, extra env). Defaults are read by the
                 factory from ``settings``.
-            user_id: App-level user UUID. When set, ``stream()`` resolves
-                per-workspace API-key overrides for this user.
+            workspace_id: Active workspace UUID. When set, ``stream()``
+                resolves per-workspace API-key overrides through
+                :func:`app.core.keys.resolve_api_key`.
         """
         self._model_id = model_id
         self._config = config or ClaudeLLMConfig()
-        self._user_id = user_id
+        self._workspace_id = workspace_id
         # PR 05: rolling buffer for the last few CLI stderr lines so a
         # ``ProcessError`` can surface useful diagnostic context.
         self._stderr_buffer: list[str] = []
@@ -513,8 +514,8 @@ class ClaudeLLM:
     def _build_env(self) -> dict[str, str]:
         """Compose the env dict forwarded to the CLI subprocess."""
         env: dict[str, str] = dict(self._config.extra_env)
-        if self._user_id:
-            token = resolve_api_key(self._user_id, "CLAUDE_CODE_OAUTH_TOKEN")
+        if self._workspace_id:
+            token = resolve_api_key(self._workspace_id, "CLAUDE_CODE_OAUTH_TOKEN")
             if token:
                 env["CLAUDE_CODE_OAUTH_TOKEN"] = token
         elif self._config.oauth_token:

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -37,7 +37,7 @@ this table must always agree.
 def resolve_llm(
     model_id: str | ParsedModelId | None,
     *,
-    user_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> AILLM:
     """Return the correct :class:`AILLM` for ``model_id``.
 
@@ -45,8 +45,9 @@ def resolve_llm(
         model_id: Canonical wire string (``host:vendor/model``) or a
             pre-parsed identifier. ``None`` defaults to the catalog's
             default model.
-        user_id: Authenticated user UUID, used to resolve per-workspace
-            API-key overrides. ``None`` falls back to the global key.
+        workspace_id: Active workspace UUID, used to resolve
+            per-workspace API-key overrides.  ``None`` falls back
+            to the global gateway key.
 
     Returns:
         A provider instance ready to ``stream()``.
@@ -76,7 +77,7 @@ def resolve_llm(
         config = ClaudeLLMConfig(
             oauth_token=settings.claude_code_oauth_token or None,
         )
-        return ClaudeLLM(parsed.model, config=config, user_id=user_id)
+        return ClaudeLLM(parsed.model, config=config, workspace_id=workspace_id)
     if provider_cls is GeminiLLM:
-        return GeminiLLM(parsed.model, user_id=user_id)
+        return GeminiLLM(parsed.model, workspace_id=workspace_id)
     raise KeyError(f"no provider class registered for host {parsed.host!r}")

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -150,10 +150,10 @@ def _build_gemini_contents(messages: list[AgentMessage]) -> list[gtypes.Content]
     return contents
 
 
-def _resolve_gemini_api_key(user_id: uuid.UUID | None) -> str:
+def _resolve_gemini_api_key(workspace_id: uuid.UUID | None) -> str:
     """Resolve the Gemini API key for this request."""
-    if user_id is not None:
-        return resolve_api_key(user_id, "GEMINI_API_KEY") or ""
+    if workspace_id is not None:
+        return resolve_api_key(workspace_id, "GEMINI_API_KEY") or ""
     return settings.google_api_key
 
 
@@ -217,7 +217,7 @@ def _tool_calls_from_chunk(chunk: Any, start_index: int) -> list[dict[str, Any]]
 
 def make_gemini_stream_fn(
     model_id: str,
-    user_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
     *,
     system_prompt: str,
 ) -> StreamFn:
@@ -225,11 +225,11 @@ def make_gemini_stream_fn(
 
     Args:
         model_id: Gemini model identifier (e.g. ``"gemini-3.1-flash-lite-preview"``).
-        user_id: Authenticated user UUID, used to resolve a per-workspace
+        workspace_id: Active workspace UUID, used to resolve a per-workspace
             ``GEMINI_API_KEY`` override. When ``None`` the gateway-global
             ``settings.google_api_key`` is used directly, matching
-            ``ClaudeLLM``'s optional ``user_id`` contract for unauthenticated
-            background work (e.g. utility agents).
+            ``ClaudeLLM``'s optional ``workspace_id`` contract for
+            unauthenticated background work (e.g. utility agents).
         system_prompt: The system prompt for this StreamFn.  Captured into the
             returned closure and bound to ``GenerateContentConfig.system_instruction``
             on every call.  ``GeminiLLM.stream`` builds a fresh StreamFn per
@@ -249,7 +249,7 @@ def make_gemini_stream_fn(
         messages: list[AgentMessage],
         tools: list[AgentTool],
     ) -> AsyncIterator[LLMEvent]:
-        client = genai.Client(api_key=_resolve_gemini_api_key(user_id))
+        client = genai.Client(api_key=_resolve_gemini_api_key(workspace_id))
         contents = _build_gemini_contents(messages)
         # ``GenerateContentConfig.tools`` is typed as the wider union
         # ``list[Tool | Callable | mcp.Tool | ClientSession] | None``;
@@ -376,18 +376,18 @@ class GeminiLLM:
     chat.py).  Tools are injected per-request via the AgentContext.
     """
 
-    def __init__(self, model_id: str, *, user_id: uuid.UUID | None = None) -> None:
+    def __init__(self, model_id: str, *, workspace_id: uuid.UUID | None = None) -> None:
         """Construct a Gemini provider.
 
         Args:
             model_id: Gemini model identifier.
-            user_id: Authenticated user UUID, optional. When supplied, a
-                per-workspace ``GEMINI_API_KEY`` override is honoured;
+            workspace_id: Active workspace UUID, optional. When supplied,
+                a per-workspace ``GEMINI_API_KEY`` override is honoured;
                 otherwise the gateway-global key is used. Optional to match
                 ``ClaudeLLM``'s contract for unauthenticated callers.
         """
         self._model_id = model_id
-        self._user_id = user_id
+        self._workspace_id = workspace_id
         # ``_stream_fn`` defaults to ``None`` because the production system
         # prompt isn't known until ``stream()`` is called — ``stream()``
         # builds a fresh StreamFn per request via ``make_gemini_stream_fn``
@@ -487,7 +487,7 @@ class GeminiLLM:
         # the injection (the script doesn't care about the prompt).
         stream_fn = self._stream_fn or make_gemini_stream_fn(
             self._model_id,
-            self._user_id,
+            self._workspace_id,
             system_prompt=context.system_prompt,
         )
 

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -44,21 +44,11 @@ from .base import ReasoningEffort, StreamEvent
 
 logger = logging.getLogger(__name__)
 
-# `_FALLBACK_SYSTEM_PROMPT` is the system prompt this provider uses
-# when *no caller supplies one*.  In production the chat router
-# always supplies one (assembled from the workspace's SOUL.md +
-# AGENTS.md per PR #113), so this fallback only fires for unit tests
-# and direct-script callers that don't wire up the assembly
-# pipeline.
-#
-# It's imported from `app.core.agent_system_prompt` instead of being
-# a string literal here so that the Gemini and Claude providers fall
-# back to the **same** constant.  Otherwise the agent's identity
-# would silently change when the user switched models — which is the
-# behaviour AGENTS.md was meant to make impossible.
-#
-# The local alias is kept for grep continuity with the previous
-# in-file constant of the same name.
+# ``_FALLBACK_SYSTEM_PROMPT`` is only used when no caller supplies a
+# system prompt (unit tests, direct scripts).  Imported from
+# ``app.core.agent_system_prompt`` so Gemini and Claude fall back to
+# the same constant — otherwise the agent's identity would silently
+# change when the user switched models.
 
 
 def _build_gemini_tool_declarations(

--- a/backend/app/core/tools/exa_search_agent.py
+++ b/backend/app/core/tools/exa_search_agent.py
@@ -74,11 +74,11 @@ _PARAMETERS: dict = {
 }
 
 
-def make_exa_search_tool(*, user_id: uuid.UUID | None = None) -> AgentTool:
+def make_exa_search_tool(*, workspace_id: uuid.UUID | None = None) -> AgentTool:
     """Return an :class:`AgentTool` wrapping the Exa web-search core.
 
     Args:
-        user_id: Authenticated user UUID, used to resolve per-workspace
+        workspace_id: Active workspace UUID, used to resolve per-workspace
             API key overrides. When ``None`` the global settings key is used.
 
     Returns:
@@ -92,8 +92,8 @@ def make_exa_search_tool(*, user_id: uuid.UUID | None = None) -> AgentTool:
         num_results = int(kwargs.get("num_results") or 5)
         include_full_text = bool(kwargs.get("include_full_text") or False)
         api_key = None
-        if user_id:
-            api_key = resolve_api_key(user_id, "EXA_API_KEY")
+        if workspace_id:
+            api_key = resolve_api_key(workspace_id, "EXA_API_KEY")
         result = await exa_search(
             query,
             num_results=num_results,

--- a/backend/app/core/tools/image_gen_agent.py
+++ b/backend/app/core/tools/image_gen_agent.py
@@ -101,14 +101,14 @@ def _make_slug(prompt: str) -> str:
 def make_image_gen_tool(
     *,
     workspace_root: Path,
-    user_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> AgentTool:
     """Return an :class:`AgentTool` that generates images via Codex OAuth.
 
     Args:
         workspace_root: The user's workspace directory.  Generated images are
             saved here under ``generated_images/``.
-        user_id: Authenticated user UUID, used to resolve the
+        workspace_id: Active workspace UUID, used to resolve the
             ``OPENAI_CODEX_OAUTH_TOKEN`` workspace override if set.
 
     Returns:
@@ -127,8 +127,8 @@ def make_image_gen_tool(
 
         # Resolve Codex OAuth token: workspace override → auth.json fallback.
         override_token: str | None = None
-        if user_id is not None:
-            override_token = resolve_api_key(user_id, "OPENAI_CODEX_OAUTH_TOKEN")
+        if workspace_id is not None:
+            override_token = resolve_api_key(workspace_id, "OPENAI_CODEX_OAUTH_TOKEN")
 
         try:
             oauth_token = resolve_codex_oauth_token(override_token)

--- a/backend/app/integrations/__init__.py
+++ b/backend/app/integrations/__init__.py
@@ -5,4 +5,15 @@ iMessage as follow-ups). Adapters are responsible for the
 provider-specific I/O — translating inbound updates into Nexus's
 domain calls and rendering Nexus's outbound text into the provider's
 native primitives.
+
+Plugin-style integrations (Notion, future Slack-as-tools, etc.) also
+live here.  Importing this module triggers each plugin subpackage's
+import, which in turn registers the plugin against
+``app.core.plugins.registry`` so :func:`app.core.agent_tools.build_agent_tools`
+sees it on the next chat turn.
 """
+
+# Triggers Notion plugin registration as an import side-effect.  Kept
+# at module scope so a single ``import app.integrations`` is enough to
+# activate every in-tree plugin.
+from app.integrations import notion  # noqa: F401

--- a/backend/app/integrations/notion/__init__.py
+++ b/backend/app/integrations/notion/__init__.py
@@ -1,0 +1,21 @@
+"""Notion integration for Pawrrtal.
+
+Importing this package registers the Notion :class:`Plugin` against
+:mod:`app.core.plugins.registry`, exposing the eighteen ``notion_*``
+tools to any agent whose workspace has a ``NOTION_API_KEY`` configured.
+
+Execution is delegated to the official Notion CLI (``ntn``):
+:mod:`app.integrations.notion.ntn_client` shells out per call with the
+workspace's token injected via ``NOTION_API_TOKEN`` and an isolated
+``HOME`` so any state ``ntn`` writes can't leak between workspaces.
+Each invocation is logged to :class:`app.models.NotionOperationLog`
+so ``notion_logs_read`` can surface history without scraping uvicorn
+output.
+
+Design rationale lives in
+``frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx``.
+"""
+
+from app.integrations.notion.plugin import notion_plugin
+
+__all__ = ["notion_plugin"]

--- a/backend/app/integrations/notion/audit.py
+++ b/backend/app/integrations/notion/audit.py
@@ -1,0 +1,206 @@
+"""Audit-log wrapper for Notion tool calls.
+
+Every ``notion_*`` tool runs its underlying work through
+:func:`with_audit`, which times the call, captures the request/response
+shape, and writes one row to :class:`app.models.NotionOperationLog`.
+Failures are logged with the error string instead of the response, so
+the ``notion_logs_read`` tool can answer "what's been failing lately?"
+without forcing every tool to remember the same boilerplate.
+
+The wrapper is intentionally tiny: it adds *only* audit logging.  Token
+isolation, subprocess management, and JSON parsing belong in
+``ntn_client``; tool-specific shaping belongs in the per-tool factory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from app.db import async_session_maker
+from app.integrations.notion.ntn_client import NtnError
+from app.models import NotionOperationLog
+
+logger = logging.getLogger(__name__)
+
+# Status strings stored in NotionOperationLog.status — kept narrow so
+# log-reader prompts can match against a literal union.
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
+# Hard cap on stored JSON payload size, in bytes after serialisation.
+# Notion responses can be enormous (a full database query), and we
+# don't need them verbatim for debugging — a head-trimmed snapshot is
+# plenty.
+MAX_AUDIT_PAYLOAD_BYTES = 4096
+
+
+async def with_audit(
+    *,
+    workspace_id: uuid.UUID,
+    tool_name: str,
+    operation: str,
+    request: dict[str, Any] | None,
+    func: Callable[[], Awaitable[Any]],
+    page_id: str | None = None,
+    database_id: str | None = None,
+) -> Any:
+    """Run ``func`` and write one audit row regardless of outcome.
+
+    Args:
+        workspace_id: The active workspace; rows cascade with its delete.
+        tool_name: Name of the calling tool (e.g. ``"notion_search"``).
+        operation: Coarse bucket — ``"search"``, ``"read"``, ``"write"``,
+            etc.  Looser than ``tool_name`` so log-reader queries can
+            slice across closely related tools.
+        request: Arbitrary JSON-safe dict capturing the call's input.
+            Pass ``None`` when the call has no meaningful input (e.g.
+            ``notion_doctor``).
+        func: Async function that performs the actual work and returns
+            the value :func:`with_audit` should forward to the caller.
+        page_id: Optional indexed column; set when the tool targets a
+            specific Notion page so ``notion_logs_read`` can filter on it.
+        database_id: Optional indexed column; set when the tool targets a
+            specific Notion database.
+        page_id / database_id: Optional indexed columns; set when the
+            tool targets a specific Notion entity so ``notion_logs_read``
+            can filter on them.
+
+    Returns:
+        Whatever ``func()`` returned, unchanged.
+
+    Raises:
+        The original exception from ``func()``, after a failure row is
+        written.  We re-raise rather than swallow because the caller's
+        tool contract expects to surface errors to the agent.
+    """
+    started_at = time.monotonic()
+    try:
+        result = await func()
+    except NtnError as exc:
+        await _persist(
+            workspace_id=workspace_id,
+            tool_name=tool_name,
+            operation=operation,
+            page_id=page_id,
+            database_id=database_id,
+            status=STATUS_ERROR,
+            duration_ms=_elapsed_ms(started_at),
+            error=str(exc),
+            request_json=request,
+            response_json=None,
+        )
+        raise
+    except (TimeoutError, OSError) as exc:
+        # ``asyncio.TimeoutError`` is ``TimeoutError`` since 3.11.  OS
+        # errors cover the case where the binary is missing or the
+        # subprocess setup itself failed.  Narrower than ``Exception``
+        # so unrelated bugs aren't masked.
+        await _persist(
+            workspace_id=workspace_id,
+            tool_name=tool_name,
+            operation=operation,
+            page_id=page_id,
+            database_id=database_id,
+            status=STATUS_ERROR,
+            duration_ms=_elapsed_ms(started_at),
+            error=str(exc),
+            request_json=request,
+            response_json=None,
+        )
+        raise
+
+    await _persist(
+        workspace_id=workspace_id,
+        tool_name=tool_name,
+        operation=operation,
+        page_id=page_id,
+        database_id=database_id,
+        status=STATUS_OK,
+        duration_ms=_elapsed_ms(started_at),
+        error=None,
+        request_json=request,
+        response_json=_jsonable(result),
+    )
+    return result
+
+
+def _elapsed_ms(started_at: float) -> int:
+    """Return the elapsed wall-clock time since ``started_at`` in ms."""
+    return int((time.monotonic() - started_at) * 1000)
+
+
+def _jsonable(value: Any) -> Any:
+    """Return a JSON-serializable snapshot of ``value`` for the log row.
+
+    Falls back to ``str()`` on anything ``json`` rejects (e.g. raw bytes,
+    custom dataclasses) so audit writes never crash on exotic returns.
+    Truncates oversized payloads at :data:`MAX_AUDIT_PAYLOAD_BYTES`.
+    """
+    try:
+        encoded = json.dumps(value)
+    except (TypeError, ValueError):
+        encoded = json.dumps(str(value))
+    if len(encoded) > MAX_AUDIT_PAYLOAD_BYTES:
+        # Store a string marker rather than truncated JSON, which would
+        # corrupt the structured representation.
+        return {
+            "_truncated": True,
+            "_size_bytes": len(encoded),
+            "head": encoded[:MAX_AUDIT_PAYLOAD_BYTES],
+        }
+    return json.loads(encoded)
+
+
+async def _persist(
+    *,
+    workspace_id: uuid.UUID,
+    tool_name: str,
+    operation: str,
+    page_id: str | None,
+    database_id: str | None,
+    status: str,
+    duration_ms: int,
+    error: str | None,
+    request_json: dict[str, Any] | None,
+    response_json: Any | None,
+) -> None:
+    """Write one audit row in its own DB session.
+
+    Uses a fresh session rather than the chat router's transactional
+    one so an audit-log write never fails the actual tool call.  The
+    write happens after the tool returns, so a failure here is logged
+    but not propagated.
+    """
+    try:
+        async with async_session_maker() as session:
+            session.add(
+                NotionOperationLog(
+                    workspace_id=workspace_id,
+                    tool_name=tool_name,
+                    operation=operation,
+                    page_id=page_id,
+                    database_id=database_id,
+                    status=status,
+                    duration_ms=duration_ms,
+                    error=error,
+                    request_json=request_json,
+                    response_json=response_json,
+                    created_at=datetime.now(UTC).replace(tzinfo=None),
+                )
+            )
+            await session.commit()
+    except OSError as exc:
+        # DB unreachable or disk full — log loudly but never block the
+        # caller.  A missed audit row is not worth a failed tool turn.
+        logger.warning(
+            "notion_audit: failed to persist row tool=%s status=%s: %s",
+            tool_name,
+            status,
+            exc,
+        )

--- a/backend/app/integrations/notion/ntn_client.py
+++ b/backend/app/integrations/notion/ntn_client.py
@@ -1,0 +1,185 @@
+"""Thin async wrapper around the official Notion CLI (``ntn``).
+
+Every Notion tool in this plugin shells out to ``ntn`` through
+:func:`call_ntn`.  The wrapper is deliberately narrow: it injects the
+workspace-scoped ``NOTION_API_TOKEN`` and an isolated ``HOME`` for
+each call, so two requests from different workspaces never share state
+on disk.  ``HOME`` isolation is defence-in-depth — ``ntn login``
+should never run server-side, but if it does, the artifacts land in a
+throw-away tempdir.
+
+The binary itself is installed into the backend image (``chore(docker):
+install ntn`` commit).  In local development, the install instructions
+in ``docs/handbook/integrations/notion.md`` get the dev environment
+set up.
+
+JSON parsing is opt-in: most ``ntn api`` calls return JSON, but ``ntn
+pages get`` returns Markdown.  :func:`call_ntn_json` and
+:func:`call_ntn_text` make the caller's intent explicit at the call
+site so we don't silently corrupt one with the other's parser.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on how long any single ``ntn`` call may take.  Notion's
+# server-side limits are far below this; we use the timeout primarily to
+# bound the impact of a hung subprocess.
+NTN_CALL_TIMEOUT_SECONDS = 30.0
+
+# Default binary name. Overridable via the ``NTN_BINARY`` env var so
+# Dockerfiles or tests can swap in a pinned path / fake script without
+# patching Python imports.
+NTN_BINARY_ENV_VAR = "NTN_BINARY"
+DEFAULT_NTN_BINARY = "ntn"
+
+
+class NtnError(RuntimeError):
+    """Raised when ``ntn`` exits non-zero.
+
+    Carries the original return code and stderr so callers (typically
+    :func:`app.integrations.notion.audit.with_audit`) can record the
+    failure mode for ``notion_logs_read`` to surface later.
+    """
+
+    def __init__(self, returncode: int, stderr: str) -> None:
+        super().__init__(f"ntn exited {returncode}: {stderr.strip()[:300]}")
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@dataclass(frozen=True)
+class NtnResult:
+    """Stdout/stderr pair from a successful ``ntn`` call.
+
+    Kept as bytes so callers can decide between ``.decode()`` text and
+    ``json.loads(stdout)`` without us guessing wrong at the seam.
+    """
+
+    stdout: bytes
+    stderr: bytes
+
+
+def _resolve_binary() -> str:
+    """Return the ``ntn`` binary to exec.
+
+    Honours the ``NTN_BINARY`` env var so the Dockerfile can pin an
+    absolute path and tests can point at a deterministic stub.
+    """
+    return os.environ.get(NTN_BINARY_ENV_VAR, DEFAULT_NTN_BINARY)
+
+
+def _build_env(token: str, home_dir: str) -> dict[str, str]:
+    """Compose the minimal env handed to the subprocess.
+
+    Keeps ``PATH`` so the OS can find shared libraries, but otherwise
+    runs with a near-empty environment to limit accidental leakage.
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "NOTION_API_TOKEN": token,
+        # Disables interactive colour codes that would otherwise pollute
+        # the captured stdout when ``ntn`` thinks it's running in a TTY.
+        "NO_COLOR": "1",
+    }
+    # Carry through proxy / locale knobs an operator might have set;
+    # everything else is intentionally dropped.
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "LANG", "LC_ALL"):
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    return env
+
+
+async def call_ntn(
+    args: Sequence[str],
+    *,
+    token: str,
+    stdin: bytes | None = None,
+    timeout_seconds: float = NTN_CALL_TIMEOUT_SECONDS,
+) -> NtnResult:
+    """Run ``ntn <args>`` and return its raw output.
+
+    Args:
+        args: Argument list passed to the binary, *excluding* the program
+            name itself (e.g. ``["api", "v1/search", "query=foo"]``).
+        token: The workspace's ``NOTION_API_KEY``.  Injected as the
+            ``NOTION_API_TOKEN`` env var so ``ntn`` picks it up the same
+            way a human shell would.
+        stdin: Optional bytes piped to ``ntn``'s stdin.  Used by file
+            uploads (``ntn files create``).
+        timeout_seconds: Wall-clock budget.  Defaults to
+            :data:`NTN_CALL_TIMEOUT_SECONDS`.
+
+    Returns:
+        An :class:`NtnResult` with the captured stdout/stderr bytes.
+
+    Raises:
+        NtnError: Process exited non-zero.
+        asyncio.TimeoutError: Process hit ``timeout_seconds``.  The
+            caller's audit-log wrapper translates this to a recorded
+            error row, so we don't try to swallow it here.
+    """
+    binary = _resolve_binary()
+    # Use a per-call ephemeral HOME — see module docstring.  The
+    # ``with`` block guarantees the directory is removed even when the
+    # subprocess raises mid-flight.
+    with tempfile.TemporaryDirectory(prefix="pawrrtal-ntn-home-") as home_dir:
+        env = _build_env(token, home_dir)
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            *args,
+            env=env,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=stdin),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        if proc.returncode != 0:
+            raise NtnError(proc.returncode or -1, stderr.decode(errors="replace"))
+        return NtnResult(stdout=stdout, stderr=stderr)
+
+
+async def call_ntn_json(args: Sequence[str], *, token: str, stdin: bytes | None = None) -> Any:
+    """Run an ``ntn`` command that emits JSON; return the parsed body."""
+    result = await call_ntn(args, token=token, stdin=stdin)
+    if not result.stdout:
+        return None
+    return json.loads(result.stdout)
+
+
+async def call_ntn_text(args: Sequence[str], *, token: str, stdin: bytes | None = None) -> str:
+    """Run an ``ntn`` command that emits Markdown / plain text."""
+    result = await call_ntn(args, token=token, stdin=stdin)
+    return result.stdout.decode(errors="replace")
+
+
+def format_query_params(params: Mapping[str, str]) -> list[str]:
+    """Translate a ``{key: value}`` map into ``key==value`` arg tokens.
+
+    ``ntn api`` uses ``==`` for query-string params and ``=`` for body
+    fields (per its built-in help text).  Callers should pass body
+    fields directly as ``"foo=bar"`` strings; this helper exists for
+    the query-string case so we don't sprinkle ``==`` literals across
+    eighteen tool factories.
+    """
+    return [f"{key}=={value}" for key, value in params.items() if value != ""]

--- a/backend/app/integrations/notion/plugin.py
+++ b/backend/app/integrations/notion/plugin.py
@@ -1,0 +1,39 @@
+"""Plugin manifest for the Notion integration.
+
+Importing this module registers the plugin against the global
+:mod:`app.core.plugins.registry`.  ``app.integrations.__init__`` is
+responsible for triggering the import; nothing else should import this
+file directly (importing it twice would attempt a duplicate
+registration and raise).
+"""
+
+from __future__ import annotations
+
+from app.core.plugins import (
+    EnvKeySpec,
+    Plugin,
+    register_plugin,
+)
+from app.integrations.notion.tools import factories
+
+NOTION_INTEGRATION_URL = "https://www.notion.so/profile/integrations"
+
+notion_plugin = Plugin(
+    id="notion",
+    name="Notion",
+    description=(
+        "Read, write, search, comment, and sync workspace content with "
+        "the connected Notion workspace via the official `ntn` CLI."
+    ),
+    env_keys=(
+        EnvKeySpec(
+            name="NOTION_API_KEY",
+            label="Notion API Key",
+            help_url=NOTION_INTEGRATION_URL,
+            required=True,
+        ),
+    ),
+    tool_factories=factories,
+)
+
+register_plugin(notion_plugin)

--- a/backend/app/integrations/notion/tools/__init__.py
+++ b/backend/app/integrations/notion/tools/__init__.py
@@ -1,0 +1,63 @@
+"""Notion tool factories grouped by concern.
+
+Eighteen tools (``notion_search``, ``notion_read``, ...) live across
+the modules in this package; each module owns the factories for one
+loose category so no single file exceeds the project's 500-LOC ceiling.
+
+``factories`` exports the flat tuple the :class:`Plugin` consumes.
+"""
+
+from app.integrations.notion.tools.comments import (
+    make_notion_comment_create_tool,
+    make_notion_comment_list_tool,
+)
+from app.integrations.notion.tools.database import make_notion_query_tool
+from app.integrations.notion.tools.diagnostics import (
+    make_notion_doctor_tool,
+    make_notion_help_tool,
+    make_notion_logs_read_tool,
+)
+from app.integrations.notion.tools.lifecycle import (
+    make_notion_delete_tool,
+    make_notion_move_tool,
+    make_notion_publish_tool,
+)
+from app.integrations.notion.tools.read import (
+    make_notion_file_tree_tool,
+    make_notion_read_markdown_tool,
+    make_notion_read_tool,
+    make_notion_search_tool,
+)
+from app.integrations.notion.tools.sync import make_notion_sync_tool
+from app.integrations.notion.tools.write import (
+    make_notion_append_tool,
+    make_notion_create_tool,
+    make_notion_update_markdown_tool,
+    make_notion_update_page_tool,
+)
+
+# Stable tuple consumed by ``plugin.notion_plugin.tool_factories``.
+# Order matches openclaw-notion's ``contracts.tools`` list so prompts
+# enumerating the tool surface get a familiar ordering.
+factories = (
+    make_notion_search_tool,
+    make_notion_read_tool,
+    make_notion_append_tool,
+    make_notion_create_tool,
+    make_notion_read_markdown_tool,
+    make_notion_update_markdown_tool,
+    make_notion_update_page_tool,
+    make_notion_comment_create_tool,
+    make_notion_comment_list_tool,
+    make_notion_query_tool,
+    make_notion_delete_tool,
+    make_notion_move_tool,
+    make_notion_publish_tool,
+    make_notion_file_tree_tool,
+    make_notion_sync_tool,
+    make_notion_help_tool,
+    make_notion_doctor_tool,
+    make_notion_logs_read_tool,
+)
+
+__all__ = ["factories"]

--- a/backend/app/integrations/notion/tools/_helpers.py
+++ b/backend/app/integrations/notion/tools/_helpers.py
@@ -1,0 +1,93 @@
+"""Shared helpers for Notion tool factories.
+
+Pulling these out of every per-category module keeps the tool files
+short and ensures all eighteen tools format their error responses
+the same way (which the agent's downstream parsing depends on).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.keys import resolve_api_key
+from app.core.plugins.types import ToolContext
+
+NOTION_API_KEY_NAME = "NOTION_API_KEY"
+
+
+def resolve_workspace_token(ctx: ToolContext) -> str | None:
+    """Return the workspace's ``NOTION_API_KEY`` or ``None`` when unset.
+
+    Centralised so every tool factory uses the same resolver / key
+    name; if Notion ever expands the env-key surface the change lands
+    in exactly one place.
+    """
+    return resolve_api_key(ctx.workspace_id, NOTION_API_KEY_NAME)
+
+
+def encode_error(message: str) -> str:
+    """Render a stable JSON error string for the agent.
+
+    Matches openclaw-notion's ``{"error": "..."}`` shape so prompts that
+    branch on the error envelope keep working unchanged.
+    """
+    return json.dumps({"error": message})
+
+
+def encode_result(payload: Any) -> str:
+    """Render a successful tool result as JSON for the LLM.
+
+    Notion responses are deeply structured; the LLM is more accurate
+    consuming the JSON verbatim than a paraphrased prose summary, so
+    we serialise straight through and let the model reason over it.
+    """
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def build_tool(
+    *,
+    name: str,
+    description: str,
+    parameters: dict[str, Any],
+    execute: Callable[[str, dict[str, Any]], Awaitable[str]],
+) -> AgentTool:
+    """Wire an ``AgentTool`` from a parameter schema and an async handler.
+
+    Centralises the kwargs → dict marshaling so each per-tool factory
+    can focus on the actual logic.
+    """
+
+    async def _execute(tool_call_id: str, **kwargs: object) -> str:
+        # Coerce kwargs straight through — the agent loop already
+        # validated them against ``parameters`` (a JSON schema) on the
+        # provider side, so we trust the keys here.
+        return await execute(tool_call_id, dict(kwargs))
+
+    return AgentTool(
+        name=name,
+        description=description,
+        parameters=parameters,
+        execute=_execute,
+    )
+
+
+def require_token(ctx: ToolContext) -> str | None:
+    """Return the token or ``None``; tools surface a clean error on miss.
+
+    Activation gating already keeps tools off the list when
+    ``NOTION_API_KEY`` isn't configured, but a race (key cleared
+    mid-turn) could still produce a missing token at execute time.
+    Surfacing a friendly message beats letting ``ntn`` exit non-zero
+    with an opaque auth error.
+    """
+    return resolve_workspace_token(ctx)
+
+
+def missing_token_error() -> str:
+    """Stable error string when the workspace token is gone at exec time."""
+    return encode_error(
+        "Notion is not configured for this workspace. Add a NOTION_API_KEY in Settings → Workspace."
+    )

--- a/backend/app/integrations/notion/tools/_helpers.py
+++ b/backend/app/integrations/notion/tools/_helpers.py
@@ -75,13 +75,16 @@ def build_tool(
 
 
 def require_token(ctx: ToolContext) -> str | None:
-    """Return the token or ``None``; tools surface a clean error on miss.
+    """Return the workspace's current token or ``None`` when unset.
 
     Activation gating already keeps tools off the list when
-    ``NOTION_API_KEY`` isn't configured, but a race (key cleared
-    mid-turn) could still produce a missing token at execute time.
-    Surfacing a friendly message beats letting ``ntn`` exit non-zero
-    with an opaque auth error.
+    ``NOTION_API_KEY`` isn't configured at build-time, but the key can
+    be rotated or cleared between ``build_agent_tools`` and a
+    subsequent tool call within the same turn.  Call this **inside
+    ``execute``** (not at factory body), so the resolution observes
+    the workspace's current state per call; on a miss surface
+    :func:`missing_token_error` instead of letting ``ntn`` exit with
+    an opaque auth error.
     """
     return resolve_workspace_token(ctx)
 

--- a/backend/app/integrations/notion/tools/comments.py
+++ b/backend/app/integrations/notion/tools/comments.py
@@ -1,0 +1,133 @@
+"""Notion comment tools: create and list comments on a page."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_json, format_query_params
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+DEFAULT_COMMENT_PAGE_SIZE = 25
+MAX_COMMENT_PAGE_SIZE = 100
+
+
+def make_notion_comment_create_tool(ctx: ToolContext) -> AgentTool:
+    """Post a comment to a Notion page."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        text = str(params.get("text") or "")
+        if not page_id or not text:
+            return encode_error("page_id and text are required")
+
+        body = json.dumps(
+            {
+                "parent": {"page_id": page_id},
+                "rich_text": [{"type": "text", "text": {"content": text}}],
+            }
+        )
+
+        async def _do() -> Any:
+            return await call_ntn_json(
+                ["api", "v1/comments", "-X", "POST", "-d", body], token=token
+            )
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_comment_create",
+                operation="write",
+                request={"page_id": page_id, "text_chars": len(text)},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_comment_create",
+        description="Add a comment to a Notion page.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "text": {"type": "string", "description": "Comment text."},
+            },
+            "required": ["page_id", "text"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_comment_list_tool(ctx: ToolContext) -> AgentTool:
+    """List comments on a Notion page."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        page_size = min(
+            int(params.get("page_size") or DEFAULT_COMMENT_PAGE_SIZE),
+            MAX_COMMENT_PAGE_SIZE,
+        )
+        if not page_id:
+            return encode_error("page_id is required")
+
+        async def _do() -> Any:
+            args = [
+                "api",
+                "v1/comments",
+                *format_query_params({"block_id": page_id, "page_size": str(page_size)}),
+            ]
+            return await call_ntn_json(args, token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_comment_list",
+                operation="read",
+                request={"page_id": page_id, "page_size": page_size},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_comment_list",
+        description="List comments on a Notion page, newest first.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "page_size": {
+                    "type": "integer",
+                    "description": (
+                        f"Max comments to return (1-{MAX_COMMENT_PAGE_SIZE}). "
+                        f"Default {DEFAULT_COMMENT_PAGE_SIZE}."
+                    ),
+                    "minimum": 1,
+                    "maximum": MAX_COMMENT_PAGE_SIZE,
+                    "default": DEFAULT_COMMENT_PAGE_SIZE,
+                },
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )

--- a/backend/app/integrations/notion/tools/comments.py
+++ b/backend/app/integrations/notion/tools/comments.py
@@ -23,9 +23,9 @@ MAX_COMMENT_PAGE_SIZE = 100
 
 def make_notion_comment_create_tool(ctx: ToolContext) -> AgentTool:
     """Post a comment to a Notion page."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -75,9 +75,9 @@ def make_notion_comment_create_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_comment_list_tool(ctx: ToolContext) -> AgentTool:
     """List comments on a Notion page."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")

--- a/backend/app/integrations/notion/tools/database.py
+++ b/backend/app/integrations/notion/tools/database.py
@@ -1,0 +1,108 @@
+"""Notion database query tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_json
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+DEFAULT_QUERY_PAGE_SIZE = 25
+MAX_QUERY_PAGE_SIZE = 100
+
+
+def make_notion_query_tool(ctx: ToolContext) -> AgentTool:
+    """Query a Notion database with optional filter / sort objects."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        database_id = str(params.get("database_id") or "")
+        if not database_id:
+            return encode_error("database_id is required")
+
+        body_dict: dict[str, Any] = {
+            "page_size": min(
+                int(params.get("page_size") or DEFAULT_QUERY_PAGE_SIZE),
+                MAX_QUERY_PAGE_SIZE,
+            ),
+        }
+        filter_obj = params.get("filter")
+        if isinstance(filter_obj, dict) and filter_obj:
+            body_dict["filter"] = filter_obj
+        sorts_obj = params.get("sorts")
+        if isinstance(sorts_obj, list) and sorts_obj:
+            body_dict["sorts"] = sorts_obj
+        body = json.dumps(body_dict)
+
+        async def _do() -> Any:
+            args = [
+                "api",
+                f"v1/databases/{database_id}/query",
+                "-X",
+                "POST",
+                "-d",
+                body,
+            ]
+            return await call_ntn_json(args, token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_query",
+                operation="read",
+                request={"database_id": database_id, **body_dict},
+                database_id=database_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_query",
+        description=(
+            "Query a Notion database. Accepts an optional Notion-shaped "
+            "`filter` object and `sorts` array; both default to none."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "database_id": {
+                    "type": "string",
+                    "description": "Database ID (UUID).",
+                },
+                "filter": {
+                    "type": "object",
+                    "description": "Notion filter object (optional).",
+                },
+                "sorts": {
+                    "type": "array",
+                    "description": "Notion sort array (optional).",
+                    "items": {"type": "object"},
+                },
+                "page_size": {
+                    "type": "integer",
+                    "description": (
+                        f"Max rows (1-{MAX_QUERY_PAGE_SIZE}). Default {DEFAULT_QUERY_PAGE_SIZE}."
+                    ),
+                    "minimum": 1,
+                    "maximum": MAX_QUERY_PAGE_SIZE,
+                    "default": DEFAULT_QUERY_PAGE_SIZE,
+                },
+            },
+            "required": ["database_id"],
+        },
+        execute=execute,
+    )

--- a/backend/app/integrations/notion/tools/database.py
+++ b/backend/app/integrations/notion/tools/database.py
@@ -23,9 +23,9 @@ MAX_QUERY_PAGE_SIZE = 100
 
 def make_notion_query_tool(ctx: ToolContext) -> AgentTool:
     """Query a Notion database with optional filter / sort objects."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         database_id = str(params.get("database_id") or "")

--- a/backend/app/integrations/notion/tools/diagnostics.py
+++ b/backend/app/integrations/notion/tools/diagnostics.py
@@ -1,0 +1,175 @@
+"""Diagnostic Notion tools: help, doctor, logs read.
+
+These three don't touch Notion's API beyond a connectivity probe in
+``notion_doctor``; their job is to make the integration self-describing
+for the agent so it can answer "is Notion configured?" / "what tools
+do I have?" / "show me the last few operations" without falling back
+to free-form text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.db import async_session_maker
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_json
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+from app.models import NotionOperationLog
+
+DEFAULT_LOGS_LIMIT = 20
+MAX_LOGS_LIMIT = 100
+
+
+def make_notion_help_tool(ctx: ToolContext) -> AgentTool:
+    """Return a static catalogue of the plugin's eighteen tools."""
+
+    async def execute(_tool_call_id: str, _params: dict[str, Any]) -> str:
+        # Help is intentionally static — the catalogue can't change at
+        # runtime without a code deploy, so audit-logging this would be
+        # noise.  Skip ``with_audit`` on this one tool.
+        catalogue = {
+            "tools": [
+                {"name": "notion_search", "summary": "Search workspace by query."},
+                {"name": "notion_read", "summary": "Read a page as raw block JSON."},
+                {"name": "notion_read_markdown", "summary": "Read a page as Markdown."},
+                {"name": "notion_append", "summary": "Append blocks to a page."},
+                {"name": "notion_create", "summary": "Create a new page from Markdown."},
+                {"name": "notion_update_markdown", "summary": "Replace a page body."},
+                {"name": "notion_update_page", "summary": "PATCH page properties."},
+                {"name": "notion_comment_create", "summary": "Post a comment to a page."},
+                {"name": "notion_comment_list", "summary": "List comments on a page."},
+                {"name": "notion_query", "summary": "Query a Notion database."},
+                {"name": "notion_delete", "summary": "Archive (soft-delete) a page."},
+                {"name": "notion_move", "summary": "Re-parent a page."},
+                {"name": "notion_publish", "summary": "Toggle public sharing on a page."},
+                {"name": "notion_file_tree", "summary": "Recursively map child pages."},
+                {"name": "notion_sync", "summary": "Push/pull a local markdown file."},
+                {"name": "notion_help", "summary": "This tool — list all Notion tools."},
+                {"name": "notion_doctor", "summary": "Health-check the connection."},
+                {"name": "notion_logs_read", "summary": "Show recent Notion operations."},
+            ],
+        }
+        return encode_result(catalogue)
+
+    return build_tool(
+        name="notion_help",
+        description="List every Notion tool available in this plugin.",
+        parameters={"type": "object", "properties": {}, "additionalProperties": False},
+        execute=execute,
+    )
+
+
+def make_notion_doctor_tool(ctx: ToolContext) -> AgentTool:
+    """Connectivity probe — calls ``v1/users/me`` to confirm auth works."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, _params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+
+        async def _do() -> Any:
+            return await call_ntn_json(["api", "v1/users/me"], token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_doctor",
+                operation="diagnostic",
+                request=None,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(
+            {
+                "ok": True,
+                "bot": {
+                    "id": result.get("id") if isinstance(result, dict) else None,
+                    "name": result.get("name") if isinstance(result, dict) else None,
+                },
+            }
+        )
+
+    return build_tool(
+        name="notion_doctor",
+        description=(
+            "Health-check the Notion connection. Calls /v1/users/me and "
+            "returns the bot's id/name on success, or an error otherwise."
+        ),
+        parameters={"type": "object", "properties": {}, "additionalProperties": False},
+        execute=execute,
+    )
+
+
+def make_notion_logs_read_tool(ctx: ToolContext) -> AgentTool:
+    """Read the last N audit rows for this workspace."""
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        limit = min(int(params.get("limit") or DEFAULT_LOGS_LIMIT), MAX_LOGS_LIMIT)
+        tool_filter = str(params.get("tool_name") or "").strip()
+
+        async with async_session_maker() as session:
+            query = (
+                select(NotionOperationLog)
+                .where(NotionOperationLog.workspace_id == ctx.workspace_id)
+                .order_by(NotionOperationLog.created_at.desc())
+                .limit(limit)
+            )
+            if tool_filter:
+                query = query.where(NotionOperationLog.tool_name == tool_filter)
+            rows = (await session.execute(query)).scalars().all()
+
+        return encode_result(
+            {
+                "logs": [
+                    {
+                        "id": str(row.id),
+                        "tool_name": row.tool_name,
+                        "operation": row.operation,
+                        "status": row.status,
+                        "duration_ms": row.duration_ms,
+                        "page_id": row.page_id,
+                        "database_id": row.database_id,
+                        "error": row.error,
+                        "created_at": row.created_at.isoformat(),
+                    }
+                    for row in rows
+                ],
+            }
+        )
+
+    return build_tool(
+        name="notion_logs_read",
+        description=(
+            "Return recent Notion operation logs for this workspace, "
+            "newest first. Filter by tool name with `tool_name`."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": f"Max rows (1-{MAX_LOGS_LIMIT}).",
+                    "minimum": 1,
+                    "maximum": MAX_LOGS_LIMIT,
+                    "default": DEFAULT_LOGS_LIMIT,
+                },
+                "tool_name": {
+                    "type": "string",
+                    "description": "Filter to one tool name (optional).",
+                },
+            },
+        },
+        execute=execute,
+    )

--- a/backend/app/integrations/notion/tools/diagnostics.py
+++ b/backend/app/integrations/notion/tools/diagnostics.py
@@ -72,9 +72,9 @@ def make_notion_help_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_doctor_tool(ctx: ToolContext) -> AgentTool:
     """Connectivity probe — calls ``v1/users/me`` to confirm auth works."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, _params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
 

--- a/backend/app/integrations/notion/tools/lifecycle.py
+++ b/backend/app/integrations/notion/tools/lifecycle.py
@@ -1,0 +1,183 @@
+"""Lifecycle Notion tools: delete (archive), move, publish."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_json
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+
+def make_notion_delete_tool(ctx: ToolContext) -> AgentTool:
+    """Archive a Notion page (Notion has no hard delete).
+
+    Maps to ``PATCH /v1/pages/{id} {"archived": true}`` so the page is
+    moved to Trash and can be restored from the Notion UI — matching
+    openclaw-notion's contract.
+    """
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        if not page_id:
+            return encode_error("page_id is required")
+
+        body = json.dumps({"archived": True})
+
+        async def _do() -> Any:
+            return await call_ntn_json(
+                ["api", f"v1/pages/{page_id}", "-X", "PATCH", "-d", body],
+                token=token,
+            )
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_delete",
+                operation="delete",
+                request={"page_id": page_id},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_delete",
+        description=(
+            "Archive (soft-delete) a Notion page. The page moves to Trash "
+            "and can be restored via the Notion UI."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_move_tool(ctx: ToolContext) -> AgentTool:
+    """Re-parent a Notion page under a new parent page."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        new_parent_id = str(params.get("new_parent_page_id") or "")
+        if not page_id or not new_parent_id:
+            return encode_error("page_id and new_parent_page_id are required")
+
+        body = json.dumps({"parent": {"page_id": new_parent_id}})
+
+        async def _do() -> Any:
+            return await call_ntn_json(
+                ["api", f"v1/pages/{page_id}", "-X", "PATCH", "-d", body],
+                token=token,
+            )
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_move",
+                operation="write",
+                request={"page_id": page_id, "new_parent_page_id": new_parent_id},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_move",
+        description="Re-parent a Notion page under a different parent page.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page to move (UUID)."},
+                "new_parent_page_id": {
+                    "type": "string",
+                    "description": "Destination parent page (UUID).",
+                },
+            },
+            "required": ["page_id", "new_parent_page_id"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_publish_tool(ctx: ToolContext) -> AgentTool:
+    """Toggle Notion page-level public sharing on or off.
+
+    Notion exposes share state via the ``public_url`` property on a
+    page; PATCHing ``{"public_url": {"public": true}}`` flips it.
+    Useful for "make this page public" agent prompts.
+    """
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        public = bool(params.get("public", True))
+        if not page_id:
+            return encode_error("page_id is required")
+
+        body = json.dumps({"public_url": {"public": public}})
+
+        async def _do() -> Any:
+            return await call_ntn_json(
+                ["api", f"v1/pages/{page_id}", "-X", "PATCH", "-d", body],
+                token=token,
+            )
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_publish",
+                operation="write",
+                request={"page_id": page_id, "public": public},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_publish",
+        description=(
+            "Toggle a Notion page's public sharing state. Pass `public: true` "
+            "to make the page accessible via a public URL; `false` to revoke."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "public": {
+                    "type": "boolean",
+                    "description": "Target sharing state.",
+                    "default": True,
+                },
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )

--- a/backend/app/integrations/notion/tools/lifecycle.py
+++ b/backend/app/integrations/notion/tools/lifecycle.py
@@ -25,9 +25,9 @@ def make_notion_delete_tool(ctx: ToolContext) -> AgentTool:
     moved to Trash and can be restored from the Notion UI — matching
     openclaw-notion's contract.
     """
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -74,9 +74,9 @@ def make_notion_delete_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_move_tool(ctx: ToolContext) -> AgentTool:
     """Re-parent a Notion page under a new parent page."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -130,9 +130,9 @@ def make_notion_publish_tool(ctx: ToolContext) -> AgentTool:
     page; PATCHing ``{"public_url": {"public": true}}`` flips it.
     Useful for "make this page public" agent prompts.
     """
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")

--- a/backend/app/integrations/notion/tools/read.py
+++ b/backend/app/integrations/notion/tools/read.py
@@ -1,0 +1,296 @@
+"""Read-side Notion tools: search, read blocks, read markdown, file tree.
+
+All four are non-mutating.  ``notion_read_markdown`` uses the dedicated
+``ntn pages get`` command (markdown-native); the rest go through the
+generic ``ntn api`` escape hatch.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import (
+    NtnError,
+    call_ntn_json,
+    call_ntn_text,
+    format_query_params,
+)
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+# Default page size for search / list endpoints — Notion's max is 100;
+# 10 keeps the response token-efficient for normal use.
+DEFAULT_SEARCH_PAGE_SIZE = 10
+MAX_SEARCH_PAGE_SIZE = 100
+
+# Recursion ceiling for ``notion_file_tree``: stops a malformed tree
+# (or an adversarial workspace with cycles) from looping forever.
+FILE_TREE_MAX_DEPTH = 6
+
+
+def make_notion_search_tool(ctx: ToolContext) -> AgentTool:
+    """Full-text search across the connected workspace."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        query = str(params.get("query") or "")
+        page_size = min(
+            int(params.get("page_size") or DEFAULT_SEARCH_PAGE_SIZE),
+            MAX_SEARCH_PAGE_SIZE,
+        )
+
+        async def _do() -> Any:
+            args = [
+                "api",
+                "v1/search",
+                *format_query_params({"query": query, "page_size": str(page_size)}),
+            ]
+            return await call_ntn_json(args, token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_search",
+                operation="search",
+                request={"query": query, "page_size": page_size},
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_search",
+        description=(
+            "Search the connected Notion workspace by query string. Returns "
+            "matching pages and databases ranked by relevance. Use this to "
+            "locate a page before reading or editing it."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural-language search query.",
+                },
+                "page_size": {
+                    "type": "integer",
+                    "description": (
+                        f"Max results (1-{MAX_SEARCH_PAGE_SIZE}). "
+                        f"Default {DEFAULT_SEARCH_PAGE_SIZE}."
+                    ),
+                    "minimum": 1,
+                    "maximum": MAX_SEARCH_PAGE_SIZE,
+                    "default": DEFAULT_SEARCH_PAGE_SIZE,
+                },
+            },
+            "required": ["query"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_read_tool(ctx: ToolContext) -> AgentTool:
+    """Return a page's block tree as raw Notion JSON.
+
+    Prefer ``notion_read_markdown`` for most agent tasks — the markdown
+    form is dramatically smaller and easier for the LLM to consume.
+    This raw shape exists for callers that need block-level metadata.
+    """
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        if not page_id:
+            return encode_error("page_id is required")
+
+        async def _do() -> Any:
+            return await call_ntn_json(["api", f"v1/blocks/{page_id}/children"], token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_read",
+                operation="read",
+                request={"page_id": page_id},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_read",
+        description=(
+            "Return the block tree of a Notion page as Notion API JSON. "
+            "Prefer notion_read_markdown unless you specifically need raw "
+            "block metadata (block types, formatting flags, child counts)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {
+                    "type": "string",
+                    "description": "The Notion page ID (UUID).",
+                },
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_read_markdown_tool(ctx: ToolContext) -> AgentTool:
+    """Return a page rendered as Markdown via ``ntn pages get``."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        if not page_id:
+            return encode_error("page_id is required")
+
+        async def _do() -> Any:
+            return await call_ntn_text(["pages", "get", page_id], token=token)
+
+        try:
+            markdown = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_read_markdown",
+                operation="read",
+                request={"page_id": page_id},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return json.dumps({"page_id": page_id, "markdown": markdown})
+
+    return build_tool(
+        name="notion_read_markdown",
+        description=(
+            "Render a Notion page as Markdown. The preferred read path for "
+            "agents: smaller, structured, and trivially patched back with "
+            "notion_update_markdown."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {
+                    "type": "string",
+                    "description": "The Notion page ID (UUID).",
+                },
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_file_tree_tool(ctx: ToolContext) -> AgentTool:
+    """Walk a page's child hierarchy and return a flat title/id list.
+
+    Composite — calls ``v1/blocks/<id>/children`` recursively up to
+    :data:`FILE_TREE_MAX_DEPTH` levels.  Used for "give me a map of
+    this section before I dive in" prompts.
+    """
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        root_id = str(params.get("page_id") or "")
+        max_depth = min(
+            int(params.get("max_depth") or FILE_TREE_MAX_DEPTH),
+            FILE_TREE_MAX_DEPTH,
+        )
+        if not root_id:
+            return encode_error("page_id is required")
+
+        async def _do() -> Any:
+            return await _walk_children(token, root_id, max_depth, 0)
+
+        try:
+            tree = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_file_tree",
+                operation="read",
+                request={"page_id": root_id, "max_depth": max_depth},
+                page_id=root_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result({"root": root_id, "tree": tree})
+
+    return build_tool(
+        name="notion_file_tree",
+        description=(
+            "Return a recursive title/id tree of a page's child pages, up "
+            f"to {FILE_TREE_MAX_DEPTH} levels deep. Useful for orienting "
+            "before deeper reads."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {
+                    "type": "string",
+                    "description": "Root page ID.",
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": (
+                        f"Recursion ceiling (1-{FILE_TREE_MAX_DEPTH}). Lower values run faster."
+                    ),
+                    "minimum": 1,
+                    "maximum": FILE_TREE_MAX_DEPTH,
+                    "default": FILE_TREE_MAX_DEPTH,
+                },
+            },
+            "required": ["page_id"],
+        },
+        execute=execute,
+    )
+
+
+async def _walk_children(
+    token: str, page_id: str, max_depth: int, current_depth: int
+) -> list[dict[str, Any]]:
+    """Recursively gather child-page summaries under ``page_id``."""
+    if current_depth >= max_depth:
+        return []
+    response = await call_ntn_json(["api", f"v1/blocks/{page_id}/children"], token=token)
+    if not isinstance(response, dict):
+        return []
+    nodes: list[dict[str, Any]] = []
+    for block in response.get("results", []) or []:
+        if not isinstance(block, dict) or block.get("type") != "child_page":
+            continue
+        child_id = block.get("id") or ""
+        title = ""
+        child_page = block.get("child_page")
+        if isinstance(child_page, dict):
+            title = str(child_page.get("title") or "")
+        nodes.append(
+            {
+                "id": child_id,
+                "title": title,
+                "children": await _walk_children(token, child_id, max_depth, current_depth + 1),
+            }
+        )
+    return nodes

--- a/backend/app/integrations/notion/tools/read.py
+++ b/backend/app/integrations/notion/tools/read.py
@@ -39,9 +39,9 @@ FILE_TREE_MAX_DEPTH = 6
 
 def make_notion_search_tool(ctx: ToolContext) -> AgentTool:
     """Full-text search across the connected workspace."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         query = str(params.get("query") or "")
@@ -108,9 +108,9 @@ def make_notion_read_tool(ctx: ToolContext) -> AgentTool:
     form is dramatically smaller and easier for the LLM to consume.
     This raw shape exists for callers that need block-level metadata.
     """
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -156,9 +156,9 @@ def make_notion_read_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_read_markdown_tool(ctx: ToolContext) -> AgentTool:
     """Return a page rendered as Markdown via ``ntn pages get``."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -209,9 +209,9 @@ def make_notion_file_tree_tool(ctx: ToolContext) -> AgentTool:
     :data:`FILE_TREE_MAX_DEPTH` levels.  Used for "give me a map of
     this section before I dive in" prompts.
     """
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         root_id = str(params.get("page_id") or "")

--- a/backend/app/integrations/notion/tools/sync.py
+++ b/backend/app/integrations/notion/tools/sync.py
@@ -1,0 +1,207 @@
+"""Local-markdown <-> Notion sync tool.
+
+``notion_sync`` reads a Markdown file from the workspace, looks at its
+YAML frontmatter for a ``notion_id`` reference, then either pushes the
+local content to Notion or pulls Notion's content into the file based
+on the ``direction`` parameter.  The simplification vs openclaw-notion
+is intentional: we surface the directional intent as an explicit
+parameter rather than auto-detecting via mtime comparisons, which
+agents handle more reliably with a small extra argument.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_text
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+DIRECTION_PUSH = "push"
+DIRECTION_PULL = "pull"
+VALID_DIRECTIONS = (DIRECTION_PUSH, DIRECTION_PULL)
+
+# Sentinel frontmatter delimiter line.
+_FRONTMATTER_FENCE = "---"
+
+
+def make_notion_sync_tool(ctx: ToolContext) -> AgentTool:
+    """Push or pull a workspace markdown file against a Notion page."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        rel_path = str(params.get("path") or "")
+        direction = str(params.get("direction") or "").strip().lower()
+        if not rel_path or direction not in VALID_DIRECTIONS:
+            return encode_error("path and direction (push|pull) are required")
+
+        try:
+            target = _safe_workspace_path(ctx.workspace_root, rel_path)
+        except ValueError as exc:
+            return encode_error(str(exc))
+
+        if direction == DIRECTION_PUSH and not await anyio.Path(target).exists():
+            return encode_error(f"path not found: {rel_path}")
+
+        if direction == DIRECTION_PUSH:
+            return await _do_push(ctx, token, target, rel_path)
+        return await _do_pull(ctx, token, target, rel_path, params)
+
+    return build_tool(
+        name="notion_sync",
+        description=(
+            "Sync a Markdown file in the workspace with a Notion page. "
+            "`direction=push` writes local markdown to Notion (page id read "
+            "from `notion_id` in YAML frontmatter). `direction=pull` reads "
+            "Notion's current markdown into the local file (specify "
+            "`page_id` if no frontmatter exists yet)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Workspace-relative path to the Markdown file.",
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": list(VALID_DIRECTIONS),
+                    "description": "Whether to push local -> Notion or pull Notion -> local.",
+                },
+                "page_id": {
+                    "type": "string",
+                    "description": (
+                        "Page UUID. Required when pulling into a file with no "
+                        "frontmatter; otherwise read from `notion_id` in frontmatter."
+                    ),
+                },
+            },
+            "required": ["path", "direction"],
+        },
+        execute=execute,
+    )
+
+
+def _safe_workspace_path(root: Path, rel_path: str) -> Path:
+    """Resolve ``rel_path`` under ``root`` and reject traversal."""
+    candidate = (root / rel_path).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError("path must stay inside the workspace") from exc
+    return candidate
+
+
+def _parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Pull a minimal ``key: value`` frontmatter block out of ``content``.
+
+    Avoids a YAML dep — the only field we read is ``notion_id``, so a
+    line-by-line key/value scan is sufficient and predictable.
+    Returns ``(frontmatter, body)``.
+    """
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
+        return {}, content
+    fm: dict[str, str] = {}
+    body_start: int | None = None
+    for idx, raw in enumerate(lines[1:], start=1):
+        if raw.strip() == _FRONTMATTER_FENCE:
+            body_start = idx + 1
+            break
+        if ":" not in raw:
+            continue
+        key, _, value = raw.partition(":")
+        fm[key.strip()] = value.strip()
+    if body_start is None:
+        return {}, content
+    return fm, "\n".join(lines[body_start:])
+
+
+def _serialise_frontmatter(fm: dict[str, str], body: str) -> str:
+    """Inverse of :func:`_parse_frontmatter`."""
+    if not fm:
+        return body
+    lines = [_FRONTMATTER_FENCE]
+    lines.extend(f"{k}: {v}" for k, v in fm.items())
+    lines.append(_FRONTMATTER_FENCE)
+    lines.append(body)
+    return "\n".join(lines)
+
+
+async def _do_push(ctx: ToolContext, token: str, target: Path, rel_path: str) -> str:
+    """Push local markdown body to its Notion page."""
+    content = await anyio.Path(target).read_text(encoding="utf-8")
+    fm, body = _parse_frontmatter(content)
+    page_id = fm.get("notion_id") or ""
+    if not page_id:
+        return encode_error("no notion_id in frontmatter; create the page first with notion_create")
+
+    async def _do() -> Any:
+        text = await call_ntn_text(["pages", "update", page_id, "--content", body], token=token)
+        return {"output": text, "page_id": page_id, "path": rel_path}
+
+    try:
+        result = await with_audit(
+            workspace_id=ctx.workspace_id,
+            tool_name="notion_sync",
+            operation="write",
+            request={"path": rel_path, "direction": DIRECTION_PUSH},
+            page_id=page_id,
+            func=_do,
+        )
+    except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        return encode_error(str(exc))
+    return encode_result(result)
+
+
+async def _do_pull(
+    ctx: ToolContext,
+    token: str,
+    target: Path,
+    rel_path: str,
+    params: dict[str, Any],
+) -> str:
+    """Pull a Notion page's markdown into the local file."""
+    explicit_page_id = str(params.get("page_id") or "").strip()
+    existing_fm: dict[str, str] = {}
+    apath = anyio.Path(target)
+    if await apath.exists():
+        existing_fm, _ = _parse_frontmatter(await apath.read_text(encoding="utf-8"))
+    page_id = explicit_page_id or existing_fm.get("notion_id") or ""
+    if not page_id:
+        return encode_error("page_id is required when no notion_id frontmatter exists")
+
+    async def _do() -> Any:
+        markdown = await call_ntn_text(["pages", "get", page_id], token=token)
+        fm = dict(existing_fm) if existing_fm else {}
+        fm["notion_id"] = page_id
+        await anyio.Path(target.parent).mkdir(parents=True, exist_ok=True)
+        await apath.write_text(_serialise_frontmatter(fm, markdown), encoding="utf-8")
+        stat = await apath.stat()
+        return {"page_id": page_id, "path": rel_path, "bytes": stat.st_size}
+
+    try:
+        result = await with_audit(
+            workspace_id=ctx.workspace_id,
+            tool_name="notion_sync",
+            operation="read",
+            request={"path": rel_path, "direction": DIRECTION_PULL},
+            page_id=page_id,
+            func=_do,
+        )
+    except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        return encode_error(str(exc))
+    return encode_result(result)

--- a/backend/app/integrations/notion/tools/sync.py
+++ b/backend/app/integrations/notion/tools/sync.py
@@ -38,9 +38,9 @@ _FRONTMATTER_FENCE = "---"
 
 def make_notion_sync_tool(ctx: ToolContext) -> AgentTool:
     """Push or pull a workspace markdown file against a Notion page."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         rel_path = str(params.get("path") or "")

--- a/backend/app/integrations/notion/tools/write.py
+++ b/backend/app/integrations/notion/tools/write.py
@@ -1,0 +1,267 @@
+"""Mutating Notion tools: append, create, update markdown, update page title.
+
+``notion_create`` and ``notion_update_markdown`` use the markdown-native
+``ntn pages`` commands; ``notion_append`` and ``notion_update_page``
+use the generic ``ntn api`` route so we can target individual blocks
+and arbitrary page properties.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.plugins.types import ToolContext
+from app.integrations.notion.audit import with_audit
+from app.integrations.notion.ntn_client import NtnError, call_ntn_json, call_ntn_text
+from app.integrations.notion.tools._helpers import (
+    build_tool,
+    encode_error,
+    encode_result,
+    missing_token_error,
+    require_token,
+)
+
+
+def make_notion_append_tool(ctx: ToolContext) -> AgentTool:
+    """Append blocks to a page via ``v1/blocks/<id>/children`` PATCH."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        children = params.get("children")
+        if not page_id:
+            return encode_error("page_id is required")
+        if not isinstance(children, list) or not children:
+            return encode_error("children must be a non-empty list of block objects")
+
+        body = json.dumps({"children": children})
+
+        async def _do() -> Any:
+            args = [
+                "api",
+                f"v1/blocks/{page_id}/children",
+                "-X",
+                "PATCH",
+                "-d",
+                body,
+            ]
+            return await call_ntn_json(args, token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_append",
+                operation="write",
+                request={"page_id": page_id, "block_count": len(children)},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_append",
+        description=(
+            "Append one or more Notion block objects to a page. `children` "
+            "is the Notion-shaped block array (e.g. "
+            '[{"object":"block","type":"paragraph",...}]).'
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "children": {
+                    "type": "array",
+                    "description": "Notion block objects to append.",
+                    "items": {"type": "object"},
+                },
+            },
+            "required": ["page_id", "children"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_create_tool(ctx: ToolContext) -> AgentTool:
+    """Create a new page under a parent via ``ntn pages create``."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        parent_id = str(params.get("parent_page_id") or "")
+        title = str(params.get("title") or "")
+        markdown = str(params.get("markdown") or "")
+        if not parent_id or not title:
+            return encode_error("parent_page_id and title are required")
+
+        async def _do() -> Any:
+            args = [
+                "pages",
+                "create",
+                "--parent",
+                f"page:{parent_id}",
+                "--title",
+                title,
+                "--content",
+                markdown,
+            ]
+            # ``ntn pages create`` returns text confirming the new page;
+            # use call_ntn_text and surface that directly.
+            text = await call_ntn_text(args, token=token)
+            return {"output": text}
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_create",
+                operation="write",
+                request={
+                    "parent_page_id": parent_id,
+                    "title": title,
+                    "markdown_chars": len(markdown),
+                },
+                page_id=parent_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_create",
+        description=(
+            "Create a new Notion page under `parent_page_id` with a "
+            "Markdown body. Returns the CLI confirmation including the "
+            "new page's URL."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "parent_page_id": {
+                    "type": "string",
+                    "description": "Parent page UUID; the new page lands under it.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Title of the new page.",
+                },
+                "markdown": {
+                    "type": "string",
+                    "description": "Markdown body. Empty string for an empty page.",
+                    "default": "",
+                },
+            },
+            "required": ["parent_page_id", "title"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_update_markdown_tool(ctx: ToolContext) -> AgentTool:
+    """Replace a page's body with new Markdown via ``ntn pages update``."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        markdown = str(params.get("markdown") or "")
+        if not page_id:
+            return encode_error("page_id is required")
+
+        async def _do() -> Any:
+            args = ["pages", "update", page_id, "--content", markdown]
+            text = await call_ntn_text(args, token=token)
+            return {"output": text}
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_update_markdown",
+                operation="write",
+                request={"page_id": page_id, "markdown_chars": len(markdown)},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_update_markdown",
+        description=(
+            "Replace a Notion page's body with the provided Markdown. "
+            "Pair with notion_read_markdown for a full read-edit-write loop."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "markdown": {
+                    "type": "string",
+                    "description": "New Markdown body for the page.",
+                },
+            },
+            "required": ["page_id", "markdown"],
+        },
+        execute=execute,
+    )
+
+
+def make_notion_update_page_tool(ctx: ToolContext) -> AgentTool:
+    """Patch page-level properties (title, icon, cover, archive flag)."""
+    token = require_token(ctx)
+
+    async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        if token is None:
+            return missing_token_error()
+        page_id = str(params.get("page_id") or "")
+        properties = params.get("properties") or {}
+        if not page_id or not isinstance(properties, dict) or not properties:
+            return encode_error("page_id and a non-empty properties object are required")
+
+        body = json.dumps({"properties": properties})
+
+        async def _do() -> Any:
+            args = ["api", f"v1/pages/{page_id}", "-X", "PATCH", "-d", body]
+            return await call_ntn_json(args, token=token)
+
+        try:
+            result = await with_audit(
+                workspace_id=ctx.workspace_id,
+                tool_name="notion_update_page",
+                operation="write",
+                request={"page_id": page_id, "property_keys": list(properties)},
+                page_id=page_id,
+                func=_do,
+            )
+        except (NtnError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            return encode_error(str(exc))
+        return encode_result(result)
+
+    return build_tool(
+        name="notion_update_page",
+        description=(
+            "Patch a Notion page's properties (title, icon, cover, etc.). "
+            "Pass a Notion-shaped `properties` object; only the keys you "
+            "include are touched. Use notion_update_markdown for body edits."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "page_id": {"type": "string", "description": "Page ID (UUID)."},
+                "properties": {
+                    "type": "object",
+                    "description": "Notion `properties` object to PATCH.",
+                },
+            },
+            "required": ["page_id", "properties"],
+        },
+        execute=execute,
+    )

--- a/backend/app/integrations/notion/tools/write.py
+++ b/backend/app/integrations/notion/tools/write.py
@@ -26,9 +26,9 @@ from app.integrations.notion.tools._helpers import (
 
 def make_notion_append_tool(ctx: ToolContext) -> AgentTool:
     """Append blocks to a page via ``v1/blocks/<id>/children`` PATCH."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -89,9 +89,9 @@ def make_notion_append_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_create_tool(ctx: ToolContext) -> AgentTool:
     """Create a new page under a parent via ``ntn pages create``."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         parent_id = str(params.get("parent_page_id") or "")
@@ -165,9 +165,9 @@ def make_notion_create_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_update_markdown_tool(ctx: ToolContext) -> AgentTool:
     """Replace a page's body with new Markdown via ``ntn pages update``."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")
@@ -216,9 +216,9 @@ def make_notion_update_markdown_tool(ctx: ToolContext) -> AgentTool:
 
 def make_notion_update_page_tool(ctx: ToolContext) -> AgentTool:
     """Patch page-level properties (title, icon, cover, archive flag)."""
-    token = require_token(ctx)
 
     async def execute(_tool_call_id: str, params: dict[str, Any]) -> str:
+        token = require_token(ctx)
         if token is None:
             return missing_token_error()
         page_id = str(params.get("page_id") or "")

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -164,7 +164,9 @@ async def _run_llm_turn(*, message: Message, context: TelegramTurnContext) -> No
         else []
     )
 
-    provider, warning = await resolve_provider_with_auto_clear(context)
+    provider, warning = await resolve_provider_with_auto_clear(
+        context, workspace_id=workspace.id if workspace is not None else None
+    )
     if warning is not None:
         await message.answer(warning)
 

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -156,6 +156,7 @@ async def _run_llm_turn(*, message: Message, context: TelegramTurnContext) -> No
         build_agent_tools(
             workspace_root=Path(workspace.path),
             user_id=context.nexus_user_id,
+            workspace_id=workspace.id,
             send_fn=tg_sender,
             surface="telegram",
         )

--- a/backend/app/integrations/telegram/bot_provider_resolution.py
+++ b/backend/app/integrations/telegram/bot_provider_resolution.py
@@ -12,6 +12,7 @@ See ``_resolve_provider_with_auto_clear`` for the auto-clear contract
 from __future__ import annotations
 
 import logging
+import uuid
 
 from app.core.providers import resolve_llm
 from app.core.providers.base import AILLM
@@ -26,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 async def resolve_provider_with_auto_clear(
     context: TelegramTurnContext,
+    *,
+    workspace_id: uuid.UUID | None,
 ) -> tuple[AILLM, str | None]:
     """Resolve a provider for ``context.model_id`` with an auto-clear safety net.
 
@@ -51,7 +54,7 @@ async def resolve_provider_with_auto_clear(
     """
     try:
         require_known(context.model_id)
-        provider = resolve_llm(context.model_id, user_id=context.nexus_user_id)
+        provider = resolve_llm(context.model_id, workspace_id=workspace_id)
     except (InvalidModelId, UnknownModelId) as exc:
         fallback_id = default_model().id
         warning = (
@@ -69,6 +72,6 @@ async def resolve_provider_with_auto_clear(
             context.conversation_id,
             context.model_id,
         )
-        provider = resolve_llm(fallback_id, user_id=context.nexus_user_id)
+        provider = resolve_llm(fallback_id, workspace_id=workspace_id)
         return provider, warning
     return provider, None

--- a/backend/app/integrations/telegram/bot_provider_resolution.py
+++ b/backend/app/integrations/telegram/bot_provider_resolution.py
@@ -45,6 +45,11 @@ async def resolve_provider_with_auto_clear(
 
     Args:
         context: Resolved turn context with the stored ``model_id``.
+        workspace_id: The user's default workspace UUID, used to scope
+            provider API-key resolution (per the workspace-keyed env
+            migration).  ``None`` when no default workspace exists yet
+            (incomplete onboarding) — provider lookups fall through to
+            the gateway-global key.
 
     Returns:
         A tuple of ``(provider, warning_text_or_None)``. When the auto-clear

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -412,6 +412,56 @@ from .governance_models import (  # noqa: E402
     WebhookEventRecord,
 )
 
+
+class NotionOperationLog(Base):
+    """One row per tool call made by the Notion plugin.
+
+    The Notion plugin shells out to the official ``ntn`` CLI; recording
+    each invocation here lets the agent (via ``notion_logs_read``) and
+    operators answer "what did this workspace do in Notion lately?"
+    without scraping uvicorn logs.  Mirrors the SQLite schema used by
+    openclaw-notion's ``audit.ts`` so prompts written against that
+    contract Just Work here.
+
+    Rows are workspace-scoped: the FK cascades on workspace delete so
+    a workspace removal sweeps its history with it.
+    """
+
+    __tablename__ = "notion_operation_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Tool that produced this row.  E.g. "notion_search", "notion_create".
+    tool_name: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # Coarse operation bucket — "search", "read", "write", "delete", etc.
+    # Useful when a single tool has multiple call shapes.
+    operation: Mapped[str] = mapped_column(String(32), nullable=False)
+    # Page / database / block IDs the call targeted, when known.  NULL when
+    # the call was workspace-wide (search) or not page-scoped.
+    page_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    database_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    # "ok" | "error" — outcome string.  Mirrored from openclaw-notion's
+    # contract so log-reader prompts portable between hosts.
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Wall-clock duration of the underlying ntn subprocess call.
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # ntn stderr or thrown exception message; NULL on success.
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Raw request / response JSON for debugging.  Stored even on success
+    # because Notion's API surfaces are wide enough that grepping
+    # human-readable history is genuinely useful.
+    request_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    response_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=_utcnow, index=True
+    )
+
+
 __all__ = [
     "AuditEvent",
     "ChannelBinding",
@@ -422,6 +472,7 @@ __all__ = [
     "LCMContextItem",
     "LCMSummary",
     "LCMSummarySource",
+    "NotionOperationLog",
     "Project",
     "ScheduledJob",
     "SenderType",

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from app.api.stt import get_stt_router
 from app.api.workspace import get_workspace_router
 from app.api.workspace_env import get_workspace_env_router
 from app.cli.admin_seed import seed_admin_user
+from app.cli.migrate_workspace_env import migrate_user_keyed_env_files_for_all_users
 from app.core.config import settings
 from app.core.event_bus import AgentHandler, EventBus, NotificationService
 from app.core.event_bus.global_bus import set_event_bus
@@ -65,6 +66,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await create_db_and_tables()
     # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
     await seed_admin_user()
+    # One-time migration of legacy user-keyed `.env` files to the new
+    # workspace-keyed layout.  Idempotent — when the source file is missing
+    # or the destination already exists, the helper returns without writing.
+    # See ADR 2026-05-15-plugin-system-and-notion-integration.mdx.
+    await migrate_user_keyed_env_files_for_all_users()
     # PR 10: spin up the event bus before any request can fire so the
     # consumer task is ready when the chat router or Telegram dispatcher
     # publishes the first ``TurnStartedEvent``.  Stashed on

--- a/backend/tests/test_keys.py
+++ b/backend/tests/test_keys.py
@@ -37,9 +37,9 @@ def tmp_workspace_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 
 def test_save_and_load_round_trips(tmp_workspace_base: Path) -> None:
     """Saving then loading returns the same key/value pairs."""
-    user_id = uuid4()
-    keys.save_workspace_env(user_id, {"GEMINI_API_KEY": "real-gemini-key"})
-    loaded = keys.load_workspace_env(user_id)
+    workspace_id = uuid4()
+    keys.save_workspace_env(workspace_id, {"GEMINI_API_KEY": "real-gemini-key"})
+    loaded = keys.load_workspace_env(workspace_id)
     assert loaded == {"GEMINI_API_KEY": "real-gemini-key"}
 
 
@@ -51,12 +51,12 @@ def test_save_strips_empty_values(tmp_workspace_base: Path) -> None:
     string as "no override". Strip during save keeps the on-disk file
     consistent with what the resolver actually honours.
     """
-    user_id = uuid4()
+    workspace_id = uuid4()
     keys.save_workspace_env(
-        user_id,
+        workspace_id,
         {"GEMINI_API_KEY": "kept", "EXA_API_KEY": ""},
     )
-    loaded = keys.load_workspace_env(user_id)
+    loaded = keys.load_workspace_env(workspace_id)
     assert loaded == {"GEMINI_API_KEY": "kept"}
     assert "EXA_API_KEY" not in loaded
 
@@ -72,9 +72,9 @@ def test_resolve_api_key_prefers_workspace_override(
 ) -> None:
     """When both workspace override and settings are set, override wins."""
     monkeypatch.setattr(settings, "exa_api_key", "from-settings")
-    user_id = uuid4()
-    keys.save_workspace_env(user_id, {"EXA_API_KEY": "from-workspace"})
-    assert keys.resolve_api_key(user_id, "EXA_API_KEY") == "from-workspace"
+    workspace_id = uuid4()
+    keys.save_workspace_env(workspace_id, {"EXA_API_KEY": "from-workspace"})
+    assert keys.resolve_api_key(workspace_id, "EXA_API_KEY") == "from-workspace"
 
 
 def test_resolve_api_key_falls_back_to_settings(
@@ -88,8 +88,8 @@ def test_resolve_api_key_falls_back_to_settings(
     Bean A across stt.py / agent_tools.py / agents.py).
     """
     monkeypatch.setattr(settings, "exa_api_key", "from-settings")
-    user_id = uuid4()
-    assert keys.resolve_api_key(user_id, "EXA_API_KEY") == "from-settings"
+    workspace_id = uuid4()
+    assert keys.resolve_api_key(workspace_id, "EXA_API_KEY") == "from-settings"
 
 
 def test_resolve_api_key_returns_none_for_unset(
@@ -117,12 +117,12 @@ def test_load_quarantines_corrupt_file(tmp_workspace_base: Path) -> None:
     Without this, a key rotation or partial write would 500 every
     request for that user permanently.
     """
-    user_id = uuid4()
-    path = keys._workspace_env_path(user_id)
+    workspace_id = uuid4()
+    path = keys._workspace_env_path(workspace_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"not encrypted at all")
 
-    loaded = keys.load_workspace_env(user_id)
+    loaded = keys.load_workspace_env(workspace_id)
 
     assert loaded == {}
     assert not path.exists(), "corrupt file should have been renamed aside"
@@ -149,8 +149,8 @@ def test_workspace_path_uses_settings_workspace_base_dir(
     dir, causing data loss on Docker (volume mounts `/data/workspaces`)
     and PermissionError on macOS dev (no `/workspace` directory).
     """
-    user_id = uuid4()
-    keys.save_workspace_env(user_id, {"GEMINI_API_KEY": "val"})
-    expected = tmp_workspace_base / str(user_id) / ".env"
+    workspace_id = uuid4()
+    keys.save_workspace_env(workspace_id, {"GEMINI_API_KEY": "val"})
+    expected = tmp_workspace_base / str(workspace_id) / ".env"
     assert expected.exists()
     assert expected.parent.parent == tmp_workspace_base

--- a/backend/tests/test_migrate_workspace_env.py
+++ b/backend/tests/test_migrate_workspace_env.py
@@ -1,0 +1,116 @@
+"""Tests for the one-time user-keyed → workspace-keyed env migration helper.
+
+The unit-level behaviour (single-file migrate, idempotency, conflict
+quarantine) is exercised here; the startup-time wiring in ``main.py``
+is covered indirectly by the existing app boot tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from app.core import keys
+from app.core.config import settings
+
+
+@pytest.fixture
+def isolate_workspace_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point ``keys.py`` at a per-test temp directory."""
+    monkeypatch.setattr(settings, "workspace_base_dir", str(tmp_path))
+    return tmp_path
+
+
+def _write_legacy_env(base: Path, user_id: uuid.UUID, payload: dict[str, str]) -> Path:
+    """Drop a legacy user-keyed encrypted env file into the fake base dir."""
+    user_dir = base / str(user_id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    # Re-use the production save helper but write to the legacy *user* path.
+    # We do that by temporarily aliasing: easier to assemble the encrypted
+    # bytes directly via the same Fernet the resolver uses.
+    plaintext = "\n".join(f"{k}={v}" for k, v in payload.items() if v)
+    # Access the cached Fernet instance through the public load/save helpers
+    # would write to the new (workspace) path; we want the *legacy* path,
+    # so go through the internal serializer + Fernet to lay the bytes down.
+    fernet = keys._fernet()
+    (user_dir / ".env").write_bytes(fernet.encrypt(plaintext.encode()))
+    (user_dir / ".env").chmod(0o600)
+    return user_dir / ".env"
+
+
+class TestMigrateUserKeyedEnvFile:
+    def test_returns_false_when_no_legacy_file_exists(self, isolate_workspace_base: Path) -> None:
+        user_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+
+        result = keys.migrate_user_keyed_env_file(
+            user_id=user_id, default_workspace_id=workspace_id
+        )
+
+        assert result is False
+
+    def test_moves_legacy_file_into_workspace_dir(self, isolate_workspace_base: Path) -> None:
+        user_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+        _write_legacy_env(isolate_workspace_base, user_id, {"GEMINI_API_KEY": "from-legacy"})
+
+        result = keys.migrate_user_keyed_env_file(
+            user_id=user_id, default_workspace_id=workspace_id
+        )
+
+        assert result is True
+        # The new path is readable through the public resolver.
+        loaded = keys.load_workspace_env(workspace_id)
+        assert loaded == {"GEMINI_API_KEY": "from-legacy"}
+
+    def test_legacy_file_renamed_after_migration(self, isolate_workspace_base: Path) -> None:
+        user_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+        legacy_path = _write_legacy_env(isolate_workspace_base, user_id, {"EXA_API_KEY": "x"})
+
+        keys.migrate_user_keyed_env_file(user_id=user_id, default_workspace_id=workspace_id)
+
+        # Source is renamed (not deleted) so the move is reversible.
+        assert not legacy_path.exists()
+        siblings = list(legacy_path.parent.iterdir())
+        assert any(s.name.startswith(".env.migrated-") for s in siblings)
+
+    def test_idempotent_second_call_is_noop(self, isolate_workspace_base: Path) -> None:
+        user_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+        _write_legacy_env(isolate_workspace_base, user_id, {"EXA_API_KEY": "x"})
+
+        first = keys.migrate_user_keyed_env_file(user_id=user_id, default_workspace_id=workspace_id)
+        second = keys.migrate_user_keyed_env_file(
+            user_id=user_id, default_workspace_id=workspace_id
+        )
+
+        assert first is True
+        assert second is False
+
+    def test_existing_destination_quarantines_legacy_source(
+        self, isolate_workspace_base: Path
+    ) -> None:
+        """When the workspace already has a ``.env``, the legacy file is
+        quarantined rather than overwriting the destination."""
+        user_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+
+        # Pre-existing workspace-keyed env (the "new" value to preserve).
+        keys.save_workspace_env(workspace_id, {"EXA_API_KEY": "workspace-value"})
+        # Legacy file with a conflicting value.
+        legacy_path = _write_legacy_env(
+            isolate_workspace_base, user_id, {"EXA_API_KEY": "legacy-value"}
+        )
+
+        result = keys.migrate_user_keyed_env_file(
+            user_id=user_id, default_workspace_id=workspace_id
+        )
+
+        assert result is False
+        # Workspace value is untouched.
+        assert keys.load_workspace_env(workspace_id) == {"EXA_API_KEY": "workspace-value"}
+        # Legacy file was quarantined.
+        assert not legacy_path.exists()

--- a/backend/tests/test_notion_plugin.py
+++ b/backend/tests/test_notion_plugin.py
@@ -1,0 +1,367 @@
+"""Tests for the Notion plugin.
+
+Three concerns are exercised:
+
+  * Registration — the plugin lands in :func:`all_plugins` with all 18
+    tool factories.
+  * ``call_ntn`` subprocess wrapping — token env injection, isolated
+    ``HOME``, error surfacing.  Each test points ``NTN_BINARY`` at a
+    small shell script written into the test tmpdir so we never need a
+    real ``ntn`` install in CI.
+  * Tool execute paths — every category gets one representative test
+    that monkeypatches the ``call_ntn_*`` seam, runs ``tool.execute()``,
+    and asserts the returned JSON shape + that an audit row was written.
+
+Heavier scenario tests (multi-turn agent loop with the Notion plugin
+loaded) belong in test_agent_loop_scenarios.py; this file stays at the
+unit level.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections.abc import Generator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.plugins import ToolContext, all_plugins
+from app.integrations.notion import notion_plugin
+from app.integrations.notion.audit import STATUS_ERROR, STATUS_OK
+from app.integrations.notion.ntn_client import NtnError, call_ntn
+from app.integrations.notion.tools.comments import make_notion_comment_create_tool
+from app.integrations.notion.tools.database import make_notion_query_tool
+from app.integrations.notion.tools.diagnostics import (
+    make_notion_help_tool,
+    make_notion_logs_read_tool,
+)
+from app.integrations.notion.tools.lifecycle import make_notion_delete_tool
+from app.integrations.notion.tools.read import make_notion_search_tool
+from app.integrations.notion.tools.write import make_notion_create_tool
+from app.models import NotionOperationLog, Workspace
+
+NTN_BINARY_ENV_VAR = "NTN_BINARY"
+
+
+@pytest.fixture
+def ctx(seeded_default_workspace: Workspace, test_user) -> ToolContext:
+    """Build a :class:`ToolContext` bound to the seeded workspace."""
+    return ToolContext(
+        workspace_id=seeded_default_workspace.id,
+        workspace_root=Path(seeded_default_workspace.path),
+        user_id=test_user.id,
+        send_fn=None,
+    )
+
+
+@pytest.fixture
+def patch_audit_sessionmaker(monkeypatch: pytest.MonkeyPatch, db_session: AsyncSession) -> None:
+    """Route audit-log writes through the test's in-memory session.
+
+    Production audit code uses ``app.db.async_session_maker`` directly so
+    a tool call's audit row never participates in the caller's
+    transaction (preventing audit failures from rolling back real work).
+    In tests we want that row visible to the same ``db_session`` that
+    the assertions query, so we monkeypatch the bound name in the audit
+    module to a no-op context manager that yields the test session.
+    """
+
+    class _TestSessionContext:
+        async def __aenter__(self) -> AsyncSession:
+            return db_session
+
+        async def __aexit__(self, *_: object) -> None:
+            # Avoid double-commit / rollback — the production code calls
+            # ``await session.commit()`` itself, which works fine on the
+            # in-memory engine.
+            return None
+
+    def fake_maker() -> _TestSessionContext:
+        return _TestSessionContext()
+
+    monkeypatch.setattr("app.integrations.notion.audit.async_session_maker", fake_maker)
+    monkeypatch.setattr("app.integrations.notion.tools.diagnostics.async_session_maker", fake_maker)
+
+
+@pytest.fixture
+def fake_ntn_binary(tmp_path: Path) -> Generator[Path]:
+    """Create a shell stub at ``tmp_path/ntn`` that echoes a known string.
+
+    Used by the ``call_ntn`` tests; tests that exercise tool factories
+    monkeypatch the ``call_ntn_json`` / ``call_ntn_text`` seam directly
+    and don't need this fixture.
+    """
+    script = tmp_path / "ntn"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        # Print the token + first arg so tests can assert env passthrough.
+        'echo \'{"token":"\'$NOTION_API_TOKEN\'","first_arg":"\'$1\'"}\'\n'
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    previous = os.environ.get(NTN_BINARY_ENV_VAR)
+    os.environ[NTN_BINARY_ENV_VAR] = str(script)
+    try:
+        yield script
+    finally:
+        if previous is None:
+            os.environ.pop(NTN_BINARY_ENV_VAR, None)
+        else:
+            os.environ[NTN_BINARY_ENV_VAR] = previous
+
+
+class TestRegistration:
+    def test_plugin_is_registered_with_eighteen_tools(self) -> None:
+        ids = [p.id for p in all_plugins()]
+        assert "notion" in ids
+        # The registry is module-global and the plugin self-registers on
+        # import; assert against the imported handle so an accidental
+        # re-import wouldn't double-count.
+        assert len(notion_plugin.tool_factories) == 18
+
+
+class TestCallNtn:
+    @pytest.mark.anyio
+    async def test_returns_stdout_when_binary_exits_zero(self, fake_ntn_binary: Path) -> None:
+        result = await call_ntn(["api", "v1/users/me"], token="secret-token")
+        body = json.loads(result.stdout)
+        assert body["token"] == "secret-token"
+        assert body["first_arg"] == "api"
+
+    @pytest.mark.anyio
+    async def test_raises_ntn_error_when_binary_exits_nonzero(self, tmp_path: Path) -> None:
+        script = tmp_path / "ntn"
+        script.write_text("#!/usr/bin/env bash\necho 'boom' >&2\nexit 9\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        previous = os.environ.get(NTN_BINARY_ENV_VAR)
+        os.environ[NTN_BINARY_ENV_VAR] = str(script)
+        try:
+            with pytest.raises(NtnError) as excinfo:
+                await call_ntn(["api", "v1/users/me"], token="t")
+            assert excinfo.value.returncode == 9
+            assert "boom" in excinfo.value.stderr
+        finally:
+            if previous is None:
+                os.environ.pop(NTN_BINARY_ENV_VAR, None)
+            else:
+                os.environ[NTN_BINARY_ENV_VAR] = previous
+
+
+class TestToolFactories:
+    @pytest.mark.anyio
+    async def test_help_tool_returns_static_catalogue(self, ctx: ToolContext) -> None:
+        tool = make_notion_help_tool(ctx)
+        raw = await tool.execute("call-1")
+        payload = json.loads(raw)
+        names = {t["name"] for t in payload["tools"]}
+        assert "notion_search" in names
+        assert "notion_help" in names
+        assert len(payload["tools"]) == 18
+
+    @pytest.mark.anyio
+    async def test_search_returns_missing_token_error_when_unconfigured(
+        self, ctx: ToolContext
+    ) -> None:
+        tool = make_notion_search_tool(ctx)
+        raw = await tool.execute("call-1", query="anything")
+        body = json.loads(raw)
+        assert "error" in body
+        assert "Notion is not configured" in body["error"]
+
+    @pytest.mark.anyio
+    async def test_search_writes_audit_row_on_success(
+        self,
+        ctx: ToolContext,
+        seeded_default_workspace: Workspace,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        patch_audit_sessionmaker: None,
+    ) -> None:
+        # Pretend the workspace has a token configured.
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok-abc",
+        )
+        # Mock the subprocess seam so we don't need a real ntn binary.
+        captured_args: list[list[str]] = []
+
+        async def fake_call(args, *, token, **_):  # type: ignore[no-untyped-def]
+            captured_args.append(list(args))
+            return {"results": [{"id": "page-1", "object": "page"}]}
+
+        monkeypatch.setattr("app.integrations.notion.tools.read.call_ntn_json", fake_call)
+
+        tool = make_notion_search_tool(ctx)
+        raw = await tool.execute("call-1", query="hello")
+        body = json.loads(raw)
+        assert body["results"][0]["id"] == "page-1"
+        assert captured_args[0][:2] == ["api", "v1/search"]
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(NotionOperationLog).where(
+                        NotionOperationLog.workspace_id == seeded_default_workspace.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].tool_name == "notion_search"
+        assert rows[0].status == STATUS_OK
+
+    @pytest.mark.anyio
+    async def test_search_writes_error_row_when_ntn_fails(
+        self,
+        ctx: ToolContext,
+        seeded_default_workspace: Workspace,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        patch_audit_sessionmaker: None,
+    ) -> None:
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok-abc",
+        )
+
+        async def fake_call(*_: Any, **__: Any) -> Any:
+            raise NtnError(2, "unauthorized")
+
+        monkeypatch.setattr("app.integrations.notion.tools.read.call_ntn_json", fake_call)
+
+        tool = make_notion_search_tool(ctx)
+        raw = await tool.execute("call-1", query="hello")
+        body = json.loads(raw)
+        assert "error" in body
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(NotionOperationLog).where(
+                        NotionOperationLog.workspace_id == seeded_default_workspace.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].status == STATUS_ERROR
+        assert rows[0].error and "unauthorized" in rows[0].error
+
+    @pytest.mark.anyio
+    async def test_create_invokes_ntn_pages_create_with_markdown_arg(
+        self,
+        ctx: ToolContext,
+        monkeypatch: pytest.MonkeyPatch,
+        patch_audit_sessionmaker: None,
+    ) -> None:
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok",
+        )
+        captured: list[list[str]] = []
+
+        async def fake_call_text(args, *, token, **_):  # type: ignore[no-untyped-def]
+            captured.append(list(args))
+            return "Created page https://www.notion.so/abc"
+
+        monkeypatch.setattr("app.integrations.notion.tools.write.call_ntn_text", fake_call_text)
+
+        tool = make_notion_create_tool(ctx)
+        raw = await tool.execute(
+            "call-1",
+            parent_page_id="parent-id",
+            title="Hello",
+            markdown="# H1",
+        )
+        body = json.loads(raw)
+        assert "Created page" in body["output"]
+        # ``--content`` arg carries the markdown verbatim — sanity-check
+        # that we didn't accidentally drop it.
+        assert "# H1" in captured[0]
+
+    @pytest.mark.anyio
+    async def test_query_rejects_missing_database_id(
+        self, ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok",
+        )
+        tool = make_notion_query_tool(ctx)
+        raw = await tool.execute("call-1")
+        assert "database_id is required" in json.loads(raw)["error"]
+
+    @pytest.mark.anyio
+    async def test_comment_create_validates_text(
+        self, ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok",
+        )
+        tool = make_notion_comment_create_tool(ctx)
+        raw = await tool.execute("call-1", page_id="p", text="")
+        assert "required" in json.loads(raw)["error"]
+
+    @pytest.mark.anyio
+    async def test_delete_sends_archived_true(
+        self,
+        ctx: ToolContext,
+        monkeypatch: pytest.MonkeyPatch,
+        patch_audit_sessionmaker: None,
+    ) -> None:
+        monkeypatch.setattr(
+            "app.integrations.notion.tools._helpers.resolve_api_key",
+            lambda *_, **__: "tok",
+        )
+        captured: list[list[str]] = []
+
+        async def fake_call(args, *, token, **_):  # type: ignore[no-untyped-def]
+            captured.append(list(args))
+            return {"id": "p", "archived": True}
+
+        monkeypatch.setattr("app.integrations.notion.tools.lifecycle.call_ntn_json", fake_call)
+        tool = make_notion_delete_tool(ctx)
+        await tool.execute("call-1", page_id="p")
+        # The PATCH body sits as the last arg (-d <body>).
+        body_arg = captured[0][-1]
+        assert json.loads(body_arg) == {"archived": True}
+
+    @pytest.mark.anyio
+    async def test_logs_read_returns_workspace_scoped_history(
+        self,
+        ctx: ToolContext,
+        seeded_default_workspace: Workspace,
+        db_session: AsyncSession,
+        patch_audit_sessionmaker: None,
+    ) -> None:
+        # Seed two rows directly — bypasses the audit wrapper since
+        # logs_read shouldn't depend on its own behaviour for the data
+        # it surfaces.
+        for tool_name in ("notion_search", "notion_read"):
+            db_session.add(
+                NotionOperationLog(
+                    workspace_id=seeded_default_workspace.id,
+                    tool_name=tool_name,
+                    operation="read",
+                    status=STATUS_OK,
+                    duration_ms=12,
+                    created_at=datetime.now(UTC).replace(tzinfo=None),
+                )
+            )
+        await db_session.commit()
+
+        tool = make_notion_logs_read_tool(ctx)
+        raw = await tool.execute("call-1", limit=10)
+        payload = json.loads(raw)
+        names = {entry["tool_name"] for entry in payload["logs"]}
+        assert names == {"notion_search", "notion_read"}

--- a/backend/tests/test_plugin_registry.py
+++ b/backend/tests/test_plugin_registry.py
@@ -1,0 +1,241 @@
+"""Tests for the plugin registry and its interaction with build_agent_tools.
+
+These tests exercise the additive seam: a plugin registered through
+:func:`register_plugin` must contribute tools through
+:func:`build_agent_tools` only when (a) the call supplies both
+``user_id`` and ``workspace_id`` and (b) the plugin's activation
+predicate returns ``True``.
+
+Core tool composition is verified by the existing ``test_agent_tools``
+suite; here we only assert that plugins extend that list correctly
+and don't perturb the core tools' order.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.core.agent_loop.types import AgentTool
+from app.core.agent_tools import build_agent_tools
+from app.core.plugins import (
+    EnvKeySpec,
+    Plugin,
+    ToolContext,
+    all_plugins,
+    register_plugin,
+)
+from app.core.plugins.registry import reset_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Generator[None]:
+    """Empty the registry before and after each test to avoid cross-test bleed."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def tmp_workspace(tmp_path: Path) -> Path:
+    """Minimal workspace directory the core tools accept."""
+    (tmp_path / "AGENTS.md").write_text("# Test workspace")
+    return tmp_path
+
+
+def _make_tool(name: str) -> AgentTool:
+    """Return a trivial AgentTool used to detect plugin contribution."""
+
+    async def _execute(_tool_call_id: str, **_kwargs: object) -> str:
+        return f"ok:{name}"
+
+    return AgentTool(
+        name=name,
+        description=f"Test tool {name}",
+        parameters={"type": "object", "properties": {}},
+        execute=_execute,
+    )
+
+
+def _factory(name: str):
+    def _build(_ctx: ToolContext) -> AgentTool:
+        return _make_tool(name)
+
+    return _build
+
+
+class TestRegistration:
+    def test_registers_plugin(self) -> None:
+        plugin = Plugin(id="alpha", name="Alpha", description="x")
+        register_plugin(plugin)
+
+        assert [p.id for p in all_plugins()] == ["alpha"]
+
+    def test_duplicate_id_rejected(self) -> None:
+        register_plugin(Plugin(id="alpha", name="A", description="x"))
+
+        with pytest.raises(ValueError, match="already registered"):
+            register_plugin(Plugin(id="alpha", name="A again", description="y"))
+
+    def test_preserves_registration_order(self) -> None:
+        for pid in ("a", "b", "c"):
+            register_plugin(Plugin(id=pid, name=pid, description=""))
+
+        assert [p.id for p in all_plugins()] == ["a", "b", "c"]
+
+
+class TestPluginsContributeToolsToAgent:
+    def test_registered_factory_appends_tool(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="alpha",
+                name="Alpha",
+                description="",
+                tool_factories=(_factory("alpha_tool"),),
+            )
+        )
+
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(
+                workspace_root=tmp_workspace,
+                user_id=uuid.uuid4(),
+                workspace_id=uuid.uuid4(),
+            )
+
+        assert "alpha_tool" in [t.name for t in tools]
+
+    def test_plugin_tools_appended_after_core(self, tmp_workspace: Path) -> None:
+        """Plugin tools land at the end of the list — stable order matters
+        for the Claude bridge's allowed_tools whitelist."""
+        register_plugin(
+            Plugin(
+                id="alpha",
+                name="Alpha",
+                description="",
+                tool_factories=(_factory("alpha_tool"),),
+            )
+        )
+
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(
+                workspace_root=tmp_workspace,
+                user_id=uuid.uuid4(),
+                workspace_id=uuid.uuid4(),
+            )
+
+        assert tools[-1].name == "alpha_tool"
+
+
+class TestActivationGating:
+    def test_skipped_when_required_env_key_missing(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="needy",
+                name="Needy",
+                description="",
+                env_keys=(EnvKeySpec(name="NEEDY_API_KEY", label="Needy"),),
+                tool_factories=(_factory("needy_tool"),),
+            )
+        )
+
+        # resolve_api_key returns None → required key missing → plugin skipped.
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(
+                workspace_root=tmp_workspace,
+                user_id=uuid.uuid4(),
+                workspace_id=uuid.uuid4(),
+            )
+
+        assert "needy_tool" not in [t.name for t in tools]
+
+    def test_included_when_required_env_key_present(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="needy",
+                name="Needy",
+                description="",
+                env_keys=(EnvKeySpec(name="NEEDY_API_KEY", label="Needy"),),
+                tool_factories=(_factory("needy_tool"),),
+            )
+        )
+
+        # Match the NEEDY_API_KEY lookup specifically; return None for
+        # everything else so core capability-gated tools (Exa,
+        # image-gen) stay absent and the assertion is unambiguous.
+        # We patch BOTH binding sites because Python's `from X import Y`
+        # captures a local reference; the activation predicate looks up
+        # the registry copy while core gating reads the keys-module copy.
+        def _resolve(_user_id, key_name: str) -> str | None:
+            return "secret-value" if key_name == "NEEDY_API_KEY" else None
+
+        with (
+            patch("app.core.keys.resolve_api_key", side_effect=_resolve),
+            patch("app.core.plugins.registry.resolve_api_key", side_effect=_resolve),
+        ):
+            tools = build_agent_tools(
+                workspace_root=tmp_workspace,
+                user_id=uuid.uuid4(),
+                workspace_id=uuid.uuid4(),
+            )
+
+        assert "needy_tool" in [t.name for t in tools]
+
+    def test_custom_predicate_overrides_default(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="picky",
+                name="Picky",
+                description="",
+                env_keys=(EnvKeySpec(name="PICKY_KEY", label="Picky"),),
+                tool_factories=(_factory("picky_tool"),),
+                # Custom predicate ignores env keys and always activates.
+                is_activated=lambda _ctx: True,
+            )
+        )
+
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(
+                workspace_root=tmp_workspace,
+                user_id=uuid.uuid4(),
+                workspace_id=uuid.uuid4(),
+            )
+
+        assert "picky_tool" in [t.name for t in tools]
+
+
+class TestLegacyCallersUnaffected:
+    """Existing callers that don't yet thread workspace_id keep working."""
+
+    def test_no_plugin_tools_when_workspace_id_missing(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="alpha",
+                name="Alpha",
+                description="",
+                tool_factories=(_factory("alpha_tool"),),
+            )
+        )
+
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(workspace_root=tmp_workspace)
+
+        assert "alpha_tool" not in [t.name for t in tools]
+
+    def test_no_plugin_tools_when_user_id_missing(self, tmp_workspace: Path) -> None:
+        register_plugin(
+            Plugin(
+                id="alpha",
+                name="Alpha",
+                description="",
+                tool_factories=(_factory("alpha_tool"),),
+            )
+        )
+
+        with patch("app.core.keys.resolve_api_key", return_value=None):
+            tools = build_agent_tools(workspace_root=tmp_workspace, workspace_id=uuid.uuid4())
+
+        assert "alpha_tool" not in [t.name for t in tools]

--- a/backend/tests/test_providers_and_schemas.py
+++ b/backend/tests/test_providers_and_schemas.py
@@ -2,7 +2,7 @@
 
 This module covers:
 - :func:`resolve_llm` routing (model-id prefix → provider class)
-- :func:`resolve_llm` user_id propagation to providers (workspace env support)
+- :func:`resolve_llm` workspace_id propagation to providers (workspace env support)
 - Schema validation for :class:`ConversationCreate`, :class:`ConversationUpdate`,
   :class:`UserCreate`
 - :func:`resolve_api_key` precedence (workspace override > settings fallback)
@@ -93,61 +93,61 @@ def test_user_create_strips_invite_code_from_create_update_dict() -> None:
 
 
 # ---------------------------------------------------------------------------
-# resolve_llm: user_id propagation
+# resolve_llm: workspace_id propagation
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_llm_accepts_user_id_for_gemini() -> None:
-    """resolve_llm with a user_id returns a GeminiLLM instance.
+def test_resolve_llm_accepts_workspace_id_for_gemini() -> None:
+    """resolve_llm with a workspace_id returns a GeminiLLM instance.
 
-    This verifies the new user_id kwarg is forwarded without blowing up.
+    This verifies the new workspace_id kwarg is forwarded without blowing up.
     The actual key resolution happens inside GeminiLLM.stream() which is
     tested separately.
     """
-    provider = resolve_llm("google/gemini-3-flash-preview", user_id=uuid4())
+    provider = resolve_llm("google/gemini-3-flash-preview", workspace_id=uuid4())
     assert isinstance(provider, GeminiLLM)
 
 
-def test_resolve_llm_accepts_user_id_for_claude() -> None:
-    """resolve_llm with a user_id returns a ClaudeLLM instance."""
-    provider = resolve_llm("anthropic/claude-sonnet-4-6", user_id=uuid4())
+def test_resolve_llm_accepts_workspace_id_for_claude() -> None:
+    """resolve_llm with a workspace_id returns a ClaudeLLM instance."""
+    provider = resolve_llm("anthropic/claude-sonnet-4-6", workspace_id=uuid4())
     assert isinstance(provider, ClaudeLLM)
 
 
-def test_resolve_llm_user_id_none_is_default() -> None:
-    """Passing user_id=None (the default) must behave identically to omitting it.
+def test_resolve_llm_workspace_id_none_is_default() -> None:
+    """Passing workspace_id=None (the default) must behave identically to omitting it.
 
-    Both paths must route by model-id prefix; user_id only affects key
+    Both paths must route by model-id prefix; workspace_id only affects key
     resolution inside the provider, not which provider class is returned.
     """
     without = resolve_llm("google/gemini-3-flash-preview")
-    with_none = resolve_llm("google/gemini-3-flash-preview", user_id=None)
+    with_none = resolve_llm("google/gemini-3-flash-preview", workspace_id=None)
 
     assert type(without) is type(with_none)
 
 
-def test_resolve_llm_gemini_accepts_user_id_without_error() -> None:
-    """resolve_llm(user_id=uid) for Gemini must not raise AttributeError or TypeError.
+def test_resolve_llm_gemini_accepts_workspace_id_without_error() -> None:
+    """resolve_llm(workspace_id=uid) for Gemini must not raise AttributeError or TypeError.
 
-    The user_id kwarg is forwarded to make_gemini_stream_fn internally;
+    The workspace_id kwarg is forwarded to make_gemini_stream_fn internally;
     this test ensures the forwarding wiring isn't accidentally dropped.
     """
     uid = uuid4()
     # Must not raise.
-    provider = resolve_llm("google/gemini-3-flash-preview", user_id=uid)
+    provider = resolve_llm("google/gemini-3-flash-preview", workspace_id=uid)
     assert isinstance(provider, GeminiLLM)
 
 
-def test_resolve_llm_claude_provider_stores_user_id() -> None:
-    """The ClaudeLLM instance returned by resolve_llm carries the user_id.
+def test_resolve_llm_claude_provider_stores_workspace_id() -> None:
+    """The ClaudeLLM instance returned by resolve_llm carries the workspace_id.
 
-    ClaudeLLM stores user_id internally as ``_user_id`` and uses it
+    ClaudeLLM stores workspace_id internally as ``_workspace_id`` and uses it
     during stream() to resolve per-workspace CLAUDE_CODE_OAUTH_TOKEN.
     """
     uid = uuid4()
-    provider = resolve_llm("anthropic/claude-sonnet-4-6", user_id=uid)
+    provider = resolve_llm("anthropic/claude-sonnet-4-6", workspace_id=uid)
     assert isinstance(provider, ClaudeLLM)
-    assert provider._user_id == uid
+    assert provider._workspace_id == uid
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -660,7 +660,7 @@ class TestResolveProviderWithAutoClear:
                 new=fake_session_maker,
             ),
         ):
-            provider, warning = await _resolve_provider_with_auto_clear(context)
+            provider, warning = await _resolve_provider_with_auto_clear(context, workspace_id=None)
 
         # Warning was produced and mentions the bad ID + the default.
         assert warning is not None
@@ -704,7 +704,7 @@ class TestResolveProviderWithAutoClear:
                 new=update_mock,
             ),
         ):
-            provider, warning = await _resolve_provider_with_auto_clear(context)
+            provider, warning = await _resolve_provider_with_auto_clear(context, workspace_id=None)
 
         # Clean path: no warning, no clear.
         assert warning is None

--- a/backend/tests/test_workspace_env_api.py
+++ b/backend/tests/test_workspace_env_api.py
@@ -1,9 +1,9 @@
-"""HTTP-level tests for the /api/v1/workspace/env router.
+"""HTTP-level tests for the /api/v1/workspaces/{workspace_id}/env router.
 
 Exercises the actual endpoints (not the helpers in keys.py — those have
 their own unit tests in test_keys.py). Covers:
 
-  * GET returns every overridable key with empty defaults for unset users.
+  * GET returns every overridable key with empty defaults for unset workspaces.
   * GET reflects what was previously persisted via PUT.
   * PUT happy path round-trips through encryption.
   * PUT rejects an unknown key with 400 (allowlist enforcement).
@@ -26,7 +26,7 @@ from httpx import AsyncClient
 from app.api.workspace_env import MAX_KEYS, MAX_VALUE_LENGTH
 from app.core import keys
 from app.core.config import settings
-from app.db import User
+from app.models import Workspace
 
 
 @pytest.fixture
@@ -44,9 +44,10 @@ def isolate_workspace_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> P
 async def test_get_returns_all_keys_empty_for_new_user(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
-    """A user who has never saved overrides sees every key with `""`."""
-    response = await client.get("/api/v1/workspace/env")
+    """A workspace that has never saved overrides sees every key with `""`."""
+    response = await client.get(f"/api/v1/workspaces/{seeded_default_workspace.id}/env")
     assert response.status_code == 200
     body = response.json()
     expected_keys = {
@@ -55,6 +56,7 @@ async def test_get_returns_all_keys_empty_for_new_user(
         "EXA_API_KEY",
         "XAI_API_KEY",
         "OPENAI_CODEX_OAUTH_TOKEN",
+        "NOTION_API_KEY",
     }
     assert set(body["vars"].keys()) == expected_keys
     assert all(v == "" for v in body["vars"].values())
@@ -64,16 +66,18 @@ async def test_get_returns_all_keys_empty_for_new_user(
 async def test_put_then_get_round_trips(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """A value persisted via PUT is reflected on the next GET."""
+    base = f"/api/v1/workspaces/{seeded_default_workspace.id}/env"
     put_response = await client.put(
-        "/api/v1/workspace/env",
+        base,
         json={"vars": {"GEMINI_API_KEY": "real-key"}},
     )
     assert put_response.status_code == 200
     assert put_response.json()["vars"]["GEMINI_API_KEY"] == "real-key"
 
-    get_response = await client.get("/api/v1/workspace/env")
+    get_response = await client.get(base)
     assert get_response.status_code == 200
     assert get_response.json()["vars"]["GEMINI_API_KEY"] == "real-key"
 
@@ -82,10 +86,11 @@ async def test_put_then_get_round_trips(
 async def test_put_rejects_unknown_keys(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """Anything not in OVERRIDABLE_KEYS is a 400; never reaches save."""
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": {"DATABASE_URL": "sneaky"}},
     )
     assert response.status_code == 400
@@ -96,10 +101,11 @@ async def test_put_rejects_unknown_keys(
 async def test_put_rejects_oversized_values(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """A value longer than MAX_VALUE_LENGTH is a 422."""
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": {"GEMINI_API_KEY": "x" * (MAX_VALUE_LENGTH + 1)}},
     )
     assert response.status_code == 422
@@ -109,15 +115,16 @@ async def test_put_rejects_oversized_values(
 async def test_put_rejects_newline_in_value(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """Newline characters trigger the validator and are rejected.
 
     Without this, a value of `valid\\nEXA_API_KEY=hijacked` would split
     into two lines on the next read and inject `EXA_API_KEY` for the
-    user.
+    workspace.
     """
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": {"GEMINI_API_KEY": "good\nEXA_API_KEY=hijacked"}},
     )
     assert response.status_code == 422
@@ -129,6 +136,7 @@ async def test_put_rejects_newline_in_value(
 async def test_put_rejects_too_many_keys(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """More than MAX_KEYS distinct entries trips the safety bound.
 
@@ -139,7 +147,7 @@ async def test_put_rejects_too_many_keys(
     """
     bogus = {f"BOGUS_KEY_{i}": "x" for i in range(MAX_KEYS + 1)}
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": bogus},
     )
     assert response.status_code == 422
@@ -150,15 +158,15 @@ async def test_put_rejects_too_many_keys(
 async def test_put_preserves_unmentioned_keys(
     client: AsyncClient,
     isolate_workspace_base: Path,
-    test_user: User,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """PUT is PATCH-like: keys not in the payload are left untouched."""
     keys.save_workspace_env(
-        test_user.id,
+        seeded_default_workspace.id,
         {"GEMINI_API_KEY": "keep-me", "EXA_API_KEY": "also-keep-me"},
     )
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": {"GEMINI_API_KEY": "updated"}},
     )
     assert response.status_code == 200
@@ -171,7 +179,7 @@ async def test_put_preserves_unmentioned_keys(
 async def test_put_empty_string_clears_key(
     client: AsyncClient,
     isolate_workspace_base: Path,
-    test_user: User,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """Sending `""` for a key removes it from the encrypted file.
 
@@ -180,13 +188,13 @@ async def test_put_empty_string_clears_key(
     identically (both fall through to settings); persisting `""` would
     be confusing on inspection, so we drop it.
     """
-    keys.save_workspace_env(test_user.id, {"GEMINI_API_KEY": "had-a-value"})
+    keys.save_workspace_env(seeded_default_workspace.id, {"GEMINI_API_KEY": "had-a-value"})
     response = await client.put(
-        "/api/v1/workspace/env",
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env",
         json={"vars": {"GEMINI_API_KEY": ""}},
     )
     assert response.status_code == 200
-    on_disk = keys.load_workspace_env(test_user.id)
+    on_disk = keys.load_workspace_env(seeded_default_workspace.id)
     assert "GEMINI_API_KEY" not in on_disk
 
 
@@ -194,17 +202,19 @@ async def test_put_empty_string_clears_key(
 async def test_delete_removes_one_key(
     client: AsyncClient,
     isolate_workspace_base: Path,
-    test_user: User,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """DELETE drops a single key without touching the others."""
     keys.save_workspace_env(
-        test_user.id,
+        seeded_default_workspace.id,
         {"GEMINI_API_KEY": "g", "EXA_API_KEY": "e"},
     )
-    response = await client.delete("/api/v1/workspace/env/GEMINI_API_KEY")
+    response = await client.delete(
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env/GEMINI_API_KEY"
+    )
     assert response.status_code == 204
 
-    remaining = keys.load_workspace_env(test_user.id)
+    remaining = keys.load_workspace_env(seeded_default_workspace.id)
     assert "GEMINI_API_KEY" not in remaining
     assert remaining.get("EXA_API_KEY") == "e"
 
@@ -213,7 +223,10 @@ async def test_delete_removes_one_key(
 async def test_delete_unknown_key_returns_404(
     client: AsyncClient,
     isolate_workspace_base: Path,
+    seeded_default_workspace: Workspace,
 ) -> None:
     """Allowlist also gates DELETE."""
-    response = await client.delete("/api/v1/workspace/env/DATABASE_URL")
+    response = await client.delete(
+        f"/api/v1/workspaces/{seeded_default_workspace.id}/env/DATABASE_URL"
+    )
     assert response.status_code == 404

--- a/frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx
+++ b/frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx
@@ -53,13 +53,14 @@ class ToolContext:
 
 Discovery is `import` — `backend/app/integrations/__init__.py` imports each integration package, and each package appends to a module-level registry in `backend/app/core/plugins/registry.py`. No dynamic loading, no manifest JSON, no hot reload. Same trust model as the current `build_agent_tools`: plugins are first-party Python code.
 
-`build_agent_tools` becomes:
+`build_agent_tools` is left intact for the existing tools (workspace files, Exa, image-gen, artifact, send_message) — they stay hardcoded where they are today. A single new block at the end iterates the plugin registry and appends plugin-contributed tools:
 
 ```python
 def build_agent_tools(*, workspace_id, workspace_root, user_id, send_fn) -> list[AgentTool]:
+    tools: list[AgentTool] = [...]  # existing core tools, unchanged
+
     ctx = ToolContext(workspace_id=workspace_id, workspace_root=workspace_root,
                       user_id=user_id, send_fn=send_fn)
-    tools: list[AgentTool] = []
     for plugin in registry.all():
         if not plugin.is_activated(ctx):
             continue
@@ -67,7 +68,7 @@ def build_agent_tools(*, workspace_id, workspace_root, user_id, send_fn) -> list
     return tools
 ```
 
-Today's tools (workspace files, Exa, image-gen, artifact, send_message) migrate to this shape in the same PR — they become four small in-tree plugins (`core_workspace`, `exa`, `image_gen`, `artifact`/`send_message` as a "channel" plugin). Net behaviour change: zero.
+This is deliberate. The plugin registry is **additive** — for capabilities like Notion, Slack, Linear that conceptually sit outside the core agent surface. The core tools (filesystem, web search, image gen, channel delivery) stay first-class citizens with no indirection. We avoid a refactor whose only payoff would be uniformity for its own sake.
 
 **Out of scope for v1:** plugin-registered channels, providers, hooks, HTTP routes. The seams exist (`Channel` protocol, `LLMProvider`) and can grow later without changing this design.
 
@@ -173,13 +174,12 @@ Once the plugin system lands, future plugins extend both lists automatically thr
 
 Single PR, committed as logical units:
 
-1. `feat(plugins): add Plugin/ToolContext types and integration registry` — types module, empty registry, no behavior change.
-2. `refactor(tools): migrate existing tools to plugin registry` — Exa/workspace-files/artifact/image-gen/send-message become four in-tree plugins. `build_agent_tools` walks the registry. Snapshot tests confirm zero behavior change.
-3. `feat(keys): migrate workspace env to workspace_id keying` — `resolve_api_key(workspace_id, ...)`, file path moves to `{workspace.path}/.env`, startup migration task, callers updated. Frontend env endpoint becomes workspace-scoped.
-4. `feat(notion): add Notion plugin with 18-tool `ntn` wrapper` — plugin manifest, `ntn_client.py` subprocess wrapper, one file per tool under `notion/tools/`, audit log table + Alembic migration, `NOTION_API_KEY` added to `OVERRIDABLE_KEYS`.
-5. `feat(settings): add Notion API key row to workspace settings` — frontend mirror + UI row.
-6. `docs(handbook): add 'adding a plugin' guide` — handbook page describing the registry shape, env-key declaration, ToolContext, testing pattern.
-7. `chore(docker): install ntn in backend image` — `curl -fsSL https://ntn.dev | bash` in the prod image with a pinned `NTN_VERSION`.
+1. `feat(plugins): add Plugin/ToolContext types and integration registry` — types module, empty registry, `build_agent_tools` gains a registry-walk tail. Core tools untouched.
+2. `feat(keys): migrate workspace env to workspace_id keying` — `resolve_api_key(workspace_id, ...)`, file path moves to `{workspace.path}/.env`, startup migration task, callers updated. Frontend env endpoint becomes workspace-scoped.
+3. `feat(notion): add Notion plugin with 18-tool `ntn` wrapper` — plugin manifest, `ntn_client.py` subprocess wrapper, one file per tool under `notion/tools/`, audit log table + Alembic migration, `NOTION_API_KEY` added to `OVERRIDABLE_KEYS`.
+4. `feat(settings): add Notion API key row to workspace settings` — frontend mirror + UI row.
+5. `docs(handbook): add 'adding a plugin' guide` — handbook page describing the registry shape, env-key declaration, ToolContext, testing pattern.
+6. `chore(docker): install ntn in backend image` — `curl -fsSL https://ntn.dev | bash` in the prod image with a pinned `NTN_VERSION`.
 
 Tests follow the `ScriptedStreamFn` pattern (per `.claude/rules/testing/agent-loop-testing-philosophy.md`) — plugin activation, tool dispatch, and audit logging are tested through the real loop with the LLM seam scripted; the `ntn` subprocess itself is mocked at the `call_ntn` seam.
 

--- a/frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx
+++ b/frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx
@@ -1,0 +1,197 @@
+---
+title: Plugin system for Pawrrtal and Notion as the first plugin
+description: ADR — formalize a Python-native, tools-only plugin registry; migrate workspace env to workspace_id keying; ship a Notion plugin that wraps the official `ntn` CLI.
+---
+
+# ADR: Plugin system and Notion integration
+
+- **Date:** 2026-05-15
+- **Owners:** OctavianTocan
+- **Tracking:** beans TBD
+- **Reference:** [openclaw-notion](https://github.com/OctavianTocan/openclaw-notion) (read for shape, not portability — Pawrrtal does not host OpenClaw plugins)
+
+<Callout type="info" title="Status: Proposed">
+Add a thin Python plugin registry in `backend/app/integrations/`, migrate workspace `.env` to per-workspace keying, and ship a Notion plugin that subprocesses the official `ntn` CLI with per-call `NOTION_API_TOKEN` injection. 18-tool parity with openclaw-notion.
+</Callout>
+
+## Context
+
+Three drivers point at the same gap:
+
+1. The agent's tool surface (`backend/app/core/agent_tools.py:42`) is one hardcoded function that knows about every tool. Adding a Notion integration today means editing it, editing `OVERRIDABLE_KEYS`, editing the Settings frontend mirror, and editing the chat router. Four touchpoints for one capability.
+2. Workspaces (`backend/app/models.py:269` — `Workspace`) are per-user-many, but workspace `.env` overrides (`backend/app/core/keys.py`) are keyed by `user_id`. A user with two workspaces shares one set of API keys across both, which contradicts the "workspace as isolated agent home" model.
+3. We want Notion next. openclaw-notion already proves the shape (18 focused tools, per-agent token routing, SQLite audit log, file-based auth). We want that shape, not its Node runtime — and not its assumption that Notion calls go through `@notionhq/client` (which we'd have to maintain).
+
+The job is therefore: pick the smallest formalization of "plugin" that fits the existing architecture, fix the workspace-keying mismatch on the way through, and ship Notion as proof.
+
+## Decision
+
+### 1. Plugin system shape (tools-only v1)
+
+A "plugin" is a Python package under `backend/app/integrations/<plugin_id>/` exporting one `Plugin` object:
+
+```python
+# backend/app/core/plugins/types.py
+@dataclass(frozen=True)
+class Plugin:
+    id: str                                      # "notion"
+    name: str                                    # "Notion"
+    description: str
+    env_keys: tuple[EnvKeySpec, ...]             # extends OVERRIDABLE_KEYS
+    tool_factories: tuple[ToolFactory, ...]      # (ctx) -> AgentTool
+    is_activated: Callable[[ToolContext], bool]  # default: all env_keys resolve
+
+ToolFactory = Callable[[ToolContext], AgentTool]
+
+@dataclass(frozen=True)
+class ToolContext:
+    workspace_id: uuid.UUID
+    workspace_root: Path
+    user_id: uuid.UUID
+    send_fn: SendFn | None
+```
+
+Discovery is `import` — `backend/app/integrations/__init__.py` imports each integration package, and each package appends to a module-level registry in `backend/app/core/plugins/registry.py`. No dynamic loading, no manifest JSON, no hot reload. Same trust model as the current `build_agent_tools`: plugins are first-party Python code.
+
+`build_agent_tools` becomes:
+
+```python
+def build_agent_tools(*, workspace_id, workspace_root, user_id, send_fn) -> list[AgentTool]:
+    ctx = ToolContext(workspace_id=workspace_id, workspace_root=workspace_root,
+                      user_id=user_id, send_fn=send_fn)
+    tools: list[AgentTool] = []
+    for plugin in registry.all():
+        if not plugin.is_activated(ctx):
+            continue
+        tools.extend(factory(ctx) for factory in plugin.tool_factories)
+    return tools
+```
+
+Today's tools (workspace files, Exa, image-gen, artifact, send_message) migrate to this shape in the same PR — they become four small in-tree plugins (`core_workspace`, `exa`, `image_gen`, `artifact`/`send_message` as a "channel" plugin). Net behaviour change: zero.
+
+**Out of scope for v1:** plugin-registered channels, providers, hooks, HTTP routes. The seams exist (`Channel` protocol, `LLMProvider`) and can grow later without changing this design.
+
+### 2. Workspace-keyed `.env` migration
+
+`workspace.path` is already the workspace directory (`backend/app/core/workspace.py`). The encrypted env file moves from `{workspace_base_dir}/{user_id}/.env` to `{workspace.path}/.env` — sitting next to `AGENTS.md`, `memory/`, `skills/`.
+
+API surface changes:
+
+- `resolve_api_key(workspace_id, key)` replaces `resolve_api_key(user_id, key)`.
+- `load_workspace_env(workspace_id)` / `save_workspace_env(workspace_id, env)` likewise.
+- `GET/PUT/DELETE /api/v1/workspace/env` becomes `/api/v1/workspaces/{workspace_id}/env` — workspace-scoped, matching the rest of the workspace router.
+
+Callers updated: `agent_tools.py` (Exa/image-gen lookups), Telegram bot (already has user → workspace lookup via `chat.py:122` pattern), `image_gen.py`.
+
+Migration:
+
+- Alembic migration adds nothing to the schema (workspace rows already exist).
+- A startup task moves each existing `{workspace_base_dir}/{user_id}/.env` to `{default_workspace.path}/.env` for the user, once, and renames the source to `.env.migrated-<timestamp>`.
+- Users with more than one workspace at migration time only get the default workspace seeded; secondary workspaces start blank, which is correct.
+
+### 3. Notion plugin — wraps `ntn` CLI
+
+The plugin lives at `backend/app/integrations/notion/`. It registers 18 tools matching openclaw-notion's contract exactly (same names, same parameter shapes, same return format), so anything written against that contract works against Pawrrtal with no change.
+
+Execution maps each tool to a `ntn` invocation:
+
+| Tool | `ntn` invocation |
+|---|---|
+| `notion_search` | `ntn api v1/search query=<q>` |
+| `notion_read` | `ntn api v1/blocks/<id>/children` |
+| `notion_read_markdown` | `ntn pages get <id>` |
+| `notion_append` | `ntn api v1/blocks/<id>/children -X PATCH -d ...` |
+| `notion_create` | `ntn pages create --parent --content` |
+| `notion_update_markdown` | `ntn pages update` |
+| `notion_update_page` | `ntn pages update` |
+| `notion_comment_create` | `ntn api v1/comments -X POST -d ...` |
+| `notion_comment_list` | `ntn api v1/comments parent_id==<id>` |
+| `notion_query` | `ntn api v1/databases/<id>/query -d ...` |
+| `notion_delete` | `ntn api v1/blocks/<id> -X DELETE` |
+| `notion_move` | `ntn api v1/pages/<id> -X PATCH parent[page_id]=...` |
+| `notion_publish` | `ntn api v1/pages/<id> -X PATCH ...` |
+| `notion_file_tree` | composite — multiple `ntn api` calls |
+| `notion_sync` | composite — local FS reads + `ntn pages get/update` |
+| `notion_help` | static markdown, no subprocess |
+| `notion_doctor` | `ntn api v1/users/me` for connectivity probe |
+| `notion_logs_read` | reads audit DB, no subprocess |
+
+Multi-user is solved by per-subprocess env injection — no `ntn login` ever runs server-side. Each call:
+
+```python
+async def call_ntn(args: list[str], token: str) -> bytes:
+    with tempfile.TemporaryDirectory() as home:
+        env = {
+            "PATH": os.environ["PATH"],
+            "HOME": home,                         # isolated; no shared `ntn` state
+            "NOTION_API_TOKEN": token,
+            "NO_COLOR": "1",
+        }
+        proc = await asyncio.create_subprocess_exec(
+            "ntn", *args, env=env, stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await proc.communicate()
+        if proc.returncode != 0:
+            raise NtnError(returncode=proc.returncode, stderr=err.decode())
+        return out
+```
+
+`HOME` is a per-call tempdir so any state `ntn` writes (e.g. residual `ntn login` artifacts) can't leak between users. We accept the closed-source-binary risk for v1 because the trust boundary is "Pawrrtal already runs trusted server code"; we'll revisit if Pawrrtal goes multi-tenant.
+
+Token entry: an Internal Integration token (`ntn_***`) pasted into Workspace Settings → encrypted into `{workspace.path}/.env` under `NOTION_API_KEY`. No OAuth in v1.
+
+Audit log: new `notion_operation_logs` SQLAlchemy table mirroring openclaw-notion's `audit.ts` schema (id, workspace_id, operation, tool_name, page_id, database_id, duration_ms, status, error, request_json, response_json, created_at). Lives in the app DB — no sidecar SQLite.
+
+### 4. Settings UI
+
+`NOTION_API_KEY` is added to `OVERRIDABLE_KEYS` in `backend/app/core/keys.py` and mirrored in `frontend/features/settings/workspace-env/use-workspace-env.ts`. Reuses the existing workspace-env settings form — one labeled row, link to `https://www.notion.so/profile/integrations` for the user to mint the token.
+
+Once the plugin system lands, future plugins extend both lists automatically through `plugin.env_keys`. This is a v1.1 follow-up; for now the Notion key is added explicitly alongside the existing keys.
+
+## Consequences
+
+**Wins**
+
+- One file per integration; adding the next one (Slack, Linear) is a localised change.
+- Per-workspace keys make multi-workspace per user actually mean something.
+- Notion gets 18 tools without writing 18 HTTP wrappers; Notion maintains the API mapping.
+- openclaw-notion stays the authoritative reference for tool shape — any agent prompt that knows that contract works against Pawrrtal.
+
+**Trade-offs**
+
+- `ntn` is closed-source. We can't audit its handling of `NOTION_API_TOKEN`. Mitigation: per-call `HOME` isolation; document the trust boundary; revisit before multi-tenant.
+- Per-call subprocess startup is ~50–100 ms on top of Notion's own latency. Acceptable for chat-tool latency; not acceptable for high-frequency loops, which the agent doesn't do today.
+- The workspace-env migration touches every existing caller of `resolve_api_key`. Risk is contained — the function returns `None` when no key is configured, which all callers already handle.
+
+**Risks**
+
+- `ntn` install on Railway prod: needs a `curl -fsSL https://ntn.dev | bash` line in `backend/Dockerfile` (or whatever the prod image is). If `ntn.dev` enforces UA gating that rejects curl from Docker build contexts, we need a fallback fetch URL — investigate during implementation.
+- `ntn`'s `--content` / `--parent` flag shapes are documented in the SKILL.md but not formally specified. Each tool's parameter shaping needs an integration test against a real `ntn` binary, not a mock.
+
+## Rollout
+
+Single PR, committed as logical units:
+
+1. `feat(plugins): add Plugin/ToolContext types and integration registry` — types module, empty registry, no behavior change.
+2. `refactor(tools): migrate existing tools to plugin registry` — Exa/workspace-files/artifact/image-gen/send-message become four in-tree plugins. `build_agent_tools` walks the registry. Snapshot tests confirm zero behavior change.
+3. `feat(keys): migrate workspace env to workspace_id keying` — `resolve_api_key(workspace_id, ...)`, file path moves to `{workspace.path}/.env`, startup migration task, callers updated. Frontend env endpoint becomes workspace-scoped.
+4. `feat(notion): add Notion plugin with 18-tool `ntn` wrapper` — plugin manifest, `ntn_client.py` subprocess wrapper, one file per tool under `notion/tools/`, audit log table + Alembic migration, `NOTION_API_KEY` added to `OVERRIDABLE_KEYS`.
+5. `feat(settings): add Notion API key row to workspace settings` — frontend mirror + UI row.
+6. `docs(handbook): add 'adding a plugin' guide` — handbook page describing the registry shape, env-key declaration, ToolContext, testing pattern.
+7. `chore(docker): install ntn in backend image` — `curl -fsSL https://ntn.dev | bash` in the prod image with a pinned `NTN_VERSION`.
+
+Tests follow the `ScriptedStreamFn` pattern (per `.claude/rules/testing/agent-loop-testing-philosophy.md`) — plugin activation, tool dispatch, and audit logging are tested through the real loop with the LLM seam scripted; the `ntn` subprocess itself is mocked at the `call_ntn` seam.
+
+## Out of scope
+
+- Plugin-registered channels, providers, hooks. Architecturally compatible; not built now.
+- OAuth (Public Integration) token flow for Notion. Internal-token paste covers the use case for v1.
+- Frontend plugin marketplace / install UI. There is no install — plugins are in-tree Python packages.
+- Hot reload / plugin reload-on-config-change.
+- Bundling `ntn` into a desktop build (Pawrrtal is currently web-only).
+
+## Open questions
+
+- Does `ntn.dev`'s install script accept Docker build contexts (no human UA)? If not, we need a direct binary download URL — to be confirmed during PR #7.
+- Should secondary workspaces inherit env keys from the default workspace on first creation, or always start blank? Current proposal: blank (forces explicit configuration; matches "isolated workspace" intent).

--- a/frontend/content/docs/handbook/integrations/adding-a-plugin.mdx
+++ b/frontend/content/docs/handbook/integrations/adding-a-plugin.mdx
@@ -1,0 +1,169 @@
+---
+title: Adding a Plugin
+description: How to add a tools-only integration to Pawrrtal via the plugin registry.
+---
+
+# Adding a Plugin
+
+Plugins are additive integrations that contribute agent tools at runtime.
+The Notion plugin
+(`backend/app/integrations/notion/`) is the canonical example; this page
+captures the moving parts so the next integration is mechanical.
+
+The design rationale is in
+[`2026-05-15-plugin-system-and-notion-integration.mdx`](../decisions/2026-05-15-plugin-system-and-notion-integration).
+Read that first if you're new to the codebase — this page focuses on the
+how, not the why.
+
+## The shape
+
+A plugin is a Python package under
+`backend/app/integrations/<plugin_id>/`. The package exports a single
+`Plugin` object built from
+[`app.core.plugins.types`](../../../../../backend/app/core/plugins/types.py):
+
+```python
+# backend/app/integrations/my_plugin/plugin.py
+from app.core.plugins import EnvKeySpec, Plugin, register_plugin
+from app.integrations.my_plugin.tools import factories
+
+my_plugin = Plugin(
+    id="my_plugin",
+    name="My Plugin",
+    description="One-sentence summary.",
+    env_keys=(
+        EnvKeySpec(
+            name="MY_API_KEY",
+            label="My API Key",
+            help_url="https://example.com/get-a-key",
+            required=True,
+        ),
+    ),
+    tool_factories=factories,
+)
+
+register_plugin(my_plugin)
+```
+
+Importing the plugin package runs `register_plugin(...)` as a side
+effect. Make `backend/app/integrations/__init__.py` import your
+subpackage so the side effect fires at app startup.
+
+## Tool factories
+
+Each entry in `tool_factories` is a function that takes a
+[`ToolContext`](../../../../../backend/app/core/plugins/types.py) and
+returns an
+[`AgentTool`](../../../../../backend/app/core/agent_loop/types.py).
+`ToolContext` carries the active workspace ID, workspace root, user
+ID, and (optionally) the channel send callback. Use it for env-key
+resolution and per-call audit logging.
+
+```python
+# backend/app/integrations/my_plugin/tools/__init__.py
+from app.integrations.my_plugin.tools.search import make_search_tool
+
+factories = (make_search_tool,)
+```
+
+A tool factory looks like this:
+
+```python
+def make_search_tool(ctx: ToolContext) -> AgentTool:
+    async def execute(_tool_call_id: str, **kwargs: object) -> str:
+        # 1. Resolve the workspace's API key.
+        token = resolve_api_key(ctx.workspace_id, "MY_API_KEY")
+        if token is None:
+            return json.dumps({"error": "My Plugin is not configured."})
+
+        # 2. Do the actual work.
+        result = await my_search(token=token, query=str(kwargs["query"]))
+
+        # 3. Return JSON for the agent to consume.
+        return json.dumps(result)
+
+    return AgentTool(
+        name="my_search",
+        description="Search My Plugin.",
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        execute=execute,
+    )
+```
+
+## Activation gating
+
+By default, a plugin's tools only reach the agent when every
+`required=True` env key in `env_keys` resolves to a non-empty value for
+the active workspace. This is what makes a not-configured plugin
+invisible to the LLM.
+
+If you need a custom predicate (e.g. "activate only when the workspace
+has both an API key *and* a saved profile"), pass `is_activated` on
+the `Plugin` object:
+
+```python
+my_plugin = Plugin(
+    id="my_plugin",
+    ...,
+    is_activated=lambda ctx: my_check(ctx),
+)
+```
+
+## Env keys + Settings UI
+
+Adding `EnvKeySpec(name="MY_API_KEY", ...)` is not enough on its own
+(yet — auto-rendering from the registry is a v1.1 follow-up). Three
+parallel places need the key today:
+
+1. **Backend allowlist** —
+   `backend/app/core/keys.py:OVERRIDABLE_KEYS`. Without this the PUT
+   endpoint rejects the key with 400.
+2. **Frontend mirror** —
+   `frontend/features/settings/workspace-env/use-workspace-env.ts:WORKSPACE_ENV_KEY_IDS`.
+   Drives the type union of valid keys.
+3. **Settings row** —
+   `frontend/features/settings/sections/WorkspacesSection.tsx:KEY_METAS`.
+   Provides the label, description, placeholder, and help URL the user
+   sees.
+
+Forgetting any of the three produces a silent failure: the user sets
+the value, the backend rejects (or never reads) it, and the plugin
+gates out at activation time with no UI clue.
+
+## Audit logging
+
+Notion's plugin runs every tool call through
+[`with_audit`](../../../../../backend/app/integrations/notion/audit.py)
+to write a row to a dedicated `*_operation_logs` table.  This is
+optional but recommended for any plugin where "what did this
+workspace do recently?" is a useful question (Notion, Slack, Linear).
+The same workspace-scoped + soft-FK + indexed
+`(workspace_id, tool_name, created_at)` shape works for most.
+
+## Testing
+
+Plugins follow the project-wide
+[ScriptedStreamFn pattern](../../../.claude/rules/testing/agent-loop-testing-philosophy.md)
+for full agent-loop scenarios.  Unit tests for individual tool
+factories monkeypatch the network seam (subprocess / HTTP client) and
+call `tool.execute()` directly.  See
+`backend/tests/test_notion_plugin.py` for a complete example covering
+registration, the subprocess wrapper, success path, error path, and
+the audit-log shape.
+
+## Checklist
+
+When you're done, the following should all be true:
+
+- `app.core.plugins.all_plugins()` includes your plugin id.
+- Your env key appears in `OVERRIDABLE_KEYS` + the frontend list +
+  the settings KEY_METAS array.
+- The plugin's tools appear in the chat agent's tool list *only when*
+  the workspace has the env key set (verified with a logged-in user
+  who configures the key in Settings → Workspace).
+- A pytest covers registration, one happy-path tool call, and one
+  error-path tool call.

--- a/frontend/features/onboarding/hooks/use-onboarding-readiness.ts
+++ b/frontend/features/onboarding/hooks/use-onboarding-readiness.ts
@@ -44,7 +44,7 @@ export function useOnboardingReadiness(): OnboardingReadiness {
 	const { hasBackend, backendFingerprint } = state;
 	const onboardingStatusQuery = useAuthedQuery<OnboardingStatusResponse>(
 		[...ONBOARDING_STATUS_QUERY_KEY, backendFingerprint],
-		API_ENDPOINTS.workspace.onboardingStatus,
+		API_ENDPOINTS.workspaces.onboardingStatus,
 		{
 			enabled: hasBackend,
 			staleTime: 15 * 1000,

--- a/frontend/features/settings/sections/WorkspacesSection.tsx
+++ b/frontend/features/settings/sections/WorkspacesSection.tsx
@@ -65,6 +65,14 @@ const KEY_METAS: readonly WorkspaceEnvKeyMeta[] = [
 		placeholder: 'Your xAI API key',
 		url: 'https://x.ai',
 	},
+	{
+		key: 'NOTION_API_KEY',
+		label: 'Notion API Key',
+		description:
+			'Unlocks the Notion plugin (search, read, write, sync). Create an Internal Integration and share the pages you want it to see.',
+		placeholder: 'ntn_...',
+		url: 'https://www.notion.so/profile/integrations',
+	},
 ];
 
 /** Empty record with every overridable key seeded to the empty string. */

--- a/frontend/features/settings/workspace-env/WorkspacesSectionView.test.tsx
+++ b/frontend/features/settings/workspace-env/WorkspacesSectionView.test.tsx
@@ -34,6 +34,7 @@ const EMPTY_VALUES = {
 	CLAUDE_CODE_OAUTH_TOKEN: '',
 	EXA_API_KEY: '',
 	XAI_API_KEY: '',
+	NOTION_API_KEY: '',
 } as const;
 
 describe('WorkspacesSectionView', () => {

--- a/frontend/features/settings/workspace-env/use-workspace-env.ts
+++ b/frontend/features/settings/workspace-env/use-workspace-env.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+import { type UseMutationResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthedFetch } from '@/hooks/use-authed-fetch';
 import { useAuthedQuery } from '@/hooks/use-authed-query';
 import { API_ENDPOINTS } from '@/lib/api';
@@ -19,24 +19,35 @@ export const WORKSPACE_ENV_KEY_IDS = [
 	'CLAUDE_CODE_OAUTH_TOKEN',
 	'EXA_API_KEY',
 	'XAI_API_KEY',
+	'NOTION_API_KEY',
 ] as const satisfies readonly string[];
 
 /** Union of valid workspace env key names. Derived from `WORKSPACE_ENV_KEY_IDS`. */
 export type WorkspaceEnvKey = (typeof WORKSPACE_ENV_KEY_IDS)[number];
 
 /**
- * Response shape returned by `GET /api/v1/workspace/env` and `PUT
- * /api/v1/workspace/env`. The backend always returns every key in
- * `OVERRIDABLE_KEYS`; unset keys are returned with an empty-string value
- * so the form can render every input without an extra schema fetch.
+ * Response shape returned by `GET /api/v1/workspaces/{workspace_id}/env`
+ * and `PUT /api/v1/workspaces/{workspace_id}/env`. The backend always
+ * returns every key in `OVERRIDABLE_KEYS`; unset keys come back with an
+ * empty-string value so the form can render every input without an extra
+ * schema fetch.
  */
 export interface WorkspaceEnvResponse {
 	/** Map of every overridable key to its current value (empty string when unset). */
 	vars: Record<WorkspaceEnvKey, string>;
 }
 
+/** Minimal workspace shape pulled from `GET /api/v1/workspaces`. */
+interface WorkspaceSummary {
+	id: string;
+	is_default: boolean;
+}
+
 /** React Query cache key shared by the GET hook and the mutation invalidate. */
 const WORKSPACE_ENV_QUERY_KEY = ['workspace-env'] as const;
+
+/** Stale-time for the workspace list lookup that drives env-key fetches. */
+const WORKSPACES_LIST_STALE_MS = 5 * 60 * 1000;
 
 /**
  * Backend error envelope when validation fails. FastAPI's `HTTPException`
@@ -71,17 +82,46 @@ export function extractApiErrorMessage(error: unknown, fallback: string): string
 }
 
 /**
- * Read the authenticated user's workspace env overrides.
+ * Internal helper: fetch the current user's default workspace ID.
+ *
+ * Mirrors the pattern in `useWorkspaceTree` — pull the workspace list,
+ * prefer the row flagged `is_default`, fall back to the first entry.
+ * Cached separately under the `workspaces` query key so adding/removing
+ * workspaces only triggers one refetch.
+ */
+function useDefaultWorkspaceId(): string | null {
+	const authedFetch = useAuthedFetch();
+	const workspacesQuery = useQuery<WorkspaceSummary[]>({
+		queryKey: ['workspaces'],
+		queryFn: async (): Promise<WorkspaceSummary[]> => {
+			const res = await authedFetch(API_ENDPOINTS.workspaces.list);
+			return res.json() as Promise<WorkspaceSummary[]>;
+		},
+		staleTime: WORKSPACES_LIST_STALE_MS,
+	});
+	const defaultWorkspace =
+		workspacesQuery.data?.find((w) => w.is_default) ?? workspacesQuery.data?.[0];
+	return defaultWorkspace?.id ?? null;
+}
+
+/**
+ * Read the authenticated user's default-workspace env overrides.
  *
  * Server-state read; cookie-authed; cached under
  * {@link WORKSPACE_ENV_QUERY_KEY}. The mutation hook below invalidates
  * this key on save so the UI re-fetches the canonical state from disk
  * (which reflects the empty-string strip step).
+ *
+ * The query is enabled only after the workspace list resolves — until
+ * then it stays in the idle state so the Settings UI can render its
+ * skeleton without firing a 404.
  */
 export function useWorkspaceEnv(): ReturnType<typeof useAuthedQuery<WorkspaceEnvResponse>> {
+	const workspaceId = useDefaultWorkspaceId();
 	return useAuthedQuery<WorkspaceEnvResponse>(
-		WORKSPACE_ENV_QUERY_KEY,
-		API_ENDPOINTS.workspace.env
+		[...WORKSPACE_ENV_QUERY_KEY, workspaceId ?? ''],
+		workspaceId ? API_ENDPOINTS.workspaces.env(workspaceId) : '',
+		{ enabled: workspaceId !== null }
 	);
 }
 
@@ -92,6 +132,9 @@ export function useWorkspaceEnv(): ReturnType<typeof useAuthedQuery<WorkspaceEnv
  * untouched on disk. Empty-string values clear the corresponding key
  * (the on-disk file omits empty entries), which the resolver treats as
  * "use the gateway default".
+ *
+ * Targets the user's default workspace. Multi-workspace switching from
+ * the Settings UI is a follow-up (`pawrrtal-TBD`).
  */
 export function useUpsertWorkspaceEnv(): UseMutationResult<
 	WorkspaceEnvResponse,
@@ -100,13 +143,19 @@ export function useUpsertWorkspaceEnv(): UseMutationResult<
 > {
 	const fetcher = useAuthedFetch();
 	const queryClient = useQueryClient();
+	const workspaceId = useDefaultWorkspaceId();
 
 	return useMutation({
-		mutationKey: ['workspace-env', 'upsert'],
+		mutationKey: ['workspace-env', 'upsert', workspaceId ?? ''],
 		mutationFn: async (
 			vars: Partial<Record<WorkspaceEnvKey, string>>
 		): Promise<WorkspaceEnvResponse> => {
-			const response = await fetcher(API_ENDPOINTS.workspace.env, {
+			if (!workspaceId) {
+				throw new Error(
+					'Cannot save workspace env: default workspace has not loaded yet.'
+				);
+			}
+			const response = await fetcher(API_ENDPOINTS.workspaces.env(workspaceId), {
 				method: 'PUT',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({ vars }),
@@ -114,7 +163,10 @@ export function useUpsertWorkspaceEnv(): UseMutationResult<
 			return (await response.json()) as WorkspaceEnvResponse;
 		},
 		onSuccess: (next) => {
-			queryClient.setQueryData<WorkspaceEnvResponse>(WORKSPACE_ENV_QUERY_KEY, next);
+			queryClient.setQueryData<WorkspaceEnvResponse>(
+				[...WORKSPACE_ENV_QUERY_KEY, workspaceId ?? ''],
+				next
+			);
 		},
 	});
 }

--- a/frontend/features/settings/workspace-env/use-workspace-env.ts
+++ b/frontend/features/settings/workspace-env/use-workspace-env.ts
@@ -1,6 +1,11 @@
 'use client';
 
-import { type UseMutationResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+	type UseMutationResult,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from '@tanstack/react-query';
 import { useAuthedFetch } from '@/hooks/use-authed-fetch';
 import { useAuthedQuery } from '@/hooks/use-authed-query';
 import { API_ENDPOINTS } from '@/lib/api';
@@ -151,9 +156,7 @@ export function useUpsertWorkspaceEnv(): UseMutationResult<
 			vars: Partial<Record<WorkspaceEnvKey, string>>
 		): Promise<WorkspaceEnvResponse> => {
 			if (!workspaceId) {
-				throw new Error(
-					'Cannot save workspace env: default workspace has not loaded yet.'
-				);
+				throw new Error('Cannot save workspace env: default workspace has not loaded yet.');
 			}
 			const response = await fetcher(API_ENDPOINTS.workspaces.env(workspaceId), {
 				method: 'PUT',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -316,11 +316,23 @@ export const API_ENDPOINTS = {
 		 * @param path - Workspace-relative POSIX path
 		 */
 		deleteFile: (id: string, path: string) => `/api/v1/workspaces/${id}/files/${path}`,
-	},
-	/** Per-user workspace environment variable overrides. */
-	workspace: {
-		/** Read the workspace env vars. */
-		env: '/api/v1/workspace/env',
+		/**
+		 * Per-workspace encrypted env-var overrides.
+		 *
+		 * Backed by `backend/app/api/workspace_env.py`. The path was workspace_id-keyed
+		 * in May 2026 (see ADR
+		 * `frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx`);
+		 * the legacy `/api/v1/workspace/env` shape was removed at the same time.
+		 *
+		 * @param id - Workspace UUID
+		 */
+		env: (id: string) => `/api/v1/workspaces/${id}/env`,
+		/**
+		 * Delete a single env-var override for a workspace.
+		 * @param id  - Workspace UUID
+		 * @param key - Override key (one of `WORKSPACE_ENV_KEY_IDS`)
+		 */
+		envKey: (id: string, key: string) => `/api/v1/workspaces/${id}/env/${key}`,
 		/** Read onboarding readiness (default workspace existence + metadata). */
 		onboardingStatus: '/api/v1/workspaces/onboarding-status',
 	},


### PR DESCRIPTION
## Summary

- Adds an additive, Python-native plugin registry under `backend/app/core/plugins/` — a `Plugin` declares env keys + tool factories; `build_agent_tools` walks the registry as a tail-append. Existing core tools (workspace files, Exa, image-gen, artifact, send-message, LCM history, Telegram caps) are unchanged.
- Migrates workspace `.env` storage from per-user (`{base}/{user_id}/.env`) to per-workspace (`{base}/{workspace_id}/.env`). `resolve_api_key(workspace_id, key)` replaces the user-keyed signature across providers, tools, STT, and the chat router. New endpoint shape: `/api/v1/workspaces/{workspace_id}/env`. Startup migration moves legacy files into each user's default workspace (non-destructive — source renamed `.env.migrated-<ts>`).
- Ships the **Notion plugin** (`backend/app/integrations/notion/`) as the first registry consumer: 18 tools mirroring openclaw-notion's contract (`notion_search`, `notion_read`, `notion_read_markdown`, `notion_append`, `notion_create`, `notion_update_markdown`, `notion_update_page`, `notion_comment_create`, `notion_comment_list`, `notion_query`, `notion_delete`, `notion_move`, `notion_publish`, `notion_file_tree`, `notion_sync`, `notion_help`, `notion_doctor`, `notion_logs_read`).
- Execution layer: per-call `subprocess.exec` of the official `ntn` CLI with `NOTION_API_TOKEN` injected and `HOME` isolated to a tempdir per call — no shared state between workspaces. New `notion_operation_logs` table + Alembic migration `013` captures every call (status, duration, page/db ids, raw payloads) for `notion_logs_read` to surface.
- Settings UI gets a Notion API Key row pointing at `notion.so/profile/integrations`; Dockerfile installs `ntn` into the backend prod image.
- Design captured in ADR `frontend/content/docs/handbook/decisions/2026-05-15-plugin-system-and-notion-integration.mdx`; handbook page `frontend/content/docs/handbook/integrations/adding-a-plugin.mdx` documents the registry shape for future plugins.

## Test plan

- [x] `pytest -q --ignore=tests/integration` — 807/807 passing (15 plugin-registry tests, 5 migration tests, 12 Notion plugin tests).
- [x] `ruff check` clean across every backend file touched.
- [x] `bun run typecheck` clean.
- [ ] Manual: paste an Internal Integration token in Settings → Workspace, confirm the 18 Notion tools appear on the next chat turn.
- [ ] Manual: confirm `curl -fsSL https://ntn.dev | bash` works inside the backend Docker build (couldn't verify in sandbox — `ntn.dev` UA-gates against curl).
- [ ] Manual: verify the one-time startup migration moves legacy `{base}/{user_id}/.env` files for an existing user.

## Risks / open questions

- `ntn` is a closed-source binary; `HOME` is per-call isolated as defence-in-depth but the trust boundary is "we already run trusted server code." Revisit if Pawrrtal goes multi-tenant.
- STT now does an extra DB round-trip to look up the user's default workspace before resolving `XAI_API_KEY`. Cheap, but flag if STT volume spikes.
- Frontend hook reads the default workspace via `useWorkspaceEnv`; once Settings grows a workspace switcher, this should accept an explicit `workspaceId`.

https://claude.ai/code/session_014Yxk4Rujpe5Sn89cHVuFhL

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yxk4Rujpe5Sn89cHVuFhL)_