### PR TITLE
feat(workspace): pin dev-admin workspace to a stable on-disk folder

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -6,7 +6,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.crud.workspace import ensure_default_workspace
+from app.crud.workspace import ensure_dev_admin_workspace
 from app.db import get_async_session
 from app.users import UserManager, auth_backend, get_jwt_strategy, get_user_manager
 
@@ -31,8 +31,10 @@ def get_auth_router() -> APIRouter:
         the onboarding wizard instead of the home shell. Personalization
         upsert still creates one for real users via
         :func:`app.crud.workspace.ensure_default_workspace` — this call
-        just hits the same idempotent path earlier so dev-login is enough
-        to land on a fully rendered app.
+        hits the dev-admin-specific seed path so the workspace folder is
+        pinned to a stable location on disk (``{workspace_base_dir}/dev-admin``).
+        That keeps a developer's working files in the same directory across
+        DB resets, so wiping Postgres doesn't force a file copy.
         """
         if settings.is_production:
             raise HTTPException(
@@ -67,13 +69,14 @@ def get_auth_router() -> APIRouter:
             )
 
         # Idempotent — returns the existing workspace if one is already
-        # present. ``create_workspace`` (called inside) does not commit,
+        # present, otherwise creates one pinned to the stable dev-admin
+        # folder. ``create_workspace`` (called inside) does not commit,
         # so we commit the outer transaction ourselves before returning
         # the login response. Errors are logged + swallowed: a failed
         # seed must never block dev-login (the user can still personalise
         # via the UI to get a workspace).
         try:
-            await ensure_default_workspace(user.id, session)
+            await ensure_dev_admin_workspace(user.id, session)
             await session.commit()
         except Exception:
             logger.exception("DEV_LOGIN_WORKSPACE_SEED_FAILED user_id=%s", user.id)

--- a/backend/app/core/workspace.py
+++ b/backend/app/core/workspace.py
@@ -418,15 +418,22 @@ def _workspace_path(workspace_id: uuid.UUID) -> Path:
 def seed_workspace(
     workspace_id: uuid.UUID,
     personalization: PersonalizationFields | None = None,
+    *,
+    path: Path | None = None,
 ) -> Path:
     """Create the workspace directory tree and write seed files.
 
     Idempotent — existing files are not overwritten, so re-running after a
     partial seed is safe.  New directories are always created.
 
+    Pass ``path`` to override the default ``{workspace_base_dir}/{uuid}``
+    location with a caller-supplied root (used by the dev-admin shortcut so
+    its workspace folder stays stable across DB resets).  When omitted, the
+    UUID-based path is used as before.
+
     Returns the workspace root path.
     """
-    root = _workspace_path(workspace_id)
+    root = path if path is not None else _workspace_path(workspace_id)
 
     # Create four-layer memory directories, skills, artifacts, and protocols.
     for subdir in (*_MEMORY_LAYERS, _SKILLS_DIR, "artifacts", _PROTOCOLS_DIR):

--- a/backend/app/crud/workspace.py
+++ b/backend/app/crud/workspace.py
@@ -23,6 +23,12 @@ from app.core.workspace import seed_workspace
 
 log = logging.getLogger(__name__)
 
+# Stable folder name reserved for the seeded dev-admin user.  Using a fixed
+# directory (instead of the random UUID layout the rest of the app uses)
+# keeps the dev admin's workspace files in the same place across DB resets,
+# so a developer can wipe Postgres without re-copying their working files.
+DEV_ADMIN_WORKSPACE_DIRNAME = "dev-admin"
+
 if TYPE_CHECKING:
     from app.models import UserPersonalization, Workspace
 
@@ -64,18 +70,24 @@ async def create_workspace(
     slug: str = "main",
     is_default: bool = True,
     personalization: UserPersonalization | None = None,
+    *,
+    path: Path | None = None,
 ) -> Workspace:
     """Create a new workspace row in the DB and seed its directory.
 
     Does NOT commit — the caller is responsible for committing the session so
     this can participate in larger transactions.
+
+    Pass ``path`` to pin the workspace directory to a caller-supplied
+    location instead of the default ``{workspace_base_dir}/{uuid}`` layout.
+    Reserved for the dev-admin stable-folder flow.
     """
     from app.models import Workspace  # noqa: PLC0415
 
     workspace_id = uuid.uuid4()
 
     # Seed filesystem first so we can capture the canonical path.
-    root = seed_workspace(workspace_id, personalization)
+    root = seed_workspace(workspace_id, personalization, path=path)
 
     ws = Workspace(
         id=workspace_id,
@@ -144,6 +156,58 @@ async def ensure_default_workspace(
             # Should never happen: the constraint fired but no row exists.
             raise RuntimeError(
                 f"ensure_default_workspace: could not find default workspace "
+                f"for user {user_id} after IntegrityError"
+            ) from None
+        return result
+
+
+async def ensure_dev_admin_workspace(
+    user_id: uuid.UUID,
+    session: AsyncSession,
+    personalization: UserPersonalization | None = None,
+) -> Workspace:
+    """Return the dev admin's default workspace, creating it at a stable path.
+
+    Mirrors :func:`ensure_default_workspace` but pins the on-disk directory
+    to ``{workspace_base_dir}/dev-admin`` so the folder survives DB resets.
+    Filesystem seeding is idempotent — :func:`seed_workspace` only writes
+    files and directories that do not already exist, so a developer's
+    working files in ``dev-admin/`` are preserved when the DB row is
+    recreated.
+
+    Reserved for the dev-login endpoint (which is itself gated to non-prod);
+    real users should keep going through :func:`ensure_default_workspace`.
+    """
+    existing = await get_default_workspace(user_id, session)
+    if existing is not None:
+        return existing
+
+    stable_path = Path(settings.workspace_base_dir) / DEV_ADMIN_WORKSPACE_DIRNAME
+    try:
+        async with session.begin_nested():
+            ws = await create_workspace(
+                user_id=user_id,
+                session=session,
+                name="Main",
+                slug="main",
+                is_default=True,
+                personalization=personalization,
+                path=stable_path,
+            )
+        return ws
+    except IntegrityError:
+        # Same concurrent-insert recovery as ensure_default_workspace; the
+        # stable directory is left in place because the winning row points
+        # at it too.
+        log.warning(
+            "ensure_dev_admin_workspace: IntegrityError for user %s — "
+            "concurrent insert detected, re-fetching existing row.",
+            user_id,
+        )
+        result = await get_default_workspace(user_id, session)
+        if result is None:
+            raise RuntimeError(
+                f"ensure_dev_admin_workspace: could not find default workspace "
                 f"for user {user_id} after IntegrityError"
             ) from None
         return result

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -31,8 +31,10 @@ from app.core.workspace import (
     seed_workspace,
 )
 from app.crud.workspace import (
+    DEV_ADMIN_WORKSPACE_DIRNAME,
     create_workspace,
     ensure_default_workspace,
+    ensure_dev_admin_workspace,
     get_default_workspace,
     list_workspaces,
 )
@@ -396,6 +398,68 @@ class TestWorkspaceService:
             await db_session.commit()
 
         assert ws1.id == ws2.id
+
+    @pytest.mark.anyio
+    async def test_ensure_dev_admin_workspace_uses_stable_path(
+        self, db_session: AsyncSession, test_user: User, tmp_path: Path
+    ) -> None:
+        with (
+            patch("app.core.workspace.settings") as mock_core_settings,
+            patch("app.crud.workspace.settings") as mock_crud_settings,
+        ):
+            mock_core_settings.workspace_base_dir = str(tmp_path)
+            mock_crud_settings.workspace_base_dir = str(tmp_path)
+            ws = await ensure_dev_admin_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        assert ws.path == str(tmp_path / DEV_ADMIN_WORKSPACE_DIRNAME)
+        assert (Path(ws.path) / "AGENTS.md").exists()
+
+    @pytest.mark.anyio
+    async def test_ensure_dev_admin_workspace_preserves_existing_files(
+        self, db_session: AsyncSession, test_user: User, tmp_path: Path
+    ) -> None:
+        """Simulates a DB-reset run: the dev-admin folder already has user
+        files; the helper must reuse the folder without overwriting them.
+        """
+        stable_root = tmp_path / DEV_ADMIN_WORKSPACE_DIRNAME
+        (stable_root / "artifacts").mkdir(parents=True)
+        user_file = stable_root / "artifacts" / "my-notes.md"
+        user_file.write_text("important user content", encoding="utf-8")
+        # Pre-existing seed file with edited content must not be clobbered.
+        edited_agents = stable_root / "AGENTS.md"
+        edited_agents.write_text("hand-edited", encoding="utf-8")
+
+        with (
+            patch("app.core.workspace.settings") as mock_core_settings,
+            patch("app.crud.workspace.settings") as mock_crud_settings,
+        ):
+            mock_core_settings.workspace_base_dir = str(tmp_path)
+            mock_crud_settings.workspace_base_dir = str(tmp_path)
+            ws = await ensure_dev_admin_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        assert ws.path == str(stable_root)
+        assert user_file.read_text(encoding="utf-8") == "important user content"
+        assert edited_agents.read_text(encoding="utf-8") == "hand-edited"
+
+    @pytest.mark.anyio
+    async def test_ensure_dev_admin_workspace_is_idempotent(
+        self, db_session: AsyncSession, test_user: User, tmp_path: Path
+    ) -> None:
+        with (
+            patch("app.core.workspace.settings") as mock_core_settings,
+            patch("app.crud.workspace.settings") as mock_crud_settings,
+        ):
+            mock_core_settings.workspace_base_dir = str(tmp_path)
+            mock_crud_settings.workspace_base_dir = str(tmp_path)
+            ws1 = await ensure_dev_admin_workspace(test_user.id, db_session)
+            await db_session.commit()
+            ws2 = await ensure_dev_admin_workspace(test_user.id, db_session)
+            await db_session.commit()
+
+        assert ws1.id == ws2.id
+        assert ws1.path == ws2.path
 
     @pytest.mark.anyio
     async def test_list_workspaces_empty_for_new_user(


### PR DESCRIPTION
## Summary

- The dev admin's workspace now lives at a fixed `{workspace_base_dir}/dev-admin` directory instead of the UUID-keyed layout the rest of the app uses, so wiping Postgres no longer forces a manual file copy. Filesystem seeding stays idempotent — only missing files/dirs are written, hand-edited content is preserved.
- New `ensure_dev_admin_workspace` helper mirrors `ensure_default_workspace` but pins the path. `seed_workspace` / `create_workspace` gain an optional `path` override that's reserved for this flow.
- `dev-login` is the only caller. Real users keep going through `ensure_default_workspace` via the personalization endpoint, so the UUID-based layout is unchanged for them. `dev-login` is already 404 in production, so the stable path is fundamentally dev-only.

## Test plan
- [x] `pytest backend/tests/test_workspace.py` — added 3 tests covering stable path, file preservation across DB-reset simulation, and idempotency; existing tests still pass.
- [x] `ruff check backend/` — clean.
- [ ] Manual: delete the DB, restart backend, hit `/api/v1/auth/dev-login`, confirm `{workspace_base_dir}/dev-admin/` files survive the next DB wipe.

https://claude.ai/code/session_01BnoZLviW56UUDSc9FTL7Uv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnoZLviW56UUDSc9FTL7Uv)_