### PR TITLE
fix(deploy): unbreak Railway — drop alembic-on-boot + merge dual-head

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -60,11 +60,14 @@ RUN mkdir -p /data/workspaces
 
 EXPOSE 8000
 
-# Run Alembic migrations then start the server.
-# `alembic upgrade head` is idempotent; if the DB is already current
-# it exits 0 immediately without making any changes.
-# In the docker-compose dev stack this CMD is overridden by the compose
-# command so --reload is active and the source volume mount is writable.
-# For production (Railway / plain Docker run) this CMD runs migrations
-# then starts uvicorn without reload.
-CMD ["sh", "-c", "alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+# Start the server. ``alembic upgrade head`` is NOT in the prod CMD
+# because the migration history currently has multiple heads (orphan
+# ``000_initial_schema`` from PR #166 + ``013_notion_operation_logs``
+# sibling of ``013_governance_and_jobs`` from PR #261) and would
+# error out before uvicorn ever ran. Migrations are applied manually
+# by the operator until the chain is consolidated to a single head.
+#
+# In the docker-compose dev stack this CMD is overridden by the
+# compose command so --reload is active and the source volume mount
+# is writable.
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/alembic/versions/016_merge_notion_into_lcm_lineage.py
+++ b/backend/alembic/versions/016_merge_notion_into_lcm_lineage.py
@@ -1,0 +1,45 @@
+"""Merge notion_operation_logs lineage into the LCM head.
+
+PR #261 added ``013_notion_operation_logs`` as a sibling of
+``013_governance_and_jobs`` (both branched off
+``012_canonicalise_conversation_model_ids``). The mainline chain ran
+on to ``014_drop_active_conversation_id`` → ``015_add_lcm_tables``,
+while ``013_notion_operation_logs`` was never reparented onto it, so
+``alembic upgrade head`` now sees two heads and fails on Railway boot
+with:
+
+    "Multiple head revisions are present for given argument 'head';
+     please specify a specific target revision."
+
+This is an empty merge migration that joins both heads at one point so
+``alembic upgrade head`` is well-defined again. It applies cleanly on
+top of either head — ``alembic upgrade head`` from a database at
+``015_add_lcm_tables`` will apply ``013_notion_operation_logs`` first
+(via the ``012`` shared parent) and then this merge, producing the
+``016_merge_notion_into_lcm_lineage`` head.
+
+Revision ID: 016_merge_notion_into_lcm_lineage
+Revises: 013_notion_operation_logs, 015_add_lcm_tables
+Create Date: 2026-05-17 21:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "016_merge_notion_into_lcm_lineage"
+down_revision: str | Sequence[str] | None = (
+    "013_notion_operation_logs",
+    "015_add_lcm_tables",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Merge-only migration — no schema changes."""
+
+
+def downgrade() -> None:
+    """Merge-only migration — no schema changes."""

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -3,8 +3,14 @@
 # Without the shell, Railway passes the command as exec-form argv and uvicorn
 # receives the literal string "$PORT", failing with:
 #   Error: Invalid value for '--port': '$PORT' is not a valid integer.
-# Migrations are idempotent — `alembic upgrade head` exits 0 immediately when
-# the DB is already current.
-startCommand = "sh -c 'alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
+#
+# Migrations are NOT run on boot here — the alembic history currently has
+# more than one head (the long-standing orphan ``000_initial_schema`` plus
+# the ``013_notion_operation_logs`` sibling of ``013_governance_and_jobs``
+# from PR #261). ``alembic upgrade head`` would error with "Multiple head
+# revisions are present" and uvicorn would never start. Until the chain is
+# consolidated to a single head, the operator applies migrations manually
+# via a Railway one-shot (``railway run -- alembic upgrade <rev>``).
+startCommand = "sh -c 'exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Railway redeploys on \`development\` are broken because \`alembic upgrade head\` errors with \"Multiple head revisions are present\" before uvicorn starts.

**Root cause (two stacked defects)**:
1. **#166** added \`000_initial_schema\` for fresh docker-compose bootstraps but never reparented \`001_add_conversation_metadata\` onto it — \`001.down_revision\` is still \`None\`, so \`000\` is an orphan head that's been sitting on dev/main since May 11.
2. **#261** added \`013_notion_operation_logs\` as a sibling of \`013_governance_and_jobs\` (both descend from \`012\`), and the mainline ran on through \`014\` / \`015_add_lcm_tables\` without pulling the Notion lineage back in. That gives the graph a second concurrent head.

\`alembic heads\` reports three heads today: \`000_initial_schema\`, \`013_notion_operation_logs\` (orphaned tip), and \`015_add_lcm_tables\`. \`alembic upgrade head\` refuses to pick one.

**Why it didn't fail before** — Railway's pre-#269 \`startCommand\` only ran uvicorn. Operator applied migrations manually via Railway one-shot. PR #269 added \`alembic upgrade head &&\` to the boot path expecting a single head; that assumption was already wrong.

## Changes
1. **Restore Railway's pre-#269 boot behavior**: drop \`alembic upgrade head &&\` from both \`backend/railway.toml\` \`startCommand\` and \`backend/Dockerfile\` CMD. Keeps the \`\${PORT:-8000}\` shell-expansion fix and the \`exec uvicorn\` signal handling from #269. Operator runs migrations manually via \`railway run -- alembic upgrade <rev>\` until the chain is consolidated.
2. **Add \`016_merge_notion_into_lcm_lineage.py\`** — empty alembic merge migration joining \`013_notion_operation_logs\` + \`015_add_lcm_tables\`. After this, that side of the graph is single-headed. The \`000_initial_schema\` orphan is deferred — fixing it cleanly needs to know prod's current \`alembic_version\` state so we don't crash the existing schema.

## Test plan
- [x] \`alembic heads\` locally shows the dual-head problem before this PR and a clean Notion-side merge after.
- [x] \`alembic history --rev-range 013_notion_operation_logs:016_merge_notion_into_lcm_lineage\` shows the merge point.
- [ ] CI: standard backend + frontend gates pass; no Railway smoke yet.
- [ ] Operator: after merging, redeploy Railway, then run \`alembic upgrade 016_merge_notion_into_lcm_lineage\` once to roll Notion's table in.