### PR TITLE
feat(providers): add LiteLLM-routed OpenAI + xAI chat models (text-only v1)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -49,7 +49,13 @@ class Settings(BaseSettings):
     # browser's MediaRecorder, uploads the blob, and the backend forwards
     # it to https://api.x.ai/v1/stt. Leave empty to disable voice input
     # (the endpoint returns 503 with a clear "not configured" message).
+    # Also consumed by the LiteLLM provider for Grok chat models.
     xai_api_key: str = ""
+    # API key for OpenAI (https://platform.openai.com).  Consumed by the
+    # LiteLLM provider for GPT-4o / o-series chat models.  Leave empty
+    # to disable those models; chat requests resolved to an OpenAI model
+    # surface a clear "not configured" error.
+    openai_api_key: str = ""
     # CORS
     cors_origins: list[str]
     cors_origin_regex: str | None = r"^https:\/\/.*\.vercel\.app$"

--- a/backend/app/core/keys.py
+++ b/backend/app/core/keys.py
@@ -58,6 +58,7 @@ OVERRIDABLE_KEYS: frozenset[str] = frozenset(
         "CLAUDE_CODE_OAUTH_TOKEN",
         "EXA_API_KEY",
         "XAI_API_KEY",
+        "OPENAI_API_KEY",
         "OPENAI_CODEX_OAUTH_TOKEN",
         # Notion plugin (see backend/app/integrations/notion/).  The plugin
         # registry declares the same key via its EnvKeySpec; this central
@@ -75,6 +76,7 @@ _SETTINGS_ATTR_MAP: dict[str, str] = {
     "CLAUDE_CODE_OAUTH_TOKEN": "claude_code_oauth_token",
     "EXA_API_KEY": "exa_api_key",
     "XAI_API_KEY": "xai_api_key",
+    "OPENAI_API_KEY": "openai_api_key",
     # OPENAI_CODEX_OAUTH_TOKEN intentionally absent — workspace-only, no
     # global settings fallback.  resolve_api_key() returns None for keys
     # missing from this map after the workspace lookup fails.

--- a/backend/app/core/providers/catalog.py
+++ b/backend/app/core/providers/catalog.py
@@ -75,10 +75,24 @@ _GEMINI_3_FLASH_OUT_USD = 2.50
 _GEMINI_3_FLASH_LITE_IN_USD = 0.10
 _GEMINI_3_FLASH_LITE_OUT_USD = 0.40
 
-# xAI Grok pricing per https://docs.x.ai/docs/models.  Used by the xAI
-# provider's cost-ledger path (no SDK-reported total).
+# xAI Grok pricing per https://docs.x.ai/docs/models.  Used by the
+# native xAI provider's cost-ledger path (no SDK-reported total).
 _GROK_4_3_IN_USD = 1.25
 _GROK_4_3_OUT_USD = 2.50
+
+# OpenAI cost rates published at https://openai.com/api/pricing/.
+# Routed via LiteLLM so the cost ledger uses these directly (no
+# SDK-reported total).  Update on each price change.
+_OPENAI_GPT_4O_IN_USD = 2.50
+_OPENAI_GPT_4O_OUT_USD = 10.00
+_OPENAI_GPT_4O_MINI_IN_USD = 0.15
+_OPENAI_GPT_4O_MINI_OUT_USD = 0.60
+_OPENAI_O1_IN_USD = 15.00
+_OPENAI_O1_OUT_USD = 60.00
+_OPENAI_O1_MINI_IN_USD = 3.00
+_OPENAI_O1_MINI_OUT_USD = 12.00
+_OPENAI_O3_MINI_IN_USD = 1.10
+_OPENAI_O3_MINI_OUT_USD = 4.40
 
 
 MODEL_CATALOG: tuple[ModelEntry, ...] = (
@@ -147,6 +161,70 @@ MODEL_CATALOG: tuple[ModelEntry, ...] = (
         is_default=False,
         cost_per_mtok_in_usd=_GROK_4_3_IN_USD,
         cost_per_mtok_out_usd=_GROK_4_3_OUT_USD,
+    ),
+    # OpenAI — routed through LiteLLM in-process SDK gateway.  Tool use
+    # is intentionally text-only for v1 (provider rejects non-empty
+    # ``tools=`` with a debug log); revisit once the OpenAI function-
+    # calling bridge lands.
+    #
+    # NOTE: xAI catalog entries via LiteLLM were intentionally dropped
+    # in favour of the native ``Host.xai`` provider (PRs #314/#324)
+    # which has full reasoning + Live Search support.  If Grok 3 needs
+    # to be available again, add it under ``Host.xai`` in this catalog.
+    ModelEntry(
+        host=Host.litellm,
+        vendor=Vendor.openai,
+        model="gpt-4o",
+        display_name="GPT-4o",
+        short_name="GPT-4o",
+        description="OpenAI's flagship multimodal",
+        is_default=False,
+        cost_per_mtok_in_usd=_OPENAI_GPT_4O_IN_USD,
+        cost_per_mtok_out_usd=_OPENAI_GPT_4O_OUT_USD,
+    ),
+    ModelEntry(
+        host=Host.litellm,
+        vendor=Vendor.openai,
+        model="gpt-4o-mini",
+        display_name="GPT-4o mini",
+        short_name="GPT-4o mini",
+        description="Cheap and fast OpenAI",
+        is_default=False,
+        cost_per_mtok_in_usd=_OPENAI_GPT_4O_MINI_IN_USD,
+        cost_per_mtok_out_usd=_OPENAI_GPT_4O_MINI_OUT_USD,
+    ),
+    ModelEntry(
+        host=Host.litellm,
+        vendor=Vendor.openai,
+        model="o1",
+        display_name="OpenAI o1",
+        short_name="o1",
+        description="Deep reasoning, slow",
+        is_default=False,
+        cost_per_mtok_in_usd=_OPENAI_O1_IN_USD,
+        cost_per_mtok_out_usd=_OPENAI_O1_OUT_USD,
+    ),
+    ModelEntry(
+        host=Host.litellm,
+        vendor=Vendor.openai,
+        model="o1-mini",
+        display_name="OpenAI o1 mini",
+        short_name="o1 mini",
+        description="Lightweight reasoning",
+        is_default=False,
+        cost_per_mtok_in_usd=_OPENAI_O1_MINI_IN_USD,
+        cost_per_mtok_out_usd=_OPENAI_O1_MINI_OUT_USD,
+    ),
+    ModelEntry(
+        host=Host.litellm,
+        vendor=Vendor.openai,
+        model="o3-mini",
+        display_name="OpenAI o3 mini",
+        short_name="o3 mini",
+        description="Newer reasoning, balanced",
+        is_default=False,
+        cost_per_mtok_in_usd=_OPENAI_O3_MINI_IN_USD,
+        cost_per_mtok_out_usd=_OPENAI_O3_MINI_OUT_USD,
     ),
 )
 

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -22,12 +22,14 @@ from app.core.config import settings
 from .base import AILLM
 from .claude_provider import ClaudeLLM, ClaudeLLMConfig
 from .gemini_provider import GeminiLLM
+from .litellm_provider import LiteLLMLLM
 from .model_id import Host, ParsedModelId, parse_model_id
 from .xai_provider import XaiLLM
 
 HOST_TO_PROVIDER: dict[Host, type[AILLM]] = {
     Host.agent_sdk: ClaudeLLM,
     Host.google_ai: GeminiLLM,
+    Host.litellm: LiteLLMLLM,
     Host.xai: XaiLLM,
 }
 """Map of host enum to the concrete provider class that serves it.
@@ -96,4 +98,9 @@ def resolve_llm(
         return GeminiLLM(parsed.model, workspace_id=workspace_id)
     if provider_cls is XaiLLM:
         return XaiLLM(parsed.model, workspace_id=workspace_id)
+    if provider_cls is LiteLLMLLM:
+        # LiteLLM is multi-vendor — the parsed vendor selects which
+        # API-key workspace name to resolve and which LiteLLM provider
+        # prefix to prepend at request time.
+        return LiteLLMLLM(parsed.model, parsed.vendor, workspace_id=workspace_id)
     raise KeyError(f"no provider class registered for host {parsed.host!r}")

--- a/backend/app/core/providers/litellm_provider.py
+++ b/backend/app/core/providers/litellm_provider.py
@@ -1,0 +1,361 @@
+"""LiteLLM provider — text-only StreamFn adapter for the agent loop.
+
+LiteLLM (https://docs.litellm.ai/) is a Python SDK that exposes a
+single OpenAI-compatible call surface (``litellm.acompletion``) over
+every major LLM provider.  We use the in-process SDK rather than the
+separate LiteLLM proxy server so this provider drops cleanly into the
+existing ``AILLM`` seam without standing up a sidecar service.  The
+proxy can be added later by swapping ``api_base`` to point at a
+``litellm --config`` deployment; the call shape is identical.
+
+This v1 is intentionally **text-only**: ``tools=`` is accepted for
+``AILLM`` protocol parity but ignored with a debug log.  The
+function-calling bridge (AgentTool → OpenAI ``tools`` schema → tool
+result roundtrip) will land in a follow-up alongside the OpenAI tool-
+flow tests.  Until then, LiteLLM-routed models cannot run workspace
+tools — pick Claude or Gemini for tool-driven flows.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+import litellm
+from litellm.exceptions import APIError as LiteLLMAPIError
+
+from app.core.agent_loop import (
+    AgentContext,
+    AgentLoopConfig,
+    AgentMessage,
+    AgentTool,
+    AssistantMessage,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    StreamFn,
+    UserMessage,
+    agent_loop,
+)
+from app.core.agent_loop.safety_factory import safety_from_settings
+from app.core.agent_loop.types import PermissionCheckFn, TextContent
+from app.core.agent_system_prompt import (
+    DEFAULT_AGENT_SYSTEM_PROMPT as _FALLBACK_SYSTEM_PROMPT,
+)
+from app.core.config import settings
+from app.core.keys import resolve_api_key
+
+from ._gemini_events import agent_event_to_stream_event, identity_convert
+from .base import ReasoningEffort, StreamEvent
+from .model_id import Vendor
+
+if TYPE_CHECKING:
+    from app.core.agent_loop.types import ToolCallContent
+
+logger = logging.getLogger(__name__)
+
+
+# Workspace-facing env-var name per vendor.  ``resolve_api_key`` reads
+# the encrypted per-workspace ``.env`` first and falls back to the
+# matching ``Settings`` attribute (see ``app/core/keys.py``).
+_VENDOR_API_KEY_NAME: dict[Vendor, str] = {
+    Vendor.openai: "OPENAI_API_KEY",
+    Vendor.xai: "XAI_API_KEY",
+}
+
+
+def _litellm_model_string(vendor: Vendor, model: str) -> str:
+    """Format ``vendor`` + ``model`` for ``litellm.acompletion(model=...)``.
+
+    LiteLLM dispatches by the ``<provider>/<model>`` prefix; the
+    provider strings happen to match our ``Vendor`` enum values for
+    every vendor we support today.  When a future vendor diverges
+    (e.g. ``mistral`` → ``mistral_chat``) add a per-vendor override
+    table rather than reaching for ``str.replace``.
+    """
+    return f"{vendor.value}/{model}"
+
+
+def _resolve_litellm_api_key(vendor: Vendor, workspace_id: uuid.UUID | None) -> str | None:
+    """Resolve the API key for ``vendor`` honouring workspace overrides."""
+    key_name = _VENDOR_API_KEY_NAME.get(vendor)
+    if key_name is None:
+        return None
+    if workspace_id is not None:
+        return resolve_api_key(workspace_id, key_name) or None
+    settings_attr = {
+        Vendor.openai: "openai_api_key",
+        Vendor.xai: "xai_api_key",
+    }[vendor]
+    value = getattr(settings, settings_attr, "") or ""
+    return value or None
+
+
+def _build_litellm_messages(
+    messages: list[AgentMessage],
+    system_prompt: str,
+) -> list[dict[str, str]]:
+    """Convert agent-loop messages to LiteLLM's OpenAI-shaped messages.
+
+    Text-only v1: ``ToolCallContent`` / ``ToolResultMessage`` are
+    dropped on purpose.  When the tool bridge lands, this helper grows
+    a per-role branch that emits the OpenAI ``tool_calls`` / ``tool``
+    message shapes.
+    """
+    out: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
+    for msg in messages:
+        if msg["role"] == "user":
+            text = msg["content"]
+            if text.strip():
+                out.append({"role": "user", "content": text})
+            continue
+        if msg["role"] == "assistant":
+            text_parts = [b["text"] for b in msg["content"] if b["type"] == "text"]
+            joined = "".join(text_parts)
+            if joined.strip():
+                out.append({"role": "assistant", "content": joined})
+            continue
+        # ``toolResult`` messages are dropped silently in v1 — no
+        # roundtrip is possible without the tool-call message that
+        # produced them.  Once tools land, emit the matching
+        # ``{"role": "tool", "tool_call_id": ..., "content": ...}``
+        # shape here.
+    return out
+
+
+def _delta_text(chunk: Any) -> str:
+    """Extract the streamed text fragment from one LiteLLM chunk.
+
+    LiteLLM normalises every provider's chunk into the OpenAI shape:
+    ``chunk.choices[0].delta.content`` is the new text (or ``None``
+    on chunks that only carry tool calls / finish_reason / usage).
+    """
+    choices = getattr(chunk, "choices", None) or []
+    if not choices:
+        return ""
+    delta = getattr(choices[0], "delta", None)
+    if delta is None:
+        return ""
+    content = getattr(delta, "content", None)
+    return content or ""
+
+
+def make_litellm_stream_fn(
+    vendor: Vendor,
+    model: str,
+    workspace_id: uuid.UUID | None = None,
+    *,
+    system_prompt: str,
+) -> StreamFn:
+    """Build a StreamFn backed by ``litellm.acompletion``.
+
+    Args:
+        vendor: The model's vendor enum (used to pick the API-key
+            workspace name and to format LiteLLM's ``provider/model``
+            string).
+        model: Bare model name (no provider prefix), e.g. ``"gpt-4o"``.
+        workspace_id: Active workspace UUID for per-workspace key
+            overrides.  ``None`` falls back to gateway-global settings.
+        system_prompt: The system prompt captured into the returned
+            closure.  Mirrors :func:`make_gemini_stream_fn`'s contract
+            so the chat router can assemble the workspace prompt and
+            bind it per request.
+
+    Returns:
+        An async generator factory the agent loop can call.  When a
+        non-empty ``tools`` list is passed, the call still runs but
+        tools are logged-and-ignored — see the v1 scope note in the
+        module docstring.
+    """
+    model_string = _litellm_model_string(vendor, model)
+
+    async def stream_fn(
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+    ) -> AsyncIterator[LLMEvent]:
+        if tools:
+            logger.debug(
+                "LITELLM_TOOLS_IGNORED model=%s count=%d (text-only v1)",
+                model_string,
+                len(tools),
+            )
+
+        api_key = _resolve_litellm_api_key(vendor, workspace_id)
+        if not api_key:
+            error_text = (
+                f"LiteLLM error: missing {_VENDOR_API_KEY_NAME[vendor]} — "
+                "set it in the workspace env or as a gateway env var."
+            )
+            yield LLMTextDeltaEvent(type="text_delta", text=error_text)
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="error",
+                content=[TextContent(type="text", text=error_text)],
+            )
+            return
+
+        litellm_messages = _build_litellm_messages(messages, system_prompt)
+
+        full_text = ""
+        try:
+            response = await litellm.acompletion(
+                model=model_string,
+                messages=litellm_messages,
+                api_key=api_key,
+                stream=True,
+            )
+            async for chunk in response:
+                text = _delta_text(chunk)
+                if text:
+                    yield LLMTextDeltaEvent(type="text_delta", text=text)
+                    full_text += text
+
+        except LiteLLMAPIError as exc:
+            logger.error(
+                "LiteLLM streaming error model=%s: %s",
+                model_string,
+                exc,
+                exc_info=True,
+            )
+            error_text = f"LiteLLM error: {exc}"
+            yield LLMTextDeltaEvent(type="text_delta", text=error_text)
+            yield LLMDoneEvent(
+                type="done",
+                stop_reason="error",
+                content=[TextContent(type="text", text=error_text)],
+            )
+            return
+
+        content: list[TextContent | ToolCallContent] = []
+        if full_text:
+            content.append(TextContent(type="text", text=full_text))
+        yield LLMDoneEvent(type="done", stop_reason="stop", content=content)
+
+    return stream_fn
+
+
+class LiteLLMLLM:
+    """AILLM backed by the agent_loop + a LiteLLM StreamFn.
+
+    Text-only v1: ``tools`` is accepted for protocol parity but the
+    underlying StreamFn ignores them.  See module docstring.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        vendor: Vendor,
+        *,
+        workspace_id: uuid.UUID | None = None,
+    ) -> None:
+        """Construct a LiteLLM provider.
+
+        Args:
+            model: Bare model name (no provider prefix), e.g. ``"gpt-4o"``.
+            vendor: The model's vendor enum — picks the API-key
+                workspace name and the LiteLLM provider prefix.
+            workspace_id: Active workspace UUID for per-workspace key
+                overrides.  Optional, matching the other providers.
+        """
+        self._model = model
+        self._vendor = vendor
+        self._workspace_id = workspace_id
+        # Tests monkeypatch this attribute to inject a
+        # ``ScriptedStreamFn``; production sets it per-request inside
+        # ``stream()`` so the captured system prompt matches the
+        # request the chat router assembled.  Mirrors GeminiLLM —
+        # see ``.claude/rules/testing/agent-loop-testing-philosophy.md``.
+        self._stream_fn: StreamFn | None = None
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+        tools: list[AgentTool] | None = None,
+        system_prompt: str | None = None,
+        reasoning_effort: ReasoningEffort | None = None,
+        permission_check: PermissionCheckFn | None = None,
+        images: list[dict[str, str]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Run the agent loop and translate AgentEvents → StreamEvents.
+
+        Args:
+            question: Current user message.
+            conversation_id: Used for logging; not persisted here.
+            user_id: Authenticated user UUID (used for logging).
+            history: Prior messages oldest-first as ``{role, content}``
+                dicts.
+            tools: Accepted for ``AILLM`` parity; ignored in v1 (the
+                StreamFn logs a debug line and drops them).
+            system_prompt: System prompt for this turn.  Falls back
+                to ``_FALLBACK_SYSTEM_PROMPT`` for bare unit-test
+                callers.
+            reasoning_effort: Accepted for protocol parity; ignored.
+                Wire to OpenAI's ``reasoning.effort`` / xAI's reasoning
+                knob when the v2 tool-flow lands.
+            permission_check: Forwarded to the loop's
+                ``AgentLoopConfig``.  Inert in v1 because no tools fire.
+            images: Multimodal inputs.  Accepted for protocol parity
+                and ignored; the LiteLLM image flow lands with the tool
+                bridge.
+        """
+        if images:
+            logger.debug(
+                "LITELLM_IMAGES_IGNORED conversation_id=%s count=%d",
+                conversation_id,
+                len(images),
+            )
+
+        prior: list[AgentMessage] = []
+        for m in history or []:
+            role = m.get("role")
+            content = m.get("content", "")
+            if role == "user":
+                prior.append(UserMessage(role="user", content=content))
+            elif role == "assistant":
+                prior.append(
+                    AssistantMessage(
+                        role="assistant",
+                        content=[TextContent(type="text", text=content)],
+                        stop_reason="stop",
+                    )
+                )
+
+        context = AgentContext(
+            system_prompt=system_prompt or _FALLBACK_SYSTEM_PROMPT,
+            messages=prior,
+            tools=list(tools or []),
+        )
+        prompt = UserMessage(role="user", content=question)
+        config = AgentLoopConfig(
+            convert_to_llm=identity_convert,
+            safety=safety_from_settings(settings),
+            permission_check=permission_check,
+        )
+
+        stream_fn = self._stream_fn or make_litellm_stream_fn(
+            self._vendor,
+            self._model,
+            self._workspace_id,
+            system_prompt=context.system_prompt,
+        )
+
+        try:
+            async for event in agent_loop([prompt], context, config, stream_fn):
+                stream_event = agent_event_to_stream_event(event)
+                if stream_event is not None:
+                    yield stream_event
+
+        except Exception as exc:
+            logger.error(
+                "LiteLLM agent-loop error model=%s/%s: %s",
+                self._vendor.value,
+                self._model,
+                exc,
+                exc_info=True,
+            )
+            yield StreamEvent(type="error", content=f"LiteLLM provider error: {exc}")

--- a/backend/app/core/providers/model_id.py
+++ b/backend/app/core/providers/model_id.py
@@ -26,6 +26,7 @@ class Vendor(StrEnum):
 
     anthropic = "anthropic"
     google = "google"
+    openai = "openai"
     xai = "xai"
 
 
@@ -33,17 +34,27 @@ class Host(StrEnum):
     """Where the model runs.
 
     One vendor's model can be served by many hosts (e.g. Claude via
-    Agent SDK, Bedrock, Copilot).
+    Agent SDK, Bedrock, Copilot).  ``litellm`` is the in-process
+    LiteLLM SDK gateway — any vendor it can route to lives behind
+    this single host enum.
     """
 
     agent_sdk = "agent-sdk"
     google_ai = "google-ai"
+    litellm = "litellm"
     xai = "xai"
 
 
 CANONICAL_HOST: dict[Vendor, Host] = {
     Vendor.anthropic: Host.agent_sdk,
     Vendor.google: Host.google_ai,
+    # OpenAI is gateway-only — there is no native Host.openai (yet).
+    # LiteLLM handles the openai-compat protocol for any GPT model.
+    Vendor.openai: Host.litellm,
+    # xAI has a native Host.xai (gRPC SDK via xai-sdk in PR #324) with
+    # full reasoning + Live Search support. LiteLLM can also route xAI
+    # but is feature-incomplete; keep the native host as the canonical
+    # so ``xai/<model>`` defaults to the full-featured path.
     Vendor.xai: Host.xai,
 }
 """Per-vendor canonical host used when the input omits ``host:``.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "fastapi-users[sqlalchemy]>=15.0.3",
     "fastapi[standard]>=0.136.0",
     "google-genai>=2.3.0",
+    "litellm>=1.55.0",
     "mcp>=1.27.0",
     "psycopg>=3.3.3",
     "pydantic>=2.12.5,<2.14",

--- a/backend/tests/test_litellm_provider.py
+++ b/backend/tests/test_litellm_provider.py
@@ -1,0 +1,152 @@
+"""Tests for LiteLLMLLM's StreamFn wiring into agent_loop.
+
+Uses ``ScriptedStreamFn`` from ``tests.agent_harness`` — no real
+LiteLLM / OpenAI / xAI API calls are made.  These tests exercise the
+provider's translation layer (AgentEvent → StreamEvent) and confirm
+that history and prompts flow through the loop.  The text-only-v1
+scope is also covered: ``tools`` must be accepted without crashing
+(logged-and-ignored) and missing API keys must surface a clear error
+through the StreamFn rather than an uncaught exception.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+
+from app.core.agent_loop.types import (
+    AgentMessage,
+    AgentTool,
+    LLMDoneEvent,
+    LLMEvent,
+    LLMTextDeltaEvent,
+    TextContent,
+)
+from app.core.providers.base import StreamEvent
+from app.core.providers.litellm_provider import (
+    LiteLLMLLM,
+    _build_litellm_messages,
+    _litellm_model_string,
+)
+from app.core.providers.model_id import Vendor
+from tests.agent_harness import ScriptedStreamFn, text_turn
+
+
+@pytest.mark.anyio
+async def test_litellm_provider_yields_delta_events_from_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LiteLLMLLM.stream() translates agent_loop text_deltas to StreamEvent deltas."""
+    provider = LiteLLMLLM("gpt-4o", Vendor.openai)
+    monkeypatch.setattr(provider, "_stream_fn", ScriptedStreamFn([text_turn("hello")]))
+
+    events: list[StreamEvent] = [
+        event
+        async for event in provider.stream(
+            question="Hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+        )
+    ]
+
+    delta_events = [e for e in events if e["type"] == "delta"]
+    assert len(delta_events) >= 1
+    assert any("hello" in e.get("content", "") for e in delta_events)
+
+
+@pytest.mark.anyio
+async def test_litellm_provider_passes_history_to_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prior messages in history are included in what the StreamFn sees."""
+    seen_messages: list[list[AgentMessage]] = []
+
+    async def recording_stream_fn(
+        messages: list[AgentMessage], tools: list[AgentTool]
+    ) -> AsyncIterator[LLMEvent]:
+        seen_messages.append(list(messages))
+        yield LLMTextDeltaEvent(type="text_delta", text="ok")
+        yield LLMDoneEvent(
+            type="done",
+            stop_reason="stop",
+            content=[TextContent(type="text", text="ok")],
+        )
+
+    provider = LiteLLMLLM("grok-3-latest", Vendor.xai)
+    monkeypatch.setattr(provider, "_stream_fn", recording_stream_fn)
+
+    history = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "4"},
+    ]
+
+    async for _ in provider.stream(
+        question="And 3+3?",
+        conversation_id=uuid4(),
+        user_id=uuid4(),
+        history=history,
+    ):
+        pass
+
+    # Two history messages + the new prompt land in the loop together,
+    # so the StreamFn sees three messages on its single LLM call.
+    assert len(seen_messages) == 1
+    assert len(seen_messages[0]) == 3
+
+
+@pytest.mark.anyio
+async def test_litellm_provider_accepts_tools_without_running_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v1 ignores tools but must not crash when a non-empty list is passed."""
+
+    async def _noop_execute(tool_call_id: str, **_kw: object) -> str:
+        return "unused"
+
+    tools = [
+        AgentTool(
+            name="noop",
+            description="placeholder",
+            parameters={"type": "object", "properties": {}},
+            execute=_noop_execute,
+        )
+    ]
+
+    provider = LiteLLMLLM("gpt-4o-mini", Vendor.openai)
+    monkeypatch.setattr(provider, "_stream_fn", ScriptedStreamFn([text_turn("ok")]))
+
+    events = [
+        event
+        async for event in provider.stream(
+            question="Hi",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+            history=[],
+            tools=tools,
+        )
+    ]
+    # The scripted text turn still produces a delta — tools are dropped silently.
+    assert any(e["type"] == "delta" for e in events)
+
+
+def test_litellm_model_string_prefixes_vendor() -> None:
+    assert _litellm_model_string(Vendor.openai, "gpt-4o") == "openai/gpt-4o"
+    assert _litellm_model_string(Vendor.xai, "grok-3-latest") == "xai/grok-3-latest"
+
+
+def test_build_litellm_messages_prepends_system_and_drops_tool_messages() -> None:
+    history: list[AgentMessage] = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "stop",
+        },
+    ]
+    out = _build_litellm_messages(history, system_prompt="SYS")
+    assert out[0] == {"role": "system", "content": "SYS"}
+    assert {"role": "user", "content": "hi"} in out
+    assert {"role": "assistant", "content": "hello"} in out

--- a/backend/tests/test_model_id.py
+++ b/backend/tests/test_model_id.py
@@ -37,12 +37,46 @@ def test_parse_google_canonical_host() -> None:
 
 
 def test_parse_xai_canonical_host() -> None:
-    """``xai/grok-4.3`` canonicalises to ``xai:xai/grok-4.3``."""
+    """``xai/grok-4.3`` canonicalises to ``xai:xai/grok-4.3``.
+
+    xAI defaults to the native ``Host.xai`` provider (PRs #314/#324)
+    not the LiteLLM gateway — ``Host.xai`` has full reasoning and
+    Live Search support, LiteLLM does not.  Override via the
+    fully-qualified ``litellm:xai/<model>`` form if needed.
+    """
     parsed = parse_model_id("xai/grok-4.3")
     assert parsed.host is Host.xai
     assert parsed.vendor is Vendor.xai
     assert parsed.model == "grok-4.3"
     assert parsed.id == "xai:xai/grok-4.3"
+
+
+def test_parse_openai_canonical_host_is_litellm() -> None:
+    """``openai/<model>`` defaults to ``litellm`` — no native OpenAI host."""
+    parsed = parse_model_id("openai/gpt-4o")
+    assert parsed.host is Host.litellm
+    assert parsed.vendor is Vendor.openai
+
+
+def test_parse_fully_qualified_litellm_openai_id() -> None:
+    """Explicit ``litellm:openai/<model>`` form parses identically to the bare form."""
+    parsed = parse_model_id("litellm:openai/gpt-4o")
+    assert parsed.host is Host.litellm
+    assert parsed.vendor is Vendor.openai
+    assert parsed.model == "gpt-4o"
+
+
+def test_parse_fully_qualified_litellm_xai_id() -> None:
+    """``litellm:xai/<model>`` is the explicit opt-in to route xAI via LiteLLM.
+
+    Without the ``litellm:`` prefix, the canonical host for xAI is the
+    native ``Host.xai`` provider — this test guards the opt-out path
+    for callers that need LiteLLM routing for xAI specifically.
+    """
+    parsed = parse_model_id("litellm:xai/grok-4.3")
+    assert parsed.host is Host.litellm
+    assert parsed.vendor is Vendor.xai
+    assert parsed.model == "grok-4.3"
 
 
 def test_id_property_round_trips_through_parse() -> None:

--- a/backend/tests/test_providers_and_schemas.py
+++ b/backend/tests/test_providers_and_schemas.py
@@ -18,7 +18,8 @@ from app.core.config import settings
 from app.core.providers.claude_provider import ClaudeLLM
 from app.core.providers.factory import resolve_llm
 from app.core.providers.gemini_provider import GeminiLLM
-from app.core.providers.model_id import InvalidModelId
+from app.core.providers.litellm_provider import LiteLLMLLM
+from app.core.providers.model_id import InvalidModelId, Vendor
 from app.schemas import ConversationCreate, ConversationUpdate, UserCreate
 
 
@@ -47,6 +48,35 @@ def test_resolve_llm_routes_google_via_host_table() -> None:
     provider = resolve_llm("google/gemini-3-flash-preview")
     assert isinstance(provider, GeminiLLM)
     assert provider._model_id == "gemini-3-flash-preview"
+
+
+def test_resolve_llm_routes_openai_via_litellm_host_table() -> None:
+    """``openai/<model>`` routes to LiteLLM via the HOST_TO_PROVIDER table.
+
+    Without the LiteLLM branch in :func:`resolve_llm`, this raises
+    ``KeyError: "no provider class registered for host <Host.litellm>"``
+    at runtime on every OpenAI chat — the HOST_TO_PROVIDER table entry
+    is unreachable without the narrowing branch.
+    """
+    provider = resolve_llm("openai/gpt-4o")
+    assert isinstance(provider, LiteLLMLLM)
+    assert provider._model == "gpt-4o"
+    assert provider._vendor is Vendor.openai
+
+
+def test_resolve_llm_routes_explicit_litellm_xai_via_host_table() -> None:
+    """Explicit ``litellm:xai/<model>`` form routes via LiteLLM.
+
+    The bare ``xai/<model>`` form canonicalises to ``Host.xai`` (the
+    native xAI provider, PRs #314/#324) because that path supports
+    full reasoning + Live Search.  Callers that need LiteLLM routing
+    for xAI specifically must opt in via the fully-qualified
+    ``litellm:xai/<model>`` form — this test guards that branch.
+    """
+    provider = resolve_llm("litellm:xai/grok-3-latest")
+    assert isinstance(provider, LiteLLMLLM)
+    assert provider._model == "grok-3-latest"
+    assert provider._vendor is Vendor.xai
 
 
 def test_resolve_llm_none_uses_catalog_default() -> None:

--- a/backend/tests/test_workspace_env_api.py
+++ b/backend/tests/test_workspace_env_api.py
@@ -55,6 +55,7 @@ async def test_get_returns_all_keys_empty_for_new_user(
         "CLAUDE_CODE_OAUTH_TOKEN",
         "EXA_API_KEY",
         "XAI_API_KEY",
+        "OPENAI_API_KEY",
         "OPENAI_CODEX_OAUTH_TOKEN",
         "NOTION_API_KEY",
     }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -926,6 +926,36 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1013,6 +1043,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [[package]]
@@ -1166,6 +1205,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1222,6 +1293,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/b6/e22bd20a25299c34b8c5922c1545a6320825b13906eb0f7298edfd034a0b/huggingface_hub-1.15.0.tar.gz", hash = "sha256:28abfdddda3927fd4de6a63cf26ab012498a2c24dae52baf150c5c6edf98a1d5", size = 784100, upload-time = "2026-05-15T11:42:52.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/11/0b64cc9024329b76d7547c19a67604a61d21d3ba678a69d1b220c29d5112/huggingface_hub-1.15.0-py3-none-any.whl", hash = "sha256:a4a59af04cbc41a3fe3fec429b171ef994ef8c971eda10136746f408dd4e3744", size = 663602, upload-time = "2026-05-15T11:42:50.487Z" },
 ]
 
 [[package]]
@@ -1446,6 +1537,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/3a/9c635ac3e8a00383ff689161d3eac8a30b3b2ddc711b40471e6b8983ea29/librt-0.10.0-cp314-cp314t-win32.whl", hash = "sha256:657860fd877fba6a241ea088ef99f63ca819945d3c715265da670bad56c37ebe", size = 60147, upload-time = "2026-05-05T16:31:00.293Z" },
     { url = "https://files.pythonhosted.org/packages/dc/e8/6f65f3e565d4ac212cddddd552eacc8035ffdf941ca0ad6fe945a211d41f/librt-0.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:56ded2d66010203a0cb5af063b609e3f079531a0e5e576d618dece859fd2e1af", size = 68649, upload-time = "2026-05-05T16:31:01.778Z" },
     { url = "https://files.pythonhosted.org/packages/51/78/a0705a67cacd81e5fa01a5035b3adbdfbb43a7b8d4bd27e2b282ae61baf2/librt-0.10.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1ee63f30abf18ed4830fdbaf87b2b6f4bba1e198d46085c314edde4045e56715", size = 58247, upload-time = "2026-05-05T16:31:03.191Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.85.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/d5/3c9b560db2ffa9e498655d0dfd74f408bc5b32ede858b5731c2a5fa4c752/litellm-1.85.0.tar.gz", hash = "sha256:babdd569809af913d08a08a7eb55df1ed3e6a3960ee365c6cef4ad031c9bc72a", size = 15344387, upload-time = "2026-05-17T01:59:15.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/38/e6a4abb062e039d18d59538cc4e6fc370c2c10cd2bff4a2e546acb69dcb9/litellm-1.85.0-py3-none-any.whl", hash = "sha256:2bb449153610691faffd76f5b94a8c29e4b66fc5394156ebf54fd4fe92759b1a", size = 16978229, upload-time = "2026-05-17T01:59:11.902Z" },
 ]
 
 [[package]]
@@ -2278,6 +2392,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "google-genai" },
+    { name = "litellm" },
     { name = "markdown-it-py" },
     { name = "markitdown", extra = ["all"] },
     { name = "mcp" },
@@ -2324,6 +2439,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.3" },
     { name = "google-genai", specifier = ">=2.3.0" },
+    { name = "litellm", specifier = ">=1.55.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.1" },
     { name = "mcp", specifier = ">=1.27.0" },
@@ -2925,6 +3041,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3325,6 +3513,73 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
 ]
 
 [[package]]

--- a/frontend/features/settings/sections/WorkspacesSection.tsx
+++ b/frontend/features/settings/sections/WorkspacesSection.tsx
@@ -61,9 +61,16 @@ const KEY_METAS: readonly WorkspaceEnvKeyMeta[] = [
 	{
 		key: 'XAI_API_KEY',
 		label: 'xAI API Key',
-		description: 'Speech-to-text. Get a key from xAI.',
+		description: 'Speech-to-text plus Grok chat models routed via LiteLLM. Get a key from xAI.',
 		placeholder: 'Your xAI API key',
 		url: 'https://x.ai',
+	},
+	{
+		key: 'OPENAI_API_KEY',
+		label: 'OpenAI API Key',
+		description: 'GPT-4o and o-series chat models routed via LiteLLM. Get a key from OpenAI.',
+		placeholder: 'sk-...',
+		url: 'https://platform.openai.com/api-keys',
 	},
 	{
 		key: 'NOTION_API_KEY',

--- a/frontend/features/settings/workspace-env/WorkspacesSectionView.test.tsx
+++ b/frontend/features/settings/workspace-env/WorkspacesSectionView.test.tsx
@@ -35,6 +35,7 @@ const EMPTY_VALUES = {
 	CLAUDE_CODE_OAUTH_TOKEN: '',
 	EXA_API_KEY: '',
 	XAI_API_KEY: '',
+	OPENAI_API_KEY: '',
 	NOTION_API_KEY: '',
 } as const;
 

--- a/frontend/features/settings/workspace-env/use-workspace-env.ts
+++ b/frontend/features/settings/workspace-env/use-workspace-env.ts
@@ -24,6 +24,7 @@ export const WORKSPACE_ENV_KEY_IDS = [
 	'CLAUDE_CODE_OAUTH_TOKEN',
 	'EXA_API_KEY',
 	'XAI_API_KEY',
+	'OPENAI_API_KEY',
 	'NOTION_API_KEY',
 ] as const satisfies readonly string[];
 


### PR DESCRIPTION
## Summary

Adds a third provider behind the existing `AILLM` seam so chat requests can resolve to **GPT-4o / GPT-4o mini / o1 / o1-mini / o3-mini** and **Grok 3 / Grok 3 mini** without standing up a separate proxy service. The LiteLLM Python SDK (`litellm.acompletion`) runs in-process and dispatches through the same agent-loop `StreamFn` pattern that already backs the Gemini provider.

- One new `Host.litellm` enum, one new `LiteLLMLLM` class, two new vendors (`openai`, `xai`) — every other extension point (catalog, factory dispatch, per-workspace env-key resolution) already existed.
- **Text-only by design for v1**: the StreamFn accepts `tools=` for `AILLM` protocol parity but logs-and-drops them. A follow-up will add an OpenAI function-calling bridge so existing AgentTools (workspace files, Exa, artifacts) light up for these models.
- **SDK in-process, not the LiteLLM proxy server** — keeps the deploy surface unchanged. If we later want the gateway / spend-tracking UI / virtual keys, swapping `api_base` on the StreamFn is the only code change; everything above stays as-is.

## Why LiteLLM (recommendation context)

LiteLLM exposes one OpenAI-compatible call surface over every major LLM provider, so a single `LiteLLMLLM(AILLM)` class unlocks the long tail (OpenAI, xAI, Mistral, DeepSeek, Groq, etc.) by changing only the catalog. We picked the SDK-in-process mode for v1 because it's half the work, fits the existing architecture cleanly, and the migration path to the proxy server later is just config — no new abstraction.

## What changed

- `backend/app/core/providers/litellm_provider.py` — new provider class + StreamFn, mirroring `gemini_provider.py`. Reuses `_gemini_events.agent_event_to_stream_event` since the loop-level events are provider-neutral.
- `backend/app/core/providers/model_id.py` — new `Vendor.openai`, `Vendor.xai`, `Host.litellm`; both vendors canonicalize to the litellm host.
- `backend/app/core/providers/catalog.py` — 7 new entries (5 OpenAI + 2 xAI) with current published pricing.
- `backend/app/core/providers/factory.py` — registers `Host.litellm: LiteLLMLLM` in the dispatch table.
- `backend/app/core/config.py` + `backend/app/core/keys.py` — adds `openai_api_key` setting and `OPENAI_API_KEY` to `OVERRIDABLE_KEYS` + `_SETTINGS_ATTR_MAP`. xAI key was already wired (was previously voice-only).
- `backend/pyproject.toml` — adds `litellm>=1.55.0`.
- Frontend env-settings UI — `OPENAI_API_KEY` is now editable per workspace alongside the others; xAI description updated to mention Grok chat in addition to STT.

## Test plan

- [x] `uv run pytest tests/` — **879 passed**, 0 failed. New `tests/test_litellm_provider.py` covers delta-event translation, history wiring, and the tools-accepted-but-dropped contract. `tests/test_model_id.py` covers the new vendor + host parsing. `tests/test_catalog.py` round-trips every new entry through `parse_model_id`. `tests/test_workspace_env_api.py` updated to include the new `OPENAI_API_KEY` in the expected key set.
- [x] `uv run ruff check` — all clean on touched files.
- [x] `uv run ruff format --check` — no changes needed.
- [x] `scripts/check-no-tools-in-providers.py` — OK (provider imports no tool factories).
- [x] `scripts/check-file-lines.mjs` — OK (no file >500 LOC; new provider is 361).
- [x] `scripts/check-nesting.py` — OK (no function nested >3 deep).
- [x] `uv run mypy app/core/providers/litellm_provider.py` — clean. (4 unrelated mypy errors remain on `agent_loop/display.py`, `agent_loop/loop.py`, `providers/base.py` — none touched by this PR; mypy is advisory in this repo per the justfile and these are existing accepted backlog. Worth a follow-up but out of scope here.)
- [x] `bunx @biomejs/biome check` on touched frontend files — all clean.
- [ ] Manual smoke against a real OpenAI key (workspace settings → enter key → send a chat with `gpt-4o-mini` selected). Pending a real key — not testable in this sandbox.

## Follow-ups (not in this PR)

1. **OpenAI function-calling tool bridge** — `_litellm_tool_bridge.py` translating `AgentTool[]` → OpenAI `tools=` + `tool_call` / `tool` message roundtrip. Unblocks workspace-file tools / Exa / artifacts on LiteLLM-routed models.
2. **Reasoning effort wiring** — `reasoning_effort` is accepted for protocol parity but ignored. Wire to OpenAI's `reasoning.effort` and the matching xAI knob when the tool bridge lands.
3. **Multimodal images** — same story; `images=` is accepted and ignored.
4. **Optional later**: stand up the LiteLLM proxy server as a sidecar for centralized spend tracking, virtual keys, and a web UI. Provider class doesn't need to change — only the `api_base` it points at.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkYm8mjDJX4pv55XcyLZ4Z)_