### PR TITLE
fix(alembic): reparent 001 onto 000 + restore alembic-upgrade on boot

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,15 +29,20 @@ FROM python:3.13-slim AS runtime
 WORKDIR /app
 
 # Install the official Notion CLI (``ntn``) used by the Notion plugin.
-# The plugin subprocesses ``ntn`` per tool call with the workspace`s
+# The plugin subprocesses ``ntn`` per tool call with the workspace's
 # token injected via ``NOTION_API_TOKEN``; see
 # ``app/integrations/notion/ntn_client.py``.  Pinned by date so the
 # install layer is reproducible — bump the env var to refresh.
+#
+# The upstream installer (https://ntn.dev) writes ``ntn`` directly to
+# ``/usr/local/bin/ntn`` when run as root (the container build case),
+# so no follow-up ``mv`` is needed.  Earlier versions of this Dockerfile
+# tried to ``mv /root/.ntn/bin/ntn /usr/local/bin/ntn`` and crashed the
+# build with "No such file or directory" — bean ``pawrrtal-ntn``.
 ENV NTN_INSTALL_DATE=2026-05-15
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && curl -fsSL https://ntn.dev | bash \
- && mv /root/.ntn/bin/ntn /usr/local/bin/ntn \
  && chmod +x /usr/local/bin/ntn \
  && apt-get purge -y curl \
  && apt-get autoremove -y \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -60,14 +60,13 @@ RUN mkdir -p /data/workspaces
 
 EXPOSE 8000
 
-# Start the server. ``alembic upgrade head`` is NOT in the prod CMD
-# because the migration history currently has multiple heads (orphan
-# ``000_initial_schema`` from PR #166 + ``013_notion_operation_logs``
-# sibling of ``013_governance_and_jobs`` from PR #261) and would
-# error out before uvicorn ever ran. Migrations are applied manually
-# by the operator until the chain is consolidated to a single head.
+# Run Alembic migrations then start the server.  The graph is
+# single-head as of ``016_merge_notion_into_lcm_lineage`` so
+# ``alembic upgrade head`` resolves unambiguously.  The advisory
+# lock in ``alembic/env.py`` serialises concurrent invocations
+# across rolling-deploy replicas.
 #
 # In the docker-compose dev stack this CMD is overridden by the
 # compose command so --reload is active and the source volume mount
 # is writable.
-CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/alembic/versions/001_add_conversation_metadata_fields.py
+++ b/backend/alembic/versions/001_add_conversation_metadata_fields.py
@@ -13,7 +13,17 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "001_add_conversation_metadata"
-down_revision: Union[str, None] = None
+# Reparented onto ``000_initial_schema`` so the migration graph has a
+# single root.  Before this, ``001`` had ``down_revision = None`` and
+# sat as a parallel root next to ``000_initial_schema``, leaving
+# ``alembic upgrade head`` ambiguous (multiple heads) and breaking
+# Railway boots that ran ``alembic upgrade head &&`` in the startCommand.
+#
+# Existing deployments (Railway prod) are already past this point —
+# alembic only walks ancestors from the current revision forward, so
+# the parent rewrite is transparent for them.  Fresh databases
+# (docker-compose) now bootstrap 000 → 001 → ... cleanly.
+down_revision: Union[str, None] = "000_initial_schema"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -4,13 +4,12 @@
 # receives the literal string "$PORT", failing with:
 #   Error: Invalid value for '--port': '$PORT' is not a valid integer.
 #
-# Migrations are NOT run on boot here — the alembic history currently has
-# more than one head (the long-standing orphan ``000_initial_schema`` plus
-# the ``013_notion_operation_logs`` sibling of ``013_governance_and_jobs``
-# from PR #261). ``alembic upgrade head`` would error with "Multiple head
-# revisions are present" and uvicorn would never start. Until the chain is
-# consolidated to a single head, the operator applies migrations manually
-# via a Railway one-shot (``railway run -- alembic upgrade <rev>``).
-startCommand = "sh -c 'exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
+# ``alembic upgrade head`` runs first; the graph is single-head as of
+# ``016_merge_notion_into_lcm_lineage`` (after PR #286 added the
+# 013-sibling merge and this PR reparented ``001`` onto
+# ``000_initial_schema``).  The advisory lock in ``alembic/env.py``
+# serialises concurrent invocations across rolling-deploy replicas.
+# Then ``exec uvicorn`` replaces sh so SIGTERM reaches uvicorn directly.
+startCommand = "sh -c 'alembic upgrade head && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Finishes the alembic cleanup started in PR #286. After this lands, the migration graph is **single-head** (\`016_merge_notion_into_lcm_lineage\`) and Railway can run \`alembic upgrade head\` on boot again.

## What changed
1. **\`backend/alembic/versions/001_add_conversation_metadata_fields.py\`** — \`down_revision\` rewritten from \`None\` to \`\"000_initial_schema\"\`. Connects what was a parallel root into the single chain.
2. **\`backend/railway.toml\` + \`backend/Dockerfile\`** — restore \`alembic upgrade head &&\` ahead of \`exec uvicorn\` in both startup commands. The advisory lock in \`alembic/env.py\` (added in #269) still protects against rolling-deploy concurrency.

## Why this is safe for prod
Alembic only walks ancestors from the **current revision** forward. Existing deployments are already at \`015_add_lcm_tables\` (or wherever they were stamped). Rewriting \`001\`'s parent is purely a graph topology change for migrations that are already applied — no DDL re-runs.

Fresh databases (docker-compose) now bootstrap cleanly: \`000 → 001 → ... → 016\`.

## Follow-up issue
Filed as #287 — covers any remaining alembic hygiene (e.g., consider stamping \`016\` explicitly post-deploy if the operator wants a known-clean baseline; consider deprecation of the dual-013 lineage in a future migration squash).

## Test plan
- [x] \`cd backend && uv run alembic heads\` → single head \`016_merge_notion_into_lcm_lineage\`
- [x] \`cd backend && uv run alembic upgrade head --sql\` → produces a clean linear plan from \`None\` (no "Multiple head revisions" error).
- [x] \`cd backend && uv run pytest -q --ignore=tests/integration\` — 871/871 pass.
- [x] \`just sentrux\` — Quality 6788, all rules pass.
- [ ] CI: standard backend gates.
- [ ] Operator: redeploy Railway — verify migrations run cleanly. From a single-head graph, \`alembic upgrade head\` is a no-op when the DB is already at \`016\`.