### PR TITLE
feat: cron scheduling agent tools (closes #313)

### DIFF
--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -47,6 +47,9 @@ from app.core.tools.markitdown_convert import make_markitdown_tool
 from app.core.tools.now import (
     make_add_task_tool,
     make_complete_task_tool,
+    make_cron_create_tool,
+    make_cron_delete_tool,
+    make_cron_list_tool,
     make_list_tasks_tool,
     make_now_tool,
 )
@@ -169,6 +172,17 @@ def build_agent_tools(
     tools.append(make_add_task_tool(workspace_root=workspace_root))
     tools.append(make_list_tasks_tool(workspace_root=workspace_root))
     tools.append(make_complete_task_tool(workspace_root=workspace_root))
+
+    # Cron scheduling (#313).  Three tools that wrap the live
+    # JobScheduler — registered via ``set_active_scheduler`` in
+    # ``backend/main.py``'s lifespan.  Gated on ``user_id`` so an
+    # unauthenticated background path doesn't get the cron surface.
+    # Tools handle the ``scheduler_enabled = False`` case themselves
+    # via ``get_active_scheduler() is None``.
+    if user_id is not None:
+        tools.append(make_cron_create_tool(user_id=user_id))
+        tools.append(make_cron_list_tool(user_id=user_id))
+        tools.append(make_cron_delete_tool(user_id=user_id))
 
     # In-process Python execution.  Opt-in via
     # ``settings.virtual_python_enabled`` because the tool is *not*

--- a/backend/app/core/scheduler/__init__.py
+++ b/backend/app/core/scheduler/__init__.py
@@ -15,4 +15,24 @@ Both are no-ops when ``settings.scheduler_enabled`` is False.
 
 from app.core.scheduler.scheduler import JobScheduler
 
-__all__ = ["JobScheduler"]
+# Module-level accessor for the live :class:`JobScheduler`.  The
+# FastAPI lifespan in ``backend/main.py`` registers the instance here
+# alongside ``app.state.scheduler`` so contexts that don't have an
+# HTTP ``Request`` (agent tools, background workers) can still reach
+# it without an injection plumbing pass.  ``None`` when the scheduler
+# is disabled via ``settings.scheduler_enabled``.
+_active_scheduler: JobScheduler | None = None
+
+
+def set_active_scheduler(scheduler: JobScheduler | None) -> None:
+    """Register the live :class:`JobScheduler` for tool callers (#313)."""
+    global _active_scheduler  # noqa: PLW0603 — lifespan singleton, set once per worker
+    _active_scheduler = scheduler
+
+
+def get_active_scheduler() -> JobScheduler | None:
+    """Return the live :class:`JobScheduler`, or ``None`` when disabled."""
+    return _active_scheduler
+
+
+__all__ = ["JobScheduler", "get_active_scheduler", "set_active_scheduler"]

--- a/backend/app/core/scheduler/scheduler.py
+++ b/backend/app/core/scheduler/scheduler.py
@@ -39,6 +39,28 @@ from app.models import ScheduledJob
 logger = logging.getLogger(__name__)
 
 
+def _row_to_dict(row: ScheduledJob) -> dict[str, object]:
+    """Convert a :class:`ScheduledJob` row into a plain dict.
+
+    Used by the agent-facing list/get methods so the ``core/tools``
+    layer (which calls them) never has to import ``app.models``.
+    Keeps the model boundary clean per the import-linter contract.
+    """
+    return {
+        "id": row.id,
+        "user_id": row.user_id,
+        "name": row.name,
+        "cron_expression": row.cron_expression,
+        "prompt": row.prompt,
+        "skill_name": row.skill_name,
+        "target_chat_ids": list(row.target_chat_ids or []),
+        "working_directory": row.working_directory,
+        "is_active": row.is_active,
+        "created_at": row.created_at,
+        "last_fired_at": getattr(row, "last_fired_at", None),
+    }
+
+
 class JobScheduler:
     """APScheduler wrapper with a Postgres-backed job catalogue."""
 
@@ -129,6 +151,44 @@ class JobScheduler:
             logger.debug("SCHEDULER_REMOVE_NOT_REGISTERED job_id=%s", job_id)
         logger.info("SCHEDULER_JOB_REMOVED job_id=%s", job_id)
         return True
+
+    async def list_jobs_for_user(
+        self,
+        *,
+        session: AsyncSession,
+        user_id: uuid.UUID,
+        include_inactive: bool = False,
+    ) -> list[dict[str, object]]:
+        """Return scheduled jobs for ``user_id`` as plain dicts.
+
+        Used by the agent-facing ``cron_list`` tool (#313). Returning
+        dicts (not ORM rows) keeps the model boundary clean — the
+        ``core/tools`` layer does not import ``app.models``.
+        """
+        stmt = select(ScheduledJob).where(ScheduledJob.user_id == user_id)
+        if not include_inactive:
+            stmt = stmt.where(ScheduledJob.is_active.is_(True))
+        stmt = stmt.order_by(ScheduledJob.created_at.desc())
+        result = await session.execute(stmt)
+        rows = list(result.scalars().all())
+        return [_row_to_dict(row) for row in rows]
+
+    async def get_job_for_user(
+        self,
+        *,
+        session: AsyncSession,
+        user_id: uuid.UUID,
+        job_id: uuid.UUID,
+    ) -> dict[str, object] | None:
+        """Return one job iff it exists AND belongs to ``user_id``.
+
+        Used by the agent-facing ``cron_delete`` tool (#313) so the
+        tool can authorise without importing ``app.models``.
+        """
+        row = await session.get(ScheduledJob, job_id)
+        if row is None or row.user_id != user_id:
+            return None
+        return _row_to_dict(row)
 
     async def _hydrate_active_jobs(self) -> None:
         """Re-register every ``is_active=True`` row at startup."""

--- a/backend/app/core/tools/cron_tools.py
+++ b/backend/app/core/tools/cron_tools.py
@@ -29,14 +29,11 @@ import logging
 import uuid
 from typing import Any
 
-from sqlalchemy import select
-
 from app.core.agent_loop.types import AgentTool
 from app.core.scheduler import get_active_scheduler
 from app.core.tools.display import make_tool_display
 from app.core.tools.errors import ToolError, ToolErrorCode
 from app.db import async_session_maker
-from app.models import ScheduledJob
 
 log = logging.getLogger(__name__)
 
@@ -47,12 +44,20 @@ _DISABLED_MSG = (
 )
 
 
-def _format_job_row(row: ScheduledJob) -> str:
-    """Return a one-line summary of a :class:`ScheduledJob`."""
-    state = "active" if row.is_active else "inactive"
+def _format_job_row(row: dict[str, object]) -> str:
+    """Return a one-line summary of a scheduler job dict.
+
+    The dict comes from :meth:`JobScheduler.list_jobs_for_user` — using
+    dicts here instead of the :class:`ScheduledJob` ORM type keeps the
+    ``core/tools`` layer free of model imports per the import-linter
+    contract.
+    """
+    state = "active" if row.get("is_active") else "inactive"
+    prompt = str(row.get("prompt") or "")
     return (
-        f"- {row.id} | {row.name} | cron={row.cron_expression!r} | "
-        f"{state} | prompt={row.prompt[:60]!r}"
+        f"- {row.get('id')} | {row.get('name')} | "
+        f"cron={row.get('cron_expression')!r} | {state} | "
+        f"prompt={prompt[:60]!r}"
     )
 
 
@@ -165,12 +170,11 @@ def make_cron_list_tool(*, user_id: uuid.UUID) -> AgentTool:
             return _DISABLED_MSG
         include_inactive = bool(kwargs.get("include_inactive"))
         async with async_session_maker() as session:
-            stmt = select(ScheduledJob).where(ScheduledJob.user_id == user_id)
-            if not include_inactive:
-                stmt = stmt.where(ScheduledJob.is_active.is_(True))
-            stmt = stmt.order_by(ScheduledJob.created_at.desc())
-            result = await session.execute(stmt)
-            rows = list(result.scalars().all())
+            rows = await scheduler.list_jobs_for_user(
+                session=session,
+                user_id=user_id,
+                include_inactive=include_inactive,
+            )
         if not rows:
             return "No active scheduled jobs." if not include_inactive else "No scheduled jobs."
         return "\n".join(_format_job_row(row) for row in rows)
@@ -225,8 +229,10 @@ def make_cron_delete_tool(*, user_id: uuid.UUID) -> AgentTool:
             return f"[invalid_job_id] {job_id_raw!r} is not a valid UUID."
         async with async_session_maker() as session:
             # Per-user scope: 404 if the row doesn't exist OR isn't theirs.
-            row = await session.get(ScheduledJob, job_id)
-            if row is None or row.user_id != user_id:
+            owned = await scheduler.get_job_for_user(
+                session=session, user_id=user_id, job_id=job_id
+            )
+            if owned is None:
                 return f"[not_found] No scheduled job {job_id_raw} owned by you."
             removed = await scheduler.remove_job(session=session, job_id=job_id)
         if removed:

--- a/backend/app/core/tools/cron_tools.py
+++ b/backend/app/core/tools/cron_tools.py
@@ -1,0 +1,260 @@
+"""Cron-scheduling agent tools (#313).
+
+Three thin wrappers around :class:`app.core.scheduler.JobScheduler`:
+
+* ``cron_create`` — register a new recurring job (validates the cron
+  expression up front).
+* ``cron_list``   — list active scheduled jobs for the current user.
+* ``cron_delete`` — soft-delete a job by explicit ID.
+
+Safety:
+
+* All tools are user-scoped via ``user_id`` — a tool call cannot
+  reach other users' jobs.
+* ``cron_delete`` requires an explicit job ID (no bulk filters) per
+  the issue's "Never allow arbitrary bulk deletion" requirement.
+* All tools return ``[scheduler_disabled]`` when
+  ``settings.scheduler_enabled`` is False — they don't crash, they
+  just tell the model the capability isn't available.
+
+The reminder half of #311 lands on top of these — once the agent can
+schedule a job whose prompt is ``"Remind <user> about <topic>"``, the
+TASKS.md tools and these cron tools compose into a reminder flow
+without any new infrastructure.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+
+from app.core.agent_loop.types import AgentTool
+from app.core.scheduler import get_active_scheduler
+from app.core.tools.display import make_tool_display
+from app.core.tools.errors import ToolError, ToolErrorCode
+from app.db import async_session_maker
+from app.models import ScheduledJob
+
+log = logging.getLogger(__name__)
+
+_DISABLED_MSG = (
+    "[scheduler_disabled] The scheduler is off on this deployment "
+    "(SCHEDULER_ENABLED=false). Tell the user you can't create / list / "
+    "delete scheduled jobs here."
+)
+
+
+def _format_job_row(row: ScheduledJob) -> str:
+    """Return a one-line summary of a :class:`ScheduledJob`."""
+    state = "active" if row.is_active else "inactive"
+    return (
+        f"- {row.id} | {row.name} | cron={row.cron_expression!r} | "
+        f"{state} | prompt={row.prompt[:60]!r}"
+    )
+
+
+def make_cron_create_tool(*, user_id: uuid.UUID) -> AgentTool:
+    """Return the ``cron_create`` :class:`AgentTool` scoped to ``user_id``."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        scheduler = get_active_scheduler()
+        if scheduler is None:
+            return _DISABLED_MSG
+        name = str(kwargs.get("name") or "").strip()
+        cron_expression = str(kwargs.get("cron_expression") or "").strip()
+        prompt = str(kwargs.get("prompt") or "").strip()
+        if not name or not cron_expression or not prompt:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "cron_create requires 'name', 'cron_expression', and 'prompt'.",
+            ).render()
+        skill_name = kwargs.get("skill_name")
+        target_chat_ids = kwargs.get("target_chat_ids")
+        if target_chat_ids is not None and not isinstance(target_chat_ids, list):
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "'target_chat_ids' must be a list of strings when supplied.",
+            ).render()
+        try:
+            async with async_session_maker() as session:
+                row = await scheduler.add_job(
+                    session=session,
+                    user_id=user_id,
+                    name=name,
+                    cron_expression=cron_expression,
+                    prompt=prompt,
+                    skill_name=str(skill_name) if skill_name else None,
+                    target_chat_ids=[str(c) for c in target_chat_ids] if target_chat_ids else None,
+                )
+        except ValueError as exc:
+            return f"[invalid_cron] {exc}"
+        except Exception as exc:
+            log.exception("CRON_CREATE_FAILED user_id=%s name=%s", user_id, name)
+            return f"[error] Could not register cron job: {exc}"
+        return (
+            f"Created cron job {row.id} ({row.name!r}) — next fire follows {row.cron_expression!r}."
+        )
+
+    return AgentTool(
+        name="cron_create",
+        description=(
+            "Schedule a recurring agent turn. Use when the user asks to "
+            "'remind me every morning', 'run this weekly', or otherwise "
+            "wants a job to repeat on a cron schedule. The prompt becomes "
+            "the agent input the next time the cron fires."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Short human-readable label for the job.",
+                },
+                "cron_expression": {
+                    "type": "string",
+                    "description": (
+                        "Standard 5-field cron expression "
+                        "(``minute hour day-of-month month day-of-week``). "
+                        "Example: ``0 9 * * 1-5`` for 9am on weekdays UTC."
+                    ),
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": (
+                        "Agent prompt to run when the cron fires. Keep it "
+                        "self-contained — the cron will run in a fresh turn."
+                    ),
+                },
+                "skill_name": {
+                    "type": "string",
+                    "description": "Optional workspace skill name to bind the run to.",
+                },
+                "target_chat_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional list of Telegram chat IDs to deliver the "
+                        "result to. Leave unset for default behaviour."
+                    ),
+                },
+            },
+            "required": ["name", "cron_expression", "prompt"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="⏰",
+            label="Schedule cron",
+            present=lambda args: (
+                f"⏰ Scheduling: {str(args.get('name') or '')[:60]}"
+                f" ({args.get('cron_expression') or ''!s})"
+            ),
+            compact=lambda args: f"cron_create({str(args.get('name') or '')[:40]})",
+        ),
+    )
+
+
+def make_cron_list_tool(*, user_id: uuid.UUID) -> AgentTool:
+    """Return the ``cron_list`` :class:`AgentTool` scoped to ``user_id``."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        scheduler = get_active_scheduler()
+        if scheduler is None:
+            return _DISABLED_MSG
+        include_inactive = bool(kwargs.get("include_inactive"))
+        async with async_session_maker() as session:
+            stmt = select(ScheduledJob).where(ScheduledJob.user_id == user_id)
+            if not include_inactive:
+                stmt = stmt.where(ScheduledJob.is_active.is_(True))
+            stmt = stmt.order_by(ScheduledJob.created_at.desc())
+            result = await session.execute(stmt)
+            rows = list(result.scalars().all())
+        if not rows:
+            return "No active scheduled jobs." if not include_inactive else "No scheduled jobs."
+        return "\n".join(_format_job_row(row) for row in rows)
+
+    return AgentTool(
+        name="cron_list",
+        description=(
+            "List the calling user's scheduled cron jobs. Use when the "
+            "user asks 'what reminders do I have?' or before scheduling a "
+            "new job that might duplicate an existing one."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "include_inactive": {
+                    "type": "boolean",
+                    "description": "Include soft-deleted jobs. Defaults to false.",
+                }
+            },
+            "required": [],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="📅",
+            label="List cron jobs",
+            present=lambda args: (
+                "📅 Listing all cron jobs"
+                if args.get("include_inactive")
+                else "📅 Listing active cron jobs"
+            ),
+            compact=lambda args: "cron_list()",
+        ),
+    )
+
+
+def make_cron_delete_tool(*, user_id: uuid.UUID) -> AgentTool:
+    """Return the ``cron_delete`` :class:`AgentTool` scoped to ``user_id``."""
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        scheduler = get_active_scheduler()
+        if scheduler is None:
+            return _DISABLED_MSG
+        job_id_raw = str(kwargs.get("job_id") or "").strip()
+        if not job_id_raw:
+            return ToolError(
+                ToolErrorCode.INVALID_PATH,
+                "cron_delete requires an explicit 'job_id' — bulk deletion is not supported.",
+            ).render()
+        try:
+            job_id = uuid.UUID(job_id_raw)
+        except ValueError:
+            return f"[invalid_job_id] {job_id_raw!r} is not a valid UUID."
+        async with async_session_maker() as session:
+            # Per-user scope: 404 if the row doesn't exist OR isn't theirs.
+            row = await session.get(ScheduledJob, job_id)
+            if row is None or row.user_id != user_id:
+                return f"[not_found] No scheduled job {job_id_raw} owned by you."
+            removed = await scheduler.remove_job(session=session, job_id=job_id)
+        if removed:
+            return f"Cancelled scheduled job {job_id_raw}."
+        return f"[not_found] Could not remove job {job_id_raw}."
+
+    return AgentTool(
+        name="cron_delete",
+        description=(
+            "Delete a scheduled cron job by its explicit ID. Bulk filters "
+            "are NOT supported — the model must pass a single UUID, "
+            "typically obtained from cron_list first."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "description": ("UUID of the job to cancel, exactly as returned by cron_list."),
+                },
+            },
+            "required": ["job_id"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="🗑",
+            label="Cancel cron job",
+            present=lambda args: f"🗑 Cancelling cron job {str(args.get('job_id') or '')[:36]}",
+            compact=lambda args: f"cron_delete({str(args.get('job_id') or '')[:8]}…)",
+        ),
+    )

--- a/backend/app/core/tools/now.py
+++ b/backend/app/core/tools/now.py
@@ -24,12 +24,17 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.core.agent_loop.types import AgentTool
-from app.core.tools.display import make_tool_display
 
 # Re-export the TASKS.md tools (#311 v1) through this module so
 # ``agent_tools.py`` can import them off ``now`` and stay under
 # sentrux's ``no_god_files`` fan-out ceiling. The aggregation is
 # purely organisational; the implementations live in ``tasks_md.py``.
+from app.core.tools.cron_tools import (  # noqa: F401
+    make_cron_create_tool,
+    make_cron_delete_tool,
+    make_cron_list_tool,
+)
+from app.core.tools.display import make_tool_display
 from app.core.tools.tasks_md import (  # noqa: F401
     make_add_task_tool,
     make_complete_task_tool,

--- a/backend/tests/test_cron_tools.py
+++ b/backend/tests/test_cron_tools.py
@@ -1,0 +1,126 @@
+"""Tests for the cron scheduling agent tools (#313)."""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.core.tools import cron_tools  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_JOB_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+async def test_cron_create_returns_disabled_when_scheduler_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: None)
+    tool = cron_tools.make_cron_create_tool(user_id=_USER_ID)
+    result = await tool.execute(
+        "call-1",
+        name="daily standup",
+        cron_expression="0 9 * * 1-5",
+        prompt="Remind me about standup",
+    )
+    assert "[scheduler_disabled]" in result
+
+
+async def test_cron_create_rejects_missing_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = AsyncMock()
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: scheduler)
+    tool = cron_tools.make_cron_create_tool(user_id=_USER_ID)
+    result = await tool.execute("call-1", name="x")
+    assert "requires" in result.lower()
+    scheduler.add_job.assert_not_called()
+
+
+async def test_cron_create_invokes_scheduler_add_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = AsyncMock()
+    row = MagicMock()
+    row.id = _JOB_ID
+    row.name = "daily standup"
+    row.cron_expression = "0 9 * * 1-5"
+    scheduler.add_job.return_value = row
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: scheduler)
+    tool = cron_tools.make_cron_create_tool(user_id=_USER_ID)
+    result = await tool.execute(
+        "call-1",
+        name="daily standup",
+        cron_expression="0 9 * * 1-5",
+        prompt="Remind me",
+    )
+    assert str(_JOB_ID) in result
+    scheduler.add_job.assert_awaited_once()
+    kwargs = scheduler.add_job.await_args.kwargs
+    assert kwargs["user_id"] == _USER_ID
+    assert kwargs["name"] == "daily standup"
+    assert kwargs["cron_expression"] == "0 9 * * 1-5"
+    assert kwargs["prompt"] == "Remind me"
+
+
+async def test_cron_create_surfaces_invalid_cron_expression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = AsyncMock()
+    scheduler.add_job.side_effect = ValueError("bad cron")
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: scheduler)
+    tool = cron_tools.make_cron_create_tool(user_id=_USER_ID)
+    result = await tool.execute(
+        "call-1",
+        name="oops",
+        cron_expression="not a cron",
+        prompt="prompt",
+    )
+    assert "[invalid_cron]" in result
+
+
+async def test_cron_list_returns_disabled_when_scheduler_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: None)
+    tool = cron_tools.make_cron_list_tool(user_id=_USER_ID)
+    result = await tool.execute("call-1")
+    assert "[scheduler_disabled]" in result
+
+
+async def test_cron_delete_rejects_empty_job_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = AsyncMock()
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: scheduler)
+    tool = cron_tools.make_cron_delete_tool(user_id=_USER_ID)
+    result = await tool.execute("call-1", job_id="")
+    assert "requires" in result.lower()
+    scheduler.remove_job.assert_not_called()
+
+
+async def test_cron_delete_rejects_malformed_uuid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = AsyncMock()
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: scheduler)
+    tool = cron_tools.make_cron_delete_tool(user_id=_USER_ID)
+    result = await tool.execute("call-1", job_id="not-a-uuid")
+    assert "[invalid_job_id]" in result
+
+
+async def test_cron_delete_disabled_when_scheduler_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cron_tools, "get_active_scheduler", lambda: None)
+    tool = cron_tools.make_cron_delete_tool(user_id=_USER_ID)
+    result = await tool.execute("call-1", job_id=str(_JOB_ID))
+    assert "[scheduler_disabled]" in result


### PR DESCRIPTION
Closes #313.

Adds three thin agent tools that wrap the existing JobScheduler:

- **cron_create**: validate cron expression + persist + register
- **cron_list**: per-user scoped, filters inactive by default
- **cron_delete**: by explicit UUID, no bulk filters

Returns a clean [scheduler_disabled] sentinel when SCHEDULER_ENABLED is false. New set_active_scheduler/get_active_scheduler module accessors in app.core.scheduler expose the live JobScheduler to non-HTTP contexts (agent tools, background workers) so we don't have to thread a Request through build_agent_tools.

Together with #311 v1 (TASKS.md tools — already merged in #319), the agent now has the primitives to handle 'remind me at 9am' natively: TASKS.md captures the intent; the cron job fires the reminder turn.

Test plan:
- cd backend && uv run pytest tests/test_cron_tools.py — 8 new tests cover disabled-scheduler, missing-fields, add_job invocation, invalid cron, list, delete (empty/malformed UUID/disabled paths)
- just check + just sentrux — clean
- Full pytest — 926 passed