### PR TITLE
feat(heartbeat): manual-trigger slice modelled on openclaw's heartbeat

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,43 +1,48 @@
 ---
-# Tracer-bullet heartbeat config — single check, fixed interval.
+# Tracer-bullet heartbeat config — single check.
 #
-# The runtime reads this file from the path in HEARTBEAT_MD_PATH (defaults
-# to <repo>/HEARTBEAT.md when running locally).  Each item under `checks`
-# is registered as an APScheduler interval job in
-# `backend/app/api/heartbeat.py::heartbeat_lifespan`.
+# The runtime reads this file from the path in HEARTBEAT_MD_PATH
+# (defaults to <repo>/HEARTBEAT.md when running locally). Each item
+# under `checks` is parsed into a `HeartbeatCheck` and is reachable via
+# `POST /api/v1/heartbeat/run` (see backend/app/api/heartbeat.py).
 checks:
   - name: pulse
-    # Interval between runs.  Kept short for the tracer so an operator can
-    # see the wiring fire without waiting.  Tune per-check once the LLM
-    # call lands (see the inline TODO in `run_heartbeat`).
+    # Interval the future JobScheduler-driven registrar will use. Not
+    # consumed by the manual endpoint that ships in this slice, but
+    # validated at parse time so misconfigs surface early.
     interval_seconds: 1800
     prompt: |
-      Heartbeat: confirm I'm still alive.  Report the wall-clock time and
+      Heartbeat: confirm I'm still alive. Report the wall-clock time and
       that the conversation pipeline is reachable.
 ---
 
 # Heartbeat
 
 Pawrrtal's heartbeat is a periodic background turn that re-enters a
-conversation on a schedule and surfaces anything noteworthy.  It mirrors
+conversation on a schedule and surfaces anything noteworthy. It mirrors
 [openclaw's heartbeat](https://docs.openclaw.ai/gateway/heartbeat): the
 YAML front matter above defines the checks, and the body is free-form
 context the future LLM-backed runner will read alongside the prompt.
 
-## Current scope
+## Current scope (this slice)
 
-Tracer-bullet vertical slice — proves the whole pipeline end-to-end with
-the smallest honest implementation:
+Manual-trigger vertical slice that proves the runner end-to-end:
 
-1. APScheduler boots inside the FastAPI lifespan when
-   `HEARTBEAT_ENABLED=true` and a target user + conversation are
-   configured.
-2. Each check registered above gets an `IntervalTrigger` job.
-3. The job opens an async session, reads this file, and writes a
-   heartbeat-tagged assistant message into the configured conversation.
-4. The existing chat UI picks the message up via the usual
-   `GET /api/v1/conversations/{id}/messages` poll/refresh path.
+1. `POST /api/v1/heartbeat/run` loads this file, picks the named (or
+   first) check, and writes a heartbeat-tagged assistant message into
+   the requested conversation.
+2. The existing chat UI surfaces the message via the same
+   `GET /api/v1/conversations/{id}/messages` path it already polls, so
+   no frontend change is needed to see the result.
 
-The LLM-backed run (real agent turn, tool access, thinking-and-tooluse
-timeline) is the next slice — see the TODO in
-`backend/app/api/heartbeat.py::run_heartbeat`.
+## Out of scope (follow-up)
+
+- **Scheduled invocation.** `TODO(heartbeat-scheduler)` —
+  pawrrtal already ships a higher-level `JobScheduler` (see
+  `backend/app/core/scheduler.py`) that runs cron-style work and
+  integrates with the EventBus. The follow-up registers
+  `run_heartbeat` there rather than booting a parallel APScheduler.
+- **Real LLM-backed run.** `TODO(heartbeat-llm)` — feed `check.prompt`
+  through the agent loop with the configured tools and persist the
+  streamed timeline. The current runner just echoes the check name +
+  prompt into the assistant message so the wiring is observable.

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,0 +1,43 @@
+---
+# Tracer-bullet heartbeat config — single check, fixed interval.
+#
+# The runtime reads this file from the path in HEARTBEAT_MD_PATH (defaults
+# to <repo>/HEARTBEAT.md when running locally).  Each item under `checks`
+# is registered as an APScheduler interval job in
+# `backend/app/api/heartbeat.py::heartbeat_lifespan`.
+checks:
+  - name: pulse
+    # Interval between runs.  Kept short for the tracer so an operator can
+    # see the wiring fire without waiting.  Tune per-check once the LLM
+    # call lands (see the inline TODO in `run_heartbeat`).
+    interval_seconds: 1800
+    prompt: |
+      Heartbeat: confirm I'm still alive.  Report the wall-clock time and
+      that the conversation pipeline is reachable.
+---
+
+# Heartbeat
+
+Pawrrtal's heartbeat is a periodic background turn that re-enters a
+conversation on a schedule and surfaces anything noteworthy.  It mirrors
+[openclaw's heartbeat](https://docs.openclaw.ai/gateway/heartbeat): the
+YAML front matter above defines the checks, and the body is free-form
+context the future LLM-backed runner will read alongside the prompt.
+
+## Current scope
+
+Tracer-bullet vertical slice — proves the whole pipeline end-to-end with
+the smallest honest implementation:
+
+1. APScheduler boots inside the FastAPI lifespan when
+   `HEARTBEAT_ENABLED=true` and a target user + conversation are
+   configured.
+2. Each check registered above gets an `IntervalTrigger` job.
+3. The job opens an async session, reads this file, and writes a
+   heartbeat-tagged assistant message into the configured conversation.
+4. The existing chat UI picks the message up via the usual
+   `GET /api/v1/conversations/{id}/messages` poll/refresh path.
+
+The LLM-backed run (real agent turn, tool access, thinking-and-tooluse
+timeline) is the next slice — see the TODO in
+`backend/app/api/heartbeat.py::run_heartbeat`.

--- a/backend/app/api/heartbeat.py
+++ b/backend/app/api/heartbeat.py
@@ -56,7 +56,7 @@ HEARTBEAT_MESSAGE_STATUS = "complete"
 # row visually distinct in the existing chat UI without needing a new
 # message kind on the model.  Once we add a dedicated heartbeat surface
 # we can swap this for a structured marker on a new column.
-HEARTBEAT_MESSAGE_PREFIX = "�ude7c Heartbeat"
+HEARTBEAT_MESSAGE_PREFIX = "🫀 Heartbeat"
 
 
 class RunHeartbeatRequest(BaseModel):

--- a/backend/app/api/heartbeat.py
+++ b/backend/app/api/heartbeat.py
@@ -1,4 +1,4 @@
-"""Heartbeat HTTP route, runner, and lifespan-scoped scheduler.
+"""Heartbeat HTTP route and runner.
 
 Concept lifted from openclaw — periodic background agent turns that
 re-enter a conversation on a schedule.  This module owns the parts that
@@ -7,33 +7,34 @@ touch the database and HTTP layer; pure config + parsing lives in
 
 ## What ships in this slice
 
-Tracer-bullet vertical slice that proves the wiring end-to-end:
+Manual-trigger vertical slice that proves the runner end-to-end:
 
-1. APScheduler boots inside the FastAPI lifespan when
-   `HEARTBEAT_ENABLED=true` AND `HEARTBEAT_USER_ID` /
-   `HEARTBEAT_CONVERSATION_ID` resolve to existing UUIDs.
-2. Each check in `HEARTBEAT.md` gets an `IntervalTrigger` job.
-3. The job writes a heartbeat-tagged assistant message into the target
-   conversation via the existing `chat_message` CRUD helpers, so the
-   message becomes visible through the same `GET .../messages` path the
-   chat UI already polls.
+1. `POST /api/v1/heartbeat/run` loads `HEARTBEAT.md`, picks the named
+   (or first) check, and calls `run_heartbeat` to persist a
+   heartbeat-tagged assistant message into the conversation.
+2. The existing chat UI surfaces the message via the same
+   `GET /api/v1/conversations/{id}/messages` path it already polls,
+   so no frontend change is needed to see the result.
 
-The real LLM-backed run — feeding the check prompt through the agent
-loop with the configured tools and persisting the streamed turn — is the
-next slice.  See the `TODO(heartbeat-llm)` marker inside `run_heartbeat`.
+Scheduled invocation is a deliberate follow-up: pawrrtal already ships
+a higher-level `JobScheduler` (see `app.core.scheduler`) for cron-style
+work, and registering `run_heartbeat` as a JobScheduler job is the
+cleanest seam.  Booting a parallel APScheduler from a lifespan here
+would duplicate plumbing.  See the `TODO(heartbeat-scheduler)` marker
+below.
+
+The real LLM-backed run — feeding `check.prompt` through the agent
+loop with the configured tools and persisting the streamed turn — is
+flagged as `TODO(heartbeat-llm)` inside `run_heartbeat`.
 """
 
 from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.interval import IntervalTrigger
 from fastapi import Depends, HTTPException
 from fastapi.routing import APIRouter
 from pydantic import BaseModel, Field
@@ -67,8 +68,8 @@ class RunHeartbeatRequest(BaseModel):
         default=None,
         description=(
             "Name of the check defined in HEARTBEAT.md to run.  When None, "
-            "runs the first check in the file (matches the scheduler's "
-            "default for single-check tracer configs)."
+            "runs the first check in the file (matches the eventual "
+            "scheduler's default for single-check tracer configs)."
         ),
     )
 
@@ -96,9 +97,9 @@ async def run_heartbeat(
 
     TODO(heartbeat-llm): feed `check.prompt` through `agent_loop` with
     the same tool composition the chat router builds for an HTTP turn,
-    persist the real timeline + tool calls, and emit an SSE event on
-    the conversation's existing channel so the UI updates without a
-    poll.  Out of scope for this slice — captured as a follow-up.
+    persist the real timeline + tool calls, and emit an event on the
+    existing EventBus so the UI updates without a poll.  Out of scope
+    for this slice — captured as a follow-up.
 
     Returns the persisted assistant message's id so the manual-trigger
     endpoint can echo it back to the caller.
@@ -133,7 +134,13 @@ async def run_heartbeat(
 
 
 def get_heartbeat_router() -> APIRouter:
-    """Build the heartbeat router (mounted at `/api/v1/heartbeat`)."""
+    """Build the heartbeat router (mounted at `/api/v1/heartbeat`).
+
+    TODO(heartbeat-scheduler): register `run_heartbeat` as a
+    `JobScheduler` job from the existing scheduler lifespan in
+    `main.py`, gated on ``settings.heartbeat_enabled`` and the
+    configured user/conversation ids. Out of scope for this slice.
+    """
     router = APIRouter(prefix="/api/v1/heartbeat", tags=["heartbeat"])
 
     @router.post("/run", response_model=RunHeartbeatResponse)
@@ -170,65 +177,6 @@ def get_heartbeat_router() -> APIRouter:
     return router
 
 
-@asynccontextmanager
-async def heartbeat_lifespan() -> AsyncIterator[AsyncIOScheduler | None]:
-    """Boot the heartbeat scheduler alongside the HTTP server.
-
-    Yields `None` when heartbeat is disabled — either by the
-    `HEARTBEAT_ENABLED` flag or because the required user/conversation
-    UUIDs aren't configured.  That lets `main.py` `async with` this
-    unconditionally without branching on settings.
-
-    A misconfigured HEARTBEAT.md (invalid YAML, schema violation) is
-    treated as fatal at boot so the problem surfaces immediately rather
-    than after the first interval elapses.
-    """
-    if not _heartbeat_should_run():
-        logger.info("HEARTBEAT_DISABLED reason=settings")
-        yield None
-        return
-
-    config = _load_config_or_empty()
-    if not config.checks:
-        logger.info("HEARTBEAT_DISABLED reason=no_checks_in_md")
-        yield None
-        return
-
-    user_id = uuid.UUID(settings.heartbeat_user_id)
-    conversation_id = uuid.UUID(settings.heartbeat_conversation_id)
-
-    scheduler = AsyncIOScheduler()
-    for check in config.checks:
-        scheduler.add_job(
-            _run_scheduled_job,
-            trigger=IntervalTrigger(seconds=check.interval_seconds),
-            args=[user_id, conversation_id, check],
-            id=f"heartbeat:{check.name}",
-            name=f"heartbeat:{check.name}",
-            replace_existing=True,
-        )
-    scheduler.start()
-    logger.info("HEARTBEAT_BOOT checks=%d", len(config.checks))
-    try:
-        yield scheduler
-    finally:
-        scheduler.shutdown(wait=False)
-        logger.info("HEARTBEAT_SHUTDOWN")
-
-
-def _heartbeat_should_run() -> bool:
-    """Return True when settings opt into running the scheduler."""
-    if not settings.heartbeat_enabled:
-        return False
-    if not settings.heartbeat_user_id or not settings.heartbeat_conversation_id:
-        logger.warning(
-            "HEARTBEAT_ENABLED_BUT_UNCONFIGURED — set HEARTBEAT_USER_ID and "
-            "HEARTBEAT_CONVERSATION_ID to activate the scheduler",
-        )
-        return False
-    return True
-
-
 def _resolve_md_path() -> Path:
     """Return the resolved path to `HEARTBEAT.md`.
 
@@ -261,28 +209,3 @@ def _resolve_check(config: HeartbeatConfig, name: str | None) -> HeartbeatCheck 
     if name is not None:
         return config.find_check(name)
     return config.checks[0] if config.checks else None
-
-
-async def _run_scheduled_job(
-    user_id: uuid.UUID,
-    conversation_id: uuid.UUID,
-    check: HeartbeatCheck,
-) -> None:
-    """APScheduler entry point — opens a session and delegates.
-
-    Kept tiny so the scheduler-specific glue (session management,
-    exception narrowing) is separate from the runner's domain logic.
-    """
-    try:
-        async with async_session_maker() as session:
-            await run_heartbeat(
-                session,
-                user_id=user_id,
-                conversation_id=conversation_id,
-                check=check,
-            )
-    except (OSError, RuntimeError) as exc:
-        # Narrow on transport-level failures.  Schema/programmer errors
-        # should propagate so they're caught in CI rather than silently
-        # swallowed by the scheduler thread.
-        logger.warning("HEARTBEAT_RUN_FAILED check=%s error=%s", check.name, exc)

--- a/backend/app/api/heartbeat.py
+++ b/backend/app/api/heartbeat.py
@@ -1,0 +1,288 @@
+"""Heartbeat HTTP route, runner, and lifespan-scoped scheduler.
+
+Concept lifted from openclaw — periodic background agent turns that
+re-enter a conversation on a schedule.  This module owns the parts that
+touch the database and HTTP layer; pure config + parsing lives in
+`app.core.heartbeat`.
+
+## What ships in this slice
+
+Tracer-bullet vertical slice that proves the wiring end-to-end:
+
+1. APScheduler boots inside the FastAPI lifespan when
+   `HEARTBEAT_ENABLED=true` AND `HEARTBEAT_USER_ID` /
+   `HEARTBEAT_CONVERSATION_ID` resolve to existing UUIDs.
+2. Each check in `HEARTBEAT.md` gets an `IntervalTrigger` job.
+3. The job writes a heartbeat-tagged assistant message into the target
+   conversation via the existing `chat_message` CRUD helpers, so the
+   message becomes visible through the same `GET .../messages` path the
+   chat UI already polls.
+
+The real LLM-backed run — feeding the check prompt through the agent
+loop with the configured tools and persisting the streamed turn — is the
+next slice.  See the `TODO(heartbeat-llm)` marker inside `run_heartbeat`.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from fastapi import Depends, HTTPException
+from fastapi.routing import APIRouter
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.heartbeat import HeartbeatCheck, HeartbeatConfig, load_heartbeat_md
+from app.crud.chat_message import append_assistant_placeholder, finalize_assistant_message
+from app.db import User, async_session_maker
+from app.users import get_allowed_user
+
+logger = logging.getLogger(__name__)
+
+# Surface a single status value on the persisted assistant row so the
+# chat UI's existing `assistant_status` rendering picks it up.  The chat
+# loop uses "complete" / "streaming" / "failed"; we reuse "complete" so
+# the row renders as a finished assistant turn.
+HEARTBEAT_MESSAGE_STATUS = "complete"
+# Conventional prefix on every heartbeat-authored message.  Keeps the
+# row visually distinct in the existing chat UI without needing a new
+# message kind on the model.  Once we add a dedicated heartbeat surface
+# we can swap this for a structured marker on a new column.
+HEARTBEAT_MESSAGE_PREFIX = "�ude7c Heartbeat"
+
+
+class RunHeartbeatRequest(BaseModel):
+    """Body for `POST /api/v1/heartbeat/run`."""
+
+    conversation_id: uuid.UUID
+    check_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the check defined in HEARTBEAT.md to run.  When None, "
+            "runs the first check in the file (matches the scheduler's "
+            "default for single-check tracer configs)."
+        ),
+    )
+
+
+class RunHeartbeatResponse(BaseModel):
+    """Response for a successful manual run."""
+
+    message_id: uuid.UUID
+    check_name: str
+
+
+async def run_heartbeat(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    check: HeartbeatCheck,
+) -> uuid.UUID:
+    """Execute one heartbeat turn against a conversation.
+
+    Tracer-bullet implementation: writes a heartbeat-tagged assistant
+    message describing the fired check.  The persisted row is finalised
+    in place (no `streaming` window) because there's nothing to stream
+    yet.
+
+    TODO(heartbeat-llm): feed `check.prompt` through `agent_loop` with
+    the same tool composition the chat router builds for an HTTP turn,
+    persist the real timeline + tool calls, and emit an SSE event on
+    the conversation's existing channel so the UI updates without a
+    poll.  Out of scope for this slice — captured as a follow-up.
+
+    Returns the persisted assistant message's id so the manual-trigger
+    endpoint can echo it back to the caller.
+    """
+    placeholder = await append_assistant_placeholder(
+        session,
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
+    fired_at = datetime.now(UTC).isoformat(timespec="seconds")
+    content = (
+        f"{HEARTBEAT_MESSAGE_PREFIX} `{check.name}` fired at {fired_at}.\n\n{check.prompt.strip()}"
+    )
+    await finalize_assistant_message(
+        session,
+        message_id=placeholder.id,
+        content=content,
+        thinking=None,
+        tool_calls=None,
+        timeline=None,
+        thinking_duration_seconds=None,
+        assistant_status=HEARTBEAT_MESSAGE_STATUS,
+    )
+    await session.commit()
+    logger.info(
+        "HEARTBEAT_FIRED check=%s conversation_id=%s message_id=%s",
+        check.name,
+        conversation_id,
+        placeholder.id,
+    )
+    return placeholder.id
+
+
+def get_heartbeat_router() -> APIRouter:
+    """Build the heartbeat router (mounted at `/api/v1/heartbeat`)."""
+    router = APIRouter(prefix="/api/v1/heartbeat", tags=["heartbeat"])
+
+    @router.post("/run", response_model=RunHeartbeatResponse)
+    async def trigger_run(
+        body: RunHeartbeatRequest,
+        user: User = Depends(get_allowed_user),
+    ) -> RunHeartbeatResponse:
+        """Manually fire a heartbeat check against a conversation.
+
+        Useful both for development (no waiting for the scheduler) and
+        for integration tests that need to exercise the end-to-end
+        pipeline deterministically.
+        """
+        config = _load_config_or_empty()
+        check = _resolve_check(config, body.check_name)
+        if check is None:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Heartbeat check '{body.check_name}' not found in HEARTBEAT.md"
+                    if body.check_name
+                    else "HEARTBEAT.md defines no checks"
+                ),
+            )
+        async with async_session_maker() as session:
+            message_id = await run_heartbeat(
+                session,
+                user_id=user.id,
+                conversation_id=body.conversation_id,
+                check=check,
+            )
+        return RunHeartbeatResponse(message_id=message_id, check_name=check.name)
+
+    return router
+
+
+@asynccontextmanager
+async def heartbeat_lifespan() -> AsyncIterator[AsyncIOScheduler | None]:
+    """Boot the heartbeat scheduler alongside the HTTP server.
+
+    Yields `None` when heartbeat is disabled — either by the
+    `HEARTBEAT_ENABLED` flag or because the required user/conversation
+    UUIDs aren't configured.  That lets `main.py` `async with` this
+    unconditionally without branching on settings.
+
+    A misconfigured HEARTBEAT.md (invalid YAML, schema violation) is
+    treated as fatal at boot so the problem surfaces immediately rather
+    than after the first interval elapses.
+    """
+    if not _heartbeat_should_run():
+        logger.info("HEARTBEAT_DISABLED reason=settings")
+        yield None
+        return
+
+    config = _load_config_or_empty()
+    if not config.checks:
+        logger.info("HEARTBEAT_DISABLED reason=no_checks_in_md")
+        yield None
+        return
+
+    user_id = uuid.UUID(settings.heartbeat_user_id)
+    conversation_id = uuid.UUID(settings.heartbeat_conversation_id)
+
+    scheduler = AsyncIOScheduler()
+    for check in config.checks:
+        scheduler.add_job(
+            _run_scheduled_job,
+            trigger=IntervalTrigger(seconds=check.interval_seconds),
+            args=[user_id, conversation_id, check],
+            id=f"heartbeat:{check.name}",
+            name=f"heartbeat:{check.name}",
+            replace_existing=True,
+        )
+    scheduler.start()
+    logger.info("HEARTBEAT_BOOT checks=%d", len(config.checks))
+    try:
+        yield scheduler
+    finally:
+        scheduler.shutdown(wait=False)
+        logger.info("HEARTBEAT_SHUTDOWN")
+
+
+def _heartbeat_should_run() -> bool:
+    """Return True when settings opt into running the scheduler."""
+    if not settings.heartbeat_enabled:
+        return False
+    if not settings.heartbeat_user_id or not settings.heartbeat_conversation_id:
+        logger.warning(
+            "HEARTBEAT_ENABLED_BUT_UNCONFIGURED — set HEARTBEAT_USER_ID and "
+            "HEARTBEAT_CONVERSATION_ID to activate the scheduler",
+        )
+        return False
+    return True
+
+
+def _resolve_md_path() -> Path:
+    """Return the resolved path to `HEARTBEAT.md`.
+
+    `HEARTBEAT_MD_PATH` wins when set; otherwise fall back to
+    `<repo>/HEARTBEAT.md` so local dev "just works" without env churn.
+    The repo root is three parents up from this file:
+    `backend/app/api/heartbeat.py` → `<repo>`.
+    """
+    if settings.heartbeat_md_path:
+        return Path(settings.heartbeat_md_path)
+    return Path(__file__).resolve().parents[3] / "HEARTBEAT.md"
+
+
+def _load_config_or_empty() -> HeartbeatConfig:
+    """Load `HEARTBEAT.md` and surface parse errors as logged warnings.
+
+    Returning an empty config on failure keeps the API endpoint
+    returning a clean 404 ("no checks defined") rather than a 500 —
+    the operator can read the warning in the logs and fix the file.
+    """
+    try:
+        return load_heartbeat_md(_resolve_md_path())
+    except ValueError as exc:
+        logger.warning("HEARTBEAT_MD_INVALID error=%s", exc)
+        return HeartbeatConfig()
+
+
+def _resolve_check(config: HeartbeatConfig, name: str | None) -> HeartbeatCheck | None:
+    """Pick the named check, or the first one when `name` is None."""
+    if name is not None:
+        return config.find_check(name)
+    return config.checks[0] if config.checks else None
+
+
+async def _run_scheduled_job(
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    check: HeartbeatCheck,
+) -> None:
+    """APScheduler entry point — opens a session and delegates.
+
+    Kept tiny so the scheduler-specific glue (session management,
+    exception narrowing) is separate from the runner's domain logic.
+    """
+    try:
+        async with async_session_maker() as session:
+            await run_heartbeat(
+                session,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                check=check,
+            )
+    except (OSError, RuntimeError) as exc:
+        # Narrow on transport-level failures.  Schema/programmer errors
+        # should propagate so they're caught in CI rather than silently
+        # swallowed by the scheduler thread.
+        logger.warning("HEARTBEAT_RUN_FAILED check=%s error=%s", check.name, exc)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -84,6 +84,30 @@ class Settings(BaseSettings):
     # Base backoff (seconds) between LLM retries; doubles each retry,
     # capped at 30s inside the loop.  Set 0 for instant retry.
     agent_llm_retry_backoff_seconds: float = 1.0
+
+    # ── Heartbeat (manual-trigger slice) ─────────────────────────────────
+    # Periodic background turns modelled on openclaw's heartbeat. This
+    # slice exposes the runner via POST /api/v1/heartbeat/run only —
+    # scheduled invocation is a follow-up that plugs into the existing
+    # JobScheduler (see app.core.scheduler) rather than booting a
+    # parallel APScheduler. Settings are kept here so the follow-up can
+    # consume them without churn.
+
+    # Master gate. When the scheduler integration lands, the registrar
+    # only runs when this is true. Currently informational.
+    heartbeat_enabled: bool = False
+    # Owner of the heartbeat-authored messages once the scheduler fires
+    # them. The manual endpoint takes the user from the auth session,
+    # so this is only consulted by the follow-up scheduler hook.
+    heartbeat_user_id: str = ""
+    # Default conversation for scheduler-driven heartbeats. The manual
+    # endpoint takes the conversation_id from the request body.
+    heartbeat_conversation_id: str = ""
+    # Absolute path to the markdown config. Empty falls back to
+    # `<repo>/HEARTBEAT.md` (resolved relative to this module so it
+    # works regardless of process CWD).
+    heartbeat_md_path: str = ""
+
     # Admin user credentials (for testing).
     admin_email: str | None = None
     admin_password: str | None = None

--- a/backend/app/core/heartbeat.py
+++ b/backend/app/core/heartbeat.py
@@ -1,0 +1,134 @@
+"""Heartbeat configuration model and `HEARTBEAT.md` parser.
+
+The heartbeat is a periodic background agent turn, modelled on openclaw's
+`Heartbeat` feature.  This module owns the *pure* concerns — config schema
+and front-matter parsing — so the API and scheduler layers can import a
+fully-typed `HeartbeatConfig` without reaching for filesystem internals.
+
+The sentrux layering rule (`entry → api → crud → models → core`) means
+this file MUST NOT import from `app.crud.*` or `app.api.*`.  Anything that
+touches the database or the chat pipeline lives one layer up in
+`app.api.heartbeat`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+# Front-matter delimiter mirroring the openclaw + DESIGN.md convention.
+FRONT_MATTER_DELIMITER = "---"
+# Hard floor on per-check cadence.  APScheduler accepts smaller intervals
+# but a sub-minute heartbeat is almost certainly a misconfiguration — the
+# LLM-backed runs are not cheap and we don't want a typo to burn through
+# tokens.  Raise the floor here rather than per-call so a single check
+# can't bypass the rule.
+MIN_INTERVAL_SECONDS = 60
+
+
+class HeartbeatCheck(BaseModel):
+    """One scheduled check inside `HEARTBEAT.md`.
+
+    `name` is the stable identifier APScheduler uses for the job id; the
+    runner also tags persisted messages with it so we can later filter the
+    chat UI to "show me the last seven `pulse` checks".
+
+    `prompt` is the verbatim text the future LLM-backed runner will hand
+    to the agent loop.  For the tracer slice the prompt is echoed into the
+    persisted assistant message so an operator can see exactly what would
+    have been sent.
+    """
+
+    name: str = Field(min_length=1, max_length=64)
+    interval_seconds: int = Field(ge=MIN_INTERVAL_SECONDS)
+    prompt: str = Field(min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        """Reject names with whitespace — they double as APScheduler job ids."""
+        if any(ch.isspace() for ch in value):
+            raise ValueError("heartbeat check `name` must not contain whitespace")
+        return value
+
+
+class HeartbeatConfig(BaseModel):
+    """The full parsed `HEARTBEAT.md` document."""
+
+    checks: list[HeartbeatCheck] = Field(default_factory=list)
+
+    def find_check(self, name: str) -> HeartbeatCheck | None:
+        """Return the check with `name`, or None when no such check is defined."""
+        for check in self.checks:
+            if check.name == name:
+                return check
+        return None
+
+
+def parse_heartbeat_md(text: str) -> HeartbeatConfig:
+    """Parse the YAML front matter out of a `HEARTBEAT.md` string.
+
+    The body after the front matter is intentionally ignored here — it's
+    free-form context for humans (and the future LLM-backed runner reads
+    it directly off disk).  Returning an empty config when the document
+    has no front matter lets callers degrade gracefully: the scheduler
+    simply registers no jobs.
+
+    Raises:
+        ValueError: when the front matter is present but malformed YAML
+            or fails `HeartbeatConfig` validation.  The scheduler treats
+            this as fatal at boot so misconfig surfaces immediately
+            rather than after the first interval elapses.
+    """
+    front_matter = _extract_front_matter(text)
+    if front_matter is None:
+        logger.info("HEARTBEAT_MD_NO_FRONT_MATTER")
+        return HeartbeatConfig()
+    try:
+        raw = yaml.safe_load(front_matter) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"HEARTBEAT.md front matter is not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise TypeError("HEARTBEAT.md front matter must be a YAML mapping")
+    return HeartbeatConfig.model_validate(raw)
+
+
+def load_heartbeat_md(path: Path) -> HeartbeatConfig:
+    """Read and parse a `HEARTBEAT.md` file from disk.
+
+    Returns an empty config when the file is missing so the scheduler can
+    boot in environments that haven't opted into heartbeat (the
+    `HEARTBEAT_ENABLED` flag in settings is the primary gate, but defence
+    in depth keeps the lifespan from crashing if the path is misconfigured
+    on a particular deployment).
+    """
+    if not path.exists():
+        logger.info("HEARTBEAT_MD_MISSING path=%s", path)
+        return HeartbeatConfig()
+    return parse_heartbeat_md(path.read_text(encoding="utf-8"))
+
+
+def _extract_front_matter(text: str) -> str | None:
+    """Return the YAML between two `---` fences at the top of `text`.
+
+    Returns None when the document does not open with a fence — i.e.
+    when the file is pure markdown with no config.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith(FRONT_MATTER_DELIMITER):
+        return None
+    # Skip the opening fence (plus its newline).
+    remainder = stripped[len(FRONT_MATTER_DELIMITER) :]
+    if remainder.startswith("\n"):
+        remainder = remainder[1:]
+    closing_index = remainder.find(f"\n{FRONT_MATTER_DELIMITER}")
+    if closing_index == -1:
+        # Unclosed fence — treat the whole rest as YAML.  Validation
+        # downstream will catch genuinely broken documents.
+        return remainder
+    return remainder[:closing_index]

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,35 +11,26 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp
 
 from app.api.appearance import get_appearance_router
-from app.api.audit import get_audit_router
 from app.api.auth import get_auth_router
 from app.api.channels import get_channels_router
 from app.api.chat import get_chat_router
 from app.api.conversations import get_conversations_router
-from app.api.cost import get_cost_router
-from app.api.exports import get_exports_router
 from app.api.health import get_health_router
+from app.api.heartbeat import get_heartbeat_router, heartbeat_lifespan
 from app.api.models import get_models_router
 from app.api.oauth import get_oauth_router
 from app.api.personalization import get_personalization_router
 from app.api.projects import get_projects_router
-from app.api.scheduled_jobs import get_scheduled_jobs_router
 from app.api.stt import get_stt_router
 from app.api.workspace import get_workspace_router
 from app.api.workspace_env import get_workspace_env_router
 from app.cli.admin_seed import seed_admin_user
-from app.cli.migrate_workspace_env import migrate_user_keyed_env_files_for_all_users
 from app.core.config import settings
-from app.core.event_bus import AgentHandler, EventBus, NotificationService
-from app.core.event_bus.global_bus import set_event_bus
-from app.core.middleware import BackendApiKeyMiddleware
 from app.core.rate_limit import ChatRateLimitMiddleware
 from app.core.request_logging import RequestLoggingMiddleware
-from app.core.scheduler import JobScheduler
 from app.core.telemetry import setup_tracing, shutdown_tracing
 from app.db import create_db_and_tables
 from app.integrations.telegram import telegram_lifespan
-from app.integrations.webhooks import get_webhooks_router
 from app.logger_setup import (
     configure_logging,  # Set up logging configuration (this should be done before any loggers are used)
 )
@@ -66,54 +57,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await create_db_and_tables()
     # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
     await seed_admin_user()
-    # One-time migration of legacy user-keyed `.env` files to the new
-    # workspace-keyed layout.  Idempotent — when the source file is missing
-    # or the destination already exists, the helper returns without writing.
-    # See ADR 2026-05-15-plugin-system-and-notion-integration.mdx.
-    await migrate_user_keyed_env_files_for_all_users()
-    # PR 10: spin up the event bus before any request can fire so the
-    # consumer task is ready when the chat router or Telegram dispatcher
-    # publishes the first ``TurnStartedEvent``.  Stashed on
-    # ``app.state`` for handlers that want to publish from inside a route.
-    event_bus = EventBus()
-    await event_bus.start()
-    app.state.event_bus = event_bus
-    set_event_bus(event_bus)
-    # PR 12: spin up the cron scheduler after the bus so re-hydrated
-    # jobs that fire on startup have a publisher to land on.  No-op
-    # when ``SCHEDULER_ENABLED=false``.
-    scheduler: JobScheduler | None = None
-    if settings.scheduler_enabled:
-        scheduler = JobScheduler()
-        await scheduler.start()
-        app.state.scheduler = scheduler
-    else:
-        app.state.scheduler = None
-    # Bring the Telegram channel up alongside the HTTP server when a bot
-    # token is configured. The context manager yields None and is a no-op
-    # when the channel is disabled, so this stays safe for stripped-down
-    # deployments (CI, ephemeral previews, ...). Stash the service on
-    # `app.state` so the webhook route can hand updates to aiogram.
-    async with telegram_lifespan() as telegram_service:
+    # Bring the Telegram channel and heartbeat scheduler up alongside the
+    # HTTP server. Both context managers yield None when their feature is
+    # disabled, so this stays safe in stripped-down deployments (CI,
+    # ephemeral previews, ...). Stash both on `app.state` so future ops
+    # endpoints can introspect them without re-importing.
+    async with (
+        telegram_lifespan() as telegram_service,
+        heartbeat_lifespan() as heartbeat_scheduler,
+    ):
         app.state.telegram_service = telegram_service
-        # Follow-on: register the agent + notification subscribers AFTER the
-        # Telegram service is up so the notification service has a live
-        # bot instance.  Both are no-ops when the relevant pieces are
-        # disabled (no bot → notifications skip; no default user → agent
-        # handler logs + skips).
-        agent_handler = AgentHandler()
-        agent_handler.register(event_bus)
-        notification_service = NotificationService(
-            telegram_bot=telegram_service.bot if telegram_service is not None else None
-        )
-        notification_service.register(event_bus)
+        app.state.heartbeat_scheduler = heartbeat_scheduler
         try:
             yield
         finally:
-            if scheduler is not None:
-                await scheduler.stop()
-            set_event_bus(None)
-            await event_bus.stop()
             shutdown_tracing()
 
 
@@ -136,9 +93,6 @@ def create_app() -> FastAPI:
     # (the default), so registering it unconditionally costs nothing in
     # dev but is wired up for prod just by flipping the env var.
     fastapi_app.add_middleware(ChatRateLimitMiddleware)
-    # Added last so Starlette wraps it outermost: invalid deployment API keys
-    # are rejected before route/auth work. Disabled when BACKEND_API_KEY is unset.
-    fastapi_app.add_middleware(BackendApiKeyMiddleware)
     fastapi_app.include_router(
         fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
     )
@@ -191,22 +145,10 @@ def create_app() -> FastAPI:
         get_workspace_env_router(),
     )
     fastapi_app.include_router(
-        get_audit_router(),
-    )
-    fastapi_app.include_router(
-        get_cost_router(),
-    )
-    fastapi_app.include_router(
-        get_exports_router(),
-    )
-    fastapi_app.include_router(
-        get_webhooks_router(),
-    )
-    fastapi_app.include_router(
-        get_scheduled_jobs_router(),
-    )
-    fastapi_app.include_router(
         get_health_router(),
+    )
+    fastapi_app.include_router(
+        get_heartbeat_router(),
     )
 
     return fastapi_app

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,26 +11,36 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp
 
 from app.api.appearance import get_appearance_router
+from app.api.audit import get_audit_router
 from app.api.auth import get_auth_router
 from app.api.channels import get_channels_router
 from app.api.chat import get_chat_router
 from app.api.conversations import get_conversations_router
+from app.api.cost import get_cost_router
+from app.api.exports import get_exports_router
 from app.api.health import get_health_router
-from app.api.heartbeat import get_heartbeat_router, heartbeat_lifespan
+from app.api.heartbeat import get_heartbeat_router
 from app.api.models import get_models_router
 from app.api.oauth import get_oauth_router
 from app.api.personalization import get_personalization_router
 from app.api.projects import get_projects_router
+from app.api.scheduled_jobs import get_scheduled_jobs_router
 from app.api.stt import get_stt_router
 from app.api.workspace import get_workspace_router
 from app.api.workspace_env import get_workspace_env_router
 from app.cli.admin_seed import seed_admin_user
+from app.cli.migrate_workspace_env import migrate_user_keyed_env_files_for_all_users
 from app.core.config import settings
+from app.core.event_bus import AgentHandler, EventBus, NotificationService
+from app.core.event_bus.global_bus import set_event_bus
+from app.core.middleware import BackendApiKeyMiddleware
 from app.core.rate_limit import ChatRateLimitMiddleware
 from app.core.request_logging import RequestLoggingMiddleware
+from app.core.scheduler import JobScheduler
 from app.core.telemetry import setup_tracing, shutdown_tracing
 from app.db import create_db_and_tables
 from app.integrations.telegram import telegram_lifespan
+from app.integrations.webhooks import get_webhooks_router
 from app.logger_setup import (
     configure_logging,  # Set up logging configuration (this should be done before any loggers are used)
 )
@@ -57,20 +67,54 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await create_db_and_tables()
     # This creates the admin user on every startup, but the UserManager will check if it already exists and skip creation if so, so it's idempotent and safe to run every time.
     await seed_admin_user()
-    # Bring the Telegram channel and heartbeat scheduler up alongside the
-    # HTTP server. Both context managers yield None when their feature is
-    # disabled, so this stays safe in stripped-down deployments (CI,
-    # ephemeral previews, ...). Stash both on `app.state` so future ops
-    # endpoints can introspect them without re-importing.
-    async with (
-        telegram_lifespan() as telegram_service,
-        heartbeat_lifespan() as heartbeat_scheduler,
-    ):
+    # One-time migration of legacy user-keyed `.env` files to the new
+    # workspace-keyed layout.  Idempotent — when the source file is missing
+    # or the destination already exists, the helper returns without writing.
+    # See ADR 2026-05-15-plugin-system-and-notion-integration.mdx.
+    await migrate_user_keyed_env_files_for_all_users()
+    # PR 10: spin up the event bus before any request can fire so the
+    # consumer task is ready when the chat router or Telegram dispatcher
+    # publishes the first ``TurnStartedEvent``.  Stashed on
+    # ``app.state`` for handlers that want to publish from inside a route.
+    event_bus = EventBus()
+    await event_bus.start()
+    app.state.event_bus = event_bus
+    set_event_bus(event_bus)
+    # PR 12: spin up the cron scheduler after the bus so re-hydrated
+    # jobs that fire on startup have a publisher to land on.  No-op
+    # when ``SCHEDULER_ENABLED=false``.
+    scheduler: JobScheduler | None = None
+    if settings.scheduler_enabled:
+        scheduler = JobScheduler()
+        await scheduler.start()
+        app.state.scheduler = scheduler
+    else:
+        app.state.scheduler = None
+    # Bring the Telegram channel up alongside the HTTP server when a bot
+    # token is configured. The context manager yields None and is a no-op
+    # when the channel is disabled, so this stays safe for stripped-down
+    # deployments (CI, ephemeral previews, ...). Stash the service on
+    # `app.state` so the webhook route can hand updates to aiogram.
+    async with telegram_lifespan() as telegram_service:
         app.state.telegram_service = telegram_service
-        app.state.heartbeat_scheduler = heartbeat_scheduler
+        # Follow-on: register the agent + notification subscribers AFTER the
+        # Telegram service is up so the notification service has a live
+        # bot instance.  Both are no-ops when the relevant pieces are
+        # disabled (no bot → notifications skip; no default user → agent
+        # handler logs + skips).
+        agent_handler = AgentHandler()
+        agent_handler.register(event_bus)
+        notification_service = NotificationService(
+            telegram_bot=telegram_service.bot if telegram_service is not None else None
+        )
+        notification_service.register(event_bus)
         try:
             yield
         finally:
+            if scheduler is not None:
+                await scheduler.stop()
+            set_event_bus(None)
+            await event_bus.stop()
             shutdown_tracing()
 
 
@@ -93,6 +137,9 @@ def create_app() -> FastAPI:
     # (the default), so registering it unconditionally costs nothing in
     # dev but is wired up for prod just by flipping the env var.
     fastapi_app.add_middleware(ChatRateLimitMiddleware)
+    # Added last so Starlette wraps it outermost: invalid deployment API keys
+    # are rejected before route/auth work. Disabled when BACKEND_API_KEY is unset.
+    fastapi_app.add_middleware(BackendApiKeyMiddleware)
     fastapi_app.include_router(
         fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
     )
@@ -145,8 +192,26 @@ def create_app() -> FastAPI:
         get_workspace_env_router(),
     )
     fastapi_app.include_router(
+        get_audit_router(),
+    )
+    fastapi_app.include_router(
+        get_cost_router(),
+    )
+    fastapi_app.include_router(
+        get_exports_router(),
+    )
+    fastapi_app.include_router(
+        get_webhooks_router(),
+    )
+    fastapi_app.include_router(
+        get_scheduled_jobs_router(),
+    )
+    fastapi_app.include_router(
         get_health_router(),
     )
+    # Heartbeat slice: manual-trigger endpoint only. Scheduled invocation
+    # lives in a follow-up that registers the runner as a JobScheduler
+    # job rather than booting a parallel APScheduler.
     fastapi_app.include_router(
         get_heartbeat_router(),
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiogram>=3.27.0",
-    "markdown-it-py>=3.0.0",
     "alembic>=1.13.0",
     "aiosqlite>=0.22.1",
     "anyio>=4.0.0",
@@ -14,14 +13,13 @@ dependencies = [
     "claude-agent-sdk",
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.136.0",
-    "google-genai>=2.3.0",
+    "google-genai>=1.56.0",
     "mcp>=1.27.0",
     "psycopg>=3.3.3",
     "pydantic>=2.12.5,<2.14",
     "pydantic-settings>=2.12.0",
     "python-dotenv>=1.2.1",
     "sqlalchemy-utils>=0.42.1",
-    "structlog>=24.0.0",
     "opentelemetry-api>=1.29.0",
     "opentelemetry-sdk>=1.29.0",
     "opentelemetry-exporter-otlp-proto-http>=1.29.0",
@@ -29,17 +27,6 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.50b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-logging>=0.50b0",
-    "markitdown[all]>=0.1.1",
-]
-
-# Optional voice transcription backends (PR 14). The ``api/stt.py``
-# xAI proxy is in the core dependencies; these are needed only when
-# ``VOICE_PROVIDER`` is ``mistral`` or ``openai``. Local whisper.cpp
-# uses subprocess calls and needs no Python package.
-[project.optional-dependencies]
-voice = [
-    "mistralai>=1.0.0",
-    "openai>=1.0.0",
 ]
 
 [dependency-groups]
@@ -51,7 +38,6 @@ dev = [
     "bandit[toml]>=1.7.10",
     "pre-commit>=4.0.0",
     "types-pyyaml>=6.0.12",
-    "import-linter>=2.11",
 ]
 
 # --- ruff: linter + formatter ----------------------------------------------
@@ -131,9 +117,6 @@ ignore = [
     "S106",    # hardcoded password (function arg)
     "S108",    # /tmp paths in test scenarios are fine
     "PT018",   # compound asserts in tests are fine if they're checking related state
-    "PLC0415", # lazy/in-fn imports in tests are intentional: avoid module-load
-               # side effects, isolate `importlib.reload` cases, and let fixtures
-               # set env before the SUT is bound. Hoisting defeats those patterns.
 ]
 "tests/conftest.py" = ["D", "E402"]   # sys.path manipulation must come before imports
 "alembic/**" = ["D", "E", "I", "S"]   # migrations are auto-generated
@@ -206,7 +189,7 @@ disallow_untyped_defs = false  # test fixtures are fine without explicit types
 
 [[tool.mypy.overrides]]
 # Third-party packages without complete type stubs.
-module = ["sqlalchemy_utils.*", "mcp.*", "markitdown.*"]
+module = ["sqlalchemy_utils.*", "agno.*", "mcp.*"]
 ignore_missing_imports = true
 
 # --- bandit: security scanner ------------------------------------------------

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiogram>=3.27.0",
+    "markdown-it-py>=3.0.0",
     "alembic>=1.13.0",
     "aiosqlite>=0.22.1",
     "anyio>=4.0.0",
@@ -13,13 +14,14 @@ dependencies = [
     "claude-agent-sdk",
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.136.0",
-    "google-genai>=1.56.0",
+    "google-genai>=2.3.0",
     "mcp>=1.27.0",
     "psycopg>=3.3.3",
     "pydantic>=2.12.5,<2.14",
     "pydantic-settings>=2.12.0",
     "python-dotenv>=1.2.1",
     "sqlalchemy-utils>=0.42.1",
+    "structlog>=24.0.0",
     "opentelemetry-api>=1.29.0",
     "opentelemetry-sdk>=1.29.0",
     "opentelemetry-exporter-otlp-proto-http>=1.29.0",
@@ -27,6 +29,17 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.50b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-logging>=0.50b0",
+    "markitdown[all]>=0.1.1",
+]
+
+# Optional voice transcription backends (PR 14). The ``api/stt.py``
+# xAI proxy is in the core dependencies; these are needed only when
+# ``VOICE_PROVIDER`` is ``mistral`` or ``openai``. Local whisper.cpp
+# uses subprocess calls and needs no Python package.
+[project.optional-dependencies]
+voice = [
+    "mistralai>=1.0.0",
+    "openai>=1.0.0",
 ]
 
 [dependency-groups]
@@ -38,6 +51,7 @@ dev = [
     "bandit[toml]>=1.7.10",
     "pre-commit>=4.0.0",
     "types-pyyaml>=6.0.12",
+    "import-linter>=2.11",
 ]
 
 # --- ruff: linter + formatter ----------------------------------------------
@@ -117,6 +131,9 @@ ignore = [
     "S106",    # hardcoded password (function arg)
     "S108",    # /tmp paths in test scenarios are fine
     "PT018",   # compound asserts in tests are fine if they're checking related state
+    "PLC0415", # lazy/in-fn imports in tests are intentional: avoid module-load
+               # side effects, isolate `importlib.reload` cases, and let fixtures
+               # set env before the SUT is bound. Hoisting defeats those patterns.
 ]
 "tests/conftest.py" = ["D", "E402"]   # sys.path manipulation must come before imports
 "alembic/**" = ["D", "E", "I", "S"]   # migrations are auto-generated
@@ -189,7 +206,7 @@ disallow_untyped_defs = false  # test fixtures are fine without explicit types
 
 [[tool.mypy.overrides]]
 # Third-party packages without complete type stubs.
-module = ["sqlalchemy_utils.*", "agno.*", "mcp.*"]
+module = ["sqlalchemy_utils.*", "mcp.*", "markitdown.*"]
 ignore_missing_imports = true
 
 # --- bandit: security scanner ------------------------------------------------

--- a/backend/tests/test_heartbeat.py
+++ b/backend/tests/test_heartbeat.py
@@ -1,0 +1,171 @@
+"""Tests for the heartbeat parser, runner, and config helpers.
+
+The runner is exercised against the in-memory SQLite session from
+`conftest.py` so the assertion surface stays the same as the rest of
+the chat-message CRUD tests.  APScheduler itself is not exercised here
+— the lifespan is a thin wrapper around `add_job`/`shutdown`, and
+exercising it would require either a real event loop with timing
+assertions (flaky) or so much monkeypatching that the test stops
+verifying anything real.  We test the things the scheduler calls into
+(`run_heartbeat`) and trust APScheduler's own test suite for the rest.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.heartbeat import HEARTBEAT_MESSAGE_PREFIX, run_heartbeat
+from app.core.heartbeat import (
+    MIN_INTERVAL_SECONDS,
+    HeartbeatCheck,
+    HeartbeatConfig,
+    parse_heartbeat_md,
+)
+from app.db import User
+from app.models import ChatMessage, Conversation
+
+
+async def _make_conversation(session: AsyncSession, user: User) -> Conversation:
+    """Insert a conversation row owned by `user`."""
+    now = datetime(2025, 1, 1)
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        title="Heartbeat Test",
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(conv)
+    await session.commit()
+    await session.refresh(conv)
+    return conv
+
+
+# ── Parser ───────────────────────────────────────────────────
+
+
+def test_parse_heartbeat_md_extracts_checks() -> None:
+    """A well-formed front matter parses into a `HeartbeatConfig`."""
+    text = """---
+check s:
+  - name: pulse
+    interval_seconds: 1800
+    prompt: |
+      Report status.
+---
+
+Free-form body that is intentionally ignored by the parser.
+""".replace("check s:", "checks:")
+    config = parse_heartbeat_md(text)
+    assert len(config.checks) == 1
+    check = config.checks[0]
+    assert check.name == "pulse"
+    assert check.interval_seconds == 1800
+    assert "Report status." in check.prompt
+
+
+def test_parse_heartbeat_md_returns_empty_when_no_front_matter() -> None:
+    """Pure markdown with no front matter yields an empty config (no crash)."""
+    config = parse_heartbeat_md("# Heartbeat\n\nJust prose.\n")
+    assert config.checks == []
+
+
+def test_parse_heartbeat_md_rejects_sub_minute_interval() -> None:
+    """The `MIN_INTERVAL_SECONDS` floor must be enforced at parse time."""
+    text = f"""---
+checks:
+  - name: too-fast
+    interval_seconds: {MIN_INTERVAL_SECONDS - 1}
+    prompt: noop
+---
+"""
+    with pytest.raises(ValueError, match="interval_seconds"):
+        parse_heartbeat_md(text)
+
+
+def test_parse_heartbeat_md_rejects_whitespace_name() -> None:
+    """Names double as APScheduler job ids, so whitespace is rejected."""
+    text = """---
+checks:
+  - name: "two words"
+    interval_seconds: 3600
+    prompt: noop
+---
+"""
+    with pytest.raises(ValueError, match="whitespace"):
+        parse_heartbeat_md(text)
+
+
+def test_find_check_returns_named_or_none() -> None:
+    """`HeartbeatConfig.find_check` is the lookup the manual endpoint uses."""
+    config = HeartbeatConfig(
+        checks=[
+            HeartbeatCheck(name="alpha", interval_seconds=3600, prompt="a"),
+            HeartbeatCheck(name="beta", interval_seconds=3600, prompt="b"),
+        ]
+    )
+    found = config.find_check("beta")
+    assert found is not None
+    assert found.prompt == "b"
+    assert config.find_check("missing") is None
+
+
+# ── Runner ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_heartbeat_persists_tagged_assistant_message(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A heartbeat run writes one assistant message tagged with the prefix.
+
+    This is the tracer assertion: the scheduler will call this function
+    on every interval, and the chat UI's existing GET /messages path
+    will surface the result without any frontend changes.
+    """
+    conv = await _make_conversation(db_session, test_user)
+    check = HeartbeatCheck(
+        name="pulse",
+        interval_seconds=1800,
+        prompt="Confirm aliveness.",
+    )
+
+    message_id = await run_heartbeat(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conv.id,
+        check=check,
+    )
+
+    result = await db_session.execute(select(ChatMessage).where(ChatMessage.id == message_id))
+    row = result.scalar_one()
+    assert row.role == "assistant"
+    assert row.assistant_status == "complete"
+    assert row.content.startswith(HEARTBEAT_MESSAGE_PREFIX)
+    assert "pulse" in row.content
+    assert "Confirm aliveness." in row.content
+
+
+@pytest.mark.anyio
+async def test_run_heartbeat_bumps_conversation_updated_at(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The sidebar orders by `Conversation.updated_at` — heartbeats must bubble."""
+    conv = await _make_conversation(db_session, test_user)
+    old = conv.updated_at
+    check = HeartbeatCheck(name="pulse", interval_seconds=1800, prompt="x")
+
+    await run_heartbeat(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conv.id,
+        check=check,
+    )
+    await db_session.refresh(conv)
+
+    assert conv.updated_at > old


### PR DESCRIPTION
## Summary

Introduces pawrrtal's first **heartbeat** — a periodic background turn that re-enters a conversation on a schedule and surfaces anything noteworthy. Modelled on [openclaw's heartbeat](https://docs.openclaw.ai/gateway/heartbeat).

**This PR is a deliberately narrow slice:** the runner + `HEARTBEAT.md` parser + manual `POST /api/v1/heartbeat/run` endpoint, end-to-end. Two follow-ups are flagged inline:

- `TODO(heartbeat-scheduler)` — register `run_heartbeat` as a `JobScheduler` job (the existing `app.core.scheduler` wrapper) gated on `settings.heartbeat_enabled`. Not a parallel APScheduler — pawrrtal already has one.
- `TODO(heartbeat-llm)` — feed `check.prompt` through `agent_loop` with the configured tools and persist the streamed timeline.

## What lands

- `HEARTBEAT.md` at the repo root, YAML front matter → `HeartbeatConfig`.
- `backend/app/core/heartbeat.py` — pure parser + Pydantic models (no DB/HTTP touch). 60-second `MIN_INTERVAL_SECONDS` floor enforced at parse time.
- `backend/app/api/heartbeat.py` — `run_heartbeat(session, ...)` writes a 🫀-prefixed assistant message via the existing `chat_message` CRUD; `POST /api/v1/heartbeat/run` exposes it.
- `backend/app/core/config.py` — four `HEARTBEAT_*` settings (added to development's full config; only `heartbeat_md_path` consumed in this slice).
- `backend/main.py` — one extra `include_router` for the heartbeat router (verbatim development otherwise).
- `backend/tests/test_heartbeat.py` — parser cases (well-formed, missing, sub-minute floor, whitespace-name, lookup) and runner tests against the in-memory SQLite fixture.

## Architecture notes

- **Sentrux layering:** parser sits in `app.core.heartbeat` (no upward imports); runner + route in `app.api.heartbeat` (calls into CRUD); registration site in `main.py`. Clean `entry → api → crud → models → core`.
- **No new dep:** `apscheduler` is already pinned on development. `pyproject.toml`/`uv.lock` are untouched on this branch.
- **Frontend:** zero changes. The persisted assistant message renders through the existing chat UI's `GET /api/v1/conversations/{id}/messages` path.

## Test plan

- [x] `uv run pytest tests/test_heartbeat.py` — 7/7 green locally
- [x] `uv run pytest tests/test_health.py tests/test_chat_message_crud.py tests/test_telegram_channel.py` — 33/33 green (smoke for adjacent code)
- [x] `uv run python -c "import main"` — app imports cleanly
- [x] `uv run ruff check` + `uv run ruff format --check` on every touched file — clean
- [ ] CI on this branch
- [ ] Manual: `POST /api/v1/heartbeat/run` with `{ "conversation_id": "<existing-conv-uuid>" }` writes a 🫀-prefixed assistant message

## Commit history note

Commit log on this branch is **noisier than ideal** — please squash on merge. The story:

1. The initial pushes (`a0b54de` … `86fca2a`) were generated from a stale `main` clone and clobbered substantial development additions in `main.py` (audit/cost/exports/webhooks/scheduled_jobs routes, EventBus + JobScheduler lifespan, BackendApiKeyMiddleware, `migrate_user_keyed_env_files_for_all_users`) and `pyproject.toml` (markdown-it-py, structlog, markitdown, the `[voice]` optional-deps, import-linter, the `PLC0415` test ignore).
2. Commits `2735942` (pyproject), `1f9b725` (main.py), and `9a08488` (config.py) restore development verbatim and re-apply only the heartbeat-specific additions on top.
3. `e2b9c48` drops the in-module APScheduler lifespan (the JobScheduler integration is the proper follow-up).
4. `565b2a0` narrows `HEARTBEAT.md` to match the slice scope.
5. `9d98ec4` fixes a JSON-escape bug that landed `U+FFFD` in place of `🫀`.

Each restoration commit was diffed against development's tree on the way back, so the working tree at HEAD is `development` + the heartbeat additions only.

## Risks / out of scope

- No scheduler integration yet — heartbeats only fire when an authenticated client hits `/api/v1/heartbeat/run`. Stub settings (`heartbeat_user_id`, `heartbeat_conversation_id`, `heartbeat_enabled`) are present for the follow-up.
- Runner posts a static message; no LLM turn yet.
- `HEARTBEAT.md` lives at the repo root for now — once we add multi-tenant heartbeats it'll move to the workspace.

https://claude.ai/code/session_016nM5zATwmDiiNgoY2ahJb5

---
_Generated by [Claude Code](https://claude.ai/code/session_016nM5zATwmDiiNgoY2ahJb5)_