### PR TITLE
feat(observability): stamp TTFT and duration on turn/LLM spans

### DIFF
--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -24,6 +24,7 @@ from app.core.lcm import assemble_context as lcm_assemble_context
 from app.core.lcm import ingest_message as lcm_ingest_message
 from app.core.lcm.background import schedule_lcm_compaction
 from app.core.observability import (
+    TurnSpanRecorder,
     aggregator_stop_reason,
     build_llm_view_messages,
     llm_span,
@@ -53,6 +54,17 @@ EventHook = Callable[["StreamEvent"], list["StreamEvent"]]
 # any string here but a recognisable placeholder makes it obvious in the
 # UI that the model wasn't pinned for this turn.
 _MODEL_ID_UNKNOWN = "unknown"
+
+# Seconds → milliseconds for the canonical CHAT_OUT / TELEGRAM_OUT log
+# line and the ``TurnCompletedEvent.duration_ms`` payload.  Named so the
+# magnitude is self-documenting rather than a bare ``* 1000``.
+_MS_PER_SECOND_FOR_LOG = 1000
+
+# Placeholder used in the canonical log line when a turn finished
+# without ever producing a user-visible event (provider error before
+# any token).  Cheaper than a conditional format string and keeps the
+# field-position contract stable for log parsers.
+_TTFT_LOG_MISSING = "-"
 
 
 @dataclass(frozen=True)
@@ -145,7 +157,7 @@ async def run_turn(
         surface=turn_input.log_tag,
         request_id=_request_id_from_extras(turn_input.log_extras),
         model_id=model_id,
-    ):
+    ) as turn_recorder:
         try:
             async for chunk in _stream_with_llm_span(
                 turn_input=turn_input,
@@ -155,6 +167,7 @@ async def run_turn(
                 counter=counter,
                 event_hooks=event_hooks,
                 model_id=model_id,
+                turn_recorder=turn_recorder,
             ):
                 yield chunk
         finally:
@@ -165,6 +178,7 @@ async def run_turn(
                 started_at=started_at,
                 event_count=counter.value,
                 event_breakdown=counter.by_type,
+                ttft_ms=turn_recorder.ttft_ms,
             )
 
 
@@ -177,6 +191,7 @@ async def _stream_with_llm_span(
     counter: _EventCounter,
     event_hooks: list[EventHook] | None,
     model_id: str | None,
+    turn_recorder: TurnSpanRecorder,
 ) -> AsyncIterator[bytes]:
     """Yield channel chunks under one ``llm_span`` context manager.
 
@@ -199,7 +214,10 @@ async def _stream_with_llm_span(
         messages=build_llm_view_messages(history, turn_input.question),
         system_prompt=system_prompt,
     ) as llm_recorder:
-        hooks = [workshop_event_hook(llm_recorder), *(event_hooks or [])]
+        hooks = [
+            workshop_event_hook(llm_recorder, turn_recorder=turn_recorder),
+            *(event_hooks or []),
+        ]
         try:
             async for chunk in turn_input.channel.deliver(
                 _guarded_stream(
@@ -384,9 +402,10 @@ async def _finalize_turn(
     started_at: float,
     event_count: int,
     event_breakdown: Counter[str],
+    ttft_ms: float | None,
 ) -> None:
     """Patch the assistant placeholder with the final aggregated stream state."""
-    duration_ms = (time.perf_counter() - started_at) * 1000
+    duration_ms = (time.perf_counter() - started_at) * _MS_PER_SECOND_FOR_LOG
     final_status = "failed" if aggregator.error_text else "complete"
     snapshot = aggregator.to_persisted_shape(status=final_status)
     try:
@@ -425,12 +444,17 @@ async def _finalize_turn(
     breakdown = (
         " ".join(f"{name}={count}" for name, count in sorted(event_breakdown.items())) or "none"
     )
+    ttft_field = f"{ttft_ms:.1f}" if ttft_ms is not None else _TTFT_LOG_MISSING
     logger.info(
-        "%s_OUT conversation_id=%s events=%d duration_ms=%.1f breakdown=[%s] %s",
+        "%s_OUT conversation_id=%s events=%d duration_ms=%.1f ttft_ms=%s "
+        "input_tokens=%d output_tokens=%d breakdown=[%s] %s",
         turn_input.log_tag,
         turn_input.conversation_id,
         event_count,
         duration_ms,
+        ttft_field,
+        aggregator.total_input_tokens,
+        aggregator.total_output_tokens,
         breakdown,
         extras,
     )
@@ -451,6 +475,9 @@ async def _finalize_turn(
             model_id=model_id,
             status=final_status,
             duration_ms=duration_ms,
+            ttft_ms=ttft_ms,
+            input_tokens=aggregator.total_input_tokens,
+            output_tokens=aggregator.total_output_tokens,
             cost_usd=aggregator.total_cost_usd,
             source=turn_input.log_tag.lower(),
         )

--- a/backend/app/core/event_bus/types.py
+++ b/backend/app/core/event_bus/types.py
@@ -61,6 +61,14 @@ class TurnCompletedEvent(Event):
     model_id: str | None = None
     status: str = "complete"
     duration_ms: float | None = None
+    # PR (latency metrics): wall-clock elapsed from turn start to the
+    # first user-visible event.  ``None`` when the turn produced no
+    # event (provider error before any token).  Surfaced so subscribers
+    # — metrics rollups, slow-request alerts — can compute provider
+    # responsiveness without re-deriving it from span exports.
+    ttft_ms: float | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
     cost_usd: float | None = None
     source: str = "chat"
 

--- a/backend/app/core/observability/__init__.py
+++ b/backend/app/core/observability/__init__.py
@@ -16,6 +16,7 @@ from app.core.observability._turn_view import (
 from app.core.observability.workshop import (
     LLMSpanRecorder,
     ToolSpanRecorder,
+    TurnSpanRecorder,
     llm_span,
     tool_span,
     turn_span,
@@ -25,6 +26,7 @@ from app.core.observability.workshop import (
 __all__ = [
     "LLMSpanRecorder",
     "ToolSpanRecorder",
+    "TurnSpanRecorder",
     "aggregator_stop_reason",
     "build_llm_view_messages",
     "llm_span",

--- a/backend/app/core/observability/_recorders.py
+++ b/backend/app/core/observability/_recorders.py
@@ -9,6 +9,7 @@ module stays inside the project's file-line budget
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from opentelemetry.trace import Span, Status, StatusCode
@@ -21,6 +22,10 @@ from app.core.observability._schema import (
     ATTR_GENAI_OUTPUT_TOKENS,
     ATTR_GENAI_RESPONSE_MODEL,
     ATTR_OTEL_STATUS_MESSAGE,
+    ATTR_PAWRRTAL_LLM_DURATION_MS,
+    ATTR_PAWRRTAL_LLM_TTFT_MS,
+    ATTR_PAWRRTAL_TURN_DURATION_MS,
+    ATTR_PAWRRTAL_TURN_TTFT_MS,
     ATTR_TRACELOOP_OUTPUT,
     EVENT_ATTR_CONTENT_TEXT,
     EVENT_ATTR_THINKING_TEXT,
@@ -28,6 +33,8 @@ from app.core.observability._schema import (
     EVENT_THINKING_DELTA,
     json_dumps,
 )
+
+_MS_PER_SECOND = 1000.0
 
 
 class LLMSpanRecorder:
@@ -52,11 +59,31 @@ class LLMSpanRecorder:
         self._thinking_parts: list[str] = []
         self._tool_calls: list[dict[str, Any]] = []
         self._finalised = False
+        # Latency clocks — wall-clock perf_counter at recorder build time
+        # (i.e. when the provider stream is about to start) and the
+        # elapsed time to the first user-visible chunk.  ``_ttft_ms`` is
+        # only stamped on the span when it's actually been observed —
+        # an LLM span that errored before any token must not lie about
+        # having a sub-zero TTFT.
+        self._started_at = time.perf_counter()
+        self._ttft_ms: float | None = None
+
+    def _mark_first_token(self) -> None:
+        """Capture wall-clock elapsed at the first streamed token.
+
+        Idempotent — only the first call wins.  Called from both
+        ``record_text_delta`` and ``record_thinking_delta`` so reasoning
+        models that emit thinking before any text still get a TTFT.
+        """
+        if self._ttft_ms is not None:
+            return
+        self._ttft_ms = (time.perf_counter() - self._started_at) * _MS_PER_SECOND
 
     def record_text_delta(self, text: str) -> None:
         """Append a streamed text chunk and emit a span event."""
         if not text:
             return
+        self._mark_first_token()
         self._text_parts.append(text)
         self._span.add_event(EVENT_CONTENT_DELTA, {EVENT_ATTR_CONTENT_TEXT: text})
 
@@ -64,6 +91,7 @@ class LLMSpanRecorder:
         """Append a streamed reasoning chunk and emit a span event."""
         if not text:
             return
+        self._mark_first_token()
         self._thinking_parts.append(text)
         self._span.add_event(EVENT_THINKING_DELTA, {EVENT_ATTR_THINKING_TEXT: text})
 
@@ -112,12 +140,19 @@ class LLMSpanRecorder:
         self._span.set_status(Status(StatusCode.ERROR, message))
         self._span.set_attribute(ATTR_OTEL_STATUS_MESSAGE, message)
 
+    @property
+    def ttft_ms(self) -> float | None:
+        """Time to first token in milliseconds, or ``None`` if no token streamed."""
+        return self._ttft_ms
+
     def flush(self) -> None:
         """Stamp ``gen_ai.output.messages`` + ``gen_ai.response.model``.
 
         Idempotent — the LLM span context-manager calls this in its
         ``finally`` block so an exception path still gets a partial
-        output stamped (the text accumulated up to the failure).
+        output stamped (the text accumulated up to the failure).  The
+        same call also stamps the ``pawrrtal.llm.*`` latency attributes
+        so a failed turn still gets its observed latency on the span.
         """
         if self._finalised:
             return
@@ -131,6 +166,63 @@ class LLMSpanRecorder:
             ATTR_GENAI_OUTPUT_MESSAGES,
             json_dumps([{"role": "assistant", "parts": parts}]),
         )
+        duration_ms = (time.perf_counter() - self._started_at) * _MS_PER_SECOND
+        self._span.set_attribute(ATTR_PAWRRTAL_LLM_DURATION_MS, float(duration_ms))
+        if self._ttft_ms is not None:
+            self._span.set_attribute(ATTR_PAWRRTAL_LLM_TTFT_MS, float(self._ttft_ms))
+
+
+class TurnSpanRecorder:
+    """Tracks turn-level latency and stamps it on the turn span.
+
+    Mirrors :class:`LLMSpanRecorder`'s contract for the outer
+    ``pawrrtal.turn`` span: the recorder is constructed when the turn
+    starts, callers ping :meth:`record_first_event` as soon as the
+    first user-visible chunk is produced, and :meth:`flush` stamps the
+    final ``pawrrtal.turn.duration_ms`` (always) and
+    ``pawrrtal.turn.ttft_ms`` (when a first event was observed).
+    Workshop's UI ignores attributes it doesn't recognise, so this is
+    safe to emit alongside the existing turn-span attributes.
+    """
+
+    def __init__(self, span: Span) -> None:
+        """Bind the recorder to *span* and start the latency clock."""
+        self._span = span
+        self._started_at = time.perf_counter()
+        self._ttft_ms: float | None = None
+        self._finalised = False
+
+    def record_first_event(self) -> None:
+        """Mark the moment the first user-visible event was emitted.
+
+        Idempotent — only the first call wins.  Called from the turn
+        runner's event hook so any event type (delta, thinking,
+        tool_use, message, error) counts as "first byte to the user".
+        """
+        if self._ttft_ms is not None:
+            return
+        self._ttft_ms = (time.perf_counter() - self._started_at) * _MS_PER_SECOND
+
+    @property
+    def ttft_ms(self) -> float | None:
+        """Time to first user-visible event in milliseconds, or ``None``."""
+        return self._ttft_ms
+
+    def flush(self) -> None:
+        """Stamp ``pawrrtal.turn.duration_ms`` and ``pawrrtal.turn.ttft_ms``.
+
+        Idempotent — repeated calls are no-ops so a caller can safely
+        invoke this in a ``finally`` block.  The recorder computes its
+        own duration from the wall-clock captured at construction so it
+        doesn't need to be threaded through the turn runner.
+        """
+        if self._finalised:
+            return
+        self._finalised = True
+        duration_ms = (time.perf_counter() - self._started_at) * _MS_PER_SECOND
+        self._span.set_attribute(ATTR_PAWRRTAL_TURN_DURATION_MS, float(duration_ms))
+        if self._ttft_ms is not None:
+            self._span.set_attribute(ATTR_PAWRRTAL_TURN_TTFT_MS, float(self._ttft_ms))
 
 
 class ToolSpanRecorder:

--- a/backend/app/core/observability/_schema.py
+++ b/backend/app/core/observability/_schema.py
@@ -66,6 +66,17 @@ ATTR_SURFACE = "pawrrtal.surface"
 ATTR_REQUEST_ID = "pawrrtal.request_id"
 ATTR_TOOL_CALL_ID = "pawrrtal.tool_call_id"
 
+# Latency attributes — Pawrrtal-namespaced rather than using OTel-GenAI
+# names (the semantic-conventions spec doesn't pin a TTFT attribute yet,
+# and our turn-level duration covers more than the LLM round-trip).
+# ``duration_ms`` is redundant with the span's natural duration but is
+# cheaper to query in log/metrics backends than computing
+# end_time - start_time per span.
+ATTR_PAWRRTAL_TURN_DURATION_MS = "pawrrtal.turn.duration_ms"
+ATTR_PAWRRTAL_TURN_TTFT_MS = "pawrrtal.turn.ttft_ms"
+ATTR_PAWRRTAL_LLM_DURATION_MS = "pawrrtal.llm.duration_ms"
+ATTR_PAWRRTAL_LLM_TTFT_MS = "pawrrtal.llm.ttft_ms"
+
 # Span event names — Workshop surfaces these in the live timeline.
 EVENT_CONTENT_DELTA = "gen_ai.content.delta"
 EVENT_THINKING_DELTA = "gen_ai.thinking.delta"

--- a/backend/app/core/observability/workshop.py
+++ b/backend/app/core/observability/workshop.py
@@ -54,9 +54,13 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace
-from opentelemetry.trace import Span, Status, StatusCode
+from opentelemetry.trace import Status, StatusCode
 
-from app.core.observability._recorders import LLMSpanRecorder, ToolSpanRecorder
+from app.core.observability._recorders import (
+    LLMSpanRecorder,
+    ToolSpanRecorder,
+    TurnSpanRecorder,
+)
 from app.core.observability._schema import (
     ATTR_CONVERSATION_ID,
     ATTR_GENAI_INPUT_MESSAGES,
@@ -91,6 +95,7 @@ if TYPE_CHECKING:
 __all__ = [
     "LLMSpanRecorder",
     "ToolSpanRecorder",
+    "TurnSpanRecorder",
     "llm_span",
     "tool_span",
     "turn_span",
@@ -108,12 +113,18 @@ def turn_span(
     surface: str,
     request_id: str,
     model_id: str | None,
-) -> Iterator[Span]:
+) -> Iterator[TurnSpanRecorder]:
     """Root span for one chat turn.
 
     Every LLM and tool span emitted inside this context-manager inherits
     the same ``trace_id``, so Workshop groups them as one "run" (see
     workshop/src/server.ts → ``upsertRun`` keyed by trace_id).
+
+    The yielded :class:`TurnSpanRecorder` carries the latency clocks:
+    callers ping :meth:`TurnSpanRecorder.record_first_event` from the
+    event hook so ``pawrrtal.turn.ttft_ms`` lands on the span, and the
+    recorder ``flush()`` call (in the ``finally`` here) stamps
+    ``pawrrtal.turn.duration_ms``.
 
     Args:
         conversation_id: Pawrrtal conversation UUID.
@@ -125,8 +136,8 @@ def turn_span(
             (e.g. ``"gemini:gemini-2.0-flash-exp"``) when known.
 
     Yields:
-        The active ``Span`` so callers can attach further attributes
-        before the turn finishes.
+        A :class:`TurnSpanRecorder` so callers can mark TTFT and read
+        it back for the canonical log line / event-bus payload.
     """
     with _tracer.start_as_current_span("pawrrtal.turn") as span:
         span.set_attribute(ATTR_CONVERSATION_ID, str(conversation_id))
@@ -135,7 +146,11 @@ def turn_span(
         span.set_attribute(ATTR_REQUEST_ID, request_id)
         if model_id:
             span.set_attribute(ATTR_GENAI_REQUEST_MODEL, model_id)
-        yield span
+        recorder = TurnSpanRecorder(span)
+        try:
+            yield recorder
+        finally:
+            recorder.flush()
 
 
 @contextmanager
@@ -280,6 +295,8 @@ _HOOK_DISPATCH: dict[str, Callable[[LLMSpanRecorder, StreamEvent], None]] = {
 
 def workshop_event_hook(
     recorder: LLMSpanRecorder,
+    *,
+    turn_recorder: TurnSpanRecorder | None = None,
 ) -> Callable[[StreamEvent], list[StreamEvent]]:
     """Return a ``turn_runner.EventHook`` that mirrors stream events onto *recorder*.
 
@@ -293,15 +310,24 @@ def workshop_event_hook(
     Dispatch is via :data:`_HOOK_DISPATCH` so the closure stays flat —
     important for the project's nesting-depth gate.
 
+    When *turn_recorder* is supplied, every observed event also pings
+    :meth:`TurnSpanRecorder.record_first_event` so the outer turn span
+    gets its TTFT — including error / message / tool_use events that
+    don't carry through to :class:`LLMSpanRecorder`.
+
     Args:
         recorder: The LLM span recorder for the current turn.  Usually
             obtained from ``with llm_span(...) as recorder``.
+        turn_recorder: Optional outer-turn recorder.  When provided,
+            the hook also marks turn-level TTFT on first event.
 
     Returns:
         A pure function consumable by ``run_turn(event_hooks=...)``.
     """
 
     def hook(event: StreamEvent) -> list[StreamEvent]:
+        if turn_recorder is not None:
+            turn_recorder.record_first_event()
         handler = _HOOK_DISPATCH.get(event.get("type", ""))
         if handler is not None:
             handler(recorder, event)

--- a/backend/tests/test_observability_workshop.py
+++ b/backend/tests/test_observability_workshop.py
@@ -29,6 +29,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from app.core.observability import workshop as workshop_module
+from app.core.observability._recorders import TurnSpanRecorder
 from app.core.observability.workshop import (
     llm_span,
     tool_span,
@@ -564,3 +565,212 @@ async def test_run_turn_passes_history_into_llm_span(
     assert payload[0]["parts"][0]["content"] == "what's 2+2?"
     assert payload[1]["parts"][0]["content"] == "4"
     assert payload[2]["parts"][0]["content"] == "and 3+3?"
+
+
+# ---------------------------------------------------------------------------
+# Latency: TTFT + duration on LLM and turn spans
+# ---------------------------------------------------------------------------
+
+
+def test_llm_recorder_stamps_duration_and_ttft_after_delta(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """A delta-bearing turn stamps both ``pawrrtal.llm.duration_ms`` and ``...ttft_ms``."""
+    with llm_span(model_id="m", messages=[], system_prompt=None) as recorder:
+        recorder.record_text_delta("hi")
+        recorder.record_text_delta("there")
+
+    attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.llm.chat"))
+    ttft = attrs.get("pawrrtal.llm.ttft_ms")
+    duration = attrs.get("pawrrtal.llm.duration_ms")
+    assert isinstance(ttft, (int, float))
+    assert isinstance(duration, (int, float))
+    # ttft <= duration is the only safe assertion — wall-clock readings
+    # otherwise vary too much to pin a numeric bound.
+    assert ttft <= duration
+    assert duration >= 0.0
+
+
+def test_llm_recorder_omits_ttft_when_no_delta(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """A turn that streams no token stamps duration but not TTFT.
+
+    Protects the invariant that ``pawrrtal.llm.ttft_ms`` only appears
+    when an actual first token was observed.  Without it, a provider
+    error before any token would show a misleading sub-millisecond TTFT
+    in dashboards that just plot the attribute.
+    """
+    with llm_span(model_id="m", messages=[], system_prompt=None):
+        pass
+
+    attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.llm.chat"))
+    assert "pawrrtal.llm.duration_ms" in attrs
+    assert "pawrrtal.llm.ttft_ms" not in attrs
+
+
+def test_llm_recorder_ttft_set_on_thinking_delta_first(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Reasoning models that emit ``thinking`` before ``text`` still get TTFT.
+
+    Otherwise a long reasoning preamble (Claude with extended thinking,
+    OpenAI o1) would log a TTFT that excludes the visible-but-pre-text
+    wait — exactly the latency a user is feeling.
+    """
+    with llm_span(model_id="m", messages=[], system_prompt=None) as recorder:
+        recorder.record_thinking_delta("planning")
+        recorder.record_text_delta("answer")
+
+    attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.llm.chat"))
+    assert "pawrrtal.llm.ttft_ms" in attrs
+
+
+def test_turn_recorder_record_first_event_is_idempotent() -> None:
+    """Only the first ``record_first_event`` call captures TTFT.
+
+    Direct recorder test — bypasses the OTel span machinery to pin the
+    idempotency contract that ``workshop_event_hook`` relies on (it
+    calls ``record_first_event`` on every event without tracking
+    whether it's already fired).
+    """
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("test") as span:
+        recorder = TurnSpanRecorder(span)
+        assert recorder.ttft_ms is None
+        recorder.record_first_event()
+        first_value = recorder.ttft_ms
+        assert first_value is not None
+        # Burning a tiny bit of wall-clock — if the second call wasn't
+        # idempotent, this would overwrite ``_ttft_ms`` with a larger
+        # number, so equality is a meaningful assertion.
+        for _ in range(100):
+            recorder.record_first_event()
+        assert recorder.ttft_ms == first_value
+
+
+def test_turn_span_stamps_duration_and_ttft_when_first_event_recorded(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """``turn_span`` flushes ``pawrrtal.turn.*`` latency attributes on exit."""
+    with turn_span(
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        surface="WEB",
+        request_id="req-1",
+        model_id="m",
+    ) as turn_recorder:
+        turn_recorder.record_first_event()
+
+    attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.turn"))
+    assert "pawrrtal.turn.duration_ms" in attrs
+    assert "pawrrtal.turn.ttft_ms" in attrs
+
+
+def test_turn_span_omits_ttft_when_no_event(span_exporter: InMemorySpanExporter) -> None:
+    """A turn that never produced an event stamps duration but not TTFT."""
+    with turn_span(
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        surface="WEB",
+        request_id="req-1",
+        model_id="m",
+    ):
+        pass
+
+    attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.turn"))
+    assert "pawrrtal.turn.duration_ms" in attrs
+    assert "pawrrtal.turn.ttft_ms" not in attrs
+
+
+def test_workshop_event_hook_marks_turn_ttft(span_exporter: InMemorySpanExporter) -> None:
+    """When provided, ``turn_recorder`` gets pinged by the LLM event hook."""
+    with (
+        turn_span(
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            surface="WEB",
+            request_id="req-1",
+            model_id="m",
+        ) as turn_recorder,
+        llm_span(model_id="m", messages=[], system_prompt=None) as llm_recorder,
+    ):
+        hook = workshop_event_hook(llm_recorder, turn_recorder=turn_recorder)
+        assert hook({"type": "delta", "content": "hi"}) == []
+
+    turn_attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.turn"))
+    assert "pawrrtal.turn.ttft_ms" in turn_attrs
+
+
+@pytest.mark.anyio
+async def test_run_turn_stamps_latency_attributes_on_turn_span(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run_turn`` populates both ``pawrrtal.turn.*`` latency attributes.
+
+    Integration check that the hook plumbing in ``_stream_with_llm_span``
+    actually wires ``turn_recorder`` through ``workshop_event_hook``.
+    Without this, a refactor that drops the kwarg would silently break
+    TTFT capture for every chat turn.
+    """
+    import uuid as _uuid
+
+    from app.channels.turn_runner import ChatTurnInput, run_turn
+
+    class _FakeProvider:
+        async def stream(self, *_args: object, **_kwargs: object):
+            yield {"type": "delta", "content": "hello"}
+            yield {
+                "type": "usage",
+                "input_tokens": 3,
+                "output_tokens": 1,
+                "cost_usd": 0.0,
+            }
+
+    class _FakeChannel:
+        surface = "test"
+
+        async def deliver(self, stream, _message):
+            async for event in stream:
+                yield str(event).encode()
+
+    channel_message = {
+        "user_id": _uuid.uuid4(),
+        "conversation_id": _uuid.uuid4(),
+        "text": "hi",
+        "surface": "test",
+        "model_id": "test:fake",
+        "metadata": {},
+    }
+
+    async def _persist(_turn_input):
+        return [], _uuid.uuid4()
+
+    async def _noop_finalize(**_kwargs):
+        # Capture the kwargs the runner forwards so the test can also
+        # assert that the latency value flows into the log / event
+        # plumbing, not only the span.
+        _noop_finalize.last_kwargs = _kwargs  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("app.channels.turn_runner._load_history_and_persist", _persist)
+    monkeypatch.setattr("app.channels.turn_runner._finalize_turn", _noop_finalize)
+
+    turn_input = ChatTurnInput(
+        conversation_id=channel_message["conversation_id"],
+        user_id=channel_message["user_id"],
+        question="hi",
+        provider=_FakeProvider(),  # type: ignore[arg-type]
+        channel=_FakeChannel(),  # type: ignore[arg-type]
+        channel_message=channel_message,  # type: ignore[arg-type]
+    )
+
+    async for _chunk in run_turn(turn_input):
+        pass
+
+    turn_attrs = _attrs(_span_by_name(span_exporter, "pawrrtal.turn"))
+    assert "pawrrtal.turn.duration_ms" in turn_attrs
+    assert "pawrrtal.turn.ttft_ms" in turn_attrs
+    forwarded = _noop_finalize.last_kwargs  # type: ignore[attr-defined]
+    assert forwarded["ttft_ms"] is not None
+    assert forwarded["ttft_ms"] >= 0.0


### PR DESCRIPTION
## Summary

Adds wall-clock latency metrics on top of the existing Workshop / OpenLLMetry span schema so dashboards can answer "how slow was the model?" without re-deriving span durations from start/end exports.

- `LLMSpanRecorder` stamps `pawrrtal.llm.duration_ms` (always) and `pawrrtal.llm.ttft_ms` (when a delta or thinking event was observed) on flush. TTFT covers both text and thinking deltas so extended-reasoning models still get a meaningful first-token reading.
- New `TurnSpanRecorder` does the same for the outer `pawrrtal.turn` span. `workshop_event_hook` now accepts an optional `turn_recorder` and pings `record_first_event` on every observed event, so error / message / tool_use events still count as "first byte to the user".
- `turn_runner`'s canonical `*_OUT` log line now carries `ttft_ms`, `input_tokens`, `output_tokens` (sourced from the existing aggregator). `TurnCompletedEvent` carries the same fields so bus subscribers (metrics rollups, slow-request alerts) can react without re-reading span exports.

## What lands on each span

| Span | New attributes |
| --- | --- |
| `pawrrtal.turn` | `pawrrtal.turn.duration_ms`, `pawrrtal.turn.ttft_ms` |
| `pawrrtal.llm.chat` | `pawrrtal.llm.duration_ms`, `pawrrtal.llm.ttft_ms` |

Existing `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.usage.cost_usd` already covered token + cost telemetry, so no changes there.

Both `*.ttft_ms` attributes are only stamped when an actual first event was observed — a provider error before any token leaves the attribute unset rather than logging a misleading sub-millisecond TTFT.

## Tests

- `pawrrtal.llm.duration_ms` / `ttft_ms` stamp on delta-bearing turns
- TTFT omission when no token streamed
- TTFT captured on `thinking` delta first (extended-reasoning path)
- `TurnSpanRecorder.record_first_event` idempotency
- `pawrrtal.turn.*` stamp + omission paths
- `workshop_event_hook` wires turn TTFT when a `turn_recorder` is passed
- End-to-end `run_turn` integration: turn span carries the attributes and `_finalize_turn` receives `ttft_ms` in its kwargs

## Test plan

- [x] `pytest tests/` — 788 passed
- [x] `ruff check app/ tests/` — clean
- [x] `ruff format --check app/ tests/` — clean
- [x] `python3 scripts/check-nesting.py` — clean
- [x] `node scripts/check-file-lines.mjs` — clean
- [x] `python3 scripts/check-no-tools-in-providers.py` — clean
- [x] `mypy` on touched files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01CccEBGDmDCrqX1W2XG5yPa)_