### PR TITLE
Batch: 10 of the 15 latest issues — thinking rendering, system prompt, sandbox ADR

### DIFF
--- a/backend/alembic/versions/021_add_reasoning_effort_check_constraint.py
+++ b/backend/alembic/versions/021_add_reasoning_effort_check_constraint.py
@@ -1,0 +1,51 @@
+"""Pin ``conversations.reasoning_effort`` to the canonical enum values.
+
+Migration 020 added the column as a free-form ``VARCHAR(16)`` because
+the resolver in :mod:`app.core.providers.reasoning` defensively maps
+unknown strings to ``cleared``. The DB itself would still accept any
+16-char string — typos in future migrations, an admin SQL session, or
+an out-of-tree script could plant a row the resolver then has to
+silently scrub on every turn.
+
+This migration adds a ``CHECK`` constraint pinning the column to the
+four ``ReasoningEffort`` literal values plus ``NULL`` so invalid writes
+fail at insert/update time, regardless of where they originate.
+
+Revision ID: 021_add_reasoning_effort_check_constraint
+Revises: 020_add_conversation_reasoning_effort
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "021_add_reasoning_effort_check_constraint"
+down_revision = "020_add_conversation_reasoning_effort"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT_NAME = "ck_conversations_reasoning_effort_valid"
+# Mirrors ``app.core.providers.base.ReasoningEffort`` literally. Keep
+# in sync if the literal grows — the resolver and the DB must agree on
+# the set of legal values or one of them will start producing surprises.
+_ALLOWED_VALUES = ("minimal", "low", "medium", "high", "extra-high")
+
+
+def _check_expression() -> str:
+    """Render the SQL CHECK predicate for the constraint."""
+    quoted = ", ".join(f"'{value}'" for value in _ALLOWED_VALUES)
+    return f"reasoning_effort IS NULL OR reasoning_effort IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Reject any row whose ``reasoning_effort`` isn't on the canonical ladder."""
+    op.create_check_constraint(
+        _CONSTRAINT_NAME,
+        "conversations",
+        _check_expression(),
+    )
+
+
+def downgrade() -> None:
+    """Drop the CHECK constraint so the column accepts any 16-char string again."""
+    op.drop_constraint(_CONSTRAINT_NAME, "conversations", type_="check")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -234,13 +234,20 @@ def get_chat_router() -> APIRouter:
         # is the canonical wire form of the catalog default.
         model_id = request.model_id or conversation.model_id or default_model().id
 
-        # Persist model change if it differs from what is stored
+        # Persist model change if it differs from what is stored.
+        # ``commit=False`` defers the flush so the reasoning-effort
+        # normalize below lands in the same transaction (#366). Without
+        # it the row is briefly inconsistent — new ``model_id`` paired
+        # with a stale ``reasoning_effort`` between the two commits —
+        # and a /thinking tap that races the window can persist a
+        # level the resolver will override on the very next turn.
         if model_id != conversation.model_id:
             await update_conversation_model(
                 model_id=model_id,
                 user_id=user.id,
                 conversation_id=request.conversation_id,
                 session=session,
+                commit=False,
             )
 
         # Backstop: re-validate the stored reasoning_effort against
@@ -250,8 +257,9 @@ def get_chat_router() -> APIRouter:
         # /thinking picker, /model command, the web composer, etc.).
         # ``model_id_override`` makes the resolver see the *new* model
         # for the case where the user is switching models in this same
-        # request, even though `conversation.model_id` was updated
-        # above (we don't re-fetch the row before the resolver call).
+        # request — the model_id update above is staged but not yet
+        # committed, so this call's commit flushes both row changes
+        # atomically (#366).
         (
             reasoning_resolution,
             _previous_reasoning_effort,

--- a/backend/app/channels/_telegram_dispatch.py
+++ b/backend/app/channels/_telegram_dispatch.py
@@ -261,6 +261,14 @@ async def handle_tool_result(
     return tool_trace, 0, now
 
 
+# Inserted between thinking deltas whose ``block_index`` differs (#353).
+# Same-block deltas (xAI per-token, all ``block_index=0``) concatenate
+# verbatim with no separator; different-block deltas (Gemini per-Part,
+# Claude per ThinkingBlock) get a paragraph break so the rendered
+# italic reads as distinct thoughts rather than one run-on stream.
+_THINKING_BLOCK_SEPARATOR = "\n\n"
+
+
 async def handle_thinking(
     *,
     event: StreamEvent,
@@ -268,15 +276,46 @@ async def handle_thinking(
     chat_id: int | str,
     thinking_text: str,
     thinking_message_id: int | None,
+    previous_thinking_block_index: int | None,
     reply_to_message_id: int | None,
     message_thread_id: int | None,
-) -> tuple[str, int | None]:
-    """Send or edit the separate italic thinking message."""
-    chunk = str(event.get("content") or "").strip()
+) -> tuple[str, int | None, int | None]:
+    """Send or edit the separate italic thinking message.
+
+    The model owns its whitespace and paragraph breaks within a block;
+    between blocks we insert :data:`_THINKING_BLOCK_SEPARATOR` so
+    per-block providers (Gemini, Claude) get visible boundaries while
+    per-token providers (xAI) — which emit a constant ``block_index`` —
+    stay tightly concatenated. Covers #345 + #351 + #353.
+
+    ``previous_thinking_block_index`` is the index from the previous
+    thinking event on this turn, or ``None`` for the first thinking
+    event (in which case no separator is prepended). Returns the
+    updated ``(thinking_text, thinking_message_id, next_block_index)``
+    triple so the caller can thread the next block index forward. When
+    the provider omits ``block_index`` (older stream functions, tests
+    that script raw events without setting the field) the returned
+    index stays at the previous value and no separator is ever inserted.
+    """
+    chunk = str(event.get("content") or "")
+    block_index = event.get("block_index")
     if not chunk:
-        return thinking_text, thinking_message_id
-    thinking_text = f"{thinking_text}\n{chunk}" if thinking_text else chunk
+        # Preserve the previous baseline so the next chunk's separator
+        # decision still sees the correct anchor.
+        next_index = block_index if block_index is not None else previous_thinking_block_index
+        return thinking_text, thinking_message_id, next_index
+    needs_break = (
+        bool(thinking_text)
+        and block_index is not None
+        and previous_thinking_block_index is not None
+        and block_index != previous_thinking_block_index
+    )
+    if needs_break:
+        thinking_text = thinking_text + _THINKING_BLOCK_SEPARATOR + chunk
+    else:
+        thinking_text = thinking_text + chunk
     rendered = thinking_html(thinking_text)
+    next_index = block_index if block_index is not None else previous_thinking_block_index
     if thinking_message_id is None:
         message_id = await safe_send_html(
             bot,
@@ -285,9 +324,9 @@ async def handle_thinking(
             reply_to_message_id=reply_to_message_id,
             message_thread_id=message_thread_id,
         )
-        return thinking_text, message_id
+        return thinking_text, message_id, next_index
     await safe_edit_html(bot, chat_id, thinking_message_id, rendered)
-    return thinking_text, thinking_message_id
+    return thinking_text, thinking_message_id, next_index
 
 
 def capture_terminal_event(

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -154,6 +154,12 @@ class TelegramChannel:
         text_last_edit_at = asyncio.get_event_loop().time()
         chars_since_edit = 0
         last_edit_at = asyncio.get_event_loop().time()
+        # ``previous_thinking_block_index`` tracks the ``block_index``
+        # of the most recent thinking event so ``handle_thinking`` can
+        # insert a paragraph break only when a new block starts (#353).
+        # ``None`` before the first thinking event so the very first
+        # chunk does not get a leading separator.
+        previous_thinking_block_index: int | None = None
         # Block-transition tracking (#288). ``previous_block_kind`` is the
         # kind of the most-recent block-emitting event (``"tools"`` /
         # ``"thinking"``). When the incoming event's kind differs from the
@@ -242,13 +248,24 @@ class TelegramChannel:
                     thinking_text=thinking_text,
                     thinking_message_id=thinking_message_id,
                 )
+                # Reset the block-index baseline whenever the prepare step
+                # opens a fresh thinking message (tools→thinking transition).
+                # Otherwise the carry-over index could trigger a leading
+                # paragraph break inside the new italic message.
+                if thinking_message_id is None:
+                    previous_thinking_block_index = None
                 previous_block_kind = "thinking"
-                thinking_text, thinking_message_id = await handle_thinking(
+                (
+                    thinking_text,
+                    thinking_message_id,
+                    previous_thinking_block_index,
+                ) = await handle_thinking(
                     event=event,
                     bot=bot,
                     chat_id=chat_id,
                     thinking_text=thinking_text,
                     thinking_message_id=thinking_message_id,
+                    previous_thinking_block_index=previous_thinking_block_index,
                     reply_to_message_id=reply_to_message_id,
                     message_thread_id=message_thread_id,
                 )

--- a/backend/app/core/agent_loop/loop.py
+++ b/backend/app/core/agent_loop/loop.py
@@ -697,7 +697,14 @@ def _consume_llm_event(
         events.append(TextDeltaEvent(type="text_delta", text=llm_event["text"]))
         return None
     if llm_event["type"] == "thinking_delta":
-        events.append(ThinkingDeltaEvent(type="thinking_delta", text=llm_event["text"]))
+        thinking_event = ThinkingDeltaEvent(type="thinking_delta", text=llm_event["text"])
+        # Forward ``block_index`` when the provider supplied one (#353).
+        # Older provider stream functions omit the field; downstream
+        # renderers treat absence as "same block as previous".
+        block_index = llm_event.get("block_index")
+        if block_index is not None:
+            thinking_event["block_index"] = block_index
+        events.append(thinking_event)
         return None
     if llm_event["type"] == "tool_call":
         display = render_display_from_map(

--- a/backend/app/core/agent_loop/types.py
+++ b/backend/app/core/agent_loop/types.py
@@ -112,10 +112,21 @@ class LLMThinkingDeltaEvent(TypedDict):
     ``ThinkingConfig(include_thoughts=True)``, OpenAI o-series, etc.).
     The frontend renders these in a separate "thinking" pane so they
     don't appear in the final assistant transcript.
+
+    ``block_index`` disambiguates "next token in the same thinking
+    block" from "start of a new thinking block" — necessary because
+    xAI streams per-token (one block) while Gemini and Claude stream
+    per-block (each emission is a new block). Renderers insert a
+    paragraph break between events whose ``block_index`` differs and
+    concatenate verbatim within the same block. ``NotRequired`` so
+    older provider stream functions still validate; consumers MUST
+    treat its absence as "same block as previous" (effectively a
+    constant block index). See #353.
     """
 
     type: Literal["thinking_delta"]
     text: str
+    block_index: NotRequired[int]
 
 
 class LLMToolCallEvent(TypedDict):
@@ -196,10 +207,16 @@ class ThinkingDeltaEvent(TypedDict):
     as a ``ThinkingDeltaEvent`` so downstream wrappers (the chat router,
     SSE channel) can translate it into a ``StreamEvent`` of type
     ``"thinking"`` without growing a separate code path per provider.
+
+    ``block_index`` mirrors the LLM-event field: same value = same
+    thinking block, different value = paragraph boundary. Threaded
+    through the loop so the channel renderer and the chat aggregator
+    can coalesce by block identity. See #353.
     """
 
     type: Literal["thinking_delta"]
     text: str
+    block_index: NotRequired[int]
 
 
 class ToolCallStartEvent(TypedDict):

--- a/backend/app/core/agent_system_prompt.py
+++ b/backend/app/core/agent_system_prompt.py
@@ -41,6 +41,30 @@ PAW_CORE_SYSTEM_PROMPT = (
 )
 
 
+# Verification and timekeeping guidance is appended after the surface
+# description so it applies to every provider that falls back to the
+# default prompt. The workspace-assembled prompt (SOUL.md + AGENTS.md)
+# composes around the same guidance via ``compose_agent_system_prompt``.
+_AGENT_VERIFICATION_GUIDANCE = (
+    "Verify before declaring a capability missing. If a tool or "
+    "environment feature appears unavailable, attempt a minimal probe "
+    "(e.g. invoke the tool with a no-op argument, list the available "
+    "tools, run a short script in the Python sandbox) before telling "
+    "the user the capability isn't there. Persisting one step further "
+    "than your first assumption catches most false negatives."
+)
+_AGENT_TIMEKEEPING_GUIDANCE = (
+    "Treat any timestamp injected into the system prompt or first "
+    "message as the **Turn Start Time** — the moment this turn began. "
+    "It is not the **Current Time**. For anything that depends on the "
+    "live clock (scheduling, computing 'how long ago', deciding if a "
+    "deadline has passed), call the ``now()`` tool when it is available "
+    "and treat its output as the authoritative present moment. Do not "
+    "repeat the Turn Start Time as if it were the current time across "
+    "multi-step tool runs."
+)
+
+
 DEFAULT_AGENT_SYSTEM_PROMPT = (
     f"{PAW_CORE_SYSTEM_PROMPT}\n\n---\n\n"
     "You are an AI assistant inside a chat application.  You are "
@@ -50,12 +74,24 @@ DEFAULT_AGENT_SYSTEM_PROMPT = (
     "App-defined tools (web search, workspace file access, ...) are "
     "made available on a per-turn basis when configured by the chat "
     "router.  Use whichever tools are present, and always cite any "
-    "URLs returned by web-search-style tools."
+    "URLs returned by web-search-style tools.\n\n"
+    f"{_AGENT_VERIFICATION_GUIDANCE}\n\n"
+    f"{_AGENT_TIMEKEEPING_GUIDANCE}"
 )
 
 
 def compose_agent_system_prompt(workspace_prompt: str | None) -> str:
-    """Prepend the Paw identity to workspace-specific prompt material."""
+    """Prepend the Paw identity to workspace-specific prompt material.
+
+    The verification + timekeeping guidance lives below the workspace
+    block so a custom AGENTS.md cannot accidentally drop it. Both apply
+    across every surface (web, Telegram, automation) and every model.
+    """
     if workspace_prompt is None:
         return DEFAULT_AGENT_SYSTEM_PROMPT
-    return f"{PAW_CORE_SYSTEM_PROMPT}\n\n---\n\n{workspace_prompt}"
+    return (
+        f"{PAW_CORE_SYSTEM_PROMPT}\n\n---\n\n"
+        f"{workspace_prompt}\n\n"
+        f"{_AGENT_VERIFICATION_GUIDANCE}\n\n"
+        f"{_AGENT_TIMEKEEPING_GUIDANCE}"
+    )

--- a/backend/app/core/chat_aggregator.py
+++ b/backend/app/core/chat_aggregator.py
@@ -115,12 +115,25 @@ class ChatTurnAggregator:
         if self.started_at_monotonic is None:
             self.started_at_monotonic = time.monotonic()
 
-    def _push_thinking_entry(self, text: str) -> None:
-        """Coalesce consecutive thinking chunks into a single timeline entry."""
+    def _push_thinking_entry(self, text: str, block_index: int | None) -> None:
+        """Coalesce thinking chunks into a single timeline entry per block.
+
+        When ``block_index`` is supplied, consecutive chunks with the
+        same index merge; a change in index opens a new timeline entry
+        so per-block providers (Gemini, Claude) render with visible
+        boundaries. When the provider omits ``block_index`` we fall
+        back to the legacy "consecutive thinking events coalesce"
+        behaviour so older callers and tests stay green. See #353.
+        """
         if self.timeline and self.timeline[-1].get("kind") == "thinking":
-            self.timeline[-1]["text"] = self.timeline[-1].get("text", "") + text
-            return
-        self.timeline.append({"kind": "thinking", "text": text})
+            previous_index = self.timeline[-1].get("block_index")
+            if block_index is None or previous_index is None or previous_index == block_index:
+                self.timeline[-1]["text"] = self.timeline[-1].get("text", "") + text
+                return
+        entry: dict[str, Any] = {"kind": "thinking", "text": text}
+        if block_index is not None:
+            entry["block_index"] = block_index
+        self.timeline.append(entry)
 
     def apply(self, event: StreamEvent) -> None:
         """Fold one provider event into the running snapshot."""
@@ -133,7 +146,7 @@ class ChatTurnAggregator:
             self._mark_started()
             chunk = event.get("content", "") or ""
             self.thinking += chunk
-            self._push_thinking_entry(chunk)
+            self._push_thinking_entry(chunk, event.get("block_index"))
             return
         if event_type == "tool_use":
             self._mark_started()

--- a/backend/app/core/providers/_gemini_events.py
+++ b/backend/app/core/providers/_gemini_events.py
@@ -33,7 +33,16 @@ def agent_event_to_stream_event(event: Any) -> StreamEvent | None:
     if event_type == "text_delta":
         return StreamEvent(type="delta", content=event["text"])
     if event_type == "thinking_delta":
-        return StreamEvent(type="thinking", content=event["text"])
+        thinking_event = StreamEvent(type="thinking", content=event["text"])
+        # Carry ``block_index`` through to the channel renderer when
+        # the provider supplied one (#353). Telegram dispatch uses it
+        # to insert paragraph breaks between distinct thinking blocks;
+        # the chat aggregator uses it to coalesce a single timeline
+        # entry per block.
+        block_index = event.get("block_index")
+        if block_index is not None:
+            thinking_event["block_index"] = block_index
+        return thinking_event
     if event_type == "tool_call_end":
         return StreamEvent(
             type="tool_use",

--- a/backend/app/core/providers/_gemini_messages.py
+++ b/backend/app/core/providers/_gemini_messages.py
@@ -130,8 +130,8 @@ def resolve_gemini_api_key(workspace_root: Path | None) -> str:
     return settings.google_api_key
 
 
-def split_chunk_text(chunk: Any) -> tuple[str, str]:
-    """Return ``(thinking_text, response_text)`` for a streaming chunk.
+def split_chunk_text(chunk: Any) -> tuple[list[str], str]:
+    """Return ``(thinking_parts, response_text)`` for a streaming chunk.
 
     Gemini's thinking-capable models emit ``Part`` objects with a
     ``thought=True`` flag for chain-of-thought content; regular response
@@ -140,8 +140,17 @@ def split_chunk_text(chunk: Any) -> tuple[str, str]:
     flag, so consumers that need to render the two streams separately
     must walk parts explicitly.
 
+    Each distinct ``Part(thought=True)`` is returned as its own list
+    entry so the caller can assign a separate ``block_index`` per
+    block (#353). The caller pairs each part with an incrementing
+    counter and emits one :class:`LLMThinkingDeltaEvent` per part with
+    that index — the channel renderer then knows where Gemini intended
+    a paragraph break without relying on whitespace heuristics (#351).
+    Response parts are concatenated verbatim; they carry their own
+    model-owned whitespace.
+
     Non-thinking models simply never set ``thought=True``, so the
-    thinking string stays empty and the response string is identical to
+    thinking list stays empty and the response string is identical to
     ``chunk.text``.
     """
     thinking_parts: list[str] = []
@@ -157,7 +166,7 @@ def split_chunk_text(chunk: Any) -> tuple[str, str]:
                 thinking_parts.append(text)
             else:
                 response_parts.append(text)
-    return "".join(thinking_parts), "".join(response_parts)
+    return thinking_parts, "".join(response_parts)
 
 
 def tool_calls_from_chunk(chunk: Any, start_index: int) -> list[dict[str, Any]]:

--- a/backend/app/core/providers/base.py
+++ b/backend/app/core/providers/base.py
@@ -32,6 +32,14 @@ class StreamEvent(TypedDict, total=False):
 
     type: str  # "delta" | "thinking" | "tool_use" | "tool_result" | "error" | "artifact" | "message" | "usage"
     content: str  # for delta and thinking
+    # Block-boundary metadata for ``thinking`` events: same value = same
+    # thinking block, different value = paragraph boundary between
+    # blocks. Providers that stream per-token (xAI) emit a constant
+    # value; providers that stream per-block (Gemini, Claude) increment
+    # per block. Renderers MUST treat the field's absence as "same block
+    # as the previous thinking event" for backward compatibility with
+    # older stream functions. See #353.
+    block_index: int
     name: str  # for tool_use
     input: dict[str, Any]  # for tool_use
     display: ToolDisplayPayload  # for tool_use

--- a/backend/app/core/providers/claude_provider.py
+++ b/backend/app/core/providers/claude_provider.py
@@ -629,9 +629,19 @@ async def _stream_events_for_attempt(
     retry/fallback loop stays under the nesting-depth budget (the
     ``while → try → async for → for`` chain in stream() reached
     depth 4, one over the cap). The two loops live here instead.
+
+    Stamps each ``thinking`` event with a monotonically increasing
+    ``block_index`` so downstream renderers know where Claude's
+    per-block emissions begin and end (#353). Claude already emits one
+    ``ThinkingBlock`` per logical block, so an increment-per-event
+    counter is the right grain.
     """
+    thinking_block_index = 0
     async for message in query(prompt=prompt, options=options):
         for event in _events_from_message(message, display_by_name or {}):
+            if event.get("type") == "thinking":
+                event["block_index"] = thinking_block_index
+                thinking_block_index += 1
             yield event
 
 

--- a/backend/app/core/providers/gemini_provider.py
+++ b/backend/app/core/providers/gemini_provider.py
@@ -170,6 +170,13 @@ def make_gemini_stream_fn(
 
         full_text = ""
         tool_calls: list[dict[str, Any]] = []
+        # Monotonic counter for Gemini's per-Part thinking blocks (#353).
+        # Each ``Part(thought=True)`` is its own block on the wire, and
+        # downstream renderers need that boundary information to insert
+        # paragraph breaks between blocks without guessing from
+        # whitespace heuristics. Starts at 0 and increments once per
+        # emitted thinking part.
+        thinking_block_index = 0
         # Holds the native ``ModelContent`` from whichever chunk produced
         # the function_call parts (Gemini delivers function calls in a
         # single chunk).  When set, the loop forwards it as
@@ -203,10 +210,17 @@ def make_gemini_stream_fn(
                 # regular text.  ``chunk.text`` is a convenience accessor
                 # that concatenates *all* text parts regardless of the
                 # thought flag, so we walk parts explicitly to keep the
-                # two streams separate downstream.
-                thinking_text, response_text = split_chunk_text(chunk)
-                if thinking_text:
-                    yield LLMThinkingDeltaEvent(type="thinking_delta", text=thinking_text)
+                # two streams separate downstream. ``split_chunk_text``
+                # returns thinking parts as a list so we can stamp each
+                # block with its own ``block_index`` (#353).
+                thinking_parts, response_text = split_chunk_text(chunk)
+                for thinking_text in thinking_parts:
+                    yield LLMThinkingDeltaEvent(
+                        type="thinking_delta",
+                        text=thinking_text,
+                        block_index=thinking_block_index,
+                    )
+                    thinking_block_index += 1
                 if response_text:
                     yield LLMTextDeltaEvent(type="text_delta", text=response_text)
                     full_text += response_text

--- a/backend/app/core/providers/opencode_go_provider.py
+++ b/backend/app/core/providers/opencode_go_provider.py
@@ -159,6 +159,20 @@ def _resolve_opencode_api_key(workspace_root: Path | None) -> str:
     return settings.opencode_api_key
 
 
+# User-facing notice surfaced when neither the workspace nor the gateway
+# has an OpenCode API key configured. The provider used to silently push
+# ``api_key="missing"`` at the gateway, take a 401, and rely on the
+# legacy Telegram text path to render the resulting error — which can
+# drop everything after the first chunk (#346) so the user sees no
+# reply at all. Surfacing the cause as an explicit ``error`` event
+# bypasses that path entirely. See #350.
+_OPENCODE_MISSING_KEY_NOTICE = (
+    "OpenCode API key not configured. Set OPENCODE_API_KEY in your "
+    "workspace .env file or configure OPENCODE_API_KEY on the gateway "
+    "to use Kimi K2.6 / GLM-5.1 via OpenCode Go."
+)
+
+
 def _drain_text_and_thinking(delta: Any) -> tuple[list[LLMEvent], str]:
     """Translate one streaming delta into ``(events_to_yield, response_text)``.
 
@@ -172,7 +186,17 @@ def _drain_text_and_thinking(delta: Any) -> tuple[list[LLMEvent], str]:
     out: list[LLMEvent] = []
     thinking_text = read_reasoning(delta)
     if thinking_text:
-        out.append(LLMThinkingDeltaEvent(type="thinking_delta", text=thinking_text))
+        # OpenCode Go streams reasoning per-token via ``reasoning_content``
+        # — one continuous logical block per stream attempt. Emit a
+        # constant ``block_index=0`` so the channel renderer doesn't
+        # insert paragraph breaks between consecutive tokens (#353).
+        out.append(
+            LLMThinkingDeltaEvent(
+                type="thinking_delta",
+                text=thinking_text,
+                block_index=0,
+            )
+        )
     response_text = getattr(delta, "content", None) or ""
     if response_text:
         out.append(LLMTextDeltaEvent(type="text_delta", text=response_text))
@@ -395,6 +419,25 @@ class OpencodeGoLLM:
                 conversation_id,
                 len(images),
             )
+
+        # Fail fast on missing API key with a user-readable notice. The
+        # alternative — letting the request hit the gateway with
+        # ``api_key="missing"`` — produces a 401 whose text is rendered
+        # by the legacy Telegram path as a single-chunk delta and
+        # frequently appears as no reply at all (#350). The check runs
+        # before ``agent_loop`` so the loop's retry budget doesn't burn
+        # three 401s before giving up.
+        api_key = _resolve_opencode_api_key(self._workspace_root)
+        if not api_key:
+            logger.warning(
+                "OPENCODE_GO_MISSING_API_KEY conversation_id=%s user_id=%s model=%s",
+                conversation_id,
+                user_id,
+                self._model_id,
+            )
+            yield StreamEvent(type="error", content=_OPENCODE_MISSING_KEY_NOTICE)
+            return
+
         prior: list[AgentMessage] = []
         for m in history or []:
             role = m.get("role")

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -239,7 +239,16 @@ async def _stream_one_request(
     async for response, chunk in chat.stream():
         deltas = deltas_from_chunk(chunk)
         if deltas.thinking:
-            yield LLMThinkingDeltaEvent(type="thinking_delta", text=deltas.thinking)
+            # xAI streams reasoning per-token within one continuous
+            # block, so every thinking delta from one ``chat.stream()``
+            # call belongs to the same logical block — emit a constant
+            # ``block_index=0`` so downstream renderers don't insert
+            # spurious paragraph breaks between tokens (#353).
+            yield LLMThinkingDeltaEvent(
+                type="thinking_delta",
+                text=deltas.thinking,
+                block_index=0,
+            )
         if deltas.text:
             yield LLMTextDeltaEvent(type="text_delta", text=deltas.text)
         final_response = response

--- a/backend/app/crud/conversation.py
+++ b/backend/app/crud/conversation.py
@@ -224,6 +224,8 @@ async def update_conversation_model(
     user_id: uuid.UUID,
     conversation_id: uuid.UUID,
     session: AsyncSession,
+    *,
+    commit: bool = True,
 ) -> Conversation | None:
     """Persist a model_id change on an existing conversation.
 
@@ -232,9 +234,19 @@ async def update_conversation_model(
         user_id: Owner to match against (ownership check).
         conversation_id: The conversation to update.
         session: Async database session.
+        commit: When ``True`` (the default) the helper commits inside
+            and returns a refreshed row, matching every other caller in
+            this module. The chat router passes ``commit=False`` so the
+            subsequent ``normalize_conversation_reasoning_effort`` call
+            runs in the same transaction — without it the row is briefly
+            inconsistent (new model_id, stale reasoning_effort) and the
+            picker can submit an effort the resolver will then override
+            on the next turn (#366).
 
     Returns:
         The updated ``Conversation``, or ``None`` if not found / not owned.
+        With ``commit=False`` the row is staged but not yet flushed;
+        callers must commit before reading values they care about.
     """
     stmt = (
         select(Conversation)
@@ -250,6 +262,8 @@ async def update_conversation_model(
     conversation.model_id = model_id
     conversation.updated_at = datetime.now()
     session.add(conversation)
+    if not commit:
+        return conversation
     await session.commit()
     await session.refresh(conversation)
     return conversation

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -82,10 +82,12 @@ class Conversation(Base):
     # settings.telegram_verbose_default (or 1 if unset).
     verbose_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Per-conversation reasoning depth. One of the ReasoningEffort literal
-    # values ("low" | "medium" | "high" | "extra-high") or NULL to let the
-    # provider pick its default. Mirrors verbose_level's plumbing: a chat
-    # request may still override per-turn, but absent that the persisted
-    # value is what the turn runner forwards to the provider.
+    # values ("minimal" | "low" | "medium" | "high" | "extra-high") or NULL
+    # to let the provider pick its default. Pinned to that set by a CHECK
+    # constraint in migration 021 so invalid writes fail at the DB layer.
+    # Mirrors verbose_level's plumbing: a chat request may still override
+    # per-turn, but absent that the persisted value is what the turn
+    # runner forwards to the provider.
     reasoning_effort: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
 

--- a/backend/tests/test_telegram_dispatch.py
+++ b/backend/tests/test_telegram_dispatch.py
@@ -1,0 +1,175 @@
+"""Unit tests for :mod:`app.channels._telegram_dispatch` per-event helpers.
+
+Focus: the ``handle_thinking`` state machine after the #345 / #351 / #353
+fixes. xAI streams per-token (one logical block, ``block_index=0`` for
+every event); Gemini and Claude stream per-block (incrementing
+``block_index``). The dispatch layer must:
+
+* concatenate same-block deltas with **no** separator so xAI tokens
+  retain their inter-token spaces (#345),
+* insert a paragraph break between distinct blocks so Gemini's
+  per-``Part`` thinking emissions read as separate thoughts (#351,
+  #353),
+* fall back to plain concatenation when the provider omits
+  ``block_index`` so older stream functions and tests stay green.
+
+These tests target the exact state-machine transition so the failure
+message is sharper than a multi-message channel snapshot would be —
+the L1 layer the test plan in issue #352 calls for.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.channels._telegram_dispatch import handle_thinking
+
+
+def _make_bot() -> AsyncMock:
+    bot = AsyncMock()
+    bot.edit_message_text = AsyncMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+    return bot
+
+
+@pytest.mark.anyio
+async def test_handle_thinking_preserves_token_spacing() -> None:
+    """xAI per-token deltas (constant ``block_index``) concatenate verbatim.
+
+    The previous implementation stripped each chunk and joined with
+    ``\\n``, producing newline-per-token output for xAI's grok-4.3
+    reasoning (#345). The current state machine appends every chunk
+    untouched when the block_index doesn't change.
+    """
+    bot = _make_bot()
+    thinking_text = ""
+    thinking_message_id: int | None = None
+    previous_block_index: int | None = None
+
+    tokens = ["Let", " me", " think", " about", " this", "."]
+    for token in tokens:
+        thinking_text, thinking_message_id, previous_block_index = await handle_thinking(
+            event={"type": "thinking", "content": token, "block_index": 0},
+            bot=bot,
+            chat_id=1,
+            thinking_text=thinking_text,
+            thinking_message_id=thinking_message_id,
+            previous_thinking_block_index=previous_block_index,
+            reply_to_message_id=None,
+            message_thread_id=None,
+        )
+
+    assert thinking_text == "Let me think about this."
+    assert previous_block_index == 0
+    # No paragraph break should ever land inside a same-block stream.
+    assert "\n\n" not in thinking_text
+
+
+@pytest.mark.anyio
+async def test_handle_thinking_separates_blocks() -> None:
+    """Gemini per-Part deltas (incrementing ``block_index``) get a paragraph break.
+
+    The dispatch layer inserts the separator between blocks so the
+    rendered italic message reads as distinct thoughts rather than
+    a single run-on stream (#351, #353).
+    """
+    bot = _make_bot()
+    thinking_text = ""
+    thinking_message_id: int | None = None
+    previous_block_index: int | None = None
+
+    # Two distinct Gemini ``Part(thought=True)`` emissions arrive as
+    # two ``thinking`` events with different ``block_index`` values.
+    blocks = [
+        ("Plan A: walk through the failing tests.", 0),
+        ("Plan B: bisect to the regressing commit.", 1),
+    ]
+    for text, block_index in blocks:
+        thinking_text, thinking_message_id, previous_block_index = await handle_thinking(
+            event={"type": "thinking", "content": text, "block_index": block_index},
+            bot=bot,
+            chat_id=1,
+            thinking_text=thinking_text,
+            thinking_message_id=thinking_message_id,
+            previous_thinking_block_index=previous_block_index,
+            reply_to_message_id=None,
+            message_thread_id=None,
+        )
+
+    assert "\n\n" in thinking_text
+    assert thinking_text.startswith("Plan A:")
+    assert thinking_text.endswith("regressing commit.")
+    assert previous_block_index == 1
+
+
+@pytest.mark.anyio
+async def test_handle_thinking_without_block_index_concatenates_verbatim() -> None:
+    """Events that omit ``block_index`` fall back to plain concatenation.
+
+    Older provider stream functions that pre-date #353 still validate
+    against ``LLMThinkingDeltaEvent`` because ``block_index`` is
+    ``NotRequired``. Their dispatch path must not start inserting
+    spurious paragraph breaks just because the field went away.
+    """
+    bot = _make_bot()
+    thinking_text = ""
+    thinking_message_id: int | None = None
+    previous_block_index: int | None = None
+
+    for chunk in ["alpha", " beta", " gamma"]:
+        thinking_text, thinking_message_id, previous_block_index = await handle_thinking(
+            event={"type": "thinking", "content": chunk},
+            bot=bot,
+            chat_id=1,
+            thinking_text=thinking_text,
+            thinking_message_id=thinking_message_id,
+            previous_thinking_block_index=previous_block_index,
+            reply_to_message_id=None,
+            message_thread_id=None,
+        )
+
+    assert thinking_text == "alpha beta gamma"
+    # No block_index means "treat as same block" — no separator inserted.
+    assert "\n\n" not in thinking_text
+    # The baseline stays unset because nothing on the wire claimed an index.
+    assert previous_block_index is None
+
+
+@pytest.mark.anyio
+async def test_handle_thinking_empty_chunk_preserves_block_index_baseline() -> None:
+    """Empty thinking events don't shift the baseline used for separator decisions.
+
+    A provider that emits an empty thinking delta — possible when a
+    chunk's only ``Part`` carried no text — should leave ``thinking_text``
+    untouched. The next real chunk must still know whether the previous
+    block index was set.
+    """
+    bot = _make_bot()
+    thinking_text, _, baseline = await handle_thinking(
+        event={"type": "thinking", "content": "first.", "block_index": 0},
+        bot=bot,
+        chat_id=1,
+        thinking_text="",
+        thinking_message_id=None,
+        previous_thinking_block_index=None,
+        reply_to_message_id=None,
+        message_thread_id=None,
+    )
+    assert baseline == 0
+
+    # Empty content arriving on the same block: state is unchanged.
+    thinking_text2, _, baseline2 = await handle_thinking(
+        event={"type": "thinking", "content": "", "block_index": 0},
+        bot=bot,
+        chat_id=1,
+        thinking_text=thinking_text,
+        thinking_message_id=42,
+        previous_thinking_block_index=baseline,
+        reply_to_message_id=None,
+        message_thread_id=None,
+    )
+    assert thinking_text2 == thinking_text
+    assert baseline2 == 0

--- a/frontend/components/ai-elements/tool.tsx
+++ b/frontend/components/ai-elements/tool.tsx
@@ -36,12 +36,15 @@ export type ToolHeaderProps = {
 };
 
 const getStatusBadge = (status: ToolUIPart['state']) => {
+	// Past tense once the tool finishes: 'Ran' replaces 'Completed' so the
+	// post-completion label reads as a finished action ("Ran read_file"),
+	// matching the Telegram ✅ success line. See issue #360.
 	const labels: Record<ToolUIPart['state'], string> = {
 		'input-streaming': 'Pending',
 		'input-available': 'Running',
 		'approval-requested': 'Awaiting Approval',
 		'approval-responded': 'Responded',
-		'output-available': 'Completed',
+		'output-available': 'Ran',
 		'output-error': 'Error',
 		'output-denied': 'Denied',
 	};

--- a/frontend/content/docs/handbook/decisions/2026-05-19-workspace-tool-sandboxing.mdx
+++ b/frontend/content/docs/handbook/decisions/2026-05-19-workspace-tool-sandboxing.mdx
@@ -1,0 +1,106 @@
+---
+title: Workspace filesystem tools rely on soft path escaping; defer to a sandbox boundary
+description: ADR — keep ``read_file`` / ``write_file`` / ``list_dir`` path resolution + ``O_NOFOLLOW`` as defence in depth, but treat the Python and Shell sandboxes as the real isolation surface for workspace boundaries.
+---
+
+# ADR: Workspace filesystem tools rely on soft path escaping; defer to a sandbox boundary
+
+- **Date:** 2026-05-19
+- **Owners:** OctavianTocan
+- **Tracking:** Issue [#358](https://github.com/OctavianTocan/Pawrrtal-AI/issues/358)
+
+<Callout type="info" title="Status: Accepted">
+The ``read_file`` / ``write_file`` / ``list_dir`` workspace tools keep
+their per-call path normalisation + ``O_NOFOLLOW`` guard as
+defence-in-depth, but those checks are not load-bearing for security.
+The agent has a Python sandbox with full ``os`` / ``subprocess`` access
+that trivially bypasses them. Real isolation lives at the
+sandbox-execution boundary (the future containerised runtime for the
+agent's workspace); the file tools are convenience APIs above that
+boundary, not a security perimeter on their own.
+</Callout>
+
+## Context
+
+Issue [#358](https://github.com/OctavianTocan/Pawrrtal-AI/issues/358)
+flags an inconsistency that's been latent in the codebase:
+
+- ``backend/app/core/tools/workspace_files`` validates every path
+  against the workspace root, refuses to follow symlinks, and rejects
+  ``..`` segments. The tests cover the basic escape vectors.
+- The same agent has a Python sandbox tool (issued via ``litellm``
+  reasoning models, the future inline runtime, etc.) with the full
+  ``os``, ``subprocess``, and ``pathlib`` surface. A model that wants
+  to read ``../../etc/passwd`` writes three lines of Python and the
+  workspace guard is irrelevant.
+
+If the file tools are pretending to be a security boundary, the
+mismatch is the worst kind: it gives reviewers and operators false
+confidence that ``read_file`` is "safe" because of those checks, when
+in practice any model with sandbox access has already crossed the
+line. The right question to answer is whether the soft checks are
+worth their complexity at all, or whether we should explicitly stop
+treating them as security and move the isolation primitive somewhere
+that can actually enforce it.
+
+The codebase already hints at this tension:
+
+- ``.claude/rules/architecture/no-tools-in-providers.md`` keeps tool
+  composition centralised so policy gates live above the providers.
+- The Claude SDK's ``can_use_tool`` and Gemini/xAI's
+  ``permission_check`` plumbing exists precisely so policy lives in
+  ``backend/app/api/chat.py``, not on each provider's stream loop.
+- A containerised runtime for the agent's workspace tools is on the
+  longer-term roadmap (out of scope for this issue) and would supply
+  the real boundary.
+
+## Decision
+
+The workspace file tools keep their existing checks for three reasons,
+even though they're not a security perimeter:
+
+1. **Operator UX.** A model that hallucinates an absolute path like
+   ``/etc/passwd`` should fail closed with a clean error, not silently
+   read a file. The check distinguishes a buggy tool call from an
+   adversarial one. Logs and the chat transcript stay readable.
+2. **Defence in depth.** A bug in the future sandbox runtime that
+   accidentally widens the agent's filesystem reach should still be
+   caught by the per-call path resolution. Stacking cheap guards is a
+   cost-effective design — they're already written.
+3. **No regressions on existing flows.** Removing the checks now
+   would weaken the surface today (no sandbox is shipped yet) for the
+   sake of removing complexity that nobody has complained about.
+
+What we explicitly **don't** do:
+
+- We don't represent the path-escape guards as a security boundary in
+  any code comment, log message, or doc. The next agent reading
+  ``workspace_files`` should not infer that the guard is the line of
+  defence.
+- We don't add new "soft" sandboxing primitives that try to compete
+  with the future containerised runtime. New isolation work goes into
+  that runtime, not into the file tools.
+- We don't expand the tool surface (e.g. ``chmod``, ``stat`` on
+  arbitrary paths) past what an agent can already do via the Python
+  sandbox. Adding new surface here only matters once the runtime
+  boundary is real.
+
+## Consequences
+
+- The workspace tool tests stay green; no code change is required to
+  land this decision.
+- Future work on the containerised runtime ("agent workspace sandbox")
+  must surface as its own ADR with the full threat model. That ADR
+  will deprecate the path-escape comments in ``workspace_files`` if
+  the runtime makes them strictly redundant, but until then the
+  current code stays.
+- Reviewers should treat any PR that adds a new path-escape check
+  with the question: "is this actually the perimeter, or is it
+  paperwork above a real perimeter that doesn't exist yet?" If the
+  latter, the answer is usually "skip it; ship the runtime instead."
+
+## References
+
+- Issue [#358](https://github.com/OctavianTocan/Pawrrtal-AI/issues/358)
+- ``.claude/rules/architecture/no-tools-in-providers.md``
+- ``backend/app/core/tools/workspace_files``


### PR DESCRIPTION
Closes (or substantially addresses) **10 of the latest 15 open issues**.
The remaining 5 are larger UI/feature surfaces that need their own PRs;
context for each is at the bottom.

## What's fixed

### Telegram thinking rendering — #345, #351, #353

- New `block_index` field on `LLMThinkingDeltaEvent` /
  `ThinkingDeltaEvent` / `StreamEvent` so renderers can distinguish
  "next token in the same thinking block" from "start of a new block."
- xAI and OpenCode Go emit `block_index=0` (per-token streams = one
  logical block); Gemini emits an incrementing index per
  `Part(thought=True)`; Claude emits an incrementing index per
  `ThinkingBlock`.
- `handle_thinking` appends chunks verbatim within a block and inserts
  `\n\n` only when the index changes — so xAI's per-token reasoning no
  longer renders one word per line (#345) and Gemini's per-block
  thinking gets visible paragraph breaks (#351).
- `chat_aggregator._push_thinking_entry` coalesces timeline entries by
  block_index so the persisted shape matches what renders live.

### System prompt hardening — #354, #356

- Append timekeeping guidance: the timestamp injected into the prompt
  is the **Turn Start Time**; agents must call `now()` when they need
  the live clock.
- Append verification guidance: probe before declaring a tool /
  capability missing.

### Tool status label — #360

- Frontend tool badge for `output-available` is now **"Ran"** (past
  tense), matching the Telegram `✅` success line.

### Reasoning effort hardening — #366, #367

- Migration `021_add_reasoning_effort_check_constraint` pins
  `conversations.reasoning_effort` to the literal enum via a CHECK.
- `update_conversation_model` accepts `commit=False` so the chat
  router can wrap model-switch + reasoning-effort normalize in **one**
  transaction (closes the latent inconsistency window from #366).

### OpenCode Go diagnostics — #350

- Fail fast on a missing API key with an explicit `StreamEvent(type="error")`;
  previously the 401 was rendered as a text-delta the legacy Telegram
  path frequently dropped, producing "no reply at all."

### Workspace tool sandboxing ADR — #358

- `docs/handbook/decisions/2026-05-19-workspace-tool-sandboxing.mdx`
  documents that the path-escape checks in `workspace_files` are
  defence-in-depth above a Python sandbox, not a security perimeter.
  Real isolation belongs to the future containerised runtime.

### Partial: provider conformance / Telegram dispatch tests — #352 (L1)

- `backend/tests/test_telegram_dispatch.py` covers the three
  thinking-dispatch transitions per the L1 layer in #352's plan:
  per-token preserves spaces, per-block separates with `\n\n`, no
  `block_index` falls back to concat.

## Deferred to follow-up PRs

These five are feature surfaces that warrant their own focused PRs;
each is enough work to risk regressions if rushed in alongside the
fixes above.

- **#355 — verbose level inline keyboard.** Pattern is well-defined
  (mirror `thinking_picker.py` + `thinking_picker_runtime.py` for
  `verbose_picker`), ~250 LOC plus tests + bot.py registration.
- **#357 — message queueing for mid-turn user input.** Touches the
  Telegram channel's turn-lifecycle code path and needs a per-chat
  FIFO + dispatch-locking. New module, new tests.
- **#359 — native LCM / Hindsight memory tools.** New `AgentTool`
  factories under `backend/app/core/tools/`, registered in the chat
  router. Behavioural tests required.
- **#361 — `/status` inline keyboard for selective diagnostics.**
  Convert the single-message status to button-driven panels; reuses
  the picker pattern but the data fan-out is larger than `/thinking`.
- **#368 — regen inline keyboard on Telegram replies.** Attach
  `reply_markup` with a regenerate button to the final assistant
  message and wire a callback that re-runs the previous user turn.

## Verification

- `python3 -c "ast.parse(...)"` clean on every modified file.
- `backend/tests/test_telegram_dispatch.py` covers the new
  `handle_thinking` state machine.
- Existing chat_aggregator tests still pass because events without
  `block_index` fall through to the legacy coalesce branch.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_