### PR TITLE
refactor(xai): swap openai-compat SDK for official xai-sdk (gRPC)

### DIFF
--- a/backend/app/core/providers/_xai_messages.py
+++ b/backend/app/core/providers/_xai_messages.py
@@ -1,17 +1,25 @@
-"""xAI request-shape helpers — AgentMessage → OpenAI ``messages`` / ``tools``.
+"""xAI request-shape helpers — AgentMessage → ``chat_pb2`` proto messages.
 
-Split out of ``xai_provider`` so that module stays under the 500-line
-file budget (``scripts/check-file-lines.mjs``).  All helpers are pure
-shape translation — no I/O, no SDK calls.  The public surface is
-:func:`build_xai_messages` and :func:`build_xai_tool_declarations`;
-their leading underscore-stripped names match how Gemini's equivalents
-live in ``_gemini_replay`` / ``gemini_provider``.
+Pure shape translation between Pawrrtal's provider-neutral
+:class:`AgentMessage` shape and xAI's gRPC ``Message`` / ``Tool``
+protos.  No I/O, no client construction — the live :class:`AsyncClient`
+lives in ``xai_provider``.
+
+The xai-sdk ships ergonomic helpers (:func:`xai_sdk.chat.system`,
+``user``, ``tool_result``, ``tool``, ``text``) that we use everywhere
+they apply.  Assistant turns that carry tool calls fall back to direct
+``chat_pb2`` construction because the SDK's ``assistant()`` helper only
+takes textual ``Content`` and not ``tool_calls`` — see
+https://github.com/xai-org/xai-sdk-python/blob/main/src/xai_sdk/chat.py
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from collections.abc import Sequence
+
+from xai_sdk.chat import text, tool, tool_result, user
+from xai_sdk.proto import chat_pb2
 
 from app.core.agent_loop.types import (
     AgentMessage,
@@ -22,93 +30,102 @@ from app.core.agent_loop.types import (
 )
 
 
-def build_xai_tool_declarations(tools: list[AgentTool]) -> list[dict[str, Any]] | None:
-    """Convert :class:`AgentTool` instances to OpenAI ``tools`` entries.
+def build_xai_tools(tools: list[AgentTool]) -> Sequence[chat_pb2.Tool] | None:
+    """Convert :class:`AgentTool` instances to xAI ``Tool`` proto messages.
 
     Returns ``None`` (not ``[]``) when there are no tools so the caller
-    can skip the parameter entirely — some OpenAI-compat servers reject
-    an empty list and we want xAI to take its default no-tool path.
+    can pass ``None`` to ``chat.create(tools=...)`` and let the SDK omit
+    the field entirely from the wire request.
     """
     if not tools:
         return None
-    return [
-        {
-            "type": "function",
-            "function": {
-                "name": t.name,
-                "description": t.description,
-                "parameters": t.parameters,
-            },
-        }
-        for t in tools
-    ]
-
-
-def _assistant_content_for_request(
-    content: list[TextContent | ToolCallContent],
-) -> tuple[str, list[dict[str, Any]]]:
-    """Split an assistant message's blocks into the OpenAI request shape.
-
-    OpenAI separates an assistant turn's text (``content`` string) from
-    its tool calls (``tool_calls`` array).  The agent loop carries both
-    in one ``content`` list, so we partition them here.
-    """
-    text_parts: list[str] = []
-    tool_calls: list[dict[str, Any]] = []
-    for block in content:
-        if block["type"] == "text":
-            text_parts.append(block["text"])
-            continue
-        tool_calls.append(
-            {
-                "id": block["tool_call_id"],
-                "type": "function",
-                "function": {
-                    "name": block["name"],
-                    "arguments": json.dumps(block["arguments"]),
-                },
-            }
-        )
-    return "".join(text_parts), tool_calls
-
-
-def _tool_result_message(msg: ToolResultMessage) -> dict[str, Any]:
-    """Render a tool result into OpenAI's ``role="tool"`` shape."""
-    text: str = "\n".join(block["text"] for block in msg["content"])
-    return {
-        "role": "tool",
-        "tool_call_id": msg["tool_call_id"],
-        "content": text,
-    }
+    return [tool(name=t.name, description=t.description, parameters=t.parameters) for t in tools]
 
 
 def build_xai_messages(
     messages: list[AgentMessage],
     system_prompt: str,
-) -> list[dict[str, Any]]:
-    """Convert AgentMessages to OpenAI ``messages`` entries, oldest-first.
+) -> list[chat_pb2.Message]:
+    """Convert AgentMessages to xAI proto ``Message`` instances, oldest-first.
 
-    The system prompt is prepended as a ``role="system"`` turn — xAI
-    follows OpenAI's convention here rather than Gemini's separate
-    ``system_instruction`` field.
+    The system prompt is rendered as a ``ROLE_DEVELOPER`` message —
+    xAI's modern role for system instructions on grok-4.1+ — which the
+    server downgrades to ``ROLE_SYSTEM`` for older models.  See the
+    helper's docstring in xai-sdk's ``chat.py``.
+
+    Per-message conversions:
+
+    * ``user`` → :func:`xai_sdk.chat.user` (text-only; empty turns are
+      dropped to match the historical behaviour).
+    * ``assistant`` → either :func:`xai_sdk.chat.text` for pure-text
+      replies or a direct ``chat_pb2.Message`` carrying ``tool_calls``
+      built from the loop's :class:`ToolCallContent` blocks.
+    * ``toolResult`` → :func:`xai_sdk.chat.tool_result` so the SDK
+      attaches the matching ``tool_call_id`` and ``ROLE_TOOL``.
     """
-    out: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+    # ``developer`` is the canonical xAI role for system instructions
+    # on current models; older models silently see it as ``system``.
+    out: list[chat_pb2.Message] = [
+        chat_pb2.Message(
+            role=chat_pb2.MessageRole.ROLE_DEVELOPER,
+            content=[text(system_prompt)],
+        )
+    ]
     for msg in messages:
         if msg["role"] == "user":
-            text = msg["content"]
-            if text.strip():
-                out.append({"role": "user", "content": text})
+            user_text = msg["content"]
+            if user_text.strip():
+                out.append(user(user_text))
             continue
         if msg["role"] == "assistant":
-            text, tool_calls = _assistant_content_for_request(msg["content"])
-            entry: dict[str, Any] = {"role": "assistant"}
-            # OpenAI rejects an entirely empty assistant turn (no content
-            # AND no tool_calls) so we ensure at least one field carries
-            # a non-falsey value.
-            entry["content"] = text or None
-            if tool_calls:
-                entry["tool_calls"] = tool_calls
-            out.append(entry)
+            out.append(_assistant_proto(msg["content"]))
             continue
-        out.append(_tool_result_message(msg))
+        # toolResult.
+        out.append(_tool_result_proto(msg))
     return out
+
+
+def _assistant_proto(
+    content: list[TextContent | ToolCallContent],
+) -> chat_pb2.Message:
+    """Render an assistant turn into a ``chat_pb2.Message`` with tool calls.
+
+    The xai-sdk helper :func:`xai_sdk.chat.assistant` only takes
+    ``Content`` (text / image / file) and does not expose ``tool_calls``,
+    so we construct the proto directly to preserve the agent loop's
+    tool-call history across iterations.  Empty text is allowed when
+    the turn is tool-calls-only — the proto handles it without complaint.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[chat_pb2.ToolCall] = []
+    for block in content:
+        if block["type"] == "text":
+            text_parts.append(block["text"])
+            continue
+        tool_calls.append(
+            chat_pb2.ToolCall(
+                id=block["tool_call_id"],
+                function=chat_pb2.FunctionCall(
+                    name=block["name"],
+                    arguments=json.dumps(block["arguments"]),
+                ),
+            )
+        )
+    combined = "".join(text_parts)
+    proto_content = [text(combined)] if combined else []
+    return chat_pb2.Message(
+        role=chat_pb2.MessageRole.ROLE_ASSISTANT,
+        content=proto_content,
+        tool_calls=tool_calls,
+    )
+
+
+def _tool_result_proto(msg: ToolResultMessage) -> chat_pb2.Message:
+    """Render a loop ``toolResult`` into the SDK's ``tool_result`` helper output.
+
+    The xai-sdk helper attaches the ``tool_call_id`` and sets
+    ``ROLE_TOOL`` correctly, so we just join the agent loop's
+    multi-block result text into one string and delegate.
+    """
+    body = "\n".join(b["text"] for b in msg["content"])
+    return tool_result(body, tool_call_id=msg["tool_call_id"])

--- a/backend/app/core/providers/_xai_stream.py
+++ b/backend/app/core/providers/_xai_stream.py
@@ -1,10 +1,15 @@
-"""xAI streaming-chunk accumulation helpers.
+"""xai-sdk streaming helpers — translate ``Chunk`` / ``Response`` → LLMEvents.
 
-Split out of ``xai_provider`` so that module stays under the 500-line
-file budget (``scripts/check-file-lines.mjs``).  The OpenAI / xAI
-chat-completions stream emits tool calls across many partial deltas,
-so the StreamFn closure needs running state per call — that state and
-its finalisation live here.  No I/O, no SDK constructor calls.
+Pulled out of ``xai_provider`` so the provider module stays under the
+500-line file budget.  All helpers are pure shape translation; the live
+gRPC client lives in ``xai_provider``.
+
+xai-sdk does the hard work for us: ``chat.stream()`` yields
+``(response, chunk)`` tuples where ``chunk`` carries the latest deltas
+and ``response`` carries the running-total accumulation, exposed via
+typed accessors (``content``, ``reasoning_content``, ``tool_calls``,
+``usage``, ``cost_usd``, ``finish_reason``).  See:
+https://github.com/xai-org/xai-sdk-python/blob/main/src/xai_sdk/chat.py
 """
 
 from __future__ import annotations
@@ -15,185 +20,130 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from xai_sdk.chat import Chunk, Response
+
 from app.core.agent_loop.types import (
     LLMDoneEvent,
+    LLMToolCallEvent,
     TextContent,
     ToolCallContent,
 )
 
 logger = logging.getLogger(__name__)
 
-# Finish reason emitted by xAI / OpenAI-compatible endpoints when the
-# model produced one or more tool calls.  Mirrors OpenAI's vocabulary.
-FINISH_REASON_TOOL_CALLS = "tool_calls"
-
-# xAI bills in "ticks" where ``1 tick = 1e-10 USD``.  Sourced from the
-# official xai-sdk Python package's ``cost.py``:
-# https://github.com/xai-org/xai-sdk-python/blob/main/src/xai_sdk/cost.py
-# (citing
-# https://github.com/xai-org/xai-proto/blob/0c0f5353aa7ab2a4ffea310f9d9364ed5c424af2/proto/xai/api/v1/usage.proto#L45).
-# Field is opaque on the wire; keeping the constant here means future
-# divisor changes are a single-line edit.
-USD_PER_TICK = 1e-10
-
 
 @dataclass(frozen=True, slots=True)
 class ChunkDeltas:
-    """The user-visible deltas extracted from a single streaming chunk.
+    """The user-visible deltas extracted from one streaming chunk.
 
     ``text`` is the regular assistant content delta; ``thinking`` is the
     reasoning-trace delta (xAI's ``reasoning_content`` field on grok-4.3
-    reasoning turns).  Either or both may be ``None`` for a chunk that
-    only contributed to tool-call accumulation or to ``finish_reason``.
+    reasoning turns).  Either or both may be ``None`` when the chunk
+    only contributed tool-call payloads or terminal usage metadata.
     """
 
     text: str | None = None
     thinking: str | None = None
 
 
-class ToolCallAccumulator:
-    """Reassembles a single OpenAI tool-call from its streamed delta fragments.
+@dataclass(frozen=True, slots=True)
+class UsageRecord:
+    """Per-request usage snapshot read off the SDK's terminal :class:`Response`.
 
-    xAI's chat-completions stream emits each tool call across many
-    chunks: the first one sets ``id`` + ``function.name``, later ones
-    append slices of ``function.arguments``.  The accumulator collects
-    them per ``index`` so we can yield a complete
-    :class:`LLMToolCallEvent` once the stream ends.
+    Mirrors the shape Pawrrtal's chat aggregator expects on
+    ``StreamEvent(type="usage")`` so :class:`XaiLLM.stream` can yield
+    it without further translation.  ``cost_usd`` comes from the SDK's
+    ``Response.cost_usd`` property (server-reported, authoritative).
     """
 
-    __slots__ = ("arguments", "id", "name")
-
-    def __init__(self) -> None:
-        self.id: str = ""
-        self.name: str = ""
-        self.arguments: str = ""
-
-    def apply(self, delta: Any) -> None:
-        """Merge one OpenAI ``ChoiceDeltaToolCall`` fragment into the buffer."""
-        if delta.id:
-            self.id = delta.id
-        fn = getattr(delta, "function", None)
-        if fn is None:
-            return
-        if fn.name:
-            self.name = fn.name
-        if fn.arguments:
-            self.arguments += fn.arguments
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
 
 
-def parse_tool_arguments(raw: str, name: str) -> dict[str, Any]:
-    """Parse the accumulated tool-arguments JSON, tolerating empty strings.
+def deltas_from_chunk(chunk: Chunk) -> ChunkDeltas:
+    """Pull the text / reasoning deltas off one streaming chunk.
 
-    xAI streams ``arguments`` as raw JSON.  An empty / missing
-    arguments object is legitimate for tools that take no parameters,
-    so we treat ``""`` as ``{}``.  Malformed JSON is surfaced as an
-    empty dict with a WARNING — the agent loop will still dispatch the
-    tool, and the resulting error is more informative than a stream-
-    level exception.
+    Both fields can be empty strings when the chunk only carries
+    tool-call payloads or finish-reason metadata; we normalise empty
+    strings to ``None`` so the caller can branch on truthiness.
     """
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.warning(
-            "xai_provider: tool '%s' returned non-JSON arguments (%s); falling back to empty dict",
-            name,
-            exc,
-        )
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+    text = chunk.content or None
+    thinking = chunk.reasoning_content or None
+    return ChunkDeltas(text=text, thinking=thinking)
 
 
-def _build_tool_call_id(name: str, fallback_id: str, ordinal: int) -> str:
-    """Return a stable tool_call_id even when the provider omitted ``id``."""
-    if fallback_id:
-        return fallback_id
-    return f"call-{name}-{ordinal}-{uuid.uuid4().hex[:8]}"
+def tool_call_events_from_response(response: Response) -> list[LLMToolCallEvent]:
+    """Translate the final ``Response.tool_calls`` into loop-shaped events.
 
-
-class ChunkAggregate:
-    """Cross-chunk streaming state for one ``chat.completions`` call.
-
-    Pulled out of the StreamFn closure so the outer factory stays under
-    the ruff complexity cap.  The aggregate owns the running text, the
-    per-index :class:`ToolCallAccumulator` map, and the most recent
-    ``finish_reason`` observed on the stream.
+    Reading from the accumulated :class:`Response` (rather than from
+    streamed chunks) sidesteps the question of whether xAI ships each
+    tool call in a single chunk or spread across several — the SDK
+    accumulates either way, and emitting once at end-of-stream is the
+    only point at which we know we have the complete list.
     """
-
-    __slots__ = ("finish_reason", "full_text", "tool_buffers")
-
-    def __init__(self) -> None:
-        self.full_text: str = ""
-        self.tool_buffers: dict[int, ToolCallAccumulator] = {}
-        self.finish_reason: str | None = None
-
-
-def absorb_chunk(chunk: Any, aggregate: ChunkAggregate) -> ChunkDeltas:
-    """Update *aggregate* with one streaming chunk and report the user-visible deltas.
-
-    Returns :class:`ChunkDeltas` carrying any text and / or
-    ``reasoning_content`` delta to forward upstream.  Both fields are
-    ``None`` when the chunk only contributed to tool-call accumulation
-    or to ``finish_reason``.  Extracted from the StreamFn closure so
-    the factory stays inside the ruff complexity cap; the branch shape
-    mirrors the OpenAI SDK's :class:`ChatCompletionChunk` exactly, plus
-    xAI's ``reasoning_content`` extra (allowed because
-    :class:`ChoiceDelta` is configured with ``extra='allow'``).
-    """
-    if not chunk.choices:
-        return ChunkDeltas()
-    choice = chunk.choices[0]
-    delta = choice.delta
-    if delta is None:
-        return ChunkDeltas()
-    text_delta: str | None = None
-    if delta.content:
-        text_delta = delta.content
-        aggregate.full_text += delta.content
-    # xAI's grok-4.3 reasoning turn surfaces chain-of-thought in
-    # ``reasoning_content`` on each delta.  The openai SDK preserves
-    # unknown fields on :class:`ChoiceDelta` via ``extra='allow'`` so a
-    # plain ``getattr`` is enough — no SDK upgrade required when xAI
-    # changes their schema, and the field stays ``None`` for non-Grok
-    # OpenAI-compat providers that never emit it.
-    thinking_value = getattr(delta, "reasoning_content", None)
-    thinking_delta = thinking_value if isinstance(thinking_value, str) and thinking_value else None
-    for tc_delta in getattr(delta, "tool_calls", None) or []:
-        idx = getattr(tc_delta, "index", 0) or 0
-        buffer = aggregate.tool_buffers.get(idx)
-        if buffer is None:
-            buffer = ToolCallAccumulator()
-            aggregate.tool_buffers[idx] = buffer
-        buffer.apply(tc_delta)
-    if choice.finish_reason:
-        aggregate.finish_reason = choice.finish_reason
-    return ChunkDeltas(text=text_delta, thinking=thinking_delta)
-
-
-def finalize_tool_calls(aggregate: ChunkAggregate) -> list[dict[str, Any]]:
-    """Drain buffered tool calls into ordered, JSON-decoded records.
-
-    Skips fragments that never carried a function name (treated as a
-    streaming bug on the upstream side and logged) and returns one
-    entry per dispatched tool call in the order the model produced them.
-    """
-    completed: list[dict[str, Any]] = []
-    for ordinal, idx in enumerate(sorted(aggregate.tool_buffers.keys())):
-        buffer = aggregate.tool_buffers[idx]
-        if not buffer.name:
-            logger.warning(
-                "xai_provider: dropping tool_call index=%d with empty name (id=%r)",
-                idx,
-                buffer.id,
+    events: list[LLMToolCallEvent] = []
+    for ordinal, call in enumerate(response.tool_calls):
+        events.append(
+            LLMToolCallEvent(
+                type="tool_call",
+                tool_call_id=_stable_tool_call_id(call, ordinal),
+                name=call.function.name,
+                arguments=_parse_arguments(call.function.arguments, call.function.name),
             )
-            continue
-        tool_call_id = _build_tool_call_id(buffer.name, buffer.id, ordinal)
-        arguments = parse_tool_arguments(buffer.arguments, buffer.name)
-        completed.append(
-            {"tool_call_id": tool_call_id, "name": buffer.name, "arguments": arguments}
         )
-    return completed
+    return events
+
+
+def done_event_from_response(response: Response) -> LLMDoneEvent:
+    """Assemble the terminal ``LLMDoneEvent`` from the accumulated response.
+
+    The loop uses ``stop_reason`` purely as a string discriminator
+    (``"tool_use"`` vs ``"stop"`` vs ``"error"``) — see
+    ``app.core.agent_loop.loop._should_stop``.  We map xAI's
+    ``REASON_TOOL_CALLS`` to ``"tool_use"`` so a tool-using turn
+    triggers the loop's tool-dispatch path, and everything else falls
+    through to ``"stop"``.
+    """
+    content: list[TextContent | ToolCallContent] = []
+    if response.content:
+        content.append(TextContent(type="text", text=response.content))
+    for ordinal, call in enumerate(response.tool_calls):
+        content.append(
+            ToolCallContent(
+                type="toolCall",
+                tool_call_id=_stable_tool_call_id(call, ordinal),
+                name=call.function.name,
+                arguments=_parse_arguments(call.function.arguments, call.function.name),
+            )
+        )
+    finish = (response.finish_reason or "").upper()
+    stop_reason = "tool_use" if response.tool_calls or finish == "REASON_TOOL_CALLS" else "stop"
+    return LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+
+
+def usage_record_from_response(response: Response) -> UsageRecord | None:
+    """Read token + cost totals off the SDK's accumulated response.
+
+    Returns ``None`` when the server reported nothing useful (token
+    counts all zero and cost missing) — the chat aggregator then
+    treats the turn as a free no-op rather than logging a zero-cost
+    ledger row.  ``response.cost_usd`` is the authoritative
+    server-reported figure (the SDK does the ``cost_in_usd_ticks``
+    conversion for us via :mod:`xai_sdk.cost`), so we don't carry
+    the constant locally.
+    """
+    usage = response.usage
+    input_tokens = int(getattr(usage, "prompt_tokens", 0))
+    output_tokens = int(getattr(usage, "completion_tokens", 0))
+    cost = response.cost_usd
+    if input_tokens == 0 and output_tokens == 0 and cost is None:
+        return None
+    return UsageRecord(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=float(cost) if cost is not None else 0.0,
+    )
 
 
 class UsageAccumulator:
@@ -201,11 +151,10 @@ class UsageAccumulator:
 
     The agent loop calls the StreamFn once per assistant turn (LLM →
     tool → LLM round-trip), so a single user prompt can drive several
-    chat-completions requests.  Each request returns its own ``usage``
-    block on the terminal streaming chunk (when
-    ``stream_options.include_usage=True``); we sum them so the chat
-    aggregator sees the total for the whole turn, matching how Claude
-    reports its per-turn cost.
+    chat-completions requests.  Each request finishes with its own
+    :class:`Response` that carries usage; we sum them so the chat
+    aggregator sees the total for the whole turn (same shape Claude
+    emits via ``_build_usage_event``).
 
     Mutable on purpose: the StreamFn closure owns one and writes into
     it from inside the stream; :class:`XaiLLM.stream` reads the totals
@@ -221,65 +170,49 @@ class UsageAccumulator:
         self.cost_usd: float = 0.0
         self.saw_any: bool = False
 
-    def absorb(self, chunk: Any) -> None:
-        """Fold one chunk's ``usage`` block into the running totals.
-
-        No-op when the chunk has no usage payload — only the final chunk
-        of a ``stream_options.include_usage=True`` stream carries it.
-        Reads ``prompt_tokens``/``completion_tokens`` (OpenAI naming)
-        AND ``input_tokens``/``output_tokens`` (xAI naming) defensively
-        because the two endpoints have historically disagreed on which
-        names land in the REST envelope.
-        """
-        usage = getattr(chunk, "usage", None)
-        if usage is None:
+    def absorb(self, record: UsageRecord | None) -> None:
+        """Fold a per-request :class:`UsageRecord` into the running totals."""
+        if record is None:
             return
         self.saw_any = True
-        prompt = _read_usage_int(usage, "prompt_tokens", "input_tokens")
-        completion = _read_usage_int(usage, "completion_tokens", "output_tokens")
-        self.input_tokens += prompt
-        self.output_tokens += completion
-        ticks = _read_usage_int(usage, "cost_in_usd_ticks")
-        if ticks > 0:
-            self.cost_usd += ticks * USD_PER_TICK
+        self.input_tokens += record.input_tokens
+        self.output_tokens += record.output_tokens
+        self.cost_usd += record.cost_usd
 
 
-def _read_usage_int(usage: Any, *names: str) -> int:
-    """Read the first non-zero integer field from ``usage``.
+def _stable_tool_call_id(call: Any, ordinal: int) -> str:
+    """Return the server-provided tool_call_id, or synthesise a stable one.
 
-    Tries each name in order using ``getattr`` (Pydantic models from
-    the openai SDK preserve unknown xAI fields via ``extra='allow'``,
-    so the xAI-specific names land on the model alongside the
-    OpenAI-standard ones).  Returns 0 when none of the names are
-    present or carry a usable integer.
+    xai-sdk always populates ``call.id``, but synthesising a fallback
+    keeps the helper robust if a future SDK version emits empty ids
+    on partial / dropped streams.
     """
-    for name in names:
-        value = getattr(usage, name, None)
-        if isinstance(value, int) and value > 0:
-            return value
-    return 0
+    server_id = getattr(call, "id", "") or ""
+    if server_id:
+        return server_id
+    name = getattr(call.function, "name", "") or "unknown"
+    return f"call-{name}-{ordinal}-{uuid.uuid4().hex[:8]}"
 
 
-def done_event_for(
-    aggregate: ChunkAggregate,
-    completed_tool_calls: list[dict[str, Any]],
-) -> LLMDoneEvent:
-    """Assemble the terminal ``LLMDoneEvent`` from the streamed turn."""
-    stop_reason = (
-        "tool_use"
-        if completed_tool_calls or aggregate.finish_reason == FINISH_REASON_TOOL_CALLS
-        else "stop"
-    )
-    content: list[TextContent | ToolCallContent] = []
-    if aggregate.full_text:
-        content.append(TextContent(type="text", text=aggregate.full_text))
-    content.extend(
-        ToolCallContent(
-            type="toolCall",
-            tool_call_id=tc["tool_call_id"],
-            name=tc["name"],
-            arguments=tc["arguments"],
+def _parse_arguments(raw: str, name: str) -> dict[str, Any]:
+    """Parse a tool call's ``arguments`` JSON string into a dict.
+
+    xai-sdk ships ``arguments`` as a JSON string for OpenAI
+    compatibility.  An empty / missing arguments object is legitimate
+    for tools that take no parameters, so ``""`` becomes ``{}``.
+    Malformed JSON is logged at WARNING and surfaced as an empty dict
+    — the agent loop will dispatch the tool and surface the resulting
+    error, which is more informative than crashing the stream.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "xai_provider: tool '%s' returned non-JSON arguments (%s); falling back to {}",
+            name,
+            exc,
         )
-        for tc in completed_tool_calls
-    )
-    return LLMDoneEvent(type="done", stop_reason=stop_reason, content=content)
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -1,45 +1,52 @@
-"""xAI (Grok) provider — StreamFn adapter for the agent loop.
+"""xAI (Grok) provider — gRPC StreamFn adapter for the agent loop.
 
-Wraps the OpenAI-compatible HTTP API exposed at ``https://api.x.ai/v1``
-(docs: https://docs.x.ai/docs/api-reference) so the agent loop can drive
-Grok the same way it drives Gemini and Claude.  The xAI surface is
-intentionally OpenAI-compatible, so we use the upstream ``openai`` SDK
-configured with ``base_url="https://api.x.ai/v1"`` rather than rolling
-our own SSE parser — every streaming chunk, tool-call delta, and finish
-reason then matches the well-understood OpenAI vocabulary.
+Wraps the official xai-sdk gRPC client (https://docs.x.ai,
+https://github.com/xai-org/xai-sdk-python) so the agent loop can drive
+Grok the same way it drives Gemini (``google-genai``) and Claude
+(``claude-agent-sdk``).  Each provider is self-contained on its
+vendor's first-party SDK — no shared HTTP-compat abstraction.
 
 Design parity with :mod:`app.core.providers.gemini_provider`:
 
-* ``make_xai_stream_fn`` builds a per-request :data:`StreamFn` that
-  closes over ``model_id``, optional ``workspace_id`` (for per-workspace
-  ``XAI_API_KEY`` overrides), and the assembled ``system_prompt``.
+* ``make_xai_stream_fn`` builds a per-request :data:`StreamFn` closing
+  over ``model_id``, optional ``workspace_id`` (for per-workspace
+  ``XAI_API_KEY`` overrides), the assembled ``system_prompt``, a
+  caller-supplied :class:`UsageAccumulator`, and the reasoning-effort
+  knob.
 * ``XaiLLM.stream`` runs :func:`agent_loop` against that StreamFn and
   translates each :class:`AgentEvent` into a :class:`StreamEvent` via
-  :func:`_xai_events.agent_event_to_stream_event`.
+  :func:`_xai_events.agent_event_to_stream_event`.  After the loop
+  returns, ``XaiLLM.stream`` emits one terminal
+  ``StreamEvent(type="usage")`` carrying the per-turn totals the chat
+  aggregator folds into the cost ledger.
 * Tools, history, and the cross-provider permission gate flow through
   the same path as Gemini — the provider stays tool-agnostic per
   ``.claude/rules/architecture/no-tools-in-providers.md``.
 
-xAI-specific extensions the openai SDK doesn't model natively all flow
-in via ``extra_body``; see :func:`_build_xai_extra_body` for the single
-source of truth:
+xAI-specific surface this provider drives natively (via typed
+proto / SDK fields, not ``extra_body``):
 
-* ``reasoning_effort`` — collapsed from Pawrrtal's four-level UI knob
-  (``low | medium | high | extra-high``) into grok-4.3's two-level enum
-  via :func:`_map_reasoning_effort`.  grok-4.3 400s on any other value
-  (https://docs.x.ai/docs/models/grok-4-3).
-* ``search_parameters`` — forced to ``{"mode": "off"}`` so xAI's
-  built-in Live Search never fires.  Pawrrtal's canonical web tool is
-  ``exa_search`` (gated by ``EXA_API_KEY``); leaving xAI's search on
-  the default ``"on"`` would silently double-search every Grok turn.
+* ``reasoning_effort`` — Pawrrtal's four-level UI knob
+  (``low | medium | high | extra-high``) is collapsed to xAI's
+  two-level enum via :func:`_map_reasoning_effort`.  Grok 4.3 400s on
+  anything else (https://docs.x.ai/docs/models/grok-4-3).
+* ``search_parameters`` — defaults to ``mode="off"`` so xAI's
+  built-in Live Search never fires; Pawrrtal's canonical web tool is
+  ``exa_search`` (gated by ``EXA_API_KEY``).  Toggling Grok-native
+  search on remains a future feature flag — when we land it the
+  knob will flow through here.
+* ``response.cost_usd`` — the SDK does the
+  ``cost_in_usd_ticks * 1e-10`` conversion for us via
+  :mod:`xai_sdk.cost` (citing
+  ``xai-proto/proto/xai/api/v1/usage.proto``).  We don't carry the
+  constant locally.
+* ``reasoning_content`` deltas — surfaced as
+  :class:`LLMThinkingDeltaEvent` so the frontend's "thinking" pane
+  (already wired for Gemini) lights up for Grok.
 
-Reasoning-trace deltas (``delta.reasoning_content``) are forwarded as
-:class:`LLMThinkingDeltaEvent` so the frontend's existing "thinking"
-pane (already wired for Gemini) lights up for Grok too.
-
-Multimodal image inputs are accepted and logged but not yet bridged —
-the chat router can still pass them conditionally without a runtime
-error.
+Multimodal image inputs are accepted on the protocol but not yet
+bridged to xai-sdk's :func:`xai_sdk.chat.image`; the chat router can
+still pass them conditionally without a runtime error.
 
 Request- and response-shape helpers live in ``_xai_messages`` and
 ``_xai_stream`` so this module stays under the project's 500-line
@@ -51,15 +58,10 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import AsyncIterator
-from typing import Any, cast
 
-from openai import AsyncOpenAI, AsyncStream
-from openai.types.chat import (
-    ChatCompletionChunk,
-    ChatCompletionMessageParam,
-    ChatCompletionStreamOptionsParam,
-    ChatCompletionToolUnionParam,
-)
+from xai_sdk import AsyncClient
+from xai_sdk.proto import chat_pb2
+from xai_sdk.search import SearchParameters
 
 from app.core.agent_loop import (
     AgentContext,
@@ -71,7 +73,6 @@ from app.core.agent_loop import (
     LLMEvent,
     LLMTextDeltaEvent,
     LLMThinkingDeltaEvent,
-    LLMToolCallEvent,
     StreamFn,
     UserMessage,
     agent_loop,
@@ -88,31 +89,17 @@ from app.core.config import settings
 from app.core.keys import resolve_api_key
 
 from ._xai_events import agent_event_to_stream_event, identity_convert
-from ._xai_messages import build_xai_messages, build_xai_tool_declarations
+from ._xai_messages import build_xai_messages, build_xai_tools
 from ._xai_stream import (
-    ChunkAggregate,
     UsageAccumulator,
-    absorb_chunk,
-    done_event_for,
-    finalize_tool_calls,
+    deltas_from_chunk,
+    done_event_from_response,
+    tool_call_events_from_response,
+    usage_record_from_response,
 )
 from .base import ReasoningEffort, StreamEvent
 
 logger = logging.getLogger(__name__)
-
-# Public xAI endpoint — kept module-level so tests can monkeypatch it.
-# The OpenAI SDK appends ``/chat/completions`` when ``base_url`` ends
-# with ``/v1``, matching the path documented at
-# https://docs.x.ai/docs/api-reference.
-XAI_BASE_URL = "https://api.x.ai/v1"
-
-# xAI's Live Search is enabled by default (``mode="on"``) on every
-# chat-completions request — see https://docs.x.ai/docs/guides/live-search.
-# Pawrrtal does its own web search through the explicit ``exa_search``
-# tool (gated by ``EXA_API_KEY``), so we turn xAI's built-in search off
-# at the SDK seam.  Otherwise every Grok turn would silently consult the
-# web, doubling up with exa_search and surprise-billing the workspace.
-_LIVE_SEARCH_DISABLED: dict[str, Any] = {"mode": "off"}
 
 
 def _resolve_xai_api_key(workspace_id: uuid.UUID | None) -> str:
@@ -127,89 +114,37 @@ def _resolve_xai_api_key(workspace_id: uuid.UUID | None) -> str:
     return settings.xai_api_key
 
 
-def _map_reasoning_effort(effort: ReasoningEffort | None) -> str | None:
-    """Map the four-level UI knob onto xAI's two-level enum.
+def _map_reasoning_effort(
+    effort: ReasoningEffort | None,
+) -> chat_pb2.ReasoningEffort | None:
+    """Map Pawrrtal's four-level UI knob onto xAI's proto enum.
 
-    Grok 4.3 accepts ``"low"`` or ``"high"``
-    (https://docs.x.ai/docs/models/grok-4-3) and 400s on anything else,
-    including the values OpenAI's o-series uses.  The Pawrrtal UI
-    surfaces ``low | medium | high | extra-high`` — we collapse the
-    lower two to ``low`` and the upper two to ``high`` so the user gets
-    a meaningful difference without overshooting xAI's schema.
-    ``None`` means "let xAI pick the model default".
+    Grok 4.3 accepts ``EFFORT_LOW`` or ``EFFORT_HIGH``
+    (https://docs.x.ai/docs/models/grok-4-3) and 400s on anything
+    else, including ``EFFORT_MEDIUM`` and ``EFFORT_NONE``.  The
+    Pawrrtal UI surfaces ``low | medium | high | extra-high`` — we
+    collapse the lower two to ``EFFORT_LOW`` and the upper two to
+    ``EFFORT_HIGH`` so the user gets a meaningful difference without
+    overshooting xAI's schema.  ``None`` means "let xAI pick the
+    model default" and the field is omitted from the request.
     """
     if effort is None:
         return None
     if effort in ("low", "medium"):
-        return "low"
-    return "high"
+        return chat_pb2.ReasoningEffort.EFFORT_LOW
+    return chat_pb2.ReasoningEffort.EFFORT_HIGH
 
 
-def _build_xai_extra_body(reasoning_effort: ReasoningEffort | None) -> dict[str, Any]:
-    """Assemble the xAI-only kwargs forwarded via ``extra_body``.
+def _live_search_off() -> SearchParameters:
+    """Return a ``SearchParameters`` that disables xAI's built-in Live Search.
 
-    ``extra_body`` is the openai SDK's escape hatch for non-OpenAI
-    fields.  We use it for the two xAI-specific concerns:
-
-    * ``reasoning_effort`` for grok-4.3 (passed only when the caller
-      supplied one — the model picks its own default otherwise).
-    * ``search_parameters`` to opt out of xAI's built-in Live Search
-      (see :data:`_LIVE_SEARCH_DISABLED` for the why).
+    Pawrrtal does its own web search through the explicit
+    ``exa_search`` tool (gated by ``EXA_API_KEY``).  Leaving xAI's
+    Live Search at its default ``"on"`` mode would silently consult
+    the web on every Grok turn, doubling up with ``exa_search`` and
+    surprise-billing the workspace.
     """
-    body: dict[str, Any] = {"search_parameters": _LIVE_SEARCH_DISABLED}
-    mapped_effort = _map_reasoning_effort(reasoning_effort)
-    if mapped_effort is not None:
-        body["reasoning_effort"] = mapped_effort
-    return body
-
-
-async def _open_xai_stream(
-    *,
-    client: AsyncOpenAI,
-    model_id: str,
-    messages: list[dict[str, Any]],
-    tools: list[dict[str, Any]] | None,
-    reasoning_effort: ReasoningEffort | None,
-) -> AsyncStream[ChatCompletionChunk]:
-    """Open the streaming chat-completions call against xAI.
-
-    The openai SDK declares ``messages`` and ``tools`` as unions of
-    TypedDicts; our wire dicts match the runtime contract but mypy
-    can't narrow a dynamically-built ``dict[str, Any]`` into the
-    union variant.  We narrow at this single SDK seam — never to
-    ``Any`` (forbidden by the project mypy config).  Splitting the
-    ``stream=True`` overload into two literal branches keeps mypy from
-    widening the return to ``ChatCompletion | AsyncStream[...]``.
-
-    xAI-specific fields (``reasoning_effort``, ``search_parameters``)
-    flow in via ``extra_body`` so the openai SDK passes them through
-    unchanged — :func:`_build_xai_extra_body` is the single source of
-    truth for what we forward.
-    """
-    typed_messages = cast("list[ChatCompletionMessageParam]", messages)
-    extra_body = _build_xai_extra_body(reasoning_effort)
-    # ``include_usage=True`` makes xAI emit a terminal chunk carrying
-    # the request's ``usage`` block — that's where ``cost_in_usd_ticks``
-    # and the token counts live.  Without it, the cost ledger sees zero
-    # for every Grok turn.
-    stream_options: ChatCompletionStreamOptionsParam = {"include_usage": True}
-    if tools is None:
-        return await client.chat.completions.create(
-            model=model_id,
-            messages=typed_messages,
-            stream=True,
-            stream_options=stream_options,
-            extra_body=extra_body,
-        )
-    typed_tools = cast("list[ChatCompletionToolUnionParam]", tools)
-    return await client.chat.completions.create(
-        model=model_id,
-        messages=typed_messages,
-        tools=typed_tools,
-        stream=True,
-        stream_options=stream_options,
-        extra_body=extra_body,
-    )
+    return SearchParameters(mode="off")
 
 
 def make_xai_stream_fn(
@@ -220,35 +155,35 @@ def make_xai_stream_fn(
     reasoning_effort: ReasoningEffort | None = None,
     usage_sink: UsageAccumulator | None = None,
 ) -> StreamFn:
-    """Build a :data:`StreamFn` backed by xAI's OpenAI-compatible API.
+    """Build a :data:`StreamFn` backed by xai-sdk's gRPC ``AsyncClient``.
 
     Args:
         model_id: xAI model identifier (e.g. ``"grok-4.3"``).  Passed
-            straight through to the chat-completions endpoint.
+            straight through to ``client.chat.create(model=...)``.
         workspace_id: Active workspace UUID, used to honour a
             per-workspace ``XAI_API_KEY`` override.  ``None`` falls back
             to the gateway-global ``settings.xai_api_key``.
         system_prompt: System prompt for this StreamFn.  Captured into
-            the returned closure and prepended as a ``role="system"``
-            entry on every call.  ``XaiLLM.stream`` builds a fresh
+            the returned closure and prepended as a ``ROLE_DEVELOPER``
+            message on every call.  ``XaiLLM.stream`` builds a fresh
             StreamFn per request so the workspace-assembled prompt
             (SOUL.md + AGENTS.md + skills) is what the model sees.
         reasoning_effort: Optional reasoning-depth knob for grok-4.3.
-            Mapped onto xAI's two-level enum (``low`` / ``high``) via
-            :func:`_map_reasoning_effort` and forwarded through
-            ``extra_body``.  ``None`` lets xAI pick the model default.
+            Mapped onto xAI's two-level proto enum via
+            :func:`_map_reasoning_effort`.  ``None`` lets xAI pick the
+            model default.
         usage_sink: Optional mutable :class:`UsageAccumulator` the
-            StreamFn writes per-chunk usage into.  Shared across every
-            agent_loop iteration for a single ``XaiLLM.stream`` call so
-            multi-turn tool-using conversations sum their cost
+            StreamFn writes per-request usage into.  Shared across
+            every agent_loop iteration for a single ``XaiLLM.stream``
+            call so multi-turn tool-using conversations sum their cost
             correctly.  ``None`` skips usage capture entirely — useful
-            for unit tests and for utility callers that don't talk to
-            the cost ledger.
+            for unit tests and utility callers that don't talk to the
+            cost ledger.
 
     Returns:
         An async generator factory that yields ``LLMEvent`` instances.
-        The factory is provider-specific; the surrounding
-        :func:`agent_loop` is not.
+        The factory is xai-specific; the surrounding :func:`agent_loop`
+        stays provider-neutral.
     """
 
     async def stream_fn(
@@ -256,27 +191,24 @@ def make_xai_stream_fn(
         tools: list[AgentTool],
     ) -> AsyncIterator[LLMEvent]:
         api_key = _resolve_xai_api_key(workspace_id)
-        client = AsyncOpenAI(api_key=api_key, base_url=XAI_BASE_URL)
         request_messages = build_xai_messages(messages, system_prompt)
-        xai_tools = build_xai_tool_declarations(tools)
-        aggregate = ChunkAggregate()
+        xai_tools = build_xai_tools(tools)
+        effort = _map_reasoning_effort(reasoning_effort)
 
         try:
-            stream = await _open_xai_stream(
-                client=client,
-                model_id=model_id,
-                messages=request_messages,
-                tools=xai_tools,
-                reasoning_effort=reasoning_effort,
-            )
-            async for chunk in stream:
-                deltas = absorb_chunk(chunk, aggregate)
-                if usage_sink is not None:
-                    usage_sink.absorb(chunk)
-                if deltas.thinking:
-                    yield LLMThinkingDeltaEvent(type="thinking_delta", text=deltas.thinking)
-                if deltas.text:
-                    yield LLMTextDeltaEvent(type="text_delta", text=deltas.text)
+            # AsyncClient owns a gRPC channel; the context manager
+            # closes it after the request so we don't leak file
+            # descriptors on long-running uvicorn workers.
+            async with AsyncClient(api_key=api_key) as client:
+                async for event in _stream_one_request(
+                    client=client,
+                    model_id=model_id,
+                    request_messages=request_messages,
+                    xai_tools=xai_tools,
+                    reasoning_effort=effort,
+                    usage_sink=usage_sink,
+                ):
+                    yield event
         except Exception as exc:
             logger.error("xAI streaming error model=%s: %s", model_id, exc, exc_info=True)
             error_text = f"xAI error: {exc}"
@@ -286,26 +218,61 @@ def make_xai_stream_fn(
                 stop_reason="error",
                 content=[TextContent(type="text", text=error_text)],
             )
-            return
-
-        # Emit the assembled tool calls (if any) before the terminal
-        # ``done`` event so the agent loop can dispatch them.  Ordering
-        # by buffer index keeps the model's intended call sequence stable.
-        completed_tool_calls = finalize_tool_calls(aggregate)
-        for tc in completed_tool_calls:
-            yield LLMToolCallEvent(
-                type="tool_call",
-                tool_call_id=tc["tool_call_id"],
-                name=tc["name"],
-                arguments=tc["arguments"],
-            )
-        yield done_event_for(aggregate, completed_tool_calls)
 
     return stream_fn
 
 
+async def _stream_one_request(
+    *,
+    client: AsyncClient,
+    model_id: str,
+    request_messages: list[chat_pb2.Message],
+    xai_tools: object,
+    reasoning_effort: chat_pb2.ReasoningEffort | None,
+    usage_sink: UsageAccumulator | None,
+) -> AsyncIterator[LLMEvent]:
+    """Drive one ``chat.stream()`` round-trip through xai-sdk.
+
+    Yields LLMEvents in the order the agent loop expects: text /
+    thinking deltas during the stream, then any tool-call events
+    sourced from the accumulated :class:`Response`, then the terminal
+    :class:`LLMDoneEvent`.  Captures usage into ``usage_sink`` if
+    supplied — the SDK populates ``Response.usage`` and
+    ``Response.cost_usd`` once the stream completes.
+    """
+    chat = client.chat.create(
+        model=model_id,
+        messages=request_messages,
+        tools=xai_tools,
+        reasoning_effort=reasoning_effort,
+        search_parameters=_live_search_off(),
+    )
+
+    final_response = None
+    async for response, chunk in chat.stream():
+        deltas = deltas_from_chunk(chunk)
+        if deltas.thinking:
+            yield LLMThinkingDeltaEvent(type="thinking_delta", text=deltas.thinking)
+        if deltas.text:
+            yield LLMTextDeltaEvent(type="text_delta", text=deltas.text)
+        final_response = response
+
+    if final_response is None:
+        # Empty stream — yield a clean done so the loop exits.
+        yield LLMDoneEvent(type="done", stop_reason="stop", content=[])
+        return
+
+    for tool_event in tool_call_events_from_response(final_response):
+        yield tool_event
+
+    if usage_sink is not None:
+        usage_sink.absorb(usage_record_from_response(final_response))
+
+    yield done_event_from_response(final_response)
+
+
 class XaiLLM:
-    """AILLM backed by the agent_loop + an xAI StreamFn.
+    """AILLM backed by the agent_loop + an xai-sdk StreamFn.
 
     History is supplied by the caller (read from the Message table in
     ``api/chat.py``).  Tools are injected per-request via the
@@ -341,7 +308,7 @@ class XaiLLM:
         self,
         question: str,
         conversation_id: uuid.UUID,
-        user_id: uuid.UUID,
+        user_id: uuid.UUID,  # kept for AILLM protocol parity
         history: list[dict[str, str]] | None = None,
         tools: list[AgentTool] | None = None,
         system_prompt: str | None = None,
@@ -353,9 +320,10 @@ class XaiLLM:
 
         Args:
             question: The current user message.
-            conversation_id: Used for logging only; xAI's
-                OpenAI-compatible API has no native session concept.
-            user_id: Authenticated user UUID (used for logging).
+            conversation_id: Used for logging only; xAI's API has no
+                native session concept — the loop ships full history
+                on every request.
+            user_id: Authenticated user UUID (kept for protocol parity).
             history: Prior messages oldest-first as ``{role, content}``
                 dicts.  Mapped onto :class:`UserMessage` /
                 :class:`AssistantMessage` instances.
@@ -364,20 +332,21 @@ class XaiLLM:
             system_prompt: System prompt for this turn.  ``None`` falls
                 back to :data:`DEFAULT_AGENT_SYSTEM_PROMPT` so bare
                 unit tests still work.
-            reasoning_effort: Optional reasoning-depth knob.  Mapped onto
-                grok-4.3's two-level enum (``low`` / ``high``) via
-                :func:`_map_reasoning_effort` and forwarded to xAI via
-                ``extra_body``.  The model's chain-of-thought streams
-                back as ``reasoning_content`` deltas and surfaces as
+            reasoning_effort: Optional reasoning-depth knob.  Mapped
+                onto grok-4.3's two-level enum via
+                :func:`_map_reasoning_effort` and passed to xai-sdk.
+                The model's chain-of-thought streams back as
+                ``reasoning_content`` deltas and surfaces as
                 :class:`StreamEvent` ``thinking`` events for the UI.
             permission_check: Optional cross-provider permission gate
                 (PR 03b).  Threaded straight into
                 :class:`AgentLoopConfig` so denial flows through the
                 same code path Gemini and Claude use.
             images: Optional multimodal image inputs.  Accepted for
-                protocol parity; not yet bridged to xAI's image-input
-                shape (a non-empty list is logged and ignored so
-                callers can switch on it without a runtime error).
+                protocol parity; not yet bridged to xai-sdk's
+                :func:`xai_sdk.chat.image` content type (a non-empty
+                list is logged and ignored so callers can switch on it
+                without a runtime error).
         """
         if images:
             logger.debug(
@@ -437,9 +406,9 @@ class XaiLLM:
 
         # Terminal usage event — the chat aggregator folds it into the
         # cost ledger (see ``ChatTurnAggregator.apply`` and
-        # ``app.channels._turn_cost.record_turn_cost_if_enabled``).  Skip
-        # when no chunk reported usage (test scripts, error-only turns)
-        # so the ledger doesn't see spurious zero rows.
+        # ``app.channels._turn_cost.record_turn_cost_if_enabled``).
+        # Skip when no chunk reported usage (test scripts, error-only
+        # turns) so the ledger doesn't see spurious zero rows.
         if usage_sink.saw_any:
             yield StreamEvent(
                 type="usage",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,18 +30,19 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-logging>=0.50b0",
     "markitdown[all]>=0.1.1",
-    "openai>=1.0.0",
+    "xai-sdk>=1.12.0",
 ]
 
 # Optional voice transcription backends (PR 14). The ``api/stt.py``
 # xAI proxy is in the core dependencies; these are needed only when
 # ``VOICE_PROVIDER`` is ``mistral`` or ``openai``. Local whisper.cpp
 # uses subprocess calls and needs no Python package.
-# ``openai`` itself is now a core dep (powers the xAI chat provider via
-# OpenAI-compatible base_url) so it's not listed here.
+# Chat is served via the official ``xai-sdk`` (gRPC) — declared above
+# under core dependencies alongside the other provider SDKs.
 [project.optional-dependencies]
 voice = [
     "mistralai>=1.0.0",
+    "openai>=1.0.0",
 ]
 
 [dependency-groups]
@@ -217,7 +218,10 @@ disallow_untyped_defs = false  # test fixtures are fine without explicit types
 
 [[tool.mypy.overrides]]
 # Third-party packages without complete type stubs.
-module = ["sqlalchemy_utils.*", "mcp.*", "markitdown.*"]
+# xai_sdk ships generated protobuf classes without a ``py.typed`` marker;
+# mypy can't follow the .pyi files the SDK omits.  The provider does its
+# own narrow type-checking at the seam.
+module = ["sqlalchemy_utils.*", "mcp.*", "markitdown.*", "xai_sdk.*"]
 ignore_missing_imports = true
 
 # --- bandit: security scanner ------------------------------------------------

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -1,10 +1,12 @@
-"""Unit tests for xAI provider request/response translation helpers.
+"""Unit tests for xAI provider's xai-sdk message/stream translation helpers.
 
-These exercise the small pure helpers that turn ``AgentMessage`` lists
-and openai-SDK streaming chunks into the OpenAI wire shape (and back).
-They do NOT hit the agent loop — that path is covered by
+Exercises the small pure helpers that turn ``AgentMessage`` lists into
+``chat_pb2`` protos and translate xai-sdk ``Chunk`` / ``Response``
+typed objects back into loop-shaped ``LLMEvent`` / ``StreamEvent``.
+
+These tests DO NOT hit the agent loop — that path is covered by
 ``test_xai_stream_fn.py`` via ``ScriptedStreamFn``.  Splitting the
-concerns keeps each test focused: the helpers only do shape
+concerns keeps each file focused: the helpers only do shape
 translation, so they should be testable without booting the loop.
 """
 
@@ -17,11 +19,11 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from xai_sdk.proto import chat_pb2
 
 from app.core.agent_loop.types import (
     AgentTool,
     AssistantMessage,
-    LLMDoneEvent,
     TextContent,
     ToolCallContent,
     ToolResultContent,
@@ -30,96 +32,202 @@ from app.core.agent_loop.types import (
 )
 from app.core.providers._xai_messages import (
     build_xai_messages,
-    build_xai_tool_declarations,
+    build_xai_tools,
 )
-from app.core.providers._xai_stream import parse_tool_arguments
+from app.core.providers._xai_stream import (
+    UsageAccumulator,
+    deltas_from_chunk,
+    done_event_from_response,
+    tool_call_events_from_response,
+    usage_record_from_response,
+)
 from app.core.providers.xai_provider import (
-    XAI_BASE_URL,
     XaiLLM,
-    _build_xai_extra_body,
+    _live_search_off,
     _map_reasoning_effort,
     _resolve_xai_api_key,
     make_xai_stream_fn,
 )
 
+# ---------------------------------------------------------------------------
+# Fake xai-sdk surface
+# ---------------------------------------------------------------------------
 
-def _delta(
+
+def _fake_chunk(
     *,
     content: str | None = None,
+    reasoning_content: str | None = None,
     tool_calls: list[Any] | None = None,
-    finish: str | None = None,
 ) -> SimpleNamespace:
-    """Shape a ``ChatCompletionChunk``-like fake the provider can iterate."""
-    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
-    choice = SimpleNamespace(delta=delta, finish_reason=finish, index=0)
-    return SimpleNamespace(choices=[choice])
+    """Shape a ``xai_sdk.chat.Chunk``-like object the provider can iterate."""
+    return SimpleNamespace(
+        content=content or "",
+        reasoning_content=reasoning_content or "",
+        tool_calls=tool_calls or [],
+    )
 
 
-def _tc_delta(
+def _fake_tool_call(
     *,
-    index: int,
-    tc_id: str | None = None,
-    name: str | None = None,
-    arguments: str | None = None,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    call_id: str = "tc-1",
 ) -> SimpleNamespace:
-    """Fake one ``ChoiceDeltaToolCall`` fragment."""
-    fn = SimpleNamespace(name=name, arguments=arguments)
-    return SimpleNamespace(index=index, id=tc_id, function=fn)
+    """One xai-sdk-style tool call: ``call.id``, ``call.function.name``, ``call.function.arguments``."""
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(arguments or {}),
+        ),
+    )
+
+
+def _fake_response(
+    *,
+    content: str = "",
+    reasoning_content: str = "",
+    tool_calls: list[Any] | None = None,
+    finish_reason: str = "REASON_STOP",
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    cost_usd: float | None = None,
+) -> SimpleNamespace:
+    """Shape a ``xai_sdk.chat.Response``-like accumulated object."""
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning_content,
+        tool_calls=tool_calls or [],
+        finish_reason=finish_reason,
+        usage=usage,
+        cost_usd=cost_usd,
+    )
+
+
+class _FakeChat:
+    """Stand-in for ``client.chat.create(...)`` returning an iterable Chat.
+
+    ``last_create_kwargs`` records the kwargs the provider passed so
+    tests can assert on request shape (model, tools, search_parameters,
+    reasoning_effort).  The constructor takes a script of
+    ``(response, chunk)`` tuples — yielded by ``stream()`` in order.
+    """
+
+    def __init__(
+        self,
+        steps: list[tuple[Any, Any]],
+        create_kwargs: dict[str, Any],
+    ) -> None:
+        self._steps = steps
+        self.last_create_kwargs = create_kwargs
+
+    async def stream(self) -> AsyncIterator[tuple[Any, Any]]:
+        for step in self._steps:
+            yield step
+
+
+class _FakeChatNamespace:
+    """Holds the captured kwargs across ``create()`` calls."""
+
+    def __init__(self, steps: list[tuple[Any, Any]]) -> None:
+        self._steps = steps
+        self.last_create_kwargs: dict[str, Any] | None = None
+
+    def create(self, **kwargs: Any) -> _FakeChat:
+        self.last_create_kwargs = kwargs
+        return _FakeChat(self._steps, kwargs)
+
+
+class _FakeAsyncClient:
+    """Async-context-manager stand-in for ``xai_sdk.AsyncClient``."""
+
+    def __init__(self, steps: list[tuple[Any, Any]]) -> None:
+        self.chat = _FakeChatNamespace(steps)
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+def _patch_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    steps: list[tuple[Any, Any]],
+) -> _FakeAsyncClient:
+    """Patch ``AsyncClient`` in the provider module and return the fake."""
+    fake = _FakeAsyncClient(steps)
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.AsyncClient",
+        lambda **_kwargs: fake,
+    )
+    return fake
 
 
 # ---------------------------------------------------------------------------
-# Pure helpers
+# build_xai_tools
 # ---------------------------------------------------------------------------
 
 
-def test_build_tool_declarations_returns_none_when_empty() -> None:
-    """No tools → None (not []) so we skip the param entirely on the wire."""
-    assert build_xai_tool_declarations([]) is None
+def test_build_tools_returns_none_when_empty() -> None:
+    """No tools → None so the create() call omits the field entirely."""
+    assert build_xai_tools([]) is None
 
 
-def test_build_tool_declarations_wraps_each_tool_in_function_shape() -> None:
-    """Each AgentTool becomes one ``{"type":"function", "function": ...}`` entry."""
+def test_build_tools_wraps_each_agent_tool_in_function_proto() -> None:
+    """Each AgentTool becomes one ``chat_pb2.Tool`` with the function spec."""
 
     async def _execute(_call_id: str, **_kwargs: Any) -> str:
         return ""
 
-    tool = AgentTool(
+    pawrrtal_tool = AgentTool(
         name="search",
         description="Search the web",
         parameters={"type": "object", "properties": {"q": {"type": "string"}}},
         execute=_execute,
     )
 
-    declarations = build_xai_tool_declarations([tool])
-
+    declarations = build_xai_tools([pawrrtal_tool])
     assert declarations is not None
-    assert declarations == [
-        {
-            "type": "function",
-            "function": {
-                "name": "search",
-                "description": "Search the web",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"q": {"type": "string"}},
-                },
-            },
-        }
-    ]
+    assert len(declarations) == 1
+    proto = declarations[0]
+    assert proto.function.name == "search"
+    assert proto.function.description == "Search the web"
+    parsed = json.loads(proto.function.parameters)
+    assert parsed == {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+    }
 
 
-def test_build_xai_messages_prepends_system_prompt() -> None:
-    """The system prompt becomes the first ``role="system"`` entry."""
+# ---------------------------------------------------------------------------
+# build_xai_messages
+# ---------------------------------------------------------------------------
+
+
+def test_build_messages_prepends_developer_system_prompt() -> None:
+    """The system prompt becomes the first ``ROLE_DEVELOPER`` message."""
     msgs = build_xai_messages(
         [UserMessage(role="user", content="hello")],
         system_prompt="you are helpful",
     )
-    assert msgs[0] == {"role": "system", "content": "you are helpful"}
-    assert msgs[1] == {"role": "user", "content": "hello"}
+    assert msgs[0].role == chat_pb2.MessageRole.ROLE_DEVELOPER
+    assert msgs[0].content[0].text == "you are helpful"
+    assert msgs[1].role == chat_pb2.MessageRole.ROLE_USER
+    assert msgs[1].content[0].text == "hello"
 
 
-def test_build_xai_messages_translates_assistant_with_tool_calls() -> None:
-    """An assistant turn splits text + tool calls into the OpenAI shape."""
+def test_build_messages_translates_assistant_with_tool_calls() -> None:
+    """An assistant turn with tool calls renders the proto's ``tool_calls`` field."""
     assistant = AssistantMessage(
         role="assistant",
         content=[
@@ -134,21 +242,18 @@ def test_build_xai_messages_translates_assistant_with_tool_calls() -> None:
         stop_reason="tool_use",
     )
     msgs = build_xai_messages([assistant], system_prompt="sys")
-    # Index 0 is the system prompt; index 1 is the assistant turn.
-    entry = msgs[1]
-    assert entry["role"] == "assistant"
-    assert entry["content"] == "searching..."
-    assert entry["tool_calls"] == [
-        {
-            "id": "tc-1",
-            "type": "function",
-            "function": {"name": "search", "arguments": json.dumps({"q": "pawrrtal"})},
-        }
-    ]
+    proto = msgs[1]
+    assert proto.role == chat_pb2.MessageRole.ROLE_ASSISTANT
+    assert proto.content[0].text == "searching..."
+    assert len(proto.tool_calls) == 1
+    call = proto.tool_calls[0]
+    assert call.id == "tc-1"
+    assert call.function.name == "search"
+    assert json.loads(call.function.arguments) == {"q": "pawrrtal"}
 
 
-def test_build_xai_messages_assistant_without_text_uses_none_content() -> None:
-    """An assistant turn that's only tool_calls still wires content=None."""
+def test_build_messages_assistant_tool_calls_only_keeps_empty_content() -> None:
+    """An assistant turn that's only tool_calls drops the text content array."""
     assistant = AssistantMessage(
         role="assistant",
         content=[
@@ -157,13 +262,13 @@ def test_build_xai_messages_assistant_without_text_uses_none_content() -> None:
         stop_reason="tool_use",
     )
     msgs = build_xai_messages([assistant], system_prompt="sys")
-    entry = msgs[1]
-    assert entry["content"] is None
-    assert entry["tool_calls"][0]["function"]["name"] == "ping"
+    proto = msgs[1]
+    assert list(proto.content) == []
+    assert proto.tool_calls[0].function.name == "ping"
 
 
-def test_build_xai_messages_translates_tool_result() -> None:
-    """A toolResult message renders into OpenAI's ``role="tool"`` entry."""
+def test_build_messages_translates_tool_result_to_role_tool() -> None:
+    """A toolResult message renders the SDK's tool_result helper output."""
     msg = ToolResultMessage(
         role="toolResult",
         tool_call_id="tc-1",
@@ -175,22 +280,26 @@ def test_build_xai_messages_translates_tool_result() -> None:
         is_error=False,
     )
     msgs = build_xai_messages([msg], system_prompt="sys")
-    assert msgs[1] == {
-        "role": "tool",
-        "tool_call_id": "tc-1",
-        "content": "line 1\nline 2",
-    }
+    proto = msgs[1]
+    assert proto.role == chat_pb2.MessageRole.ROLE_TOOL
+    assert proto.tool_call_id == "tc-1"
+    assert proto.content[0].text == "line 1\nline 2"
 
 
-def test_parse_tool_arguments_handles_empty_and_invalid() -> None:
-    """Empty string → empty dict; bad JSON → empty dict with a warning."""
-    assert parse_tool_arguments("", "ping") == {}
-    assert parse_tool_arguments('{"x": 1}', "ping") == {"x": 1}
-    # Invalid JSON should fall back to empty, not raise.
-    assert parse_tool_arguments("{not json", "ping") == {}
+def test_build_messages_drops_empty_user_messages() -> None:
+    """Blank-only user messages are dropped — historical behaviour."""
+    msgs = build_xai_messages([UserMessage(role="user", content="   ")], system_prompt="sys")
+    # Only the system prompt survives.
+    assert len(msgs) == 1
+    assert msgs[0].role == chat_pb2.MessageRole.ROLE_DEVELOPER
 
 
-def test_resolve_xai_api_key_uses_settings_when_no_workspace(
+# ---------------------------------------------------------------------------
+# _resolve_xai_api_key
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_api_key_uses_settings_when_no_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No workspace_id → use the gateway-global key from Settings."""
@@ -201,7 +310,7 @@ def test_resolve_xai_api_key_uses_settings_when_no_workspace(
     assert _resolve_xai_api_key(None) == "gateway-key"
 
 
-def test_resolve_xai_api_key_workspace_override(
+def test_resolve_api_key_workspace_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """workspace_id present → delegate to resolve_api_key (mocked)."""
@@ -214,353 +323,262 @@ def test_resolve_xai_api_key_workspace_override(
 
 
 # ---------------------------------------------------------------------------
-# StreamFn integration with a fake openai client
-# ---------------------------------------------------------------------------
-
-
-class _FakeStream:
-    """Async-iterable wrapper around a list of chunk fakes."""
-
-    def __init__(self, chunks: list[Any]) -> None:
-        self._chunks = chunks
-
-    def __aiter__(self) -> AsyncIterator[Any]:
-        return self._iterate()
-
-    async def _iterate(self) -> AsyncIterator[Any]:
-        for chunk in self._chunks:
-            yield chunk
-
-
-class _FakeCompletions:
-    """Captures the kwargs the provider passes to ``chat.completions.create``."""
-
-    def __init__(self, chunks: list[Any]) -> None:
-        self._chunks = chunks
-        self.last_kwargs: dict[str, Any] | None = None
-
-    async def create(self, **kwargs: Any) -> _FakeStream:
-        self.last_kwargs = kwargs
-        return _FakeStream(self._chunks)
-
-
-class _FakeClient:
-    """Replaces ``AsyncOpenAI`` so no network call happens during tests."""
-
-    def __init__(self, chunks: list[Any]) -> None:
-        self.chat = SimpleNamespace(completions=_FakeCompletions(chunks))
-
-
-@pytest.mark.anyio
-async def test_stream_fn_assembles_tool_call_from_streamed_fragments(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Streamed tool-call arg fragments are accumulated into one LLMToolCallEvent."""
-    chunks = [
-        _delta(content="thinking..."),
-        _delta(
-            tool_calls=[
-                _tc_delta(index=0, tc_id="call-1", name="search", arguments='{"q":'),
-            ]
-        ),
-        _delta(tool_calls=[_tc_delta(index=0, arguments=' "grok"')]),
-        _delta(tool_calls=[_tc_delta(index=0, arguments="}")]),
-        _delta(finish="tool_calls"),
-    ]
-    fake = _FakeClient(chunks)
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
-
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
-    events = [event async for event in stream_fn([], [])]
-
-    text_events = [e for e in events if e["type"] == "text_delta"]
-    tool_events = [e for e in events if e["type"] == "tool_call"]
-    done_events = [e for e in events if e["type"] == "done"]
-
-    assert [e["text"] for e in text_events] == ["thinking..."]
-    assert len(tool_events) == 1
-    assert tool_events[0]["name"] == "search"
-    assert tool_events[0]["arguments"] == {"q": "grok"}
-    assert tool_events[0]["tool_call_id"] == "call-1"
-
-    assert len(done_events) == 1
-    done = done_events[0]
-    assert done["stop_reason"] == "tool_use"
-    assert any(b["type"] == "toolCall" for b in done["content"])
-
-
-@pytest.mark.anyio
-async def test_stream_fn_plain_text_turn_emits_stop(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A pure-text turn ends with ``stop_reason='stop'`` and one text block."""
-    chunks = [_delta(content="hi"), _delta(content=" there"), _delta(finish="stop")]
-    fake = _FakeClient(chunks)
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
-
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
-    events = [event async for event in stream_fn([], [])]
-
-    assert events[-1]["type"] == "done"
-    assert events[-1]["stop_reason"] == "stop"
-    assert events[-1]["content"] == [TextContent(type="text", text="hi there")]
-
-
-@pytest.mark.anyio
-async def test_stream_fn_request_payload_includes_system_and_tools(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The request kwargs carry the system prompt and tool declarations."""
-    fake = _FakeClient([_delta(finish="stop")])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
-
-    async def _execute(_call_id: str, **_kwargs: Any) -> str:
-        return ""
-
-    tool = AgentTool(
-        name="ping",
-        description="ping",
-        parameters={"type": "object", "properties": {}},
-        execute=_execute,
-    )
-
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="custom-sys")
-    async for _ in stream_fn([UserMessage(role="user", content="hello")], [tool]):
-        pass
-
-    kwargs = fake.chat.completions.last_kwargs
-    assert kwargs is not None
-    assert kwargs["model"] == "grok-4.3"
-    assert kwargs["stream"] is True
-    assert kwargs["messages"][0] == {"role": "system", "content": "custom-sys"}
-    assert kwargs["tools"] is not None
-    # Live Search must be disabled by default: pawrrtal uses exa_search
-    # as the canonical web tool and we don't want xAI double-billing or
-    # ghost-searching every turn.  See ``_LIVE_SEARCH_DISABLED``.
-    assert kwargs["extra_body"]["search_parameters"] == {"mode": "off"}
-    assert kwargs["tools"][0]["function"]["name"] == "ping"
-
-
-@pytest.mark.anyio
-async def test_stream_fn_surfaces_upstream_error_as_done_event(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An exception raised by the SDK becomes a graceful error ``done`` event."""
-
-    class _ExplodingCompletions:
-        async def create(self, **_kwargs: Any) -> Any:
-            raise RuntimeError("upstream 503")
-
-    class _ExplodingClient:
-        chat = SimpleNamespace(completions=_ExplodingCompletions())
-
-    monkeypatch.setattr(
-        "app.core.providers.xai_provider.AsyncOpenAI",
-        lambda **_kwargs: _ExplodingClient(),
-    )
-
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
-    events = [event async for event in stream_fn([], [])]
-
-    text = next(e for e in events if e["type"] == "text_delta")
-    done = next(e for e in events if e["type"] == "done")
-    assert "upstream 503" in text["text"]
-    assert done["stop_reason"] == "error"
-
-
-def test_xai_base_url_points_at_xai_v1() -> None:
-    """Regression guard: ensure we never accidentally hit api.openai.com."""
-    assert XAI_BASE_URL == "https://api.x.ai/v1"
-
-
-def test_provider_class_construction_records_model_and_workspace() -> None:
-    """Smoke check the class shape (the chat router constructs the provider)."""
-    workspace = uuid4()
-    provider = XaiLLM("grok-4.3", workspace_id=workspace)
-    # No public getters — assert via private slots since this is an internal contract.
-    assert provider._model_id == "grok-4.3"
-    assert provider._workspace_id == workspace
-
-
-@pytest.mark.anyio
-async def test_done_assistant_blocks_include_unstreamed_text_and_tool_calls(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """LLMDoneEvent.content lists every text + tool-call block from the turn."""
-    chunks = [
-        _delta(content="ack"),
-        _delta(
-            tool_calls=[
-                _tc_delta(index=0, tc_id="call-A", name="echo", arguments='{"value":"hi"}'),
-            ]
-        ),
-        _delta(finish="tool_calls"),
-    ]
-    fake = _FakeClient(chunks)
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
-
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
-    events = [event async for event in stream_fn([], [])]
-
-    done = next(e for e in events if e["type"] == "done")
-    assert isinstance(done, dict)
-    # Narrow for the type checker so mypy understands the union shape.
-    done_event: LLMDoneEvent = done  # type: ignore[assignment]
-    text_blocks = [b for b in done_event["content"] if b["type"] == "text"]
-    tool_blocks = [b for b in done_event["content"] if b["type"] == "toolCall"]
-    assert [b["text"] for b in text_blocks] == ["ack"]
-    assert len(tool_blocks) == 1
-    assert tool_blocks[0]["name"] == "echo"
-    assert tool_blocks[0]["arguments"] == {"value": "hi"}
-
-
-# ---------------------------------------------------------------------------
-# xAI-specific extensions: reasoning_effort + reasoning_content + Live Search
+# _map_reasoning_effort + _live_search_off
 # ---------------------------------------------------------------------------
 
 
 def test_map_reasoning_effort_collapses_four_levels_to_two() -> None:
-    """Pawrrtal's four-level UI knob → grok-4.3's two-level enum.
-
-    grok-4.3 rejects anything other than ``"low"`` or ``"high"``
-    (https://docs.x.ai/docs/models/grok-4-3), so the mapper has to
-    collapse ``medium``/``extra-high`` rather than pass them through.
-    """
+    """Pawrrtal's four-level UI knob → grok-4.3's two-level proto enum."""
     assert _map_reasoning_effort(None) is None
-    assert _map_reasoning_effort("low") == "low"
-    assert _map_reasoning_effort("medium") == "low"
-    assert _map_reasoning_effort("high") == "high"
-    assert _map_reasoning_effort("extra-high") == "high"
+    assert _map_reasoning_effort("low") == chat_pb2.ReasoningEffort.EFFORT_LOW
+    assert _map_reasoning_effort("medium") == chat_pb2.ReasoningEffort.EFFORT_LOW
+    assert _map_reasoning_effort("high") == chat_pb2.ReasoningEffort.EFFORT_HIGH
+    assert _map_reasoning_effort("extra-high") == chat_pb2.ReasoningEffort.EFFORT_HIGH
 
 
-def test_build_xai_extra_body_always_disables_live_search() -> None:
-    """search_parameters.mode is always ``off`` regardless of effort."""
-    assert _build_xai_extra_body(None) == {"search_parameters": {"mode": "off"}}
-    assert _build_xai_extra_body("low") == {
-        "search_parameters": {"mode": "off"},
-        "reasoning_effort": "low",
-    }
-    assert _build_xai_extra_body("high") == {
-        "search_parameters": {"mode": "off"},
-        "reasoning_effort": "high",
-    }
+def test_live_search_off_returns_off_mode() -> None:
+    """The default Live Search guard sets ``mode="off"``."""
+    sp = _live_search_off()
+    # ``SearchParameters`` is the xai-sdk dataclass; the live wire mode
+    # is exposed via the ``mode`` attribute as a string literal.
+    assert sp.mode == "off"
 
 
-@pytest.mark.anyio
-async def test_stream_fn_forwards_mapped_reasoning_effort(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``reasoning_effort='extra-high'`` lands as ``'high'`` in extra_body."""
-    fake = _FakeClient([_delta(finish="stop")])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+# ---------------------------------------------------------------------------
+# Stream helpers (Chunk → ChunkDeltas, Response → events)
+# ---------------------------------------------------------------------------
 
-    stream_fn = make_xai_stream_fn(
-        "grok-4.3", None, system_prompt="sys", reasoning_effort="extra-high"
+
+def test_deltas_from_chunk_text_only() -> None:
+    """A plain text chunk yields ``ChunkDeltas(text=..., thinking=None)``."""
+    deltas = deltas_from_chunk(_fake_chunk(content="hi"))
+    assert deltas.text == "hi"
+    assert deltas.thinking is None
+
+
+def test_deltas_from_chunk_reasoning_only() -> None:
+    """A reasoning-only chunk yields ``thinking`` without bleeding into ``text``."""
+    deltas = deltas_from_chunk(_fake_chunk(reasoning_content="Let me think..."))
+    assert deltas.text is None
+    assert deltas.thinking == "Let me think..."
+
+
+def test_deltas_from_chunk_empty_strings_normalise_to_none() -> None:
+    """Empty-string fields normalise to None so the caller can branch on truthiness."""
+    deltas = deltas_from_chunk(_fake_chunk(content="", reasoning_content=""))
+    assert deltas.text is None
+    assert deltas.thinking is None
+
+
+def test_tool_call_events_from_response_translates_each_call() -> None:
+    """Each accumulated tool call becomes one :class:`LLMToolCallEvent`."""
+    response = _fake_response(
+        tool_calls=[
+            _fake_tool_call(name="search", arguments={"q": "x"}, call_id="tc-A"),
+            _fake_tool_call(name="get_weather", arguments={"city": "Paris"}, call_id="tc-B"),
+        ],
     )
-    async for _ in stream_fn([], []):
-        pass
+    events = tool_call_events_from_response(response)
+    assert len(events) == 2
+    assert events[0]["name"] == "search"
+    assert events[0]["arguments"] == {"q": "x"}
+    assert events[0]["tool_call_id"] == "tc-A"
+    assert events[1]["name"] == "get_weather"
+    assert events[1]["arguments"] == {"city": "Paris"}
+    assert events[1]["tool_call_id"] == "tc-B"
 
-    kwargs = fake.chat.completions.last_kwargs
-    assert kwargs is not None
-    assert kwargs["extra_body"]["reasoning_effort"] == "high"
-    assert kwargs["extra_body"]["search_parameters"] == {"mode": "off"}
+
+def test_tool_call_events_handle_empty_arguments_as_dict() -> None:
+    """A tool call with empty-string arguments becomes ``{}``."""
+    call = SimpleNamespace(
+        id="tc-1",
+        function=SimpleNamespace(name="ping", arguments=""),
+    )
+    response = _fake_response(tool_calls=[call])
+    events = tool_call_events_from_response(response)
+    assert events[0]["arguments"] == {}
 
 
-@pytest.mark.anyio
-async def test_stream_fn_emits_thinking_deltas_from_reasoning_content(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """xAI's ``delta.reasoning_content`` surfaces as ``thinking_delta`` events.
+def test_done_event_marks_tool_use_when_tool_calls_present() -> None:
+    """``done.stop_reason="tool_use"`` when the response carries tool calls."""
+    response = _fake_response(
+        content="thinking...",
+        tool_calls=[_fake_tool_call(name="search", arguments={"q": "x"})],
+        finish_reason="REASON_TOOL_CALLS",
+    )
+    done = done_event_from_response(response)
+    assert done["stop_reason"] == "tool_use"
+    blocks = list(done["content"])
+    text_blocks = [b for b in blocks if b["type"] == "text"]
+    tool_blocks = [b for b in blocks if b["type"] == "toolCall"]
+    assert text_blocks[0]["text"] == "thinking..."
+    assert tool_blocks[0]["name"] == "search"
 
-    Mirrors the Gemini regression test for issue #98 — without this
-    wiring the frontend's thinking pane is empty for Grok even though
-    grok-4.3 streams its chain-of-thought back on every reasoning turn.
+
+def test_done_event_marks_stop_for_text_only_response() -> None:
+    """``done.stop_reason="stop"`` when there are no tool calls."""
+    response = _fake_response(content="final answer", finish_reason="REASON_STOP")
+    done = done_event_from_response(response)
+    assert done["stop_reason"] == "stop"
+    assert done["content"] == [TextContent(type="text", text="final answer")]
+
+
+def test_done_event_marks_tool_use_when_finish_reason_says_so() -> None:
+    """Even with no tool_calls list, ``REASON_TOOL_CALLS`` flips stop_reason.
+
+    Defensive — guards against an SDK chunk-vs-response race where the
+    response's ``tool_calls`` is empty momentarily but the finish reason
+    has already been written.
     """
-    # ``ChoiceDelta`` has ``extra='allow'``; the openai SDK preserves
-    # ``reasoning_content`` on unknown-field deltas via Pydantic.  We
-    # mimic that here so the test stays decoupled from the SDK's
-    # internal mutation API.
-    thinking_chunk = SimpleNamespace(
-        choices=[
-            SimpleNamespace(
-                delta=SimpleNamespace(
-                    content=None,
-                    tool_calls=None,
-                    reasoning_content="Let me think... 2 + 2 = 4.",
-                ),
-                finish_reason=None,
-                index=0,
-            )
-        ]
+    response = _fake_response(content="", finish_reason="REASON_TOOL_CALLS")
+    done = done_event_from_response(response)
+    assert done["stop_reason"] == "tool_use"
+
+
+def test_usage_record_reads_tokens_and_cost() -> None:
+    """``usage_record_from_response`` reads ``cost_usd`` and token counts."""
+    response = _fake_response(prompt_tokens=42, completion_tokens=17, cost_usd=0.0001234)
+    record = usage_record_from_response(response)
+    assert record is not None
+    assert record.input_tokens == 42
+    assert record.output_tokens == 17
+    assert record.cost_usd == pytest.approx(0.0001234)
+
+
+def test_usage_record_returns_none_when_nothing_reported() -> None:
+    """Empty usage + missing cost → None, so the ledger sees nothing."""
+    response = _fake_response(prompt_tokens=0, completion_tokens=0, cost_usd=None)
+    assert usage_record_from_response(response) is None
+
+
+def test_usage_accumulator_sums_across_iterations() -> None:
+    """The accumulator sums multiple :class:`UsageRecord` instances."""
+    from app.core.providers._xai_stream import UsageRecord
+
+    sink = UsageAccumulator()
+    sink.absorb(UsageRecord(input_tokens=10, output_tokens=5, cost_usd=0.001))
+    sink.absorb(UsageRecord(input_tokens=20, output_tokens=15, cost_usd=0.003))
+    sink.absorb(None)  # no-op for turns without usage
+    assert sink.saw_any is True
+    assert sink.input_tokens == 30
+    assert sink.output_tokens == 20
+    assert sink.cost_usd == pytest.approx(0.004)
+
+
+# ---------------------------------------------------------------------------
+# StreamFn integration against a fake xai-sdk client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stream_fn_yields_text_and_thinking_deltas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text chunks → ``LLMTextDeltaEvent``; reasoning chunks → ``LLMThinkingDeltaEvent``.
+
+    The frontend's "thinking" pane (already wired for Gemini) renders
+    these as a separate panel from the assistant transcript.
+    """
+    response_text_only = _fake_response(content="4", finish_reason="REASON_STOP")
+    response_after_reasoning = _fake_response(
+        content="4",
+        reasoning_content="Let me think... 2 + 2 = 4.",
+        finish_reason="REASON_STOP",
     )
-    answer_chunk = _delta(content="4", finish="stop")
-    fake = _FakeClient([thinking_chunk, answer_chunk])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+    steps: list[tuple[Any, Any]] = [
+        (response_after_reasoning, _fake_chunk(reasoning_content="Let me think... 2 + 2 = 4.")),
+        (response_text_only, _fake_chunk(content="4")),
+    ]
+    _patch_async_client(monkeypatch, steps)
 
     stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
     events = [event async for event in stream_fn([], [])]
-
-    thinking_events = [e for e in events if e["type"] == "thinking_delta"]
-    text_events = [e for e in events if e["type"] == "text_delta"]
-    assert any("2 + 2 = 4" in e["text"] for e in thinking_events)
-    # Reasoning content must NOT bleed into the regular text stream — the
-    # frontend renders text_delta in the assistant transcript.
-    assert not any("Let me think" in e["text"] for e in text_events)
-    assert any(e["text"] == "4" for e in text_events)
-
-
-# ---------------------------------------------------------------------------
-# Cost tracking: usage capture + terminal StreamEvent
-# ---------------------------------------------------------------------------
+    thinking = [e for e in events if e["type"] == "thinking_delta"]
+    text = [e for e in events if e["type"] == "text_delta"]
+    assert any("2 + 2 = 4" in e["text"] for e in thinking)
+    assert any(e["text"] == "4" for e in text)
+    # Reasoning must not bleed into the regular text stream.
+    assert not any("Let me think" in e["text"] for e in text)
 
 
 @pytest.mark.anyio
-async def test_stream_fn_requests_include_usage(
+async def test_stream_fn_emits_tool_calls_after_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``stream_options.include_usage=True`` is on every request.
+    """Tool calls surface as ``LLMToolCallEvent`` after the stream ends.
 
-    Without it xAI never emits the ``usage`` block and the cost ledger
-    sees zero for every Grok turn.
+    Reading from the accumulated :class:`Response` (not from streamed
+    chunks) sidesteps the question of how xAI partitions tool-call
+    chunks — the SDK accumulates either way.
     """
-    fake = _FakeClient([_delta(finish="stop")])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+    final_response = _fake_response(
+        content="searching",
+        tool_calls=[_fake_tool_call(name="search", arguments={"q": "pawrrtal"})],
+        finish_reason="REASON_TOOL_CALLS",
+    )
+    steps: list[tuple[Any, Any]] = [
+        (final_response, _fake_chunk(content="searching")),
+    ]
+    _patch_async_client(monkeypatch, steps)
 
     stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
-    async for _ in stream_fn([], []):
-        pass
-
-    kwargs = fake.chat.completions.last_kwargs
-    assert kwargs is not None
-    assert kwargs["stream_options"] == {"include_usage": True}
+    events = [event async for event in stream_fn([], [])]
+    tool_events = [e for e in events if e["type"] == "tool_call"]
+    assert len(tool_events) == 1
+    assert tool_events[0]["name"] == "search"
+    assert tool_events[0]["arguments"] == {"q": "pawrrtal"}
+    # Tool call must arrive after every delta but before the done event.
+    delta_idx = next(i for i, e in enumerate(events) if e["type"] == "text_delta")
+    tool_idx = next(i for i, e in enumerate(events) if e["type"] == "tool_call")
+    done_idx = next(i for i, e in enumerate(events) if e["type"] == "done")
+    assert delta_idx < tool_idx < done_idx
 
 
 @pytest.mark.anyio
-async def test_stream_fn_accumulates_usage_from_final_chunk(
+async def test_stream_fn_request_carries_search_off_and_reasoning_effort(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The final chunk's ``usage`` block lands on the shared accumulator.
-
-    xAI emits one ``usage`` block per request on the chunk just before
-    ``[DONE]``; the StreamFn must read both the OpenAI-standard names
-    (``prompt_tokens``/``completion_tokens``) and the xAI extras
-    (``cost_in_usd_ticks``) and convert ticks → USD at the documented
-    ``1e-10`` rate.
-    """
-    from app.core.providers._xai_stream import UsageAccumulator
-
-    usage_chunk = SimpleNamespace(
-        choices=[],
-        usage=SimpleNamespace(
-            prompt_tokens=120,
-            completion_tokens=45,
-            total_tokens=165,
-            cost_in_usd_ticks=4_250_000_000,  # 0.000425 USD
-        ),
+    """The create() kwargs always disable Live Search and forward the mapped effort."""
+    fake = _patch_async_client(
+        monkeypatch, [(_fake_response(content="hi"), _fake_chunk(content="hi"))]
     )
-    chunks = [_delta(content="hi"), _delta(finish="stop"), usage_chunk]
-    fake = _FakeClient(chunks)
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+
+    stream_fn = make_xai_stream_fn(
+        "grok-4.3", None, system_prompt="custom-sys", reasoning_effort="extra-high"
+    )
+    async for _ in stream_fn([UserMessage(role="user", content="hello")], []):
+        pass
+
+    kwargs = fake.chat.last_create_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "grok-4.3"
+    # First message is the system prompt rendered as ROLE_DEVELOPER.
+    assert kwargs["messages"][0].role == chat_pb2.MessageRole.ROLE_DEVELOPER
+    assert kwargs["messages"][0].content[0].text == "custom-sys"
+    # extra-high → EFFORT_HIGH (the upper bucket of grok-4.3's two-level enum).
+    assert kwargs["reasoning_effort"] == chat_pb2.ReasoningEffort.EFFORT_HIGH
+    # Live Search forced off so xAI's built-in search doesn't fire.
+    assert kwargs["search_parameters"].mode == "off"
+
+
+@pytest.mark.anyio
+async def test_stream_fn_captures_usage_into_accumulator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The terminal :class:`Response`'s usage lands on the shared accumulator.
+
+    Multiple iterations of the agent loop each call the StreamFn; the
+    accumulator must sum across them so a tool-using turn pays for
+    every internal LLM call.
+    """
+    final_response = _fake_response(
+        content="hi",
+        prompt_tokens=120,
+        completion_tokens=45,
+        cost_usd=0.0001234,
+        finish_reason="REASON_STOP",
+    )
+    _patch_async_client(monkeypatch, [(final_response, _fake_chunk(content="hi"))])
 
     sink = UsageAccumulator()
     stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys", usage_sink=sink)
@@ -570,65 +588,67 @@ async def test_stream_fn_accumulates_usage_from_final_chunk(
     assert sink.saw_any
     assert sink.input_tokens == 120
     assert sink.output_tokens == 45
-    # 4_250_000_000 ticks * 1e-10 USD/tick = 0.425 USD.
-    assert sink.cost_usd == pytest.approx(0.425, abs=1e-9)
+    assert sink.cost_usd == pytest.approx(0.0001234)
 
 
 @pytest.mark.anyio
-async def test_stream_fn_accumulator_reads_xai_naming_fallback(
+async def test_stream_fn_surfaces_upstream_error_as_done_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``input_tokens``/``output_tokens`` (xAI naming) is read if OpenAI names missing.
+    """An exception during streaming becomes a graceful error ``done`` event."""
 
-    The Chat Completions endpoint uses the OpenAI names by default, but
-    xAI's own SDK proto uses ``input_tokens``/``output_tokens`` — guard
-    against an endpoint variant that emits the latter only.
-    """
-    from app.core.providers._xai_stream import UsageAccumulator
+    class _ExplodingChatNamespace:
+        def create(self, **_kwargs: Any) -> Any:
+            raise RuntimeError("upstream 503")
 
-    usage_chunk = SimpleNamespace(
-        choices=[],
-        usage=SimpleNamespace(input_tokens=10, output_tokens=20, cost_in_usd_ticks=0),
+    class _ExplodingClient:
+        def __init__(self) -> None:
+            self.chat = _ExplodingChatNamespace()
+
+        async def __aenter__(self) -> _ExplodingClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "app.core.providers.xai_provider.AsyncClient",
+        lambda **_kwargs: _ExplodingClient(),
     )
-    fake = _FakeClient([_delta(finish="stop"), usage_chunk])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
 
-    sink = UsageAccumulator()
-    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys", usage_sink=sink)
-    async for _ in stream_fn([], []):
-        pass
+    stream_fn = make_xai_stream_fn("grok-4.3", None, system_prompt="sys")
+    events = [event async for event in stream_fn([], [])]
+    text_events = [e for e in events if e["type"] == "text_delta"]
+    done_events = [e for e in events if e["type"] == "done"]
+    assert any("upstream 503" in e["text"] for e in text_events)
+    assert done_events[-1]["stop_reason"] == "error"
 
-    assert sink.input_tokens == 10
-    assert sink.output_tokens == 20
-    assert sink.cost_usd == 0.0
+
+# ---------------------------------------------------------------------------
+# End-to-end: XaiLLM.stream emits the terminal usage StreamEvent
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
 async def test_xai_provider_emits_terminal_usage_stream_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``XaiLLM.stream`` emits ``StreamEvent(type='usage', ...)`` after agent_loop.
+    """``XaiLLM.stream`` emits ``StreamEvent(type="usage", ...)`` after agent_loop.
 
     The chat aggregator folds this into the cost ledger via
     :func:`record_turn_cost_if_enabled`, same shape as Claude's
-    ``_build_usage_event``.  Real ``agent_loop`` runs end-to-end with a
-    fake :class:`AsyncOpenAI` that emits a text chunk plus a final
-    usage chunk — exercising the actual ``stream_options.include_usage``
-    code path, not a patched factory.
+    ``_build_usage_event``.  Real ``agent_loop`` runs end-to-end with
+    a fake :class:`AsyncClient` so the actual usage-capture code path
+    is exercised, not a patched factory.
     """
-    from app.core.providers.xai_provider import XaiLLM
-
-    usage_chunk = SimpleNamespace(
-        choices=[],
-        usage=SimpleNamespace(
-            prompt_tokens=42,
-            completion_tokens=17,
-            total_tokens=59,
-            cost_in_usd_ticks=1_234_000,  # 1.234e-4 USD
-        ),
+    final_response = _fake_response(
+        content="hi",
+        prompt_tokens=42,
+        completion_tokens=17,
+        cost_usd=0.000125,
+        finish_reason="REASON_STOP",
     )
-    fake = _FakeClient([_delta(content="hi"), _delta(finish="stop"), usage_chunk])
-    monkeypatch.setattr("app.core.providers.xai_provider.AsyncOpenAI", lambda **_kwargs: fake)
+    _patch_async_client(monkeypatch, [(final_response, _fake_chunk(content="hi"))])
 
     provider = XaiLLM("grok-4.3")
     events = [
@@ -640,34 +660,28 @@ async def test_xai_provider_emits_terminal_usage_stream_event(
             history=[],
         )
     ]
-
     usage_events = [e for e in events if e["type"] == "usage"]
     assert len(usage_events) == 1
     usage_event = usage_events[0]
     assert usage_event["input_tokens"] == 42
     assert usage_event["output_tokens"] == 17
-    assert usage_event["cost_usd"] == pytest.approx(1.234e-4, abs=1e-12)
-    # Must arrive after the text delta the model produced — the cost
-    # ledger row is finalised once the user-visible reply is on the wire.
-    assert events.index(usage_event) > events.index(next(e for e in events if e["type"] == "delta"))
+    assert usage_event["cost_usd"] == pytest.approx(0.000125)
+    # Usage event arrives after the visible reply — cost ledger row is
+    # finalised once the user-visible reply is on the wire.
+    delta_idx = events.index(next(e for e in events if e["type"] == "delta"))
+    usage_idx = events.index(usage_event)
+    assert usage_idx > delta_idx
 
 
 @pytest.mark.anyio
 async def test_xai_provider_skips_usage_event_when_no_chunk_reported(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When no chunk carries usage (early failure, test stream), no usage event fires.
-
-    Stops spurious zero-cost rows in the ledger.
-    """
-    from app.core.providers.xai_provider import XaiLLM
+    """When no turn reported usage, no usage event fires — no spurious zeros."""
     from tests.agent_harness import ScriptedStreamFn, text_turn
 
-    # Real ScriptedStreamFn — no real chunks, so usage_sink never sees
-    # a ``usage`` field.
     provider = XaiLLM("grok-4.3")
     monkeypatch.setattr(provider, "_stream_fn", ScriptedStreamFn([text_turn("hi")]))
-
     events = [
         e
         async for e in provider.stream(
@@ -677,5 +691,4 @@ async def test_xai_provider_skips_usage_event_when_no_chunk_reported(
             history=[],
         )
     ]
-
     assert not any(e["type"] == "usage" for e in events)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1157,6 +1157,37 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2204,11 +2235,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -2281,7 +2312,6 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "markitdown", extra = ["all"] },
     { name = "mcp" },
-    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -2295,11 +2325,13 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "sqlalchemy-utils" },
     { name = "structlog" },
+    { name = "xai-sdk" },
 ]
 
 [package.optional-dependencies]
 voice = [
     { name = "mistralai" },
+    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -2328,7 +2360,7 @@ requires-dist = [
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.1" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "mistralai", marker = "extra == 'voice'", specifier = ">=1.0.0" },
-    { name = "openai", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'voice'", specifier = ">=1.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },
@@ -2342,6 +2374,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "sqlalchemy-utils", specifier = ">=0.42.1" },
     { name = "structlog", specifier = ">=24.0.0" },
+    { name = "xai-sdk", specifier = ">=1.12.0" },
 ]
 provides-extras = ["voice"]
 
@@ -3623,6 +3656,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "xai-sdk"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/21/b6683eeb797bac6dd46e55e9fbdb15c598b34fadd862120da4c09d1d01d0/xai_sdk-1.12.2.tar.gz", hash = "sha256:917d1887e6afdb49fff9f0dc6ae1bceede43a747365a406a3486af3e23509be4", size = 414440, upload-time = "2026-05-07T00:07:01.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/b1/76da151f71a2dc9a65ef725ad4bac597a8d02da6618fb0474468a3355a34/xai_sdk-1.12.2-py3-none-any.whl", hash = "sha256:a3b4079f0629637009c5e3d58388f8c88591658dde31f202d5f5e8560fe6e120", size = 256654, upload-time = "2026-05-07T00:06:59.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stacked on top of #314.  Each Pawrrtal chat provider is now self-contained on its vendor's first-party SDK — Claude uses `claude-agent-sdk`, Gemini uses `google-genai`, and (with this PR) xAI uses the official `xai-sdk` (gRPC, v1.12.2).  Replaces the openai-compat HTTP path #314 introduced.

## What changed

| Concern | Before (openai-compat HTTP) | After (xai-sdk gRPC) |
|---|---|---|
| Client | `AsyncOpenAI(base_url="https://api.x.ai/v1")` | `xai_sdk.AsyncClient(api_key=...)` with `async with` lifecycle |
| Messages | dynamic `dict[str, Any]` + named-type casts at the SDK seam | typed `chat_pb2.Message` built via SDK helpers (`system`, `user`, `tool_result`, `tool`) |
| System prompt | `{role:"system"}` first message | `ROLE_DEVELOPER` (xAI's modern role; server downgrades to system for grok-4.1 and below) |
| `reasoning_effort` | string in `extra_body` | typed `chat_pb2.ReasoningEffort` proto enum |
| `reasoning_content` deltas | `getattr(delta, "reasoning_content", None)` via `extra='allow'` | typed `chunk.reasoning_content` accessor |
| `search_parameters` | dict in `extra_body` | typed `xai_sdk.search.SearchParameters(mode="off")` |
| Tool calls | accumulated across streamed fragments via `ToolCallAccumulator` | the SDK accumulates internally; we read `response.tool_calls` once after the stream ends |
| Cost | locally computed `cost_in_usd_ticks * 1e-10` | `response.cost_usd` (SDK does the conversion via `xai_sdk.cost`) |
| `usage` capture | reading `prompt_tokens` / `input_tokens` defensively off `extra='allow'` | typed `response.usage.prompt_tokens` / `.completion_tokens` |

Pawrrtal's 4-level reasoning-effort UI knob still collapses to grok-4.3's 2 levels (`low | medium` → `EFFORT_LOW`, `high | extra-high` → `EFFORT_HIGH`).

## What I considered changing but didn't

**STT** — `xai-sdk` does not expose audio/speech-to-text.  `backend/app/api/stt.py` already calls `POST https://api.x.ai/v1/stt` over `httpx` (never used the openai SDK for the xAI path), so the swap is a no-op for STT.

**Responses API** — `client.responses.*` is reachable from this SDK now, but actually migrating chat to it is a larger semantic change (different streaming events, `previous_response_id` history reuse, server-side `web_search` tool).  Worth its own PR — opened the door, didn't walk through.

**`openai` core dep** — now removed.  `openai` returns to the `voice` extras (still used by `app/integrations/voice/transcriber.py` for the Whisper backend when `VOICE_PROVIDER=openai`).

## Test plan

- [x] 39 xAI-specific tests pass (35 before this PR + 4 net new for `Chunk`/`Response`-shape helpers).
- [x] Full backend suite: 906 passed, 1 skipped, 0 regressions.
- [x] `ruff check` clean.  `mypy` clean on new files (added `xai_sdk.*` to the missing-stubs override since the SDK ships generated protobuf without `py.typed` — matches the existing `mcp.*` / `markitdown.*` entries).
- [x] All architecture gates pass: file-line, nesting, tools-in-providers, import-linter.
- [x] Provider stays under the 500-line budget (418 lines); helpers split into `_xai_messages` / `_xai_stream` / `_xai_events`.
- [ ] Live smoke against `https://api.x.ai` with a real `XAI_API_KEY` — gated on credentials.  The test suite covers the SDK boundary via a fake `AsyncClient`.

## Base branch

This PR targets `claude/add-xai-grok-provider-CLrWY` (PR #314), not `development`.  Once #314 merges, this rebases onto development as a clean refactor commit.

https://claude.ai/code/session_01TTKYnNfdc1KFNDkktv7TKX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTKYnNfdc1KFNDkktv7TKX)_