### PR TITLE
feat(dev): scope local SQLite db to the current git branch

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -5,6 +5,29 @@
  */
 import { $ } from 'bun';
 
+const SQLITE_DB_FILENAME_PREFIX = 'pawrrtal';
+const MAX_BRANCH_FILENAME_LENGTH = 80;
+
+/**
+ * Resolve a filesystem-safe SQLite filename scoped to the current git branch
+ * so switching branches no longer trashes a shared `pawrrtal.db`. Returns
+ * `null` when there is no current branch (detached HEAD, not a git repo,
+ * empty output), letting the backend's built-in default apply.
+ */
+async function sqliteDbFilenameForBranch(): Promise<string | null> {
+	const result = await $`git rev-parse --abbrev-ref HEAD`.quiet().nothrow();
+	if (result.exitCode !== 0) return null;
+	const branch = result.stdout.toString().trim();
+	if (!branch || branch === 'HEAD') return null;
+	const sanitized = branch
+		.replace(/[^A-Za-z0-9._-]+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^[-.]+|[-.]+$/g, '')
+		.slice(0, MAX_BRANCH_FILENAME_LENGTH);
+	if (!sanitized) return null;
+	return `${SQLITE_DB_FILENAME_PREFIX}-${sanitized}.db`;
+}
+
 // Free up dev ports before starting (handles ghost processes from previous runs).
 // `.nothrow()` keeps the script running even if no process is bound to the port.
 await $`lsof -ti:3001 | xargs kill -9`.quiet().nothrow();
@@ -12,6 +35,18 @@ await $`lsof -ti:8000 | xargs kill -9`.quiet().nothrow();
 
 // Clear Next.js dev lock to avoid the "Unable to acquire lock" error on restart.
 await $`rm -rf frontend/.next/dev/lock`.quiet().nothrow();
+
+// Scope the implicit SQLite database to the current git branch. Honour an
+// existing `SQLITE_DB_FILENAME` override (one-off experiments) and never
+// overwrite an explicit `DATABASE_URL` — the backend's config falls through
+// to `SQLITE_DB_FILENAME` only when `DATABASE_URL` is empty.
+if (!process.env.SQLITE_DB_FILENAME) {
+	const branchDbFilename = await sqliteDbFilenameForBranch();
+	if (branchDbFilename) {
+		process.env.SQLITE_DB_FILENAME = branchDbFilename;
+		console.log(`Using branch-scoped SQLite database: ${branchDbFilename}`);
+	}
+}
 
 console.log(
 	'Starting dev servers — frontend on http://localhost:3001, backend on http://localhost:8000'


### PR DESCRIPTION
## Summary

- `dev.ts` now derives a filesystem-safe `SQLITE_DB_FILENAME` from the current git branch (sanitized, prefixed `pawrrtal-`) before launching the backend, so switching branches no longer trashes a shared `pawrrtal.db`.
- Honours an existing `SQLITE_DB_FILENAME` shell override and falls back to the backend's built-in default in detached-HEAD / non-git states.
- Reuses the existing `SQLITE_DB_FILENAME` knob in `backend/app/core/config.py` — an explicit `DATABASE_URL` (e.g. Postgres) always wins, so this is purely additive for users on the SQLite fallback.

Example: on branch `claude/database-branch-naming-rYwIT`, `just dev` now writes to `pawrrtal-claude-database-branch-naming-rYwIT.db`. `*.db` is already gitignored.

## Test plan

- [x] `bun -e` smoke test of the branch → filename logic on the current branch (`claude/database-branch-naming-rYwIT` → `pawrrtal-claude-database-branch-naming-rYwIT.db`).
- [x] `bunx biome check dev.ts` clean.
- [ ] `just dev` locally on two branches → verify each produces its own `pawrrtal-<branch>.db` and no cross-branch schema breakage.
- [ ] Confirm a user with an explicit `DATABASE_URL` (e.g. Postgres) is unaffected (settings fall through to `SQLITE_DB_FILENAME` only when `DATABASE_URL` is empty).

---
_Generated by [Claude Code](https://claude.ai/code/session_013MQYF4bShEUbGg7mjYvzpw)_