### PR TITLE
🎨 Palette: Add loading spinner to signup form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## Initializing Palette UX Journal
+## 2024-05-18 - Loading States on Async Form Submissions
+**Learning:** Auth forms with multiple backend steps (register + immediate login) can cause a noticeable delay before redirection. Without visual feedback, users may click submit multiple times or assume the application is frozen. Adding disabled states with explicit loading spinners and text changes (e.g. "Creating Account...") provides crucial reassurance during these async multi-step operations.
+**Action:** Always add loading spinners (`Loader2Icon` or similar) inside submit buttons and disable the button while `isSubmitting` is true on critical user-blocking forms.

--- a/frontend/components/signup-form.tsx
+++ b/frontend/components/signup-form.tsx
@@ -6,6 +6,7 @@
 
 'use client';
 
+import { Loader2Icon } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useId, useState } from 'react';
@@ -161,7 +162,13 @@ export function SignupForm({ ...props }: React.ComponentProps<typeof Card>) {
 						<FieldGroup>
 							<Field>
 								<Button type="submit" disabled={isSubmitting}>
-									Create Account
+									{isSubmitting && (
+										<Loader2Icon
+											className="mr-2 size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									)}
+									{isSubmitting ? 'Creating Account...' : 'Create Account'}
 								</Button>
 								{/* <Button variant="outline" type="button">
                                     Sign up with Google


### PR DESCRIPTION
- Added a `Loader2Icon` with `animate-spin` when `isSubmitting` is true.
- Updated the text to "Creating Account..." during submission.
- Added a journal entry to `.Jules/palette.md` noting the UX pattern of giving loading feedback on signup form submissions.

---
*PR created automatically by Jules for task [15894870977497354749](https://jules.google.com/task/15894870977497354749) started by @OctavianTocan*