### PR TITLE
feat(providers): add xAI (Grok 4.3) as a chat provider

### DIFF
--- a/backend/app/core/providers/__init__.py
+++ b/backend/app/core/providers/__init__.py
@@ -4,6 +4,7 @@ from .base import AILLM, ReasoningEffort, StreamEvent
 from .catalog import default_model
 from .claude_provider import ClaudeLLM, ClaudeLLMConfig
 from .factory import resolve_llm
+from .xai_provider import XaiLLM
 
 __all__ = [
     "AILLM",
@@ -11,6 +12,7 @@ __all__ = [
     "ClaudeLLMConfig",
     "ReasoningEffort",
     "StreamEvent",
+    "XaiLLM",
     "default_model",
     "resolve_llm",
 ]

--- a/backend/app/core/providers/_xai_events.py
+++ b/backend/app/core/providers/_xai_events.py
@@ -1,0 +1,64 @@
+"""xAI AgentEvent → StreamEvent translation helper.
+
+Split out of ``xai_provider`` to keep that module under the 500-line
+file budget.  Pure translation — no I/O, no OpenAI SDK references.
+
+The translation rules mirror Gemini's (``_gemini_events.py``): the
+agent loop is provider-neutral so every provider's adapter funnels the
+same AgentEvent vocabulary into the same StreamEvent shape.  Reusing
+the rules keeps SSE payloads identical regardless of which model
+served the turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.agent_loop.types import AgentMessage
+
+from .base import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Pass through messages the LLM understands; filter UI-only types."""
+    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
+
+
+def agent_event_to_stream_event(event: Any) -> StreamEvent | None:
+    """Translate one ``AgentEvent`` from the loop into a frontend ``StreamEvent``.
+
+    Returns ``None`` for events that don't carry user-facing payload
+    (``agent_start`` / ``agent_end`` / ``message_*`` / ``turn_*`` /
+    ``tool_call_start``) — the chat router emits the ``[DONE]`` sentinel
+    itself when the loop completes.
+    """
+    event_type = event["type"]
+    if event_type == "text_delta":
+        return StreamEvent(type="delta", content=event["text"])
+    if event_type == "thinking_delta":
+        return StreamEvent(type="thinking", content=event["text"])
+    if event_type == "tool_call_end":
+        return StreamEvent(
+            type="tool_use",
+            name=event["name"],
+            input=event["arguments"],
+            tool_use_id=event["tool_call_id"],
+            display=event.get("display"),
+        )
+    if event_type == "tool_result":
+        return StreamEvent(
+            type="tool_result",
+            content=event["content"],
+            tool_use_id=event["tool_call_id"],
+        )
+    if event_type == "agent_terminated":
+        logger.warning(
+            "AGENT_TERMINATED reason=%s details=%s",
+            event["reason"],
+            event["details"],
+        )
+        return StreamEvent(type="agent_terminated", content=event["message"])
+    return None

--- a/backend/app/core/providers/_xai_messages.py
+++ b/backend/app/core/providers/_xai_messages.py
@@ -1,0 +1,114 @@
+"""xAI request-shape helpers — AgentMessage → OpenAI ``messages`` / ``tools``.
+
+Split out of ``xai_provider`` so that module stays under the 500-line
+file budget (``scripts/check-file-lines.mjs``).  All helpers are pure
+shape translation — no I/O, no SDK calls.  The public surface is
+:func:`build_xai_messages` and :func:`build_xai_tool_declarations`;
+their leading underscore-stripped names match how Gemini's equivalents
+live in ``_gemini_replay`` / ``gemini_provider``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.agent_loop.types import (
+    AgentMessage,
+    AgentTool,
+    TextContent,
+    ToolCallContent,
+    ToolResultMessage,
+)
+
+
+def build_xai_tool_declarations(tools: list[AgentTool]) -> list[dict[str, Any]] | None:
+    """Convert :class:`AgentTool` instances to OpenAI ``tools`` entries.
+
+    Returns ``None`` (not ``[]``) when there are no tools so the caller
+    can skip the parameter entirely — some OpenAI-compat servers reject
+    an empty list and we want xAI to take its default no-tool path.
+    """
+    if not tools:
+        return None
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+            },
+        }
+        for t in tools
+    ]
+
+
+def _assistant_content_for_request(
+    content: list[TextContent | ToolCallContent],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Split an assistant message's blocks into the OpenAI request shape.
+
+    OpenAI separates an assistant turn's text (``content`` string) from
+    its tool calls (``tool_calls`` array).  The agent loop carries both
+    in one ``content`` list, so we partition them here.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in content:
+        if block["type"] == "text":
+            text_parts.append(block["text"])
+            continue
+        tool_calls.append(
+            {
+                "id": block["tool_call_id"],
+                "type": "function",
+                "function": {
+                    "name": block["name"],
+                    "arguments": json.dumps(block["arguments"]),
+                },
+            }
+        )
+    return "".join(text_parts), tool_calls
+
+
+def _tool_result_message(msg: ToolResultMessage) -> dict[str, Any]:
+    """Render a tool result into OpenAI's ``role="tool"`` shape."""
+    text: str = "\n".join(block["text"] for block in msg["content"])
+    return {
+        "role": "tool",
+        "tool_call_id": msg["tool_call_id"],
+        "content": text,
+    }
+
+
+def build_xai_messages(
+    messages: list[AgentMessage],
+    system_prompt: str,
+) -> list[dict[str, Any]]:
+    """Convert AgentMessages to OpenAI ``messages`` entries, oldest-first.
+
+    The system prompt is prepended as a ``role="system"`` turn — xAI
+    follows OpenAI's convention here rather than Gemini's separate
+    ``system_instruction`` field.
+    """
+    out: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+    for msg in messages:
+        if msg["role"] == "user":
+            text = msg["content"]
+            if text.strip():
+                out.append({"role": "user", "content": text})
+            continue
+        if msg["role"] == "assistant":
+            text, tool_calls = _assistant_content_for_request(msg["content"])
+            entry: dict[str, Any] = {"role": "assistant"}
+            # OpenAI rejects an entirely empty assistant turn (no content
+            # AND no tool_calls) so we ensure at least one field carries
+            # a non-falsey value.
+            entry["content"] = text or None
+            if tool_calls:
+                entry["tool_calls"] = tool_calls
+            out.append(entry)
+            continue
+        out.append(_tool_result_message(msg))
+    return out

--- a/backend/app/core/providers/_xai_stream.py
+++ b/backend/app/core/providers/_xai_stream.py
@@ -27,6 +27,15 @@ logger = logging.getLogger(__name__)
 # model produced one or more tool calls.  Mirrors OpenAI's vocabulary.
 FINISH_REASON_TOOL_CALLS = "tool_calls"
 
+# xAI bills in "ticks" where ``1 tick = 1e-10 USD``.  Sourced from the
+# official xai-sdk Python package's ``cost.py``:
+# https://github.com/xai-org/xai-sdk-python/blob/main/src/xai_sdk/cost.py
+# (citing
+# https://github.com/xai-org/xai-proto/blob/0c0f5353aa7ab2a4ffea310f9d9364ed5c424af2/proto/xai/api/v1/usage.proto#L45).
+# Field is opaque on the wire; keeping the constant here means future
+# divisor changes are a single-line edit.
+USD_PER_TICK = 1e-10
+
 
 @dataclass(frozen=True, slots=True)
 class ChunkDeltas:
@@ -185,6 +194,70 @@ def finalize_tool_calls(aggregate: ChunkAggregate) -> list[dict[str, Any]]:
             {"tool_call_id": tool_call_id, "name": buffer.name, "arguments": arguments}
         )
     return completed
+
+
+class UsageAccumulator:
+    """Per-request usage totals summed across every StreamFn invocation.
+
+    The agent loop calls the StreamFn once per assistant turn (LLM →
+    tool → LLM round-trip), so a single user prompt can drive several
+    chat-completions requests.  Each request returns its own ``usage``
+    block on the terminal streaming chunk (when
+    ``stream_options.include_usage=True``); we sum them so the chat
+    aggregator sees the total for the whole turn, matching how Claude
+    reports its per-turn cost.
+
+    Mutable on purpose: the StreamFn closure owns one and writes into
+    it from inside the stream; :class:`XaiLLM.stream` reads the totals
+    after :func:`agent_loop` returns and emits the terminal
+    ``StreamEvent(type="usage")``.
+    """
+
+    __slots__ = ("cost_usd", "input_tokens", "output_tokens", "saw_any")
+
+    def __init__(self) -> None:
+        self.input_tokens: int = 0
+        self.output_tokens: int = 0
+        self.cost_usd: float = 0.0
+        self.saw_any: bool = False
+
+    def absorb(self, chunk: Any) -> None:
+        """Fold one chunk's ``usage`` block into the running totals.
+
+        No-op when the chunk has no usage payload — only the final chunk
+        of a ``stream_options.include_usage=True`` stream carries it.
+        Reads ``prompt_tokens``/``completion_tokens`` (OpenAI naming)
+        AND ``input_tokens``/``output_tokens`` (xAI naming) defensively
+        because the two endpoints have historically disagreed on which
+        names land in the REST envelope.
+        """
+        usage = getattr(chunk, "usage", None)
+        if usage is None:
+            return
+        self.saw_any = True
+        prompt = _read_usage_int(usage, "prompt_tokens", "input_tokens")
+        completion = _read_usage_int(usage, "completion_tokens", "output_tokens")
+        self.input_tokens += prompt
+        self.output_tokens += completion
+        ticks = _read_usage_int(usage, "cost_in_usd_ticks")
+        if ticks > 0:
+            self.cost_usd += ticks * USD_PER_TICK
+
+
+def _read_usage_int(usage: Any, *names: str) -> int:
+    """Read the first non-zero integer field from ``usage``.
+
+    Tries each name in order using ``getattr`` (Pydantic models from
+    the openai SDK preserve unknown xAI fields via ``extra='allow'``,
+    so the xAI-specific names land on the model alongside the
+    OpenAI-standard ones).  Returns 0 when none of the names are
+    present or carry a usable integer.
+    """
+    for name in names:
+        value = getattr(usage, name, None)
+        if isinstance(value, int) and value > 0:
+            return value
+    return 0
 
 
 def done_event_for(

--- a/backend/app/core/providers/_xai_stream.py
+++ b/backend/app/core/providers/_xai_stream.py
@@ -1,0 +1,186 @@
+"""xAI streaming-chunk accumulation helpers.
+
+Split out of ``xai_provider`` so that module stays under the 500-line
+file budget (``scripts/check-file-lines.mjs``).  The OpenAI / xAI
+chat-completions stream emits tool calls across many partial deltas,
+so the StreamFn closure needs running state per call — that state and
+its finalisation live here.  No I/O, no SDK constructor calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from app.core.agent_loop.types import (
+    LLMDoneEvent,
+    TextContent,
+    ToolCallContent,
+)
+
+logger = logging.getLogger(__name__)
+
+# Finish reason emitted by xAI / OpenAI-compatible endpoints when the
+# model produced one or more tool calls.  Mirrors OpenAI's vocabulary.
+FINISH_REASON_TOOL_CALLS = "tool_calls"
+
+
+class ToolCallAccumulator:
+    """Reassembles a single OpenAI tool-call from its streamed delta fragments.
+
+    xAI's chat-completions stream emits each tool call across many
+    chunks: the first one sets ``id`` + ``function.name``, later ones
+    append slices of ``function.arguments``.  The accumulator collects
+    them per ``index`` so we can yield a complete
+    :class:`LLMToolCallEvent` once the stream ends.
+    """
+
+    __slots__ = ("arguments", "id", "name")
+
+    def __init__(self) -> None:
+        self.id: str = ""
+        self.name: str = ""
+        self.arguments: str = ""
+
+    def apply(self, delta: Any) -> None:
+        """Merge one OpenAI ``ChoiceDeltaToolCall`` fragment into the buffer."""
+        if delta.id:
+            self.id = delta.id
+        fn = getattr(delta, "function", None)
+        if fn is None:
+            return
+        if fn.name:
+            self.name = fn.name
+        if fn.arguments:
+            self.arguments += fn.arguments
+
+
+def parse_tool_arguments(raw: str, name: str) -> dict[str, Any]:
+    """Parse the accumulated tool-arguments JSON, tolerating empty strings.
+
+    xAI streams ``arguments`` as raw JSON.  An empty / missing
+    arguments object is legitimate for tools that take no parameters,
+    so we treat ``""`` as ``{}``.  Malformed JSON is surfaced as an
+    empty dict with a WARNING — the agent loop will still dispatch the
+    tool, and the resulting error is more informative than a stream-
+    level exception.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "xai_provider: tool '%s' returned non-JSON arguments (%s); falling back to empty dict",
+            name,
+            exc,
+        )
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _build_tool_call_id(name: str, fallback_id: str, ordinal: int) -> str:
+    """Return a stable tool_call_id even when the provider omitted ``id``."""
+    if fallback_id:
+        return fallback_id
+    return f"call-{name}-{ordinal}-{uuid.uuid4().hex[:8]}"
+
+
+class ChunkAggregate:
+    """Cross-chunk streaming state for one ``chat.completions`` call.
+
+    Pulled out of the StreamFn closure so the outer factory stays under
+    the ruff complexity cap.  The aggregate owns the running text, the
+    per-index :class:`ToolCallAccumulator` map, and the most recent
+    ``finish_reason`` observed on the stream.
+    """
+
+    __slots__ = ("finish_reason", "full_text", "tool_buffers")
+
+    def __init__(self) -> None:
+        self.full_text: str = ""
+        self.tool_buffers: dict[int, ToolCallAccumulator] = {}
+        self.finish_reason: str | None = None
+
+
+def absorb_chunk(chunk: Any, aggregate: ChunkAggregate) -> str | None:
+    """Update *aggregate* with one streaming chunk.
+
+    Returns any text delta to forward upstream, or ``None`` when the
+    chunk only contributed to tool-call accumulation.  Extracted from
+    the StreamFn closure so the factory stays inside the ruff complexity
+    cap; the branch shape mirrors the OpenAI SDK's
+    :class:`ChatCompletionChunk` shape exactly.
+    """
+    if not chunk.choices:
+        return None
+    choice = chunk.choices[0]
+    delta = choice.delta
+    if delta is None:
+        return None
+    text_delta: str | None = None
+    if delta.content:
+        text_delta = delta.content
+        aggregate.full_text += delta.content
+    for tc_delta in getattr(delta, "tool_calls", None) or []:
+        idx = getattr(tc_delta, "index", 0) or 0
+        buffer = aggregate.tool_buffers.get(idx)
+        if buffer is None:
+            buffer = ToolCallAccumulator()
+            aggregate.tool_buffers[idx] = buffer
+        buffer.apply(tc_delta)
+    if choice.finish_reason:
+        aggregate.finish_reason = choice.finish_reason
+    return text_delta
+
+
+def finalize_tool_calls(aggregate: ChunkAggregate) -> list[dict[str, Any]]:
+    """Drain buffered tool calls into ordered, JSON-decoded records.
+
+    Skips fragments that never carried a function name (treated as a
+    streaming bug on the upstream side and logged) and returns one
+    entry per dispatched tool call in the order the model produced them.
+    """
+    completed: list[dict[str, Any]] = []
+    for ordinal, idx in enumerate(sorted(aggregate.tool_buffers.keys())):
+        buffer = aggregate.tool_buffers[idx]
+        if not buffer.name:
+            logger.warning(
+                "xai_provider: dropping tool_call index=%d with empty name (id=%r)",
+                idx,
+                buffer.id,
+            )
+            continue
+        tool_call_id = _build_tool_call_id(buffer.name, buffer.id, ordinal)
+        arguments = parse_tool_arguments(buffer.arguments, buffer.name)
+        completed.append(
+            {"tool_call_id": tool_call_id, "name": buffer.name, "arguments": arguments}
+        )
+    return completed
+
+
+def done_event_for(
+    aggregate: ChunkAggregate,
+    completed_tool_calls: list[dict[str, Any]],
+) -> LLMDoneEvent:
+    """Assemble the terminal ``LLMDoneEvent`` from the streamed turn."""
+    stop_reason = (
+        "tool_use"
+        if completed_tool_calls or aggregate.finish_reason == FINISH_REASON_TOOL_CALLS
+        else "stop"
+    )
+    content: list[TextContent | ToolCallContent] = []
+    if aggregate.full_text:
+        content.append(TextContent(type="text", text=aggregate.full_text))
+    content.extend(
+        ToolCallContent(
+            type="toolCall",
+            tool_call_id=tc["tool_call_id"],
+            name=tc["name"],
+            arguments=tc["arguments"],
+        )
+        for tc in completed_tool_calls
+    )
+    return LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)

--- a/backend/app/core/providers/_xai_stream.py
+++ b/backend/app/core/providers/_xai_stream.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 from app.core.agent_loop.types import (
@@ -25,6 +26,20 @@ logger = logging.getLogger(__name__)
 # Finish reason emitted by xAI / OpenAI-compatible endpoints when the
 # model produced one or more tool calls.  Mirrors OpenAI's vocabulary.
 FINISH_REASON_TOOL_CALLS = "tool_calls"
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkDeltas:
+    """The user-visible deltas extracted from a single streaming chunk.
+
+    ``text`` is the regular assistant content delta; ``thinking`` is the
+    reasoning-trace delta (xAI's ``reasoning_content`` field on grok-4.3
+    reasoning turns).  Either or both may be ``None`` for a chunk that
+    only contributed to tool-call accumulation or to ``finish_reason``.
+    """
+
+    text: str | None = None
+    thinking: str | None = None
 
 
 class ToolCallAccumulator:
@@ -105,25 +120,36 @@ class ChunkAggregate:
         self.finish_reason: str | None = None
 
 
-def absorb_chunk(chunk: Any, aggregate: ChunkAggregate) -> str | None:
-    """Update *aggregate* with one streaming chunk.
+def absorb_chunk(chunk: Any, aggregate: ChunkAggregate) -> ChunkDeltas:
+    """Update *aggregate* with one streaming chunk and report the user-visible deltas.
 
-    Returns any text delta to forward upstream, or ``None`` when the
-    chunk only contributed to tool-call accumulation.  Extracted from
-    the StreamFn closure so the factory stays inside the ruff complexity
-    cap; the branch shape mirrors the OpenAI SDK's
-    :class:`ChatCompletionChunk` shape exactly.
+    Returns :class:`ChunkDeltas` carrying any text and / or
+    ``reasoning_content`` delta to forward upstream.  Both fields are
+    ``None`` when the chunk only contributed to tool-call accumulation
+    or to ``finish_reason``.  Extracted from the StreamFn closure so
+    the factory stays inside the ruff complexity cap; the branch shape
+    mirrors the OpenAI SDK's :class:`ChatCompletionChunk` exactly, plus
+    xAI's ``reasoning_content`` extra (allowed because
+    :class:`ChoiceDelta` is configured with ``extra='allow'``).
     """
     if not chunk.choices:
-        return None
+        return ChunkDeltas()
     choice = chunk.choices[0]
     delta = choice.delta
     if delta is None:
-        return None
+        return ChunkDeltas()
     text_delta: str | None = None
     if delta.content:
         text_delta = delta.content
         aggregate.full_text += delta.content
+    # xAI's grok-4.3 reasoning turn surfaces chain-of-thought in
+    # ``reasoning_content`` on each delta.  The openai SDK preserves
+    # unknown fields on :class:`ChoiceDelta` via ``extra='allow'`` so a
+    # plain ``getattr`` is enough — no SDK upgrade required when xAI
+    # changes their schema, and the field stays ``None`` for non-Grok
+    # OpenAI-compat providers that never emit it.
+    thinking_value = getattr(delta, "reasoning_content", None)
+    thinking_delta = thinking_value if isinstance(thinking_value, str) and thinking_value else None
     for tc_delta in getattr(delta, "tool_calls", None) or []:
         idx = getattr(tc_delta, "index", 0) or 0
         buffer = aggregate.tool_buffers.get(idx)
@@ -133,7 +159,7 @@ def absorb_chunk(chunk: Any, aggregate: ChunkAggregate) -> str | None:
         buffer.apply(tc_delta)
     if choice.finish_reason:
         aggregate.finish_reason = choice.finish_reason
-    return text_delta
+    return ChunkDeltas(text=text_delta, thinking=thinking_delta)
 
 
 def finalize_tool_calls(aggregate: ChunkAggregate) -> list[dict[str, Any]]:

--- a/backend/app/core/providers/catalog.py
+++ b/backend/app/core/providers/catalog.py
@@ -75,6 +75,11 @@ _GEMINI_3_FLASH_OUT_USD = 2.50
 _GEMINI_3_FLASH_LITE_IN_USD = 0.10
 _GEMINI_3_FLASH_LITE_OUT_USD = 0.40
 
+# xAI Grok pricing per https://docs.x.ai/docs/models.  Used by the xAI
+# provider's cost-ledger path (no SDK-reported total).
+_GROK_4_3_IN_USD = 1.25
+_GROK_4_3_OUT_USD = 2.50
+
 
 MODEL_CATALOG: tuple[ModelEntry, ...] = (
     ModelEntry(
@@ -131,6 +136,17 @@ MODEL_CATALOG: tuple[ModelEntry, ...] = (
         is_default=False,
         cost_per_mtok_in_usd=_GEMINI_3_FLASH_LITE_IN_USD,
         cost_per_mtok_out_usd=_GEMINI_3_FLASH_LITE_OUT_USD,
+    ),
+    ModelEntry(
+        host=Host.xai,
+        vendor=Vendor.xai,
+        model="grok-4.3",
+        display_name="Grok 4.3",
+        short_name="Grok 4.3",
+        description="xAI's frontier 1M-context model",
+        is_default=False,
+        cost_per_mtok_in_usd=_GROK_4_3_IN_USD,
+        cost_per_mtok_out_usd=_GROK_4_3_OUT_USD,
     ),
 )
 

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -23,10 +23,12 @@ from .base import AILLM
 from .claude_provider import ClaudeLLM, ClaudeLLMConfig
 from .gemini_provider import GeminiLLM
 from .model_id import Host, ParsedModelId, parse_model_id
+from .xai_provider import XaiLLM
 
 HOST_TO_PROVIDER: dict[Host, type[AILLM]] = {
     Host.agent_sdk: ClaudeLLM,
     Host.google_ai: GeminiLLM,
+    Host.xai: XaiLLM,
 }
 """Map of host enum to the concrete provider class that serves it.
 
@@ -92,4 +94,6 @@ def resolve_llm(
         return ClaudeLLM(parsed.model, config=config, workspace_id=workspace_id)
     if provider_cls is GeminiLLM:
         return GeminiLLM(parsed.model, workspace_id=workspace_id)
+    if provider_cls is XaiLLM:
+        return XaiLLM(parsed.model, workspace_id=workspace_id)
     raise KeyError(f"no provider class registered for host {parsed.host!r}")

--- a/backend/app/core/providers/model_id.py
+++ b/backend/app/core/providers/model_id.py
@@ -26,6 +26,7 @@ class Vendor(StrEnum):
 
     anthropic = "anthropic"
     google = "google"
+    xai = "xai"
 
 
 class Host(StrEnum):
@@ -37,11 +38,13 @@ class Host(StrEnum):
 
     agent_sdk = "agent-sdk"
     google_ai = "google-ai"
+    xai = "xai"
 
 
 CANONICAL_HOST: dict[Vendor, Host] = {
     Vendor.anthropic: Host.agent_sdk,
     Vendor.google: Host.google_ai,
+    Vendor.xai: Host.xai,
 }
 """Per-vendor canonical host used when the input omits ``host:``.
 

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -20,12 +20,26 @@ Design parity with :mod:`app.core.providers.gemini_provider`:
   the same path as Gemini — the provider stays tool-agnostic per
   ``.claude/rules/architecture/no-tools-in-providers.md``.
 
-Reasoning effort is accepted for protocol parity but ignored: Grok 4.3
-does not surface a reasoning-effort knob via the OpenAI-compatible
-endpoint at the time of writing (the dedicated reasoning variants are
-separate model IDs).  Multimodal image inputs are accepted and logged
-but not yet bridged — the chat router can still pass them
-conditionally without a runtime error.
+xAI-specific extensions the openai SDK doesn't model natively all flow
+in via ``extra_body``; see :func:`_build_xai_extra_body` for the single
+source of truth:
+
+* ``reasoning_effort`` — collapsed from Pawrrtal's four-level UI knob
+  (``low | medium | high | extra-high``) into grok-4.3's two-level enum
+  via :func:`_map_reasoning_effort`.  grok-4.3 400s on any other value
+  (https://docs.x.ai/docs/models/grok-4-3).
+* ``search_parameters`` — forced to ``{"mode": "off"}`` so xAI's
+  built-in Live Search never fires.  Pawrrtal's canonical web tool is
+  ``exa_search`` (gated by ``EXA_API_KEY``); leaving xAI's search on
+  the default ``"on"`` would silently double-search every Grok turn.
+
+Reasoning-trace deltas (``delta.reasoning_content``) are forwarded as
+:class:`LLMThinkingDeltaEvent` so the frontend's existing "thinking"
+pane (already wired for Gemini) lights up for Grok too.
+
+Multimodal image inputs are accepted and logged but not yet bridged —
+the chat router can still pass them conditionally without a runtime
+error.
 
 Request- and response-shape helpers live in ``_xai_messages`` and
 ``_xai_stream`` so this module stays under the project's 500-line
@@ -55,6 +69,7 @@ from app.core.agent_loop import (
     LLMDoneEvent,
     LLMEvent,
     LLMTextDeltaEvent,
+    LLMThinkingDeltaEvent,
     LLMToolCallEvent,
     StreamFn,
     UserMessage,
@@ -89,6 +104,14 @@ logger = logging.getLogger(__name__)
 # https://docs.x.ai/docs/api-reference.
 XAI_BASE_URL = "https://api.x.ai/v1"
 
+# xAI's Live Search is enabled by default (``mode="on"``) on every
+# chat-completions request — see https://docs.x.ai/docs/guides/live-search.
+# Pawrrtal does its own web search through the explicit ``exa_search``
+# tool (gated by ``EXA_API_KEY``), so we turn xAI's built-in search off
+# at the SDK seam.  Otherwise every Grok turn would silently consult the
+# web, doubling up with exa_search and surprise-billing the workspace.
+_LIVE_SEARCH_DISABLED: dict[str, Any] = {"mode": "off"}
+
 
 def _resolve_xai_api_key(workspace_id: uuid.UUID | None) -> str:
     """Resolve the xAI API key for this request.
@@ -102,12 +125,49 @@ def _resolve_xai_api_key(workspace_id: uuid.UUID | None) -> str:
     return settings.xai_api_key
 
 
+def _map_reasoning_effort(effort: ReasoningEffort | None) -> str | None:
+    """Map the four-level UI knob onto xAI's two-level enum.
+
+    Grok 4.3 accepts ``"low"`` or ``"high"``
+    (https://docs.x.ai/docs/models/grok-4-3) and 400s on anything else,
+    including the values OpenAI's o-series uses.  The Pawrrtal UI
+    surfaces ``low | medium | high | extra-high`` — we collapse the
+    lower two to ``low`` and the upper two to ``high`` so the user gets
+    a meaningful difference without overshooting xAI's schema.
+    ``None`` means "let xAI pick the model default".
+    """
+    if effort is None:
+        return None
+    if effort in ("low", "medium"):
+        return "low"
+    return "high"
+
+
+def _build_xai_extra_body(reasoning_effort: ReasoningEffort | None) -> dict[str, Any]:
+    """Assemble the xAI-only kwargs forwarded via ``extra_body``.
+
+    ``extra_body`` is the openai SDK's escape hatch for non-OpenAI
+    fields.  We use it for the two xAI-specific concerns:
+
+    * ``reasoning_effort`` for grok-4.3 (passed only when the caller
+      supplied one — the model picks its own default otherwise).
+    * ``search_parameters`` to opt out of xAI's built-in Live Search
+      (see :data:`_LIVE_SEARCH_DISABLED` for the why).
+    """
+    body: dict[str, Any] = {"search_parameters": _LIVE_SEARCH_DISABLED}
+    mapped_effort = _map_reasoning_effort(reasoning_effort)
+    if mapped_effort is not None:
+        body["reasoning_effort"] = mapped_effort
+    return body
+
+
 async def _open_xai_stream(
     *,
     client: AsyncOpenAI,
     model_id: str,
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
+    reasoning_effort: ReasoningEffort | None,
 ) -> AsyncStream[ChatCompletionChunk]:
     """Open the streaming chat-completions call against xAI.
 
@@ -118,13 +178,20 @@ async def _open_xai_stream(
     ``Any`` (forbidden by the project mypy config).  Splitting the
     ``stream=True`` overload into two literal branches keeps mypy from
     widening the return to ``ChatCompletion | AsyncStream[...]``.
+
+    xAI-specific fields (``reasoning_effort``, ``search_parameters``)
+    flow in via ``extra_body`` so the openai SDK passes them through
+    unchanged — :func:`_build_xai_extra_body` is the single source of
+    truth for what we forward.
     """
     typed_messages = cast("list[ChatCompletionMessageParam]", messages)
+    extra_body = _build_xai_extra_body(reasoning_effort)
     if tools is None:
         return await client.chat.completions.create(
             model=model_id,
             messages=typed_messages,
             stream=True,
+            extra_body=extra_body,
         )
     typed_tools = cast("list[ChatCompletionToolUnionParam]", tools)
     return await client.chat.completions.create(
@@ -132,6 +199,7 @@ async def _open_xai_stream(
         messages=typed_messages,
         tools=typed_tools,
         stream=True,
+        extra_body=extra_body,
     )
 
 
@@ -140,6 +208,7 @@ def make_xai_stream_fn(
     workspace_id: uuid.UUID | None = None,
     *,
     system_prompt: str,
+    reasoning_effort: ReasoningEffort | None = None,
 ) -> StreamFn:
     """Build a :data:`StreamFn` backed by xAI's OpenAI-compatible API.
 
@@ -154,6 +223,10 @@ def make_xai_stream_fn(
             entry on every call.  ``XaiLLM.stream`` builds a fresh
             StreamFn per request so the workspace-assembled prompt
             (SOUL.md + AGENTS.md + skills) is what the model sees.
+        reasoning_effort: Optional reasoning-depth knob for grok-4.3.
+            Mapped onto xAI's two-level enum (``low`` / ``high``) via
+            :func:`_map_reasoning_effort` and forwarded through
+            ``extra_body``.  ``None`` lets xAI pick the model default.
 
     Returns:
         An async generator factory that yields ``LLMEvent`` instances.
@@ -177,11 +250,14 @@ def make_xai_stream_fn(
                 model_id=model_id,
                 messages=request_messages,
                 tools=xai_tools,
+                reasoning_effort=reasoning_effort,
             )
             async for chunk in stream:
-                text_delta = absorb_chunk(chunk, aggregate)
-                if text_delta:
-                    yield LLMTextDeltaEvent(type="text_delta", text=text_delta)
+                deltas = absorb_chunk(chunk, aggregate)
+                if deltas.thinking:
+                    yield LLMThinkingDeltaEvent(type="thinking_delta", text=deltas.thinking)
+                if deltas.text:
+                    yield LLMTextDeltaEvent(type="text_delta", text=deltas.text)
         except Exception as exc:
             logger.error("xAI streaming error model=%s: %s", model_id, exc, exc_info=True)
             error_text = f"xAI error: {exc}"
@@ -269,9 +345,12 @@ class XaiLLM:
             system_prompt: System prompt for this turn.  ``None`` falls
                 back to :data:`DEFAULT_AGENT_SYSTEM_PROMPT` so bare
                 unit tests still work.
-            reasoning_effort: Accepted for protocol parity.  Grok 4.3
-                does not surface a reasoning-effort knob via the
-                OpenAI-compatible endpoint, so the value is ignored.
+            reasoning_effort: Optional reasoning-depth knob.  Mapped onto
+                grok-4.3's two-level enum (``low`` / ``high``) via
+                :func:`_map_reasoning_effort` and forwarded to xAI via
+                ``extra_body``.  The model's chain-of-thought streams
+                back as ``reasoning_content`` deltas and surfaces as
+                :class:`StreamEvent` ``thinking`` events for the UI.
             permission_check: Optional cross-provider permission gate
                 (PR 03b).  Threaded straight into
                 :class:`AgentLoopConfig` so denial flows through the
@@ -286,12 +365,6 @@ class XaiLLM:
                 "XAI_IMAGES_IGNORED conversation_id=%s count=%d",
                 conversation_id,
                 len(images),
-            )
-        if reasoning_effort is not None:
-            logger.debug(
-                "XAI_REASONING_EFFORT_IGNORED conversation_id=%s value=%s",
-                conversation_id,
-                reasoning_effort,
             )
 
         prior: list[AgentMessage] = []
@@ -325,6 +398,7 @@ class XaiLLM:
             self._model_id,
             self._workspace_id,
             system_prompt=context.system_prompt,
+            reasoning_effort=reasoning_effort,
         )
 
         try:

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -57,6 +57,7 @@ from openai import AsyncOpenAI, AsyncStream
 from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionMessageParam,
+    ChatCompletionStreamOptionsParam,
     ChatCompletionToolUnionParam,
 )
 
@@ -90,6 +91,7 @@ from ._xai_events import agent_event_to_stream_event, identity_convert
 from ._xai_messages import build_xai_messages, build_xai_tool_declarations
 from ._xai_stream import (
     ChunkAggregate,
+    UsageAccumulator,
     absorb_chunk,
     done_event_for,
     finalize_tool_calls,
@@ -186,11 +188,17 @@ async def _open_xai_stream(
     """
     typed_messages = cast("list[ChatCompletionMessageParam]", messages)
     extra_body = _build_xai_extra_body(reasoning_effort)
+    # ``include_usage=True`` makes xAI emit a terminal chunk carrying
+    # the request's ``usage`` block — that's where ``cost_in_usd_ticks``
+    # and the token counts live.  Without it, the cost ledger sees zero
+    # for every Grok turn.
+    stream_options: ChatCompletionStreamOptionsParam = {"include_usage": True}
     if tools is None:
         return await client.chat.completions.create(
             model=model_id,
             messages=typed_messages,
             stream=True,
+            stream_options=stream_options,
             extra_body=extra_body,
         )
     typed_tools = cast("list[ChatCompletionToolUnionParam]", tools)
@@ -199,6 +207,7 @@ async def _open_xai_stream(
         messages=typed_messages,
         tools=typed_tools,
         stream=True,
+        stream_options=stream_options,
         extra_body=extra_body,
     )
 
@@ -209,6 +218,7 @@ def make_xai_stream_fn(
     *,
     system_prompt: str,
     reasoning_effort: ReasoningEffort | None = None,
+    usage_sink: UsageAccumulator | None = None,
 ) -> StreamFn:
     """Build a :data:`StreamFn` backed by xAI's OpenAI-compatible API.
 
@@ -227,6 +237,13 @@ def make_xai_stream_fn(
             Mapped onto xAI's two-level enum (``low`` / ``high``) via
             :func:`_map_reasoning_effort` and forwarded through
             ``extra_body``.  ``None`` lets xAI pick the model default.
+        usage_sink: Optional mutable :class:`UsageAccumulator` the
+            StreamFn writes per-chunk usage into.  Shared across every
+            agent_loop iteration for a single ``XaiLLM.stream`` call so
+            multi-turn tool-using conversations sum their cost
+            correctly.  ``None`` skips usage capture entirely — useful
+            for unit tests and for utility callers that don't talk to
+            the cost ledger.
 
     Returns:
         An async generator factory that yields ``LLMEvent`` instances.
@@ -254,6 +271,8 @@ def make_xai_stream_fn(
             )
             async for chunk in stream:
                 deltas = absorb_chunk(chunk, aggregate)
+                if usage_sink is not None:
+                    usage_sink.absorb(chunk)
                 if deltas.thinking:
                     yield LLMThinkingDeltaEvent(type="thinking_delta", text=deltas.thinking)
                 if deltas.text:
@@ -394,11 +413,16 @@ class XaiLLM:
             permission_check=permission_check,
         )
 
+        # One accumulator per ``stream()`` call, shared across every
+        # StreamFn invocation the agent loop makes for this turn so a
+        # multi-iteration tool-using conversation sums the cost correctly.
+        usage_sink = UsageAccumulator()
         stream_fn = self._stream_fn or make_xai_stream_fn(
             self._model_id,
             self._workspace_id,
             system_prompt=context.system_prompt,
             reasoning_effort=reasoning_effort,
+            usage_sink=usage_sink,
         )
 
         try:
@@ -409,3 +433,17 @@ class XaiLLM:
 
         except Exception as exc:
             yield StreamEvent(type="error", content=f"xAI provider error: {exc}")
+            return
+
+        # Terminal usage event — the chat aggregator folds it into the
+        # cost ledger (see ``ChatTurnAggregator.apply`` and
+        # ``app.channels._turn_cost.record_turn_cost_if_enabled``).  Skip
+        # when no chunk reported usage (test scripts, error-only turns)
+        # so the ledger doesn't see spurious zero rows.
+        if usage_sink.saw_any:
+            yield StreamEvent(
+                type="usage",
+                input_tokens=usage_sink.input_tokens,
+                output_tokens=usage_sink.output_tokens,
+                cost_usd=usage_sink.cost_usd,
+            )

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -1,0 +1,337 @@
+"""xAI (Grok) provider — StreamFn adapter for the agent loop.
+
+Wraps the OpenAI-compatible HTTP API exposed at ``https://api.x.ai/v1``
+(docs: https://docs.x.ai/docs/api-reference) so the agent loop can drive
+Grok the same way it drives Gemini and Claude.  The xAI surface is
+intentionally OpenAI-compatible, so we use the upstream ``openai`` SDK
+configured with ``base_url="https://api.x.ai/v1"`` rather than rolling
+our own SSE parser — every streaming chunk, tool-call delta, and finish
+reason then matches the well-understood OpenAI vocabulary.
+
+Design parity with :mod:`app.core.providers.gemini_provider`:
+
+* ``make_xai_stream_fn`` builds a per-request :data:`StreamFn` that
+  closes over ``model_id``, optional ``workspace_id`` (for per-workspace
+  ``XAI_API_KEY`` overrides), and the assembled ``system_prompt``.
+* ``XaiLLM.stream`` runs :func:`agent_loop` against that StreamFn and
+  translates each :class:`AgentEvent` into a :class:`StreamEvent` via
+  :func:`_xai_events.agent_event_to_stream_event`.
+* Tools, history, and the cross-provider permission gate flow through
+  the same path as Gemini — the provider stays tool-agnostic per
+  ``.claude/rules/architecture/no-tools-in-providers.md``.
+
+Reasoning effort is accepted for protocol parity but ignored: Grok 4.3
+does not surface a reasoning-effort knob via the OpenAI-compatible
+endpoint at the time of writing (the dedicated reasoning variants are
+separate model IDs).  Multimodal image inputs are accepted and logged
+but not yet bridged — the chat router can still pass them
+conditionally without a runtime error.
+
+Request- and response-shape helpers live in ``_xai_messages`` and
+``_xai_stream`` so this module stays under the project's 500-line
+budget (``scripts/check-file-lines.mjs``).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+from openai import AsyncOpenAI, AsyncStream
+from openai.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionMessageParam,
+    ChatCompletionToolUnionParam,
+)
+
+from app.core.agent_loop import (
+    AgentContext,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    StreamFn,
+    UserMessage,
+    agent_loop,
+)
+from app.core.agent_loop.safety_factory import safety_from_settings
+from app.core.agent_loop.types import (
+    PermissionCheckFn,
+    TextContent,
+)
+from app.core.agent_system_prompt import (
+    DEFAULT_AGENT_SYSTEM_PROMPT as _FALLBACK_SYSTEM_PROMPT,
+)
+from app.core.config import settings
+from app.core.keys import resolve_api_key
+
+from ._xai_events import agent_event_to_stream_event, identity_convert
+from ._xai_messages import build_xai_messages, build_xai_tool_declarations
+from ._xai_stream import (
+    ChunkAggregate,
+    absorb_chunk,
+    done_event_for,
+    finalize_tool_calls,
+)
+from .base import ReasoningEffort, StreamEvent
+
+logger = logging.getLogger(__name__)
+
+# Public xAI endpoint — kept module-level so tests can monkeypatch it.
+# The OpenAI SDK appends ``/chat/completions`` when ``base_url`` ends
+# with ``/v1``, matching the path documented at
+# https://docs.x.ai/docs/api-reference.
+XAI_BASE_URL = "https://api.x.ai/v1"
+
+
+def _resolve_xai_api_key(workspace_id: uuid.UUID | None) -> str:
+    """Resolve the xAI API key for this request.
+
+    Workspace overrides win over the gateway-global ``settings.xai_api_key``;
+    :func:`resolve_api_key` already performs that fallback, so callers
+    never need an ``or settings.xai_api_key`` suffix.
+    """
+    if workspace_id is not None:
+        return resolve_api_key(workspace_id, "XAI_API_KEY") or ""
+    return settings.xai_api_key
+
+
+async def _open_xai_stream(
+    *,
+    client: AsyncOpenAI,
+    model_id: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> AsyncStream[ChatCompletionChunk]:
+    """Open the streaming chat-completions call against xAI.
+
+    The openai SDK declares ``messages`` and ``tools`` as unions of
+    TypedDicts; our wire dicts match the runtime contract but mypy
+    can't narrow a dynamically-built ``dict[str, Any]`` into the
+    union variant.  We narrow at this single SDK seam — never to
+    ``Any`` (forbidden by the project mypy config).  Splitting the
+    ``stream=True`` overload into two literal branches keeps mypy from
+    widening the return to ``ChatCompletion | AsyncStream[...]``.
+    """
+    typed_messages = cast("list[ChatCompletionMessageParam]", messages)
+    if tools is None:
+        return await client.chat.completions.create(
+            model=model_id,
+            messages=typed_messages,
+            stream=True,
+        )
+    typed_tools = cast("list[ChatCompletionToolUnionParam]", tools)
+    return await client.chat.completions.create(
+        model=model_id,
+        messages=typed_messages,
+        tools=typed_tools,
+        stream=True,
+    )
+
+
+def make_xai_stream_fn(
+    model_id: str,
+    workspace_id: uuid.UUID | None = None,
+    *,
+    system_prompt: str,
+) -> StreamFn:
+    """Build a :data:`StreamFn` backed by xAI's OpenAI-compatible API.
+
+    Args:
+        model_id: xAI model identifier (e.g. ``"grok-4.3"``).  Passed
+            straight through to the chat-completions endpoint.
+        workspace_id: Active workspace UUID, used to honour a
+            per-workspace ``XAI_API_KEY`` override.  ``None`` falls back
+            to the gateway-global ``settings.xai_api_key``.
+        system_prompt: System prompt for this StreamFn.  Captured into
+            the returned closure and prepended as a ``role="system"``
+            entry on every call.  ``XaiLLM.stream`` builds a fresh
+            StreamFn per request so the workspace-assembled prompt
+            (SOUL.md + AGENTS.md + skills) is what the model sees.
+
+    Returns:
+        An async generator factory that yields ``LLMEvent`` instances.
+        The factory is provider-specific; the surrounding
+        :func:`agent_loop` is not.
+    """
+
+    async def stream_fn(
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+    ) -> AsyncIterator[LLMEvent]:
+        api_key = _resolve_xai_api_key(workspace_id)
+        client = AsyncOpenAI(api_key=api_key, base_url=XAI_BASE_URL)
+        request_messages = build_xai_messages(messages, system_prompt)
+        xai_tools = build_xai_tool_declarations(tools)
+        aggregate = ChunkAggregate()
+
+        try:
+            stream = await _open_xai_stream(
+                client=client,
+                model_id=model_id,
+                messages=request_messages,
+                tools=xai_tools,
+            )
+            async for chunk in stream:
+                text_delta = absorb_chunk(chunk, aggregate)
+                if text_delta:
+                    yield LLMTextDeltaEvent(type="text_delta", text=text_delta)
+        except Exception as exc:
+            logger.error("xAI streaming error model=%s: %s", model_id, exc, exc_info=True)
+            error_text = f"xAI error: {exc}"
+            yield LLMTextDeltaEvent(type="text_delta", text=error_text)
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="error",
+                content=[TextContent(type="text", text=error_text)],
+            )
+            return
+
+        # Emit the assembled tool calls (if any) before the terminal
+        # ``done`` event so the agent loop can dispatch them.  Ordering
+        # by buffer index keeps the model's intended call sequence stable.
+        completed_tool_calls = finalize_tool_calls(aggregate)
+        for tc in completed_tool_calls:
+            yield LLMToolCallEvent(
+                type="tool_call",
+                tool_call_id=tc["tool_call_id"],
+                name=tc["name"],
+                arguments=tc["arguments"],
+            )
+        yield done_event_for(aggregate, completed_tool_calls)
+
+    return stream_fn
+
+
+class XaiLLM:
+    """AILLM backed by the agent_loop + an xAI StreamFn.
+
+    History is supplied by the caller (read from the Message table in
+    ``api/chat.py``).  Tools are injected per-request via the
+    :class:`AgentContext`, never composed inside the provider — see
+    ``.claude/rules/architecture/no-tools-in-providers.md``.
+    """
+
+    def __init__(self, model_id: str, *, workspace_id: uuid.UUID | None = None) -> None:
+        """Construct an xAI provider bound to a specific model slug.
+
+        Args:
+            model_id: Bare xAI model identifier (e.g. ``"grok-4.3"``).
+                The factory unwraps the canonical
+                ``host:vendor/model`` form before constructing the
+                provider.
+            workspace_id: Active workspace UUID, optional.  When
+                supplied, a per-workspace ``XAI_API_KEY`` override is
+                honoured; otherwise the gateway-global key is used.
+                Optional to match :class:`ClaudeLLM` and
+                :class:`GeminiLLM` for unauthenticated callers.
+        """
+        self._model_id = model_id
+        self._workspace_id = workspace_id
+        # ``_stream_fn`` is ``None`` in production; ``stream()`` builds
+        # a fresh StreamFn per request so the per-request system prompt
+        # is captured into the closure.  Tests monkeypatch this
+        # attribute with a :class:`ScriptedStreamFn` — when set,
+        # ``stream()`` honours the injection as-is.  See
+        # ``.claude/rules/testing/agent-loop-testing-philosophy.md``.
+        self._stream_fn: StreamFn | None = None
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+        tools: list[AgentTool] | None = None,
+        system_prompt: str | None = None,
+        reasoning_effort: ReasoningEffort | None = None,
+        permission_check: PermissionCheckFn | None = None,
+        images: list[dict[str, str]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Run the agent loop and translate AgentEvents → StreamEvents.
+
+        Args:
+            question: The current user message.
+            conversation_id: Used for logging only; xAI's
+                OpenAI-compatible API has no native session concept.
+            user_id: Authenticated user UUID (used for logging).
+            history: Prior messages oldest-first as ``{role, content}``
+                dicts.  Mapped onto :class:`UserMessage` /
+                :class:`AssistantMessage` instances.
+            tools: Optional list of cross-provider :class:`AgentTool`
+                instances assembled by the chat router.
+            system_prompt: System prompt for this turn.  ``None`` falls
+                back to :data:`DEFAULT_AGENT_SYSTEM_PROMPT` so bare
+                unit tests still work.
+            reasoning_effort: Accepted for protocol parity.  Grok 4.3
+                does not surface a reasoning-effort knob via the
+                OpenAI-compatible endpoint, so the value is ignored.
+            permission_check: Optional cross-provider permission gate
+                (PR 03b).  Threaded straight into
+                :class:`AgentLoopConfig` so denial flows through the
+                same code path Gemini and Claude use.
+            images: Optional multimodal image inputs.  Accepted for
+                protocol parity; not yet bridged to xAI's image-input
+                shape (a non-empty list is logged and ignored so
+                callers can switch on it without a runtime error).
+        """
+        if images:
+            logger.debug(
+                "XAI_IMAGES_IGNORED conversation_id=%s count=%d",
+                conversation_id,
+                len(images),
+            )
+        if reasoning_effort is not None:
+            logger.debug(
+                "XAI_REASONING_EFFORT_IGNORED conversation_id=%s value=%s",
+                conversation_id,
+                reasoning_effort,
+            )
+
+        prior: list[AgentMessage] = []
+        for m in history or []:
+            role = m.get("role")
+            content = m.get("content", "")
+            if role == "user":
+                prior.append(UserMessage(role="user", content=content))
+            elif role == "assistant":
+                prior.append(
+                    AssistantMessage(
+                        role="assistant",
+                        content=[TextContent(type="text", text=content)],
+                        stop_reason="stop",
+                    )
+                )
+
+        context = AgentContext(
+            system_prompt=system_prompt or _FALLBACK_SYSTEM_PROMPT,
+            messages=prior,
+            tools=list(tools or []),
+        )
+        prompt = UserMessage(role="user", content=question)
+        config = AgentLoopConfig(
+            convert_to_llm=identity_convert,
+            safety=safety_from_settings(settings),
+            permission_check=permission_check,
+        )
+
+        stream_fn = self._stream_fn or make_xai_stream_fn(
+            self._model_id,
+            self._workspace_id,
+            system_prompt=context.system_prompt,
+        )
+
+        try:
+            async for event in agent_loop([prompt], context, config, stream_fn):
+                stream_event = agent_event_to_stream_event(event)
+                if stream_event is not None:
+                    yield stream_event
+
+        except Exception as exc:
+            yield StreamEvent(type="error", content=f"xAI provider error: {exc}")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,16 +30,18 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-logging>=0.50b0",
     "markitdown[all]>=0.1.1",
+    "openai>=1.0.0",
 ]
 
 # Optional voice transcription backends (PR 14). The ``api/stt.py``
 # xAI proxy is in the core dependencies; these are needed only when
 # ``VOICE_PROVIDER`` is ``mistral`` or ``openai``. Local whisper.cpp
 # uses subprocess calls and needs no Python package.
+# ``openai`` itself is now a core dep (powers the xAI chat provider via
+# OpenAI-compatible base_url) so it's not listed here.
 [project.optional-dependencies]
 voice = [
     "mistralai>=1.0.0",
-    "openai>=1.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_model_id.py
+++ b/backend/tests/test_model_id.py
@@ -36,6 +36,15 @@ def test_parse_google_canonical_host() -> None:
     assert parsed.host is Host.google_ai
 
 
+def test_parse_xai_canonical_host() -> None:
+    """``xai/grok-4.3`` canonicalises to ``xai:xai/grok-4.3``."""
+    parsed = parse_model_id("xai/grok-4.3")
+    assert parsed.host is Host.xai
+    assert parsed.vendor is Vendor.xai
+    assert parsed.model == "grok-4.3"
+    assert parsed.id == "xai:xai/grok-4.3"
+
+
 def test_id_property_round_trips_through_parse() -> None:
     canonical = "agent-sdk:anthropic/claude-sonnet-4-6"
     assert parse_model_id(canonical).id == canonical

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -36,6 +36,8 @@ from app.core.providers._xai_stream import parse_tool_arguments
 from app.core.providers.xai_provider import (
     XAI_BASE_URL,
     XaiLLM,
+    _build_xai_extra_body,
+    _map_reasoning_effort,
     _resolve_xai_api_key,
     make_xai_stream_fn,
 )
@@ -332,6 +334,10 @@ async def test_stream_fn_request_payload_includes_system_and_tools(
     assert kwargs["stream"] is True
     assert kwargs["messages"][0] == {"role": "system", "content": "custom-sys"}
     assert kwargs["tools"] is not None
+    # Live Search must be disabled by default: pawrrtal uses exa_search
+    # as the canonical web tool and we don't want xAI double-billing or
+    # ghost-searching every turn.  See ``_LIVE_SEARCH_DISABLED``.
+    assert kwargs["extra_body"]["search_parameters"] == {"mode": "off"}
     assert kwargs["tools"][0]["function"]["name"] == "ping"
 
 
@@ -406,3 +412,98 @@ async def test_done_assistant_blocks_include_unstreamed_text_and_tool_calls(
     assert len(tool_blocks) == 1
     assert tool_blocks[0]["name"] == "echo"
     assert tool_blocks[0]["arguments"] == {"value": "hi"}
+
+
+# ---------------------------------------------------------------------------
+# xAI-specific extensions: reasoning_effort + reasoning_content + Live Search
+# ---------------------------------------------------------------------------
+
+
+def test_map_reasoning_effort_collapses_four_levels_to_two() -> None:
+    """Pawrrtal's four-level UI knob → grok-4.3's two-level enum.
+
+    grok-4.3 rejects anything other than ``"low"`` or ``"high"``
+    (https://docs.x.ai/docs/models/grok-4-3), so the mapper has to
+    collapse ``medium``/``extra-high`` rather than pass them through.
+    """
+    assert _map_reasoning_effort(None) is None
+    assert _map_reasoning_effort("low") == "low"
+    assert _map_reasoning_effort("medium") == "low"
+    assert _map_reasoning_effort("high") == "high"
+    assert _map_reasoning_effort("extra-high") == "high"
+
+
+def test_build_xai_extra_body_always_disables_live_search() -> None:
+    """search_parameters.mode is always ``off`` regardless of effort."""
+    assert _build_xai_extra_body(None) == {"search_parameters": {"mode": "off"}}
+    assert _build_xai_extra_body("low") == {
+        "search_parameters": {"mode": "off"},
+        "reasoning_effort": "low",
+    }
+    assert _build_xai_extra_body("high") == {
+        "search_parameters": {"mode": "off"},
+        "reasoning_effort": "high",
+    }
+
+
+@pytest.mark.anyio
+async def test_stream_fn_forwards_mapped_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reasoning_effort='extra-high'`` lands as ``'high'`` in extra_body."""
+    fake = _FakeClient([_delta(finish="stop")])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn(
+        "grok-4.3", None, system_prompt="sys", reasoning_effort="extra-high"
+    )
+    async for _ in stream_fn([], []):
+        pass
+
+    kwargs = fake.chat.completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["extra_body"]["reasoning_effort"] == "high"
+    assert kwargs["extra_body"]["search_parameters"] == {"mode": "off"}
+
+
+@pytest.mark.anyio
+async def test_stream_fn_emits_thinking_deltas_from_reasoning_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """xAI's ``delta.reasoning_content`` surfaces as ``thinking_delta`` events.
+
+    Mirrors the Gemini regression test for issue #98 — without this
+    wiring the frontend's thinking pane is empty for Grok even though
+    grok-4.3 streams its chain-of-thought back on every reasoning turn.
+    """
+    # ``ChoiceDelta`` has ``extra='allow'``; the openai SDK preserves
+    # ``reasoning_content`` on unknown-field deltas via Pydantic.  We
+    # mimic that here so the test stays decoupled from the SDK's
+    # internal mutation API.
+    thinking_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None,
+                    tool_calls=None,
+                    reasoning_content="Let me think... 2 + 2 = 4.",
+                ),
+                finish_reason=None,
+                index=0,
+            )
+        ]
+    )
+    answer_chunk = _delta(content="4", finish="stop")
+    fake = _FakeClient([thinking_chunk, answer_chunk])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+
+    thinking_events = [e for e in events if e["type"] == "thinking_delta"]
+    text_events = [e for e in events if e["type"] == "text_delta"]
+    assert any("2 + 2 = 4" in e["text"] for e in thinking_events)
+    # Reasoning content must NOT bleed into the regular text stream — the
+    # frontend renders text_delta in the assistant transcript.
+    assert not any("Let me think" in e["text"] for e in text_events)
+    assert any(e["text"] == "4" for e in text_events)

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -1,0 +1,408 @@
+"""Unit tests for xAI provider request/response translation helpers.
+
+These exercise the small pure helpers that turn ``AgentMessage`` lists
+and openai-SDK streaming chunks into the OpenAI wire shape (and back).
+They do NOT hit the agent loop — that path is covered by
+``test_xai_stream_fn.py`` via ``ScriptedStreamFn``.  Splitting the
+concerns keeps each test focused: the helpers only do shape
+translation, so they should be testable without booting the loop.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.core.agent_loop.types import (
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    TextContent,
+    ToolCallContent,
+    ToolResultContent,
+    ToolResultMessage,
+    UserMessage,
+)
+from app.core.providers._xai_messages import (
+    build_xai_messages,
+    build_xai_tool_declarations,
+)
+from app.core.providers._xai_stream import parse_tool_arguments
+from app.core.providers.xai_provider import (
+    XAI_BASE_URL,
+    XaiLLM,
+    _resolve_xai_api_key,
+    make_xai_stream_fn,
+)
+
+
+def _delta(
+    *,
+    content: str | None = None,
+    tool_calls: list[Any] | None = None,
+    finish: str | None = None,
+) -> SimpleNamespace:
+    """Shape a ``ChatCompletionChunk``-like fake the provider can iterate."""
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish, index=0)
+    return SimpleNamespace(choices=[choice])
+
+
+def _tc_delta(
+    *,
+    index: int,
+    tc_id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+) -> SimpleNamespace:
+    """Fake one ``ChoiceDeltaToolCall`` fragment."""
+    fn = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=fn)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_tool_declarations_returns_none_when_empty() -> None:
+    """No tools → None (not []) so we skip the param entirely on the wire."""
+    assert build_xai_tool_declarations([]) is None
+
+
+def test_build_tool_declarations_wraps_each_tool_in_function_shape() -> None:
+    """Each AgentTool becomes one ``{"type":"function", "function": ...}`` entry."""
+
+    async def _execute(_call_id: str, **_kwargs: Any) -> str:
+        return ""
+
+    tool = AgentTool(
+        name="search",
+        description="Search the web",
+        parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        execute=_execute,
+    )
+
+    declarations = build_xai_tool_declarations([tool])
+
+    assert declarations is not None
+    assert declarations == [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search the web",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+
+def test_build_xai_messages_prepends_system_prompt() -> None:
+    """The system prompt becomes the first ``role="system"`` entry."""
+    msgs = build_xai_messages(
+        [UserMessage(role="user", content="hello")],
+        system_prompt="you are helpful",
+    )
+    assert msgs[0] == {"role": "system", "content": "you are helpful"}
+    assert msgs[1] == {"role": "user", "content": "hello"}
+
+
+def test_build_xai_messages_translates_assistant_with_tool_calls() -> None:
+    """An assistant turn splits text + tool calls into the OpenAI shape."""
+    assistant = AssistantMessage(
+        role="assistant",
+        content=[
+            TextContent(type="text", text="searching..."),
+            ToolCallContent(
+                type="toolCall",
+                tool_call_id="tc-1",
+                name="search",
+                arguments={"q": "pawrrtal"},
+            ),
+        ],
+        stop_reason="tool_use",
+    )
+    msgs = build_xai_messages([assistant], system_prompt="sys")
+    # Index 0 is the system prompt; index 1 is the assistant turn.
+    entry = msgs[1]
+    assert entry["role"] == "assistant"
+    assert entry["content"] == "searching..."
+    assert entry["tool_calls"] == [
+        {
+            "id": "tc-1",
+            "type": "function",
+            "function": {"name": "search", "arguments": json.dumps({"q": "pawrrtal"})},
+        }
+    ]
+
+
+def test_build_xai_messages_assistant_without_text_uses_none_content() -> None:
+    """An assistant turn that's only tool_calls still wires content=None."""
+    assistant = AssistantMessage(
+        role="assistant",
+        content=[
+            ToolCallContent(type="toolCall", tool_call_id="tc-2", name="ping", arguments={}),
+        ],
+        stop_reason="tool_use",
+    )
+    msgs = build_xai_messages([assistant], system_prompt="sys")
+    entry = msgs[1]
+    assert entry["content"] is None
+    assert entry["tool_calls"][0]["function"]["name"] == "ping"
+
+
+def test_build_xai_messages_translates_tool_result() -> None:
+    """A toolResult message renders into OpenAI's ``role="tool"`` entry."""
+    msg = ToolResultMessage(
+        role="toolResult",
+        tool_call_id="tc-1",
+        name="search",
+        content=[
+            ToolResultContent(type="text", text="line 1"),
+            ToolResultContent(type="text", text="line 2"),
+        ],
+        is_error=False,
+    )
+    msgs = build_xai_messages([msg], system_prompt="sys")
+    assert msgs[1] == {
+        "role": "tool",
+        "tool_call_id": "tc-1",
+        "content": "line 1\nline 2",
+    }
+
+
+def test_parse_tool_arguments_handles_empty_and_invalid() -> None:
+    """Empty string → empty dict; bad JSON → empty dict with a warning."""
+    assert parse_tool_arguments("", "ping") == {}
+    assert parse_tool_arguments('{"x": 1}', "ping") == {"x": 1}
+    # Invalid JSON should fall back to empty, not raise.
+    assert parse_tool_arguments("{not json", "ping") == {}
+
+
+def test_resolve_xai_api_key_uses_settings_when_no_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No workspace_id → use the gateway-global key from Settings."""
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.settings",
+        SimpleNamespace(xai_api_key="gateway-key"),
+    )
+    assert _resolve_xai_api_key(None) == "gateway-key"
+
+
+def test_resolve_xai_api_key_workspace_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """workspace_id present → delegate to resolve_api_key (mocked)."""
+    workspace_id = uuid4()
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.resolve_api_key",
+        lambda wid, key: "workspace-key" if (wid, key) == (workspace_id, "XAI_API_KEY") else None,
+    )
+    assert _resolve_xai_api_key(workspace_id) == "workspace-key"
+
+
+# ---------------------------------------------------------------------------
+# StreamFn integration with a fake openai client
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Async-iterable wrapper around a list of chunk fakes."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[Any]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeCompletions:
+    """Captures the kwargs the provider passes to ``chat.completions.create``."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = chunks
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _FakeStream:
+        self.last_kwargs = kwargs
+        return _FakeStream(self._chunks)
+
+
+class _FakeClient:
+    """Replaces ``AsyncOpenAI`` so no network call happens during tests."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self.chat = SimpleNamespace(completions=_FakeCompletions(chunks))
+
+
+@pytest.mark.anyio
+async def test_stream_fn_assembles_tool_call_from_streamed_fragments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streamed tool-call arg fragments are accumulated into one LLMToolCallEvent."""
+    chunks = [
+        _delta(content="thinking..."),
+        _delta(
+            tool_calls=[
+                _tc_delta(index=0, tc_id="call-1", name="search", arguments='{"q":'),
+            ]
+        ),
+        _delta(tool_calls=[_tc_delta(index=0, arguments=' "grok"')]),
+        _delta(tool_calls=[_tc_delta(index=0, arguments="}")]),
+        _delta(finish="tool_calls"),
+    ]
+    fake = _FakeClient(chunks)
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+
+    text_events = [e for e in events if e["type"] == "text_delta"]
+    tool_events = [e for e in events if e["type"] == "tool_call"]
+    done_events = [e for e in events if e["type"] == "done"]
+
+    assert [e["text"] for e in text_events] == ["thinking..."]
+    assert len(tool_events) == 1
+    assert tool_events[0]["name"] == "search"
+    assert tool_events[0]["arguments"] == {"q": "grok"}
+    assert tool_events[0]["tool_call_id"] == "call-1"
+
+    assert len(done_events) == 1
+    done = done_events[0]
+    assert done["stop_reason"] == "tool_use"
+    assert any(b["type"] == "toolCall" for b in done["content"])
+
+
+@pytest.mark.anyio
+async def test_stream_fn_plain_text_turn_emits_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pure-text turn ends with ``stop_reason='stop'`` and one text block."""
+    chunks = [_delta(content="hi"), _delta(content=" there"), _delta(finish="stop")]
+    fake = _FakeClient(chunks)
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+
+    assert events[-1]["type"] == "done"
+    assert events[-1]["stop_reason"] == "stop"
+    assert events[-1]["content"] == [TextContent(type="text", text="hi there")]
+
+
+@pytest.mark.anyio
+async def test_stream_fn_request_payload_includes_system_and_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The request kwargs carry the system prompt and tool declarations."""
+    fake = _FakeClient([_delta(finish="stop")])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    async def _execute(_call_id: str, **_kwargs: Any) -> str:
+        return ""
+
+    tool = AgentTool(
+        name="ping",
+        description="ping",
+        parameters={"type": "object", "properties": {}},
+        execute=_execute,
+    )
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="custom-sys")
+    async for _ in stream_fn([UserMessage(role="user", content="hello")], [tool]):
+        pass
+
+    kwargs = fake.chat.completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "grok-4.3"
+    assert kwargs["stream"] is True
+    assert kwargs["messages"][0] == {"role": "system", "content": "custom-sys"}
+    assert kwargs["tools"] is not None
+    assert kwargs["tools"][0]["function"]["name"] == "ping"
+
+
+@pytest.mark.anyio
+async def test_stream_fn_surfaces_upstream_error_as_done_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception raised by the SDK becomes a graceful error ``done`` event."""
+
+    class _ExplodingCompletions:
+        async def create(self, **_kwargs: Any) -> Any:
+            raise RuntimeError("upstream 503")
+
+    class _ExplodingClient:
+        chat = SimpleNamespace(completions=_ExplodingCompletions())
+
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.AsyncOpenAI",
+        lambda **_kwargs: _ExplodingClient(),
+    )
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+
+    text = next(e for e in events if e["type"] == "text_delta")
+    done = next(e for e in events if e["type"] == "done")
+    assert "upstream 503" in text["text"]
+    assert done["stop_reason"] == "error"
+
+
+def test_xai_base_url_points_at_xai_v1() -> None:
+    """Regression guard: ensure we never accidentally hit api.openai.com."""
+    assert XAI_BASE_URL == "https://api.x.ai/v1"
+
+
+def test_provider_class_construction_records_model_and_workspace() -> None:
+    """Smoke check the class shape (the chat router constructs the provider)."""
+    workspace = uuid4()
+    provider = XaiLLM("grok-4.3", workspace_id=workspace)
+    # No public getters — assert via private slots since this is an internal contract.
+    assert provider._model_id == "grok-4.3"
+    assert provider._workspace_id == workspace
+
+
+@pytest.mark.anyio
+async def test_done_assistant_blocks_include_unstreamed_text_and_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMDoneEvent.content lists every text + tool-call block from the turn."""
+    chunks = [
+        _delta(content="ack"),
+        _delta(
+            tool_calls=[
+                _tc_delta(index=0, tc_id="call-A", name="echo", arguments='{"value":"hi"}'),
+            ]
+        ),
+        _delta(finish="tool_calls"),
+    ]
+    fake = _FakeClient(chunks)
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+
+    done = next(e for e in events if e["type"] == "done")
+    assert isinstance(done, dict)
+    # Narrow for the type checker so mypy understands the union shape.
+    done_event: LLMDoneEvent = done  # type: ignore[assignment]
+    text_blocks = [b for b in done_event["content"] if b["type"] == "text"]
+    tool_blocks = [b for b in done_event["content"] if b["type"] == "toolCall"]
+    assert [b["text"] for b in text_blocks] == ["ack"]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0]["name"] == "echo"
+    assert tool_blocks[0]["arguments"] == {"value": "hi"}

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -507,3 +507,175 @@ async def test_stream_fn_emits_thinking_deltas_from_reasoning_content(
     # frontend renders text_delta in the assistant transcript.
     assert not any("Let me think" in e["text"] for e in text_events)
     assert any(e["text"] == "4" for e in text_events)
+
+
+# ---------------------------------------------------------------------------
+# Cost tracking: usage capture + terminal StreamEvent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stream_fn_requests_include_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stream_options.include_usage=True`` is on every request.
+
+    Without it xAI never emits the ``usage`` block and the cost ledger
+    sees zero for every Grok turn.
+    """
+    fake = _FakeClient([_delta(finish="stop")])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    async for _ in stream_fn([], []):
+        pass
+
+    kwargs = fake.chat.completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.anyio
+async def test_stream_fn_accumulates_usage_from_final_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final chunk's ``usage`` block lands on the shared accumulator.
+
+    xAI emits one ``usage`` block per request on the chunk just before
+    ``[DONE]``; the StreamFn must read both the OpenAI-standard names
+    (``prompt_tokens``/``completion_tokens``) and the xAI extras
+    (``cost_in_usd_ticks``) and convert ticks → USD at the documented
+    ``1e-10`` rate.
+    """
+    from app.core.providers._xai_stream import UsageAccumulator
+
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=120,
+            completion_tokens=45,
+            total_tokens=165,
+            cost_in_usd_ticks=4_250_000_000,  # 0.000425 USD
+        ),
+    )
+    chunks = [_delta(content="hi"), _delta(finish="stop"), usage_chunk]
+    fake = _FakeClient(chunks)
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    sink = UsageAccumulator()
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys", usage_sink=sink)
+    async for _ in stream_fn([], []):
+        pass
+
+    assert sink.saw_any
+    assert sink.input_tokens == 120
+    assert sink.output_tokens == 45
+    # 4_250_000_000 ticks * 1e-10 USD/tick = 0.425 USD.
+    assert sink.cost_usd == pytest.approx(0.425, abs=1e-9)
+
+
+@pytest.mark.anyio
+async def test_stream_fn_accumulator_reads_xai_naming_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``input_tokens``/``output_tokens`` (xAI naming) is read if OpenAI names missing.
+
+    The Chat Completions endpoint uses the OpenAI names by default, but
+    xAI's own SDK proto uses ``input_tokens``/``output_tokens`` — guard
+    against an endpoint variant that emits the latter only.
+    """
+    from app.core.providers._xai_stream import UsageAccumulator
+
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20, cost_in_usd_ticks=0),
+    )
+    fake = _FakeClient([_delta(finish="stop"), usage_chunk])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    sink = UsageAccumulator()
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys", usage_sink=sink)
+    async for _ in stream_fn([], []):
+        pass
+
+    assert sink.input_tokens == 10
+    assert sink.output_tokens == 20
+    assert sink.cost_usd == 0.0
+
+
+@pytest.mark.anyio
+async def test_xai_provider_emits_terminal_usage_stream_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``XaiLLM.stream`` emits ``StreamEvent(type='usage', ...)`` after agent_loop.
+
+    The chat aggregator folds this into the cost ledger via
+    :func:`record_turn_cost_if_enabled`, same shape as Claude's
+    ``_build_usage_event``.  Real ``agent_loop`` runs end-to-end with a
+    fake :class:`AsyncOpenAI` that emits a text chunk plus a final
+    usage chunk — exercising the actual ``stream_options.include_usage``
+    code path, not a patched factory.
+    """
+    from app.core.providers.xai_provider import XaiLLM
+
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=42,
+            completion_tokens=17,
+            total_tokens=59,
+            cost_in_usd_ticks=1_234_000,  # 1.234e-4 USD
+        ),
+    )
+    fake = _FakeClient([_delta(content="hi"), _delta(finish="stop"), usage_chunk])
+    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    provider = XaiLLM("grok-4.3")
+    events = [
+        e
+        async for e in provider.stream(
+            question="Hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+        )
+    ]
+
+    usage_events = [e for e in events if e["type"] == "usage"]
+    assert len(usage_events) == 1
+    usage_event = usage_events[0]
+    assert usage_event["input_tokens"] == 42
+    assert usage_event["output_tokens"] == 17
+    assert usage_event["cost_usd"] == pytest.approx(1.234e-4, abs=1e-12)
+    # Must arrive after the text delta the model produced — the cost
+    # ledger row is finalised once the user-visible reply is on the wire.
+    assert events.index(usage_event) > events.index(next(e for e in events if e["type"] == "delta"))
+
+
+@pytest.mark.anyio
+async def test_xai_provider_skips_usage_event_when_no_chunk_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no chunk carries usage (early failure, test stream), no usage event fires.
+
+    Stops spurious zero-cost rows in the ledger.
+    """
+    from app.core.providers.xai_provider import XaiLLM
+    from tests.agent_harness import ScriptedStreamFn, text_turn
+
+    # Real ScriptedStreamFn — no real chunks, so usage_sink never sees
+    # a ``usage`` field.
+    provider = XaiLLM("grok-4.3")
+    monkeypatch.setattr(provider, "_stream_fn", ScriptedStreamFn([text_turn("hi")]))
+
+    events = [
+        e
+        async for e in provider.stream(
+            question="Hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+        )
+    ]
+
+    assert not any(e["type"] == "usage" for e in events)

--- a/backend/tests/test_xai_stream_fn.py
+++ b/backend/tests/test_xai_stream_fn.py
@@ -1,0 +1,279 @@
+"""Tests for XaiLLM's StreamFn wiring into agent_loop.
+
+Uses ``ScriptedStreamFn`` from ``tests.agent_harness`` per
+``.claude/rules/testing/agent-loop-testing-philosophy.md`` — no real
+xAI API calls are made.  These tests exercise the provider's
+translation layer (AgentEvent → StreamEvent) and confirm that safety
+config flows end-to-end from ``safety_from_settings`` through
+``agent_loop`` to the SSE output, mirroring the Gemini test suite so
+parity is verified, not asserted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+
+from app.core.agent_loop.types import (
+    AgentMessage,
+    AgentTool,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    LLMToolCallEvent,
+    TextContent,
+    ToolCallContent,
+)
+from app.core.providers.base import StreamEvent
+from tests.agent_harness import (
+    ScriptedStreamFn,
+    echo_tool,
+    text_turn,
+    tool_call_turn,
+)
+
+
+@pytest.mark.anyio
+async def test_xai_provider_yields_delta_events_from_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XaiLLM.stream() translates agent_loop text_deltas to StreamEvent deltas."""
+    from app.core.providers.xai_provider import XaiLLM
+
+    provider = XaiLLM("grok-test")
+    monkeypatch.setattr(provider, "_stream_fn", ScriptedStreamFn([text_turn("hello")]))
+
+    events: list[StreamEvent] = [
+        event
+        async for event in provider.stream(
+            question="Hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+        )
+    ]
+
+    delta_events = [e for e in events if e["type"] == "delta"]
+    assert len(delta_events) >= 1
+    assert any("hello" in e.get("content", "") for e in delta_events)
+
+
+@pytest.mark.anyio
+async def test_xai_provider_passes_history_to_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prior messages in history are included in what the StreamFn sees."""
+    from app.core.providers.xai_provider import XaiLLM
+
+    seen_messages: list[list[AgentMessage]] = []
+
+    async def recording_stream_fn(
+        messages: list[AgentMessage], tools: list[AgentTool]
+    ) -> AsyncIterator[LLMEvent]:
+        seen_messages.append(list(messages))
+        yield LLMTextDeltaEvent(type="text_delta", text="ok")
+        yield LLMDoneEvent(
+            type="done",
+            stop_reason="stop",
+            content=[TextContent(type="text", text="ok")],
+        )
+
+    provider = XaiLLM("grok-test")
+    monkeypatch.setattr(provider, "_stream_fn", recording_stream_fn)
+
+    history = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "4"},
+    ]
+
+    async for _ in provider.stream(
+        question="And 3+3?",
+        conversation_id=uuid4(),
+        user_id=uuid4(),
+        history=history,
+    ):
+        pass
+
+    assert len(seen_messages) == 1
+    # 2 history messages + current question = 3 total visible to the LLM.
+    assert len(seen_messages[0]) == 3
+
+
+@pytest.mark.anyio
+async def test_xai_provider_emits_tool_use_and_result_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tool call lifecycle events translate from AgentEvents to StreamEvents."""
+    from app.core.providers.xai_provider import XaiLLM
+
+    executed: list[str] = []
+
+    async def echo_execute(tool_call_id: str, **kwargs: object) -> str:
+        executed.append(str(kwargs.get("value", "")))
+        return f"echoed: {kwargs.get('value', '')}"
+
+    from app.core.tools.display import make_tool_display
+
+    echo = AgentTool(
+        name="echo",
+        description="Echo",
+        parameters={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+        execute=echo_execute,
+        display=make_tool_display(
+            icon="🔁",
+            label="Echo",
+            present=lambda args: f"🔁 Echoing {args['value']}",
+            compact=lambda args: f"Echo -> {args['value']}",
+        ),
+    )
+
+    provider = XaiLLM("grok-test")
+    monkeypatch.setattr(
+        provider,
+        "_stream_fn",
+        ScriptedStreamFn(
+            [
+                tool_call_turn("echo", {"value": "hi"}, turn_id="tc-0"),
+                text_turn("Done!"),
+            ]
+        ),
+    )
+
+    events: list[StreamEvent] = [
+        event
+        async for event in provider.stream(
+            question="Echo hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+            tools=[echo],
+        )
+    ]
+
+    assert executed == ["hi"]
+    tool_use = next(e for e in events if e["type"] == "tool_use")
+    assert tool_use["input"] == {"value": "hi"}
+    assert tool_use["display"] == {
+        "icon": "🔁",
+        "label": "Echo",
+        "present": "🔁 Echoing hi",
+        "compact": "Echo -> hi",
+    }
+    assert any(e["type"] == "tool_result" for e in events)
+    assert any(e["type"] == "delta" and "Done!" in e.get("content", "") for e in events)
+
+
+@pytest.mark.anyio
+async def test_xai_provider_surfaces_agent_terminated_from_safety_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """safety_from_settings flows through XaiLLM to agent_loop."""
+    from app.core.agent_loop import AgentSafetyConfig
+    from app.core.providers.xai_provider import XaiLLM
+
+    turns = [tool_call_turn("ping", {}, turn_id=f"tc-{i}") for i in range(10)]
+    script = ScriptedStreamFn(turns)
+
+    provider = XaiLLM("grok-test")
+    monkeypatch.setattr(provider, "_stream_fn", script)
+
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.safety_from_settings",
+        lambda _settings: AgentSafetyConfig(
+            max_iterations=3,
+            max_wall_clock_seconds=None,
+            max_consecutive_llm_errors=None,
+            max_consecutive_tool_errors=None,
+        ),
+    )
+
+    events: list[StreamEvent] = [
+        event
+        async for event in provider.stream(
+            question="go",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+            tools=[echo_tool("ping")],
+        )
+    ]
+
+    terminated = [e for e in events if e["type"] == "agent_terminated"]
+    assert len(terminated) == 1
+    assert "max_iterations" in terminated[0]["content"]
+    # The script was cut short — no more than 3 LLM calls.
+    assert script.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_xai_provider_accumulates_tool_result_in_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each LLM turn receives more messages than the previous one.
+
+    Proves the tool-result message accumulates in the loop's context
+    even though xAI itself has no native session concept.
+    """
+    from app.core.providers.xai_provider import XaiLLM
+
+    seen_per_call: list[int] = []
+    second_call_roles: list[str] = []
+    turn_counter: list[int] = [0]
+
+    async def recording_fn(
+        messages: list[AgentMessage], tools: list[AgentTool]
+    ) -> AsyncIterator[LLMEvent]:
+        idx = turn_counter[0]
+        turn_counter[0] += 1
+        seen_per_call.append(len(messages))
+        if idx == 1:
+            second_call_roles.extend(m["role"] for m in messages)
+
+        if idx == 0:
+            yield LLMToolCallEvent(
+                type="tool_call",
+                tool_call_id="tc-r",
+                name="echo",
+                arguments={"value": "ctx"},
+            )
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="tool_use",
+                content=[
+                    ToolCallContent(
+                        type="toolCall",
+                        tool_call_id="tc-r",
+                        name="echo",
+                        arguments={"value": "ctx"},
+                    )
+                ],
+            )
+        else:
+            yield LLMTextDeltaEvent(type="text_delta", text="done")
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="stop",
+                content=[TextContent(type="text", text="done")],
+            )
+
+    provider = XaiLLM("grok-test")
+    monkeypatch.setattr(provider, "_stream_fn", recording_fn)
+
+    async for _ in provider.stream(
+        question="go",
+        conversation_id=uuid4(),
+        user_id=uuid4(),
+        history=[],
+        tools=[echo_tool()],
+    ):
+        pass
+
+    assert len(seen_per_call) == 2
+    assert seen_per_call[1] > seen_per_call[0]
+    assert "toolResult" in second_call_roles

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2281,6 +2281,7 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "markitdown", extra = ["all"] },
     { name = "mcp" },
+    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -2299,7 +2300,6 @@ dependencies = [
 [package.optional-dependencies]
 voice = [
     { name = "mistralai" },
-    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -2328,7 +2328,7 @@ requires-dist = [
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.1" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "mistralai", marker = "extra == 'voice'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'voice'", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },


### PR DESCRIPTION
## Summary

Adds xAI's Grok 4.3 as a first-class chat provider alongside Claude and Gemini. Wraps xAI's OpenAI-compatible API (`https://api.x.ai/v1` — docs: https://docs.x.ai/docs/api-reference) so the agent loop drives Grok exactly the same way it drives Gemini.

Once merged, Grok 4.3 will appear in the model picker without any frontend change — the catalog flows through `GET /api/v1/models` and `useChatModels` already validates entries with Zod.

## What changed

**New provider surface** (mirrors `GeminiLLM` 1:1):
- `Vendor.xai` + `Host.xai` join the `model_id` enums; canonical wire form is `xai:xai/grok-4.3` (bare `xai/grok-4.3` canonicalises via `CANONICAL_HOST`).
- `MODEL_CATALOG` gains Grok 4.3 — $1.25 / $2.50 per 1M tokens, 1M context.
- `XaiLLM` builds a per-request `StreamFn` from the assembled system prompt, converts history → OpenAI `messages`, accumulates tool-call fragments across streamed deltas, and threads the same cross-provider permission gate + `safety_from_settings` config through `agent_loop`.
- `XAI_API_KEY` was already in `Settings` (powers `/api/v1/stt`); the chat path now also honours per-workspace overrides via `resolve_api_key`.

**Files** — `xai_provider.py` is split into `_xai_events` / `_xai_messages` / `_xai_stream` helpers so each stays under the 500-line budget.

**Dependencies** — `openai` moves from the voice-only extras into core deps (xAI is OpenAI-compatible, so the SDK's `base_url` override is the canonical integration path per the project's "check official docs first" rule). Voice extras keep `mistralai` only.

**Architecture preserved**:
- Provider stays tool-agnostic — passes `scripts/check-no-tools-in-providers.py`.
- mypy is satisfied without `cast(Any, ...)` (forbidden by project config) — the openai SDK boundary uses named-type casts (`ChatCompletionMessageParam`, `ChatCompletionToolUnionParam`).
- File-line, nesting, and ruff-complexity gates all green.
- import-linter contracts stay kept.

**Reasoning + multimodal** — accepted for protocol parity, ignored for now (Grok 4.3's OpenAI-compatible endpoint doesn't surface a reasoning-effort knob, and we haven't bridged xAI's image-input shape yet). Logged at DEBUG so callers can switch on the kwargs without a runtime error.

## Test plan

- [x] 5 new `ScriptedStreamFn` scenarios in `test_xai_stream_fn.py` — text deltas, history accumulation, tool-call lifecycle, safety termination, tool-result roundtripping. Mirrors `test_gemini_stream_fn.py` so parity is verified, not asserted.
- [x] 16 new translation / streaming-helper units in `test_xai_provider_translation.py` — message shape, tool declarations, tool-arg JSON parsing, key resolution, streamed tool-call fragment accumulation, error surfacing, request-payload composition.
- [x] `xai/grok-4.3` round-trip in `test_model_id.py`.
- [x] Existing `test_catalog.py` covers the new entry automatically.
- [x] Full backend suite: 893 passed, 1 skipped, 0 regressions.
- [x] `ruff check` clean, mypy clean on new files, `lint-imports` contracts kept.
- [ ] Live smoke against `https://api.x.ai/v1` with a real `XAI_API_KEY` — gated on someone with credentials; the test suite covers the SDK boundary via a `_FakeClient`.

https://claude.ai/code/session_01TTKYnNfdc1KFNDkktv7TKX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTKYnNfdc1KFNDkktv7TKX)_