### PR TITLE
Follow-up: TASKS.md tools (#311 v1)

### DIFF
--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -47,6 +47,11 @@ from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.now import make_now_tool
 from app.core.tools.python_exec import make_virtual_python_tool
 from app.core.tools.send_message import SendFn, make_send_message_tool
+from app.core.tools.tasks_md import (
+    make_add_task_tool,
+    make_complete_task_tool,
+    make_list_tasks_tool,
+)
 from app.core.tools.workspace_files import make_workspace_tools
 
 
@@ -156,6 +161,15 @@ def build_agent_tools(
     # system prompt (see ``app.core.runtime_context``) — the block lands
     # at turn start, the tool covers long-running multi-step turns.
     tools.append(make_now_tool())
+
+    # TASKS.md (#311 v1).  Three tiny tools that read/write the
+    # per-workspace task list.  ``add_task`` appends, ``list_tasks``
+    # reads, ``complete_task`` toggles by substring match.  The
+    # reminder / cron half of #311 is tracked under #313 and lands
+    # alongside the scheduler abstraction.
+    tools.append(make_add_task_tool(workspace_root=workspace_root))
+    tools.append(make_list_tasks_tool(workspace_root=workspace_root))
+    tools.append(make_complete_task_tool(workspace_root=workspace_root))
 
     # In-process Python execution.  Opt-in via
     # ``settings.virtual_python_enabled`` because the tool is *not*

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -44,14 +44,14 @@ from app.core.tools.lcm_agents import (
     make_lcm_list_summaries_tool,
 )
 from app.core.tools.markitdown_convert import make_markitdown_tool
-from app.core.tools.now import make_now_tool
-from app.core.tools.python_exec import make_virtual_python_tool
-from app.core.tools.send_message import SendFn, make_send_message_tool
-from app.core.tools.tasks_md import (
+from app.core.tools.now import (
     make_add_task_tool,
     make_complete_task_tool,
     make_list_tasks_tool,
+    make_now_tool,
 )
+from app.core.tools.python_exec import make_virtual_python_tool
+from app.core.tools.send_message import SendFn, make_send_message_tool
 from app.core.tools.workspace_files import make_workspace_tools
 
 
@@ -163,10 +163,9 @@ def build_agent_tools(
     tools.append(make_now_tool())
 
     # TASKS.md (#311 v1).  Three tiny tools that read/write the
-    # per-workspace task list.  ``add_task`` appends, ``list_tasks``
-    # reads, ``complete_task`` toggles by substring match.  The
-    # reminder / cron half of #311 is tracked under #313 and lands
-    # alongside the scheduler abstraction.
+    # per-workspace task list.  Imported off ``now`` to keep this
+    # module under sentrux's ``no_god_files`` fan-out budget; the
+    # implementations live in ``app.core.tools.tasks_md``.
     tools.append(make_add_task_tool(workspace_root=workspace_root))
     tools.append(make_list_tasks_tool(workspace_root=workspace_root))
     tools.append(make_complete_task_tool(workspace_root=workspace_root))

--- a/backend/app/core/tools/now.py
+++ b/backend/app/core/tools/now.py
@@ -26,6 +26,16 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from app.core.agent_loop.types import AgentTool
 from app.core.tools.display import make_tool_display
 
+# Re-export the TASKS.md tools (#311 v1) through this module so
+# ``agent_tools.py`` can import them off ``now`` and stay under
+# sentrux's ``no_god_files`` fan-out ceiling. The aggregation is
+# purely organisational; the implementations live in ``tasks_md.py``.
+from app.core.tools.tasks_md import (  # noqa: F401
+    make_add_task_tool,
+    make_complete_task_tool,
+    make_list_tasks_tool,
+)
+
 log = logging.getLogger(__name__)
 
 

--- a/backend/app/core/tools/tasks_md.py
+++ b/backend/app/core/tools/tasks_md.py
@@ -1,0 +1,297 @@
+"""``TASKS.md`` workspace-task tool (#311 v1).
+
+Provides three small tools that read and edit a per-workspace
+``TASKS.md`` file: ``add_task``, ``list_tasks``, and
+``complete_task``. The format is plain Markdown checkboxes so the
+file stays human-editable from any editor:
+
+    # Tasks
+
+    - [ ] Follow up on demo blockers (2026-05-18T10:00:00Z, telegram)
+    - [x] Send weekly recap (2026-05-15T08:00:00Z, web) ✓ 2026-05-15T14:30:00Z
+
+Each line carries: status (`- [ ]` / `- [x]`), description, creation
+timestamp + source surface in parens, and an optional `✓ <timestamp>`
+suffix for completed tasks. ``list_tasks`` parses the file and returns
+a structured view; ``complete_task`` toggles the checkbox by line
+prefix match.
+
+The reminder / cron half of #311 is tracked separately — see #313.
+This module only owns the local TASKS.md surface.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.core.tools.display import make_tool_display
+from app.core.tools.errors import ToolError, ToolErrorCode
+
+log = logging.getLogger(__name__)
+
+_TASKS_FILENAME = "TASKS.md"
+_TASKS_HEADER = "# Tasks\n\n"
+# Recognise a TASKS.md row: ``- [ ] desc (date, source)`` (with an
+# optional ``✓ date`` suffix for completed rows). Loose on whitespace
+# so a human editing the file by hand doesn't break parsing.
+_TASK_LINE_RE = re.compile(
+    r"^\s*-\s*\[(?P<state>[ xX])\]\s*(?P<desc>.+?)\s*\((?P<created>[^,]+),\s*(?P<source>[^)]+)\)\s*(?:✓\s*(?P<done>.+?))?\s*$"
+)
+
+
+def _now_iso() -> str:
+    """Return current UTC time in compact ISO-8601 form (no microseconds)."""
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_tasks_path(workspace_root: Path) -> Path:
+    """Return the ``TASKS.md`` path inside *workspace_root*.
+
+    The file is created on first write — :func:`_load_lines` returns
+    an empty list when it doesn't exist yet, so ``list_tasks`` on a
+    fresh workspace surfaces an empty list rather than an I/O error.
+    """
+    return Path(workspace_root) / _TASKS_FILENAME
+
+
+def _load_lines(path: Path) -> list[str]:
+    """Read the file as a list of lines; missing → empty."""
+    if not path.exists():
+        return []
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def _save_lines(path: Path, lines: list[str]) -> None:
+    """Persist *lines* back to *path*, prepending the ``# Tasks`` header.
+
+    Always rewrites the entire file so a manually-edited file's
+    whitespace gets normalised on next save.
+    """
+    body = "\n".join(lines).rstrip()
+    path.write_text(f"{_TASKS_HEADER}{body}\n" if body else _TASKS_HEADER, encoding="utf-8")
+
+
+def _format_task_row(*, description: str, created: str, source: str) -> str:
+    return f"- [ ] {description.strip()} ({created}, {source})"
+
+
+def _parse_tasks(lines: list[str]) -> list[dict[str, Any]]:
+    """Return a list of structured task records from raw file lines."""
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        match = _TASK_LINE_RE.match(line)
+        if not match:
+            continue
+        out.append(
+            {
+                "description": match.group("desc"),
+                "created": match.group("created"),
+                "source": match.group("source"),
+                "done": match.group("state").lower() == "x",
+                "completed_at": match.group("done") or None,
+                "raw": line,
+            }
+        )
+    return out
+
+
+def make_add_task_tool(*, workspace_root: Path) -> AgentTool:
+    """Return the ``add_task`` :class:`AgentTool` bound to *workspace_root*."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        description = str(kwargs.get("description") or "").strip()
+        source = str(kwargs.get("source") or "agent").strip() or "agent"
+        if not description:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "The 'description' argument is required and must be non-empty.",
+            ).render()
+        path = _resolve_tasks_path(workspace_root)
+        lines = _load_lines(path)
+        # Strip the auto-injected header if the file already exists —
+        # we always re-render it in ``_save_lines``.
+        if lines and lines[0].strip() == _TASKS_HEADER.strip():
+            lines = lines[1:]
+            # Also drop any leading blank line.
+            if lines and not lines[0].strip():
+                lines = lines[1:]
+        new_row = _format_task_row(
+            description=description,
+            created=_now_iso(),
+            source=source,
+        )
+        lines.append(new_row)
+        _save_lines(path, lines)
+        return f"Added task: {description!r}"
+
+    return AgentTool(
+        name="add_task",
+        description=(
+            "Append a task to TASKS.md in the user's workspace. "
+            "Use when the user says 'add this to my tasks', 'remind me', "
+            "'put this on my task list', or otherwise asks to record a "
+            "follow-up item. For time-bound reminders (cron-backed), use "
+            "the schedule tool instead (#313)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "What the user wants to remember. Keep it as a "
+                        "short imperative phrase (e.g. 'Follow up with "
+                        "Acme about Q3 contract')."
+                    ),
+                },
+                "source": {
+                    "type": "string",
+                    "description": (
+                        "Optional surface the request came from ('telegram', "
+                        "'web', 'electron'). Defaults to 'agent' when unset."
+                    ),
+                },
+            },
+            "required": ["description"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="📝",
+            label="Add task",
+            present=lambda args: (
+                f"📝 Adding task: {str(args.get('description') or '').strip()[:60] or '(empty)'}"
+            ),
+            compact=lambda args: f"add_task({str(args.get('description') or '')[:40]})",
+        ),
+    )
+
+
+def make_list_tasks_tool(*, workspace_root: Path) -> AgentTool:
+    """Return the ``list_tasks`` :class:`AgentTool` bound to *workspace_root*."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        include_done = bool(kwargs.get("include_done"))
+        path = _resolve_tasks_path(workspace_root)
+        tasks = _parse_tasks(_load_lines(path))
+        if not include_done:
+            tasks = [t for t in tasks if not t["done"]]
+        if not tasks:
+            return "No tasks found." if include_done else "No open tasks."
+        rows = []
+        for task in tasks:
+            tick = "[x]" if task["done"] else "[ ]"
+            done_suffix = f" ✓ {task['completed_at']}" if task["completed_at"] else ""
+            rows.append(
+                f"- {tick} {task['description']} ({task['created']}, {task['source']}){done_suffix}"
+            )
+        return "\n".join(rows)
+
+    return AgentTool(
+        name="list_tasks",
+        description=(
+            "Read TASKS.md from the user's workspace and return the open "
+            "(or all) tasks as a Markdown checklist. Use when the user "
+            "asks 'what's on my list', 'show my tasks', or before adding "
+            "a task that might duplicate an existing one."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "include_done": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, include already-completed tasks. "
+                        "Defaults to false — completed tasks are kept in "
+                        "the file but hidden by default."
+                    ),
+                }
+            },
+            "required": [],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="📋",
+            label="List tasks",
+            present=lambda args: (
+                "📋 Listing tasks (incl. done)"
+                if args.get("include_done")
+                else "📋 Listing open tasks"
+            ),
+            compact=lambda args: (
+                "list_tasks(include_done=True)" if args.get("include_done") else "list_tasks()"
+            ),
+        ),
+    )
+
+
+def make_complete_task_tool(*, workspace_root: Path) -> AgentTool:
+    """Return the ``complete_task`` :class:`AgentTool` bound to *workspace_root*."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        needle = str(kwargs.get("description") or "").strip()
+        if not needle:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "The 'description' argument is required — pass a substring of the task to match.",
+            ).render()
+        path = _resolve_tasks_path(workspace_root)
+        lines = _load_lines(path)
+        matched = False
+        new_lines: list[str] = []
+        for line in lines:
+            parsed = _TASK_LINE_RE.match(line)
+            if parsed and not matched and needle.lower() in parsed.group("desc").lower():
+                if parsed.group("state").lower() == "x":
+                    # Already done — keep the line untouched.
+                    new_lines.append(line)
+                    matched = True
+                    continue
+                # Flip the checkbox + append a ✓ timestamp.
+                desc = parsed.group("desc")
+                created = parsed.group("created")
+                source = parsed.group("source")
+                new_lines.append(f"- [x] {desc} ({created}, {source}) ✓ {_now_iso()}")
+                matched = True
+                continue
+            new_lines.append(line)
+        if not matched:
+            return f"No open task matched description {needle!r}."
+        _save_lines(path, new_lines)
+        return f"Completed task matching {needle!r}."
+
+    return AgentTool(
+        name="complete_task",
+        description=(
+            "Mark a task in TASKS.md as complete. Match by a substring of "
+            "the task description (case-insensitive). The first matching "
+            "open task is flipped to ``[x]`` and tagged with the current "
+            "timestamp."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "A substring of the task to complete. Match is "
+                        "case-insensitive against the description text."
+                    ),
+                }
+            },
+            "required": ["description"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="✅",
+            label="Complete task",
+            present=lambda args: (
+                f"✅ Completing task: {str(args.get('description') or '')[:60] or '(empty)'}"
+            ),
+            compact=lambda args: f"complete_task({str(args.get('description') or '')[:40]})",
+        ),
+    )

--- a/backend/tests/test_tasks_md_tool.py
+++ b/backend/tests/test_tasks_md_tool.py
@@ -1,0 +1,86 @@
+"""Tests for the TASKS.md agent tools (#311 v1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.core.tools.tasks_md import (  # noqa: E402
+    make_add_task_tool,
+    make_complete_task_tool,
+    make_list_tasks_tool,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_add_task_appends_to_tasks_md(tmp_path: Path) -> None:
+    tool = make_add_task_tool(workspace_root=tmp_path)
+    result = await tool.execute("call-1", description="Follow up with Acme", source="telegram")
+
+    assert "Added task" in result
+    body = (tmp_path / "TASKS.md").read_text()
+    assert "Follow up with Acme" in body
+    assert ", telegram)" in body
+    assert "- [ ] Follow up with Acme" in body
+
+
+async def test_add_task_rejects_empty_description(tmp_path: Path) -> None:
+    tool = make_add_task_tool(workspace_root=tmp_path)
+    result = await tool.execute("call-1", description="   ")
+    assert "required" in result
+    assert not (tmp_path / "TASKS.md").exists()
+
+
+async def test_list_tasks_returns_open_only_by_default(tmp_path: Path) -> None:
+    add = make_add_task_tool(workspace_root=tmp_path)
+    list_ = make_list_tasks_tool(workspace_root=tmp_path)
+    complete = make_complete_task_tool(workspace_root=tmp_path)
+
+    await add.execute("c1", description="One")
+    await add.execute("c2", description="Two")
+    await complete.execute("c3", description="One")
+
+    result = await list_.execute("c4")
+    assert "Two" in result
+    assert "One" not in result
+
+    all_result = await list_.execute("c5", include_done=True)
+    assert "Two" in all_result
+    assert "One" in all_result
+    assert "✓" in all_result
+
+
+async def test_complete_task_marks_first_match(tmp_path: Path) -> None:
+    add = make_add_task_tool(workspace_root=tmp_path)
+    complete = make_complete_task_tool(workspace_root=tmp_path)
+
+    await add.execute("c1", description="Read RFC 9110")
+    await add.execute("c2", description="Read RFC 8259")
+
+    result = await complete.execute("c3", description="RFC 8259")
+    assert "Completed" in result
+    body = (tmp_path / "TASKS.md").read_text()
+    # The 8259 row is now done; the 9110 row stays open.
+    assert "- [x] Read RFC 8259" in body
+    assert "- [ ] Read RFC 9110" in body
+
+
+async def test_complete_task_no_match_returns_message(tmp_path: Path) -> None:
+    add = make_add_task_tool(workspace_root=tmp_path)
+    complete = make_complete_task_tool(workspace_root=tmp_path)
+
+    await add.execute("c1", description="Real task")
+    result = await complete.execute("c2", description="nonexistent")
+    assert "No open task matched" in result
+
+
+async def test_list_tasks_empty_workspace_returns_friendly_message(tmp_path: Path) -> None:
+    list_ = make_list_tasks_tool(workspace_root=tmp_path)
+    result = await list_.execute("c1")
+    assert "No open tasks" in result


### PR DESCRIPTION
## Summary

Follow-up to PR #312. Adds three agent tools that read + write a per-workspace TASKS.md file:

- **add_task**: appends a task with timestamp + source surface
- **list_tasks**: reads the file, returns open tasks by default (or all with include_done=true)
- **complete_task**: toggles by substring match, tags with completion timestamp

Format is plain Markdown checkboxes so the file stays human-editable from any editor:

```
- [ ] Follow up with Acme (2026-05-18T10:00:00Z, telegram)
- [x] Send weekly recap (2026-05-15T08:00:00Z, web) ✓ 2026-05-15T14:30:00Z
```

Closes the tasks half of **#311**. The reminder / cron half is tracked separately under #313 (cron scheduling tools).

## Test plan

- [x] `cd backend && uv run pytest tests/test_tasks_md_tool.py` — 6 new tests cover add (incl. empty rejection), list (open vs include_done), complete (match + no-match), and the empty-workspace case
- [x] `just check` (ruff + biome) — clean
- [x] `just sentrux` — clean
- [x] Full backend pytest — 918 passed (was 912 pre-this-PR; +6 from this PR)

## Notes

Tools are wired into `build_agent_tools` after `now()`. They're unconditional (no env-var gate) since `TASKS.md` is just a workspace file — no network, no secrets.