### PR TITLE
Fix Railway port binding and add DB migrations to startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 8000
 # command so --reload is active and the source volume mount is writable.
 # For production (Railway / plain Docker run) this CMD runs migrations
 # then starts uvicorn without reload.
-CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 8000
 # command so --reload is active and the source volume mount is writable.
 # For production (Railway / plain Docker run) this CMD runs migrations
 # then starts uvicorn without reload.
-CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -2,10 +2,15 @@
 
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 
 from alembic import context
 from app.core.config import settings
+
+# Stable advisory-lock id so concurrent `alembic upgrade head` invocations
+# (e.g. Railway rolling deploys booting two replicas at once) serialise
+# instead of racing on schema mutation. Postgres-only; ignored on SQLite.
+ALEMBIC_MIGRATION_LOCK_ID = 0xA1EBAB1C
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -55,10 +60,23 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        is_postgres = connection.dialect.name == "postgresql"
+        if is_postgres:
+            connection.execute(
+                text("SELECT pg_advisory_lock(:lock_id)"),
+                {"lock_id": ALEMBIC_MIGRATION_LOCK_ID},
+            )
+        try:
+            context.configure(connection=connection, target_metadata=target_metadata)
 
-        with context.begin_transaction():
-            context.run_migrations()
+            with context.begin_transaction():
+                context.run_migrations()
+        finally:
+            if is_postgres:
+                connection.execute(
+                    text("SELECT pg_advisory_unlock(:lock_id)"),
+                    {"lock_id": ALEMBIC_MIGRATION_LOCK_ID},
+                )
 
 
 if context.is_offline_mode():

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,4 +1,10 @@
 [deploy]
-startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
+# Wrap in `sh -c` so `$PORT` (injected by Railway at runtime) is shell-expanded.
+# Without the shell, Railway passes the command as exec-form argv and uvicorn
+# receives the literal string "$PORT", failing with:
+#   Error: Invalid value for '--port': '$PORT' is not a valid integer.
+# Migrations are idempotent — `alembic upgrade head` exits 0 immediately when
+# the DB is already current.
+startCommand = "sh -c 'alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -5,6 +5,6 @@
 #   Error: Invalid value for '--port': '$PORT' is not a valid integer.
 # Migrations are idempotent — `alembic upgrade head` exits 0 immediately when
 # the DB is already current.
-startCommand = "sh -c 'alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
+startCommand = "sh -c 'alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Updates the application startup configuration to properly handle Railway's runtime `$PORT` injection and ensures database migrations run before the server starts in production environments.

## Changes
- **`backend/railway.toml`**: Updated `startCommand` to wrap the startup sequence in `sh -c` so the shell expands `$PORT` at runtime (Railway injects this as an environment variable). Also added `alembic upgrade head` to run migrations before uvicorn starts, with a fallback to port 8000 if `$PORT` is not set.
- **`backend/Dockerfile`**: Updated the production `CMD` to use `${PORT:-8000}` instead of hardcoded `8000`, ensuring the container respects the `PORT` environment variable when provided while maintaining backward compatibility.

## Implementation Details
- The `sh -c` wrapper is necessary because Railway passes the command as exec-form argv; without the shell, uvicorn receives the literal string `"$PORT"` instead of the expanded value, causing a port binding error.
- Migrations are idempotent — `alembic upgrade head` exits cleanly (status 0) when the database is already current, so it's safe to run on every startup.
- Both changes use the same pattern (`${PORT:-8000}`) for consistency and to support local development/testing without requiring the `PORT` environment variable.

https://claude.ai/code/session_013iJ4LyGmScW7zE4yBK7stu

## Summary by Sourcery

Update backend deployment configuration to support runtime PORT injection and run database migrations before starting the application server.

Build:
- Adjust Railway deploy command to run Alembic migrations and start uvicorn via a shell so the injected PORT environment variable is expanded correctly.
- Update Docker CMD to run Alembic migrations and bind uvicorn to a configurable PORT with a default of 8000 for compatibility.