### PR TITLE
fix(playwright): in-progress test infrastructure cleanup + design-system color contrast

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,16 +9,16 @@ description: >
   @font-face rules in frontend/app/globals.css; token --font-sans-stack in
   frontend/app/globals.css).
 colors:
-  primary: "#FA520F"
+  primary: "#D14100"
   on-primary: "#FFFFFF"
   background: "#FFF8E0"
   foreground: "#1F1F1F"
-  accent: "#FA520F"
+  accent: "#D14100"
   info: "#FF8105"
   success: "#22783C"
   destructive: "#CC3A05"
   border: "#E8E0C9"
-  muted-foreground: "#8A8888"
+  muted-foreground: "#787570"
   user-message-bubble: "#F5EDD0"
   info-text: "#6F4419"
   success-text: "#1F4A30"

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,16 +1,9 @@
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import Response
 from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.crud.workspace import ensure_default_workspace
-from app.db import get_async_session
 from app.users import UserManager, auth_backend, get_jwt_strategy, get_user_manager
-
-logger = logging.getLogger(__name__)
 
 
 def get_auth_router() -> APIRouter:
@@ -20,19 +13,17 @@ def get_auth_router() -> APIRouter:
     @router.post("/auth/dev-login")
     async def dev_login(
         user_manager: UserManager = Depends(get_user_manager),
-        session: AsyncSession = Depends(get_async_session),
     ) -> Response:
         """Log in with the seeded admin account without exposing its password to the client.
 
-        Auto-provisions a default workspace for the admin user when none
-        exists yet. The web app refuses to render the sidebar until the
-        active user has a default workspace (`onboarding-status`); without
-        this step, Playwright suites that drive the seeded admin land on
-        the onboarding wizard instead of the home shell. Personalization
-        upsert still creates one for real users via
-        :func:`app.crud.workspace.ensure_default_workspace` — this call
-        just hits the same idempotent path earlier so dev-login is enough
-        to land on a fully rendered app.
+        The dev-login endpoint is intentionally minimal: it authenticates
+        the seeded admin and returns the session cookie. It does **not**
+        seed a workspace — that's left to the personalization flow so
+        Playwright suites can drive both pre-onboarding and post-onboarding
+        states independently. The workspace seed lives in the
+        ``authenticatedPageWithWorkspace`` fixture in
+        ``frontend/e2e/fixtures.ts`` for tests that need a fully-rendered
+        home shell.
         """
         if settings.is_production:
             raise HTTPException(
@@ -65,19 +56,6 @@ def get_auth_router() -> APIRouter:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="The dev admin account is inactive.",
             )
-
-        # Idempotent — returns the existing workspace if one is already
-        # present. ``create_workspace`` (called inside) does not commit,
-        # so we commit the outer transaction ourselves before returning
-        # the login response. Errors are logged + swallowed: a failed
-        # seed must never block dev-login (the user can still personalise
-        # via the UI to get a workspace).
-        try:
-            await ensure_default_workspace(user.id, session)
-            await session.commit()
-        except Exception:
-            logger.exception("DEV_LOGIN_WORKSPACE_SEED_FAILED user_id=%s", user.id)
-            await session.rollback()
 
         return await auth_backend.login(get_jwt_strategy(), user)
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -220,9 +220,13 @@
 	--foreground-rgb: 31, 31, 31;
 	--user-message-bubble: oklch(from var(--foreground) l c h / 0.05);
 	--user-message-bubble-dimmed: oklch(from var(--foreground) l c h / 0.03);
-	/* Mistral orange ~#fa520f — saturated brand CTA + active states. */
-	--accent: oklch(0.66 0.21 38);
-	--accent-rgb: 250, 82, 15;
+	/* Mistral orange ~#fa520f — saturated brand CTA + active states.
+	 * Lightness pulled down from 0.66 → 0.58 so white text on the
+	 * primary button passes WCAG AA (≥ 4.5:1) — the previous shade
+	 * computed to 3.4:1 on axe-core. The hue + chroma stay so the
+	 * brand identity reads identically. */
+	--accent: oklch(0.58 0.21 38);
+	--accent-rgb: 209, 65, 0;
 	/* Mistral sunshine ~#ff8105 — warm sunlight for "Ask" / warnings. */
 	--info: oklch(0.74 0.18 55);
 	--info-rgb: 255, 129, 5;
@@ -303,7 +307,12 @@
 	--secondary: oklch(from var(--foreground) l c h / 0.05);
 	--secondary-foreground: var(--foreground);
 	--muted: oklch(from var(--foreground) l c h / 0.05);
-	--muted-foreground: var(--foreground-50);
+	/* WCAG AA secondary text needs 4.5:1 contrast against ``--background``.
+	 * ``--foreground-50`` (50% mix of fg into bg) computes to ~3.34:1 on
+	 * the cream canvas — fails axe-core's color-contrast rule. ``--foreground-60``
+	 * pushes the mix darker (≥ 4.5:1) and keeps the same visual hierarchy.
+	 * Mirrors what dark mode already uses (see line ~504). */
+	--muted-foreground: var(--foreground-60);
 	--card: var(--background);
 	--card-foreground: var(--foreground);
 	--popover: var(--background);

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -36,11 +36,21 @@ test.describe('a11y smoke', () => {
 	test('authenticated home shell has no auto-detectable a11y violations', async ({
 		page,
 		context,
+		request,
 	}) => {
-		const response = await context.request.post(
+		const loginResponse = await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		expect(loginResponse.ok()).toBe(true);
+		// Home shell + settings render only when a default workspace
+		// exists (see ``useOnboardingReadiness``). Trigger the
+		// personalization upsert so onboarding-status reports
+		// has_workspace_ready=true before we navigate.
+		const provisionResponse = await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{ data: { name: 'E2E Admin' } }
+		);
+		expect(provisionResponse.ok()).toBe(true);
 		await page.goto('/');
 		await expect(
 			page.getByPlaceholder(/^(Ask|Type|Send)/i).or(page.getByRole('textbox'))
@@ -54,11 +64,24 @@ test.describe('a11y smoke', () => {
 		expect(results.violations).toEqual([]);
 	});
 
-	test('settings page has no auto-detectable a11y violations', async ({ page, context }) => {
-		const response = await context.request.post(
+	test('settings page has no auto-detectable a11y violations', async ({
+		page,
+		context,
+		request,
+	}) => {
+		const loginResponse = await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		expect(loginResponse.ok()).toBe(true);
+		// Home shell + settings render only when a default workspace
+		// exists (see ``useOnboardingReadiness``). Trigger the
+		// personalization upsert so onboarding-status reports
+		// has_workspace_ready=true before we navigate.
+		const provisionResponse = await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{ data: { name: 'E2E Admin' } }
+		);
+		expect(provisionResponse.ok()).toBe(true);
 		await page.goto('/settings');
 		// AxeBuilder's `Page` type comes from `playwright-core`'s d.ts; our
 		// fixture's `page` comes from `@playwright/test`. The two are
@@ -72,11 +95,21 @@ test.describe('a11y smoke', () => {
 	test('chat composer with a draft has no auto-detectable a11y violations', async ({
 		page,
 		context,
+		request,
 	}) => {
-		const response = await context.request.post(
+		const loginResponse = await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		expect(loginResponse.ok()).toBe(true);
+		// Home shell + settings render only when a default workspace
+		// exists (see ``useOnboardingReadiness``). Trigger the
+		// personalization upsert so onboarding-status reports
+		// has_workspace_ready=true before we navigate.
+		const provisionResponse = await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{ data: { name: 'E2E Admin' } }
+		);
+		expect(provisionResponse.ok()).toBe(true);
 		await page.goto('/');
 		const composer = page
 			.getByPlaceholder(/^(Ask|Type|Send)/i)

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -17,9 +17,27 @@
  */
 
 import AxeBuilder from '@axe-core/playwright';
+import type { BrowserContext } from '@playwright/test';
 import { expect, test } from './fixtures';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+/**
+ * Authenticate + provision a default workspace via the backend so the
+ * authenticated home shell / settings page render the same chrome a
+ * real user sees. ``context.request`` shares cookies with the browser
+ * context, so the dev-login session carries into the personalization
+ * upsert that triggers ``ensure_default_workspace`` server-side.
+ */
+async function seedAuthenticatedHomeShell(context: BrowserContext): Promise<void> {
+	const backend = process.env.E2E_API_URL ?? 'http://localhost:8000';
+	const loginResponse = await context.request.post(`${backend}/auth/dev-login`);
+	expect(loginResponse.ok()).toBe(true);
+	const provisionResponse = await context.request.put(`${backend}/api/v1/personalization`, {
+		data: { name: 'E2E Admin' },
+	});
+	expect(provisionResponse.ok()).toBe(true);
+}
 
 test.describe('a11y smoke', () => {
 	test('login page has no auto-detectable a11y violations', async ({ page }) => {
@@ -36,58 +54,19 @@ test.describe('a11y smoke', () => {
 	test('authenticated home shell has no auto-detectable a11y violations', async ({
 		page,
 		context,
-		request,
 	}) => {
-		const loginResponse = await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
-		expect(loginResponse.ok()).toBe(true);
-		// Home shell + settings render only when a default workspace
-		// exists (see ``useOnboardingReadiness``). Trigger the
-		// personalization upsert so onboarding-status reports
-		// has_workspace_ready=true before we navigate.
-		const provisionResponse = await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{ data: { name: 'E2E Admin' } }
-		);
-		expect(provisionResponse.ok()).toBe(true);
+		await seedAuthenticatedHomeShell(context);
 		await page.goto('/');
 		await expect(
 			page.getByPlaceholder(/^(Ask|Type|Send)/i).or(page.getByRole('textbox'))
 		).toBeVisible();
-		// AxeBuilder's `Page` type comes from `playwright-core`'s d.ts; our
-		// fixture's `page` comes from `@playwright/test`. The two are
-		// structurally compatible but TS sees them as distinct nominal
-		// types — cast through `as never` to silence the duplicate-module
-		// noise without `as any`.
 		const results = await new AxeBuilder({ page: page as never }).withTags(WCAG_TAGS).analyze();
 		expect(results.violations).toEqual([]);
 	});
 
-	test('settings page has no auto-detectable a11y violations', async ({
-		page,
-		context,
-		request,
-	}) => {
-		const loginResponse = await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
-		expect(loginResponse.ok()).toBe(true);
-		// Home shell + settings render only when a default workspace
-		// exists (see ``useOnboardingReadiness``). Trigger the
-		// personalization upsert so onboarding-status reports
-		// has_workspace_ready=true before we navigate.
-		const provisionResponse = await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{ data: { name: 'E2E Admin' } }
-		);
-		expect(provisionResponse.ok()).toBe(true);
+	test('settings page has no auto-detectable a11y violations', async ({ page, context }) => {
+		await seedAuthenticatedHomeShell(context);
 		await page.goto('/settings');
-		// AxeBuilder's `Page` type comes from `playwright-core`'s d.ts; our
-		// fixture's `page` comes from `@playwright/test`. The two are
-		// structurally compatible but TS sees them as distinct nominal
-		// types — cast through `as never` to silence the duplicate-module
-		// noise without `as any`.
 		const results = await new AxeBuilder({ page: page as never }).withTags(WCAG_TAGS).analyze();
 		expect(results.violations).toEqual([]);
 	});
@@ -95,32 +74,14 @@ test.describe('a11y smoke', () => {
 	test('chat composer with a draft has no auto-detectable a11y violations', async ({
 		page,
 		context,
-		request,
 	}) => {
-		const loginResponse = await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
-		expect(loginResponse.ok()).toBe(true);
-		// Home shell + settings render only when a default workspace
-		// exists (see ``useOnboardingReadiness``). Trigger the
-		// personalization upsert so onboarding-status reports
-		// has_workspace_ready=true before we navigate.
-		const provisionResponse = await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{ data: { name: 'E2E Admin' } }
-		);
-		expect(provisionResponse.ok()).toBe(true);
+		await seedAuthenticatedHomeShell(context);
 		await page.goto('/');
 		const composer = page
 			.getByPlaceholder(/^(Ask|Type|Send)/i)
 			.or(page.getByRole('textbox'))
 			.first();
 		await composer.fill('Hello — this is an a11y smoke draft.');
-		// AxeBuilder's `Page` type comes from `playwright-core`'s d.ts; our
-		// fixture's `page` comes from `@playwright/test`. The two are
-		// structurally compatible but TS sees them as distinct nominal
-		// types — cast through `as never` to silence the duplicate-module
-		// noise without `as any`.
 		const results = await new AxeBuilder({ page: page as never }).withTags(WCAG_TAGS).analyze();
 		expect(results.violations).toEqual([]);
 	});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,23 +1,36 @@
 /**
  * Shared Playwright fixtures.
  *
- * `authenticatedPage` runs the dev-admin login via the backend (no UI
- * clicks) and forwards the resulting session cookie into the browser
- * context, so every spec starts already signed in. Per the project's
- * api-setup-not-ui rule.
+ * The suite needs two distinct authenticated states — onboarding tests
+ * exercise the personalization wizard (which only opens when the user
+ * has no workspace yet), while home-shell / sidebar tests expect a
+ * fully provisioned workspace. Splitting the state setup into two
+ * fixtures keeps each test self-contained and prevents cross-test
+ * state leakage.
+ *
+ * `devLogin` does just the auth half: hits `/auth/dev-login`, confirms
+ * the response is 2xx, and returns. The session cookie lands in the
+ * context's cookie jar automatically.
+ *
+ * `ensureProvisionedWorkspace` adds the workspace seed via the
+ * personalization upsert endpoint (which calls
+ * `ensure_default_workspace` server-side). Tests that need the
+ * sidebar visible call this before navigating.
+ *
+ * Per the api-setup-not-ui rule, both helpers drive state through
+ * the backend, not through UI clicks.
  */
 
-import { type BrowserContext, test as base } from '@playwright/test';
+import { type APIRequestContext, type BrowserContext, test as base } from '@playwright/test';
 
 const BACKEND_URL = process.env.E2E_API_URL ?? 'http://localhost:8000';
 
 /**
  * Authenticate the supplied browser context with the dev-admin user.
  *
- * Hits the backend `/auth/dev-login` endpoint directly — the response
- * body is the session payload, and the Set-Cookie header is what the
- * regular browser flow would normally land. We replay that cookie into
- * the context's cookie jar so the next page navigation is signed in.
+ * Hits the backend `/auth/dev-login` endpoint directly. The Set-Cookie
+ * header is captured into the context's cookie jar so subsequent
+ * `page.goto()` calls share the auth session.
  */
 async function devLogin(context: BrowserContext): Promise<void> {
 	const response = await context.request.post(`${BACKEND_URL}/auth/dev-login`);
@@ -26,15 +39,79 @@ async function devLogin(context: BrowserContext): Promise<void> {
 			`Dev login failed (${response.status()}). Make sure ADMIN_EMAIL + ADMIN_PASSWORD are set in backend/.env and the backend is running.`
 		);
 	}
-	// dev-login returns the session cookie via Set-Cookie. Playwright's
-	// request context automatically captures it into the context's cookie
-	// jar, so subsequent page.goto() calls share the auth session.
 }
 
-export const test = base.extend<{ authenticatedPage: void }>({
+/**
+ * Provision a default workspace for the authenticated user.
+ *
+ * Posts a minimal personalization profile, which triggers
+ * `ensure_default_workspace` server-side. Idempotent — calling it
+ * twice in the same test is safe. Tests that need the home shell
+ * fully rendered (sidebar, chat composer, settings) call this after
+ * `devLogin`.
+ */
+async function ensureProvisionedWorkspace(request: APIRequestContext): Promise<void> {
+	const response = await request.put(`${BACKEND_URL}/api/v1/personalization`, {
+		data: {
+			name: 'E2E Admin',
+		},
+	});
+	if (!response.ok()) {
+		throw new Error(
+			`Provisioning the dev workspace failed (${response.status()}). The PUT /api/v1/personalization endpoint is required for sidebar / home-shell tests to land on a populated app shell.`
+		);
+	}
+}
+
+/**
+ * Seed one conversation so the sidebar renders the Projects section.
+ *
+ * ``NavChatsView`` hides the Projects header while the chat list is
+ * empty (see the inline comment near the ``<ProjectsList />`` mount).
+ * Tests that assert on Projects-related UI need at least one
+ * conversation to exist. We generate a UUID client-side and POST it
+ * to ``/api/v1/conversations/{id}`` — matching the FE's
+ * ``createConversationFirst`` pattern.
+ */
+async function seedConversation(request: APIRequestContext): Promise<void> {
+	const conversationId = crypto.randomUUID();
+	const response = await request.post(`${BACKEND_URL}/api/v1/conversations/${conversationId}`, {
+		data: { title: 'E2E Seed Conversation' },
+	});
+	if (!response.ok()) {
+		throw new Error(
+			`Seeding the dev conversation failed (${response.status()}). The sidebar Projects header only renders when at least one chat row exists.`
+		);
+	}
+}
+
+export const test = base.extend<{
+	authenticatedPage: void;
+	authenticatedPageWithWorkspace: void;
+	authenticatedPageWithWorkspaceAndChat: void;
+}>({
 	authenticatedPage: [
 		async ({ context }, use) => {
 			await devLogin(context);
+			await use();
+		},
+		{ auto: false },
+	],
+
+	authenticatedPageWithWorkspace: [
+		async ({ context }, use) => {
+			await devLogin(context);
+			await ensureProvisionedWorkspace(context.request);
+			await use();
+		},
+		{ auto: false },
+	],
+
+	authenticatedPageWithWorkspaceAndChat: [
+		async ({ context }, use) => {
+			await devLogin(context);
+			await ensureProvisionedWorkspace(context.request);
+			await seedConversation(context.request);
 			await use();
 		},
 		{ auto: false },

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -26,23 +26,19 @@ test.describe('login page', () => {
 });
 
 test.describe('authenticated landing', () => {
-	test('dev-login + provisioned workspace lands on the home shell', async ({
-		page,
-		context,
-		request,
-	}) => {
-		const loginResponse = await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
+	test('dev-login + provisioned workspace lands on the home shell', async ({ page, context }) => {
+		const backend = process.env.E2E_API_URL ?? 'http://localhost:8000';
+		// ``context.request`` shares cookies with the browser context, so
+		// the dev-login session carries into the personalization upsert.
+		const loginResponse = await context.request.post(`${backend}/auth/dev-login`);
 		expect(loginResponse.ok()).toBe(true);
 		// The home shell only renders once the user has a provisioned
 		// workspace (see ``useOnboardingReadiness`` + ``AppShell``).
 		// Trigger the personalization upsert so onboarding-status reports
 		// has_workspace_ready=true before we navigate.
-		const provisionResponse = await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{ data: { name: 'E2E Admin' } }
-		);
+		const provisionResponse = await context.request.put(`${backend}/api/v1/personalization`, {
+			data: { name: 'E2E Admin' },
+		});
 		expect(provisionResponse.ok()).toBe(true);
 
 		await page.goto('/');

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -26,11 +26,25 @@ test.describe('login page', () => {
 });
 
 test.describe('authenticated landing', () => {
-	test('dev-login lands on the home shell', async ({ page, context }) => {
-		const response = await context.request.post(
+	test('dev-login + provisioned workspace lands on the home shell', async ({
+		page,
+		context,
+		request,
+	}) => {
+		const loginResponse = await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		expect(loginResponse.ok()).toBe(true);
+		// The home shell only renders once the user has a provisioned
+		// workspace (see ``useOnboardingReadiness`` + ``AppShell``).
+		// Trigger the personalization upsert so onboarding-status reports
+		// has_workspace_ready=true before we navigate.
+		const provisionResponse = await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{ data: { name: 'E2E Admin' } }
+		);
+		expect(provisionResponse.ok()).toBe(true);
+
 		await page.goto('/');
 		// The chat composer is visible from the home page once authenticated.
 		await expect(

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -6,18 +6,18 @@
 import { expect, test } from './fixtures';
 
 test.describe('settings page', () => {
-	test.beforeEach(async ({ context, request }) => {
-		const loginResponse = await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
+	test.beforeEach(async ({ context }) => {
+		const backend = process.env.E2E_API_URL ?? 'http://localhost:8000';
+		// ``context.request`` shares cookies with the browser context, so
+		// the dev-login session carries into the personalization upsert.
+		const loginResponse = await context.request.post(`${backend}/auth/dev-login`);
 		expect(loginResponse.ok()).toBe(true);
 		// Settings page sits under the app shell which gates rendering
 		// on a provisioned workspace. Trigger personalization upsert to
 		// satisfy ``useOnboardingReadiness.hasWorkspaceReady``.
-		const provisionResponse = await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{ data: { name: 'E2E Admin' } }
-		);
+		const provisionResponse = await context.request.put(`${backend}/api/v1/personalization`, {
+			data: { name: 'E2E Admin' },
+		});
 		expect(provisionResponse.ok()).toBe(true);
 	});
 

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -6,11 +6,19 @@
 import { expect, test } from './fixtures';
 
 test.describe('settings page', () => {
-	test.beforeEach(async ({ context }) => {
-		const response = await context.request.post(
+	test.beforeEach(async ({ context, request }) => {
+		const loginResponse = await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		expect(loginResponse.ok()).toBe(true);
+		// Settings page sits under the app shell which gates rendering
+		// on a provisioned workspace. Trigger personalization upsert to
+		// satisfy ``useOnboardingReadiness.hasWorkspaceReady``.
+		const provisionResponse = await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{ data: { name: 'E2E Admin' } }
+		);
+		expect(provisionResponse.ok()).toBe(true);
 	});
 
 	test('General tab renders Profile / Preferences / Notifications groups', async ({ page }) => {

--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -1,6 +1,11 @@
 /**
  * Sidebar smoke: open, close, and project header visibility.
  *
+ * The sidebar's Projects section is only rendered when the chat list
+ * is non-empty (see ``NavChatsView`` for the gate). We use the
+ * ``authenticatedPageWithWorkspaceAndChat`` fixture so the test
+ * starts on a fully populated sidebar.
+ *
  * Multi-select + drag-and-drop need a richer fixture (a real
  * conversation list seeded via the backend) — split into a follow-up
  * suite once the seed helper lands.
@@ -9,11 +14,22 @@
 import { expect, test } from './fixtures';
 
 test.describe('sidebar', () => {
-	test.beforeEach(async ({ context }) => {
-		const response = await context.request.post(
+	test.beforeEach(async ({ context, request }) => {
+		// Re-use the shared fixture's setup so the test is otherwise
+		// independent of the suite ordering.
+		await context.request.post(
 			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
 		);
-		expect(response.ok()).toBe(true);
+		await request.put(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
+			{
+				data: { name: 'E2E Admin' },
+			}
+		);
+		await request.post(
+			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/conversations/${crypto.randomUUID()}`,
+			{ data: { title: 'E2E Seed Conversation' } }
+		);
 	});
 
 	test('renders the Projects header + create-project button', async ({ page }) => {
@@ -24,7 +40,7 @@ test.describe('sidebar', () => {
 
 	test('opens the Create project modal with a name input', async ({ page }) => {
 		await page.goto('/');
-		await page.getByRole('button', { name: 'Create new project' }).click({ force: false });
+		await page.getByRole('button', { name: 'Create new project' }).click();
 		await expect(page.getByRole('heading', { name: 'Create project' })).toBeVisible();
 		await expect(page.getByLabel('Project name')).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Create project' })).toBeDisabled();

--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -2,9 +2,9 @@
  * Sidebar smoke: open, close, and project header visibility.
  *
  * The sidebar's Projects section is only rendered when the chat list
- * is non-empty (see ``NavChatsView`` for the gate). We use the
- * ``authenticatedPageWithWorkspaceAndChat`` fixture so the test
- * starts on a fully populated sidebar.
+ * is non-empty (see ``NavChatsView`` for the gate). Tests seed the
+ * required state via the same ``context.request`` so cookies from
+ * dev-login carry into every subsequent setup call.
  *
  * Multi-select + drag-and-drop need a richer fixture (a real
  * conversation list seeded via the backend) — split into a follow-up
@@ -14,22 +14,22 @@
 import { expect, test } from './fixtures';
 
 test.describe('sidebar', () => {
-	test.beforeEach(async ({ context, request }) => {
-		// Re-use the shared fixture's setup so the test is otherwise
-		// independent of the suite ordering.
-		await context.request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/auth/dev-login`
-		);
-		await request.put(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/personalization`,
-			{
-				data: { name: 'E2E Admin' },
-			}
-		);
-		await request.post(
-			`${process.env.E2E_API_URL ?? 'http://localhost:8000'}/api/v1/conversations/${crypto.randomUUID()}`,
+	test.beforeEach(async ({ context }) => {
+		const backend = process.env.E2E_API_URL ?? 'http://localhost:8000';
+		// ``context.request`` shares cookies with the browser context, so
+		// the dev-login session cookie is available for the personalization
+		// and conversation seed calls below.
+		const loginResponse = await context.request.post(`${backend}/auth/dev-login`);
+		expect(loginResponse.ok()).toBe(true);
+		const provisionResponse = await context.request.put(`${backend}/api/v1/personalization`, {
+			data: { name: 'E2E Admin' },
+		});
+		expect(provisionResponse.ok()).toBe(true);
+		const conversationResponse = await context.request.post(
+			`${backend}/api/v1/conversations/${crypto.randomUUID()}`,
 			{ data: { title: 'E2E Seed Conversation' } }
 		);
+		expect(conversationResponse.ok()).toBe(true);
 	});
 
 	test('renders the Projects header + create-project button', async ({ page }) => {


### PR DESCRIPTION
## Summary — partial progress, in-progress PR

This PR addresses three independent Playwright root causes uncovered after the issue-batch-2 merge (#321) dropped `--bun` from the workflow. Real progress made but **11 tests still fail** — see "Known remaining failures" below.

### Done

1. **WCAG AA color contrast fixes** in the design system:
   - `--accent` lightness 0.66 → 0.58 (white-on-orange clears 4.5:1; was 3.4:1).
   - `--muted-foreground` swaps to `--foreground-60` (cream-bg secondary text clears 4.5:1; was 3.34:1).
   - `DESIGN.md` token values updated; `bun run design:lint` clean.
2. **Revert dev-login workspace auto-seed.** The earlier shortcut on `/auth/dev-login` broke the onboarding suite (the wizard expects no workspace). State seeding belongs in test fixtures, not auth.
3. **Test fixtures split by required state.** `frontend/e2e/fixtures.ts` now exposes three fixtures — `authenticatedPage`, `authenticatedPageWithWorkspace`, `authenticatedPageWithWorkspaceAndChat` — so each spec lands on the state it needs.
4. **Per-spec beforeEach hooks** seed via the backend through `context.request` (shares the dev-login cookie). The earlier `request` fixture didn't carry cookies, returning 401 on every personalization PUT.

### Known remaining failures

11 tests still fail with the home shell / onboarding modal interaction. Likely root causes:

- The FE's `useOnboardingReadiness` queries `/api/v1/workspaces/onboarding-status` via TanStack Query. After PUT personalization, the workspace exists server-side, but the FE either hasn't fetched fresh state on `page.goto('/')` or the modal still opens before the readiness signal updates.
- `getByRole('textbox')` in the a11y home shell test matches multiple textboxes (onboarding modal name + chat composer), so `toBeVisible()` fails the locator-must-be-unique check.

The fix likely requires either (a) updating the test locators to be unique, (b) waiting for the onboarding-status response before asserting on the composer, or (c) further investigating the FE auth/onboarding state plumbing.

### Test plan

- [x] `uv run pytest --ignore=tests/integration --ignore=tests/evals` — 974 passed
- [x] `just check` — ruff + Biome all green
- [x] `bun run design:lint` — DESIGN.md valid
- [x] Local gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)