### PR TITLE
fix(deploy): install libpq5 so psycopg loads in Railway runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,20 +28,34 @@ FROM python:3.13-slim AS runtime
 
 WORKDIR /app
 
-# Install the official Notion CLI (``ntn``) used by the Notion plugin.
-# The plugin subprocesses ``ntn`` per tool call with the workspace's
-# token injected via ``NOTION_API_TOKEN``; see
-# ``app/integrations/notion/ntn_client.py``.  Pinned by date so the
-# install layer is reproducible — bump the env var to refresh.
+# Install runtime OS deps:
 #
-# The upstream installer (https://ntn.dev) writes ``ntn`` directly to
-# ``/usr/local/bin/ntn`` when run as root (the container build case),
-# so no follow-up ``mv`` is needed.  Earlier versions of this Dockerfile
-# tried to ``mv /root/.ntn/bin/ntn /usr/local/bin/ntn`` and crashed the
-# build with "No such file or directory" — bean ``pawrrtal-ntn``.
+#   * ``libpq5`` — the Postgres client library.  ``psycopg`` (we depend on
+#     plain ``psycopg``, not ``psycopg[binary]``) loads ``libpq`` via
+#     ctypes at import time.  Without it the container crashes at startup
+#     with ``ImportError: no pq wrapper available`` from
+#     ``psycopg.pq.import_from_libpq`` — every ``alembic upgrade head``
+#     and every ``uvicorn`` boot fails because ``app/db.py`` imports
+#     ``psycopg`` transitively through SQLAlchemy.  ``python:3.13-slim``
+#     does not include ``libpq`` so we install it explicitly.
+#   * ``ntn`` — the official Notion CLI used by the Notion plugin.
+#     The plugin subprocesses ``ntn`` per tool call with the workspace's
+#     token injected via ``NOTION_API_TOKEN``; see
+#     ``app/integrations/notion/ntn_client.py``.  Pinned by date so the
+#     install layer is reproducible — bump the env var to refresh.
+#     The upstream installer (https://ntn.dev) writes ``ntn`` directly to
+#     ``/usr/local/bin/ntn`` when run as root (the container build case),
+#     so no follow-up ``mv`` is needed.  Earlier versions of this
+#     Dockerfile tried to ``mv /root/.ntn/bin/ntn /usr/local/bin/ntn`` and
+#     crashed the build with "No such file or directory" — bean
+#     ``pawrrtal-ntn``.
+#
+# ``curl`` and ``ca-certificates`` are only needed for the ``ntn``
+# installer, so we install them and ``apt-get purge`` curl afterwards
+# to keep the runtime image small.  ``libpq5`` must NOT be purged.
 ENV NTN_INSTALL_DATE=2026-05-15
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates \
+ && apt-get install -y --no-install-recommends libpq5 curl ca-certificates \
  && curl -fsSL https://ntn.dev | bash \
  && chmod +x /usr/local/bin/ntn \
  && apt-get purge -y curl \


### PR DESCRIPTION
## Summary

- Railway redeploys crash on boot with `ImportError: no pq wrapper available` / `libpq library not found` — psycopg's pure-python implementation can't find the OS-level Postgres client library.
- Adds `libpq5` (~150 KB Debian package) to the runtime apt step in `backend/Dockerfile`, alongside the existing `ca-certificates`. `curl` is still purged afterwards because it's only used for the `ntn` installer.
- Verified locally: `docker build` succeeds, `python -c "import psycopg"` succeeds inside the runtime image, and the `from app import models` chain that was crashing now reaches pydantic-settings validation (i.e. past psycopg).

## Why this is the right fix

- `backend/pyproject.toml` depends on plain `psycopg` (no `[binary]` extra). The pure-python implementation looks up `libpq` via ctypes at `psycopg/pq/__init__.py` → `import_from_libpq()`.
- `python:3.13-slim` does not ship `libpq`. The previous Dockerfile installed `curl` + `ca-certificates` only for the `ntn` installer and then purged the apt cache, so nothing satisfied the lookup at runtime.
- Adding the OS package keeps the existing deps surface and avoids pulling the ~10 MB `psycopg-binary` wheel; it's the same approach Railway-style deploys typically take.

## Reproducing the failure (before this PR)

```
ImportError: no pq wrapper available.
Attempts made:
- couldn't import psycopg 'c' implementation: No module named 'psycopg_c'
- couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'
- couldn't import psycopg 'python' implementation: libpq library not found
```

…fired at the very first `from app import models` triggered by `alembic upgrade head` in the start command, so uvicorn never started.

## Verification

```bash
$ docker build -t pawrrtal-backend-libpq-test backend/
$ docker run --rm pawrrtal-backend-libpq-test python -c "import psycopg; print(psycopg.pq.__impl__)"
python
```

## Test plan

- [x] Local Docker build succeeds with `libpq5` installed.
- [x] `import psycopg` succeeds in a fresh container.
- [x] `from app import models` (alembic env.py's first import) gets past psycopg and into application config code.
- [ ] Railway redeploy reaches uvicorn boot (operator confirms once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)