### PR TITLE
feat(telegram): add user-level default model via /model and picker

### DIFF
--- a/backend/alembic/versions/021_add_user_preferences_default_model_id.py
+++ b/backend/alembic/versions/021_add_user_preferences_default_model_id.py
@@ -22,7 +22,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    """Add the nullable ``default_model_id`` column."""
     op.add_column(
         "user_preferences",
         sa.Column("default_model_id", sa.String(length=128), nullable=True),
@@ -30,5 +29,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Drop the ``default_model_id`` column."""
     op.drop_column("user_preferences", "default_model_id")

--- a/backend/alembic/versions/021_add_user_preferences_default_model_id.py
+++ b/backend/alembic/versions/021_add_user_preferences_default_model_id.py
@@ -1,0 +1,34 @@
+"""Add ``default_model_id`` column to ``user_preferences``.
+
+Per-user default model selection. When set, this overrides the
+catalog default for conversations that don't carry their own
+explicit ``model_id``.  Used primarily by the Telegram ``/model``
+command so a user can pin a preferred model once and have every
+new Telegram conversation default to it.
+
+Revision ID: 021_add_user_preferences_default_model_id
+Revises: 020_add_conversation_reasoning_effort
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "021_add_user_preferences_default_model_id"
+down_revision = "020_add_conversation_reasoning_effort"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``default_model_id`` column."""
+    op.add_column(
+        "user_preferences",
+        sa.Column("default_model_id", sa.String(length=128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``default_model_id`` column."""
+    op.drop_column("user_preferences", "default_model_id")

--- a/backend/alembic/versions/022_user_preferences_font_size_nullable.py
+++ b/backend/alembic/versions/022_user_preferences_font_size_nullable.py
@@ -1,0 +1,35 @@
+"""Make ``user_preferences.font_size`` nullable.
+
+NULL means "use the UI default" — the frontend appearance settings
+own the canonical default value. Previously the column was NOT NULL
+with no schema default, which forced anyone seeding the row on
+demand to duplicate the frontend's default literal in Python.
+
+Revision ID: 022_user_preferences_font_size_nullable
+Revises: 021_add_user_preferences_default_model_id
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "022_user_preferences_font_size_nullable"
+down_revision = "021_add_user_preferences_default_model_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user_preferences") as batch_op:
+        batch_op.alter_column("font_size", existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    # Back-fill NULL rows before re-applying the NOT NULL constraint —
+    # the previous schema had no schema default, so the only thing we
+    # can safely re-insert is the historical Python-side seed (14).
+    bind = op.get_bind()
+    bind.execute(sa.text("UPDATE user_preferences SET font_size = 14 WHERE font_size IS NULL"))
+    with op.batch_alter_table("user_preferences") as batch_op:
+        batch_op.alter_column("font_size", existing_type=sa.Integer(), nullable=False)

--- a/backend/app/crud/user_preferences.py
+++ b/backend/app/crud/user_preferences.py
@@ -21,11 +21,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import UserPreferences
 
-# Seed value used when the row is created on demand for a user who's
-# only setting their default model. Column is NOT NULL in the
-# existing schema; matches the implicit frontend appearance default.
-_DEFAULT_FONT_SIZE = 14
-
 
 async def get_user_default_model_id(
     session: AsyncSession,
@@ -55,11 +50,7 @@ async def set_user_default_model_id(
     """
     row = await session.get(UserPreferences, user_id)
     if row is None:
-        row = UserPreferences(
-            user_id=user_id,
-            font_size=_DEFAULT_FONT_SIZE,
-            default_model_id=model_id,
-        )
+        row = UserPreferences(user_id=user_id, default_model_id=model_id)
         session.add(row)
     else:
         row.default_model_id = model_id

--- a/backend/app/crud/user_preferences.py
+++ b/backend/app/crud/user_preferences.py
@@ -1,0 +1,67 @@
+"""CRUD helpers for :class:`UserPreferences`.
+
+The row is created on demand the first time a preference is written.
+Reads tolerate a missing row by returning ``None``, since most users
+will not have customised anything (the row only exists once they
+flip a preference).
+
+This module owns the read/write surface for ``default_model_id``,
+the per-user default model used as a fallback when a conversation
+doesn't carry its own explicit ``Conversation.model_id`` override.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import UserPreferences
+
+# Default ``font_size`` used when the row is created on demand for a
+# user who's only setting their default model. The column is non-null
+# in the existing schema; this seed value matches the implicit
+# frontend default used by the appearance settings.
+_DEFAULT_FONT_SIZE = 14
+
+
+async def get_user_default_model_id(
+    *,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+) -> str | None:
+    """Return the user's persisted default model ID, or ``None``.
+
+    ``None`` means "no row" OR "row exists but column is NULL" — both
+    map to "fall back to the catalog default" at the call site, so
+    callers don't need to distinguish.
+    """
+    row = await session.get(UserPreferences, user_id)
+    if row is None:
+        return None
+    return row.default_model_id
+
+
+async def set_user_default_model_id(
+    *,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    model_id: str | None,
+) -> None:
+    """Persist the user's default model ID, creating the row if absent.
+
+    Pass ``model_id=None`` to clear the override so the next resolution
+    falls back to ``catalog.default_model()``. Idempotent: writing the
+    same value twice is a no-op behaviourally.
+    """
+    row = await session.get(UserPreferences, user_id)
+    if row is None:
+        row = UserPreferences(
+            user_id=user_id,
+            font_size=_DEFAULT_FONT_SIZE,
+            default_model_id=model_id,
+        )
+        session.add(row)
+    else:
+        row.default_model_id = model_id
+    await session.commit()

--- a/backend/app/crud/user_preferences.py
+++ b/backend/app/crud/user_preferences.py
@@ -1,13 +1,16 @@
 """CRUD helpers for :class:`UserPreferences`.
 
 The row is created on demand the first time a preference is written.
-Reads tolerate a missing row by returning ``None``, since most users
-will not have customised anything (the row only exists once they
-flip a preference).
+Reads tolerate a missing row by returning ``None`` so reads stay
+cheap for the common "user hasn't customised anything" case.
 
-This module owns the read/write surface for ``default_model_id``,
-the per-user default model used as a fallback when a conversation
-doesn't carry its own explicit ``Conversation.model_id`` override.
+Owns the read/write surface for ``default_model_id`` — the per-user
+default model used as a fallback when a conversation doesn't carry
+its own explicit ``Conversation.model_id`` override.
+
+Signature convention: ``session`` first positional, then the owning
+identity (``user_id``), then the domain argument — see
+``.claude/rules/clean-code/python-parameter-order.md``.
 """
 
 from __future__ import annotations
@@ -18,15 +21,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import UserPreferences
 
-# Default ``font_size`` used when the row is created on demand for a
-# user who's only setting their default model. The column is non-null
-# in the existing schema; this seed value matches the implicit
-# frontend default used by the appearance settings.
+# Seed value used when the row is created on demand for a user who's
+# only setting their default model. Column is NOT NULL in the
+# existing schema; matches the implicit frontend appearance default.
 _DEFAULT_FONT_SIZE = 14
 
 
 async def get_user_default_model_id(
-    *,
     session: AsyncSession,
     user_id: uuid.UUID,
 ) -> str | None:
@@ -43,16 +44,14 @@ async def get_user_default_model_id(
 
 
 async def set_user_default_model_id(
-    *,
     session: AsyncSession,
     user_id: uuid.UUID,
     model_id: str | None,
 ) -> None:
     """Persist the user's default model ID, creating the row if absent.
 
-    Pass ``model_id=None`` to clear the override so the next resolution
-    falls back to ``catalog.default_model()``. Idempotent: writing the
-    same value twice is a no-op behaviourally.
+    Pass ``model_id=None`` to clear the override so the next
+    resolution falls back to ``catalog.default_model()``.
     """
     row = await session.get(UserPreferences, user_id)
     if row is None:

--- a/backend/app/integrations/telegram/compact_command.py
+++ b/backend/app/integrations/telegram/compact_command.py
@@ -31,13 +31,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.lcm import compact_leaf_if_needed
 from app.core.lcm.background import acquire_lcm_lock
-from app.core.providers.catalog import default_model
 from app.core.providers.model_id import InvalidModelId
 from app.crud.channel import (
     get_or_create_telegram_conversation_full,
     get_user_id_for_external,
 )
 from app.db import async_session_maker
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
 
 
 class _TelegramSenderLike(Protocol):
@@ -116,10 +116,14 @@ async def handle_compact_command(
 
     # Default the summary model to whatever the conversation is using
     # (matches the fallback in ``compact_leaf_if_needed`` when
-    # ``lcm_summary_model`` is unset). Picking the catalog default for
-    # never-modelled conversations keeps the call shape valid even on a
-    # fresh row that has not picked a model yet.
-    summary_model_id = conversation.model_id or default_model().id
+    # ``lcm_summary_model`` is unset). Honours the user's pinned default
+    # before falling back to the catalog default — see
+    # :func:`resolve_effective_model_id`.
+    summary_model_id = await resolve_effective_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        conversation_model_id=conversation.model_id,
+    )
 
     # Take the per-conversation lock to serialize against any
     # background pass that turn_runner.py just scheduled — both paths

--- a/backend/app/integrations/telegram/handlers.py
+++ b/backend/app/integrations/telegram/handlers.py
@@ -39,6 +39,7 @@ from app.crud.channel import (
     redeem_link_code,
     update_conversation_verbose_level,
 )
+from app.crud.user_preferences import get_user_default_model_id
 
 # Re-export so ``bot.py`` imports both ``handle_plain_message`` and
 # ``collect_attachments`` from the same module — keeps ``bot.py`` under
@@ -230,7 +231,13 @@ async def handle_plain_message(
         thread_id=sender.thread_id,
     )
 
-    model_id = conversation.model_id or default_model().id
+    # Conversation override wins; otherwise the user's pinned default;
+    # otherwise the system-wide catalog default.
+    user_default = await get_user_default_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+    )
+    model_id = conversation.model_id or user_default or default_model().id
 
     logger.info(
         "TELEGRAM_TURN user_id=%s conversation_id=%s model=%s thread_id=%s text_len=%d",

--- a/backend/app/integrations/telegram/handlers.py
+++ b/backend/app/integrations/telegram/handlers.py
@@ -33,13 +33,11 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.providers.catalog import default_model
 from app.crud.channel import (
     get_or_create_telegram_conversation_full,
     redeem_link_code,
     update_conversation_verbose_level,
 )
-from app.crud.user_preferences import get_user_default_model_id
 
 # Re-export so ``bot.py`` imports both ``handle_plain_message`` and
 # ``collect_attachments`` from the same module — keeps ``bot.py`` under
@@ -49,6 +47,7 @@ from app.integrations.telegram._attachments import (
     collect_attachments as collect_attachments,  # noqa: PLC0414
 )
 from app.integrations.telegram.dev_admin import resolve_or_autolink_telegram_user
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
 from app.integrations.telegram.sender import TelegramSender as TelegramSender  # noqa: PLC0414
 
 # Loose match for the link-code shape (8 chars from the look-alike-free
@@ -230,14 +229,11 @@ async def handle_plain_message(
         session=session,
         thread_id=sender.thread_id,
     )
-
-    # Conversation override wins; otherwise the user's pinned default;
-    # otherwise the system-wide catalog default.
-    user_default = await get_user_default_model_id(
+    model_id = await resolve_effective_model_id(
         session=session,
         user_id=pawrrtal_user_id,
+        conversation_model_id=conversation.model_id,
     )
-    model_id = conversation.model_id or user_default or default_model().id
 
     logger.info(
         "TELEGRAM_TURN user_id=%s conversation_id=%s model=%s thread_id=%s text_len=%d",

--- a/backend/app/integrations/telegram/model_command.py
+++ b/backend/app/integrations/telegram/model_command.py
@@ -1,20 +1,17 @@
-"""``/model`` command handler — pulled out of ``handlers.py``.
+"""``/model`` command handler for the Telegram channel.
 
-Moved here so ``handlers.py`` stays under the project's 500-line file
-budget after the reasoning-effort backstop landed.
-
-The command supports three shapes:
+Supports three shapes:
 
 - ``/model <vendor>/<model>`` — switch this conversation only.
 - ``/model <vendor>/<model> default`` (or ``/model default <id>``)
-  — switch this conversation **and** set the user's default model,
+  — switch this conversation **and** set the user's default model
   so future conversations inherit it.
 - ``/model default`` — promote the conversation's *current* model
   to the user's default, without switching to anything else.
 
-Imported by :mod:`app.integrations.telegram.model_picker_runtime`
-(the aiogram glue) and indirectly reached from ``bot.py`` through
-``answer_model_command``.
+The aiogram glue lives in
+:mod:`app.integrations.telegram.model_picker_runtime`; this module
+stays framework-free and unit-testable.
 """
 
 from __future__ import annotations
@@ -70,6 +67,12 @@ _MODEL_DEFAULT_NO_CURRENT_MESSAGE = (
     "No current model to promote. Switch with <code>/model &lt;id&gt;</code> first, "
     "or pass an ID alongside <code>default</code>."
 )
+_MODEL_DEFAULT_STALE_MESSAGE = (
+    "This conversation's current model (<code>{model_id}</code>) is no longer "
+    "in the catalog. Pick a fresh one with <code>/model</code> first, then "
+    "promote it with <code>/model default</code> — or pass an ID directly: "
+    "<code>/model &lt;id&gt; default</code>."
+)
 _MODEL_FAIL_MESSAGE = "Couldn't update model — please try again."
 
 
@@ -88,15 +91,20 @@ class _ParsedArgs:
 
 
 def _parse_model_args(raw: str) -> _ParsedArgs:
-    """Split the trailing ``default`` keyword from the model token.
+    """Split the optional ``default`` keyword from the model token.
 
-    Accepts the two common shapes:
+    Accepted shapes:
 
     - ``<id> default``  → ``model_id=<id>, make_default=True``
     - ``default <id>``  → ``model_id=<id>, make_default=True``
     - ``default``       → ``model_id="", make_default=True``
     - ``<id>``          → ``model_id=<id>, make_default=False``
     - empty             → ``model_id="", make_default=False``
+
+    Keyword match is case-insensitive. Only strips one occurrence of
+    ``default`` per call — ``default default`` keeps the second as a
+    parse error candidate, surfacing as ``_MODEL_UNKNOWN_MESSAGE``
+    downstream.
     """
     tokens = raw.split()
     if not tokens:
@@ -179,6 +187,8 @@ async def _switch_and_maybe_default(
         thread_id=sender.thread_id,
     )
 
+    # Store the canonical "host:vendor/model" form regardless of how
+    # the user typed it, so persisted model_ids stay consistent.
     canonical_id = entry.id
     updated = await update_conversation_model(
         conversation_id=conversation.id,
@@ -227,10 +237,15 @@ async def _promote_current_to_default(
 ) -> str:
     """Handle the bare ``/model default`` shape.
 
-    Reads the conversation's current ``model_id`` and writes it to
-    ``UserPreferences.default_model_id``. Refuses when the
-    conversation hasn't been pinned to anything explicit yet — there
-    would be nothing meaningful to promote.
+    Reads the conversation's current ``model_id``, re-validates it
+    against the catalog, and writes the canonical form to
+    ``UserPreferences.default_model_id``. Refuses when:
+
+    - the conversation hasn't been pinned to anything explicit yet,
+      because there'd be nothing meaningful to promote; or
+    - the stored ``model_id`` is no longer in the catalog (e.g. after
+      a catalog rotation removed it), because promoting a stale ID
+      would silently poison every future conversation.
     """
     conversation = await get_or_create_telegram_conversation_full(
         user_id=pawrrtal_user_id,
@@ -241,17 +256,36 @@ async def _promote_current_to_default(
     if not current_id:
         return _MODEL_DEFAULT_NO_CURRENT_MESSAGE
 
+    canonical_id = _canonical_catalog_id(current_id)
+    if canonical_id is None:
+        logger.warning(
+            "TELEGRAM_DEFAULT_PROMOTE_STALE user_id=%s stale_model_id=%s",
+            pawrrtal_user_id,
+            current_id,
+        )
+        return _MODEL_DEFAULT_STALE_MESSAGE.format(model_id=current_id)
+
     await set_user_default_model_id(
         session=session,
         user_id=pawrrtal_user_id,
-        model_id=current_id,
+        model_id=canonical_id,
     )
     logger.info(
         "TELEGRAM_DEFAULT_MODEL_SET user_id=%s model_id=%s",
         pawrrtal_user_id,
-        current_id,
+        canonical_id,
     )
-    return _MODEL_DEFAULT_ONLY_MESSAGE.format(model_id=current_id)
+    return _MODEL_DEFAULT_ONLY_MESSAGE.format(model_id=canonical_id)
+
+
+def _canonical_catalog_id(model_id: str) -> str | None:
+    """Return the canonical catalog ID for ``model_id`` or ``None`` if stale."""
+    try:
+        parsed = parse_model_id(model_id)
+    except InvalidModelId:
+        return None
+    entry = find(parsed)
+    return None if entry is None else entry.id
 
 
 async def set_user_default_model_from_callback(

--- a/backend/app/integrations/telegram/model_command.py
+++ b/backend/app/integrations/telegram/model_command.py
@@ -1,9 +1,16 @@
 """``/model`` command handler — pulled out of ``handlers.py``.
 
 Moved here so ``handlers.py`` stays under the project's 500-line file
-budget after the reasoning-effort backstop landed. The command itself
-is unchanged: parse → catalog-validate → persist → maybe-append
-reasoning-effort notice.
+budget after the reasoning-effort backstop landed.
+
+The command supports three shapes:
+
+- ``/model <vendor>/<model>`` — switch this conversation only.
+- ``/model <vendor>/<model> default`` (or ``/model default <id>``)
+  — switch this conversation **and** set the user's default model,
+  so future conversations inherit it.
+- ``/model default`` — promote the conversation's *current* model
+  to the user's default, without switching to anything else.
 
 Imported by :mod:`app.integrations.telegram.model_picker_runtime`
 (the aiogram glue) and indirectly reached from ``bot.py`` through
@@ -13,6 +20,8 @@ Imported by :mod:`app.integrations.telegram.model_picker_runtime`
 from __future__ import annotations
 
 import logging
+import uuid
+from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,16 +31,25 @@ from app.crud.channel import (
     get_or_create_telegram_conversation_full,
     update_conversation_model,
 )
+from app.crud.user_preferences import set_user_default_model_id
 from app.integrations.telegram.dev_admin import resolve_or_autolink_telegram_user
 from app.integrations.telegram.reasoning_notify import maybe_append_model_switch_notice
 from app.integrations.telegram.sender import TelegramSender
 
 logger = logging.getLogger(__name__)
 
+# Keyword the user types to also persist the choice as their default.
+# Case-insensitive; accepts both leading- and trailing-position syntax
+# (``/model default <id>`` or ``/model <id> default``).
+DEFAULT_KEYWORD = "default"
+
 _MODEL_MISSING_MESSAGE = (
-    "Usage: /model &lt;vendor&gt;/&lt;model&gt;\n\n"
+    "Usage: /model &lt;vendor&gt;/&lt;model&gt; [default]\n\n"
     "The structural form is <code>[host:]vendor/model</code>; the host "
-    "prefix is optional and filled in automatically."
+    "prefix is optional and filled in automatically.\n\n"
+    "Add <code>default</code> to also set the model as your personal "
+    "default for future conversations — e.g. "
+    "<code>/model anthropic/claude-sonnet-4-6 default</code>."
 )
 _MODEL_INVALID_MESSAGE = (
     "Couldn't parse <code>{raw}</code> as a model ID ({reason}).\n\n"
@@ -43,7 +61,57 @@ _MODEL_UNKNOWN_MESSAGE = (
 )
 _MODEL_NOT_BOUND_MESSAGE = "You need to connect your account first before switching models."
 _MODEL_OK_MESSAGE = "Model switched to <code>{model_id}</code> ✅"
+_MODEL_DEFAULT_SUFFIX = " (also set as your default for future conversations ⭐)"
+_MODEL_DEFAULT_ONLY_MESSAGE = (
+    "Default model set to <code>{model_id}</code> ⭐\n\n"
+    "Future Telegram conversations will use this model unless overridden."
+)
+_MODEL_DEFAULT_NO_CURRENT_MESSAGE = (
+    "No current model to promote. Switch with <code>/model &lt;id&gt;</code> first, "
+    "or pass an ID alongside <code>default</code>."
+)
 _MODEL_FAIL_MESSAGE = "Couldn't update model — please try again."
+
+
+@dataclass(frozen=True)
+class _ParsedArgs:
+    """Result of parsing the free-form text after ``/model``.
+
+    ``model_id`` is whatever non-keyword token the user typed (still
+    pre-catalog-validation) and ``make_default`` is true when the
+    ``default`` keyword appeared in either leading or trailing
+    position.
+    """
+
+    model_id: str
+    make_default: bool
+
+
+def _parse_model_args(raw: str) -> _ParsedArgs:
+    """Split the trailing ``default`` keyword from the model token.
+
+    Accepts the two common shapes:
+
+    - ``<id> default``  → ``model_id=<id>, make_default=True``
+    - ``default <id>``  → ``model_id=<id>, make_default=True``
+    - ``default``       → ``model_id="", make_default=True``
+    - ``<id>``          → ``model_id=<id>, make_default=False``
+    - empty             → ``model_id="", make_default=False``
+    """
+    tokens = raw.split()
+    if not tokens:
+        return _ParsedArgs(model_id="", make_default=False)
+
+    make_default = False
+    if tokens[0].lower() == DEFAULT_KEYWORD:
+        make_default = True
+        tokens = tokens[1:]
+    elif tokens[-1].lower() == DEFAULT_KEYWORD:
+        make_default = True
+        tokens = tokens[:-1]
+
+    model_id = " ".join(tokens).strip()
+    return _ParsedArgs(model_id=model_id, make_default=make_default)
 
 
 async def handle_model_command(
@@ -52,29 +120,58 @@ async def handle_model_command(
     model_arg: str,
     session: AsyncSession,
 ) -> str:
-    """Process a ``/model <id>`` command and persist the model override.
+    """Process a ``/model <id> [default]`` command and persist the choice.
 
     Resolves the sender's binding, finds (or creates) their Telegram
     conversation, and updates ``Conversation.model_id`` so subsequent
-    turns use the requested model. When the new model honours a
-    different set of reasoning levels than the stored one, the
-    shared backstop appends a notice describing the change.
-    """
-    raw = model_arg.strip()
-    if not raw:
-        return _MODEL_MISSING_MESSAGE
+    turns use the requested model. When the ``default`` keyword is
+    present, additionally writes ``UserPreferences.default_model_id``
+    so future conversations inherit the choice.
 
-    try:
-        parsed = parse_model_id(raw)
-    except InvalidModelId as exc:
-        return _MODEL_INVALID_MESSAGE.format(raw=raw, reason=str(exc))
-    entry = find(parsed)
-    if entry is None:
-        return _MODEL_UNKNOWN_MESSAGE.format(raw=raw)
+    The bare ``/model default`` shape promotes the conversation's
+    current model to the user's default without switching to anything
+    else.
+    """
+    parsed_args = _parse_model_args(model_arg)
+    if not parsed_args.model_id and not parsed_args.make_default:
+        return _MODEL_MISSING_MESSAGE
 
     pawrrtal_user_id = await resolve_or_autolink_telegram_user(session=session, sender=sender)
     if pawrrtal_user_id is None:
         return _MODEL_NOT_BOUND_MESSAGE
+
+    if parsed_args.model_id:
+        return await _switch_and_maybe_default(
+            sender=sender,
+            session=session,
+            pawrrtal_user_id=pawrrtal_user_id,
+            raw_model_id=parsed_args.model_id,
+            make_default=parsed_args.make_default,
+        )
+
+    return await _promote_current_to_default(
+        sender=sender,
+        session=session,
+        pawrrtal_user_id=pawrrtal_user_id,
+    )
+
+
+async def _switch_and_maybe_default(
+    *,
+    sender: TelegramSender,
+    session: AsyncSession,
+    pawrrtal_user_id: uuid.UUID,
+    raw_model_id: str,
+    make_default: bool,
+) -> str:
+    """Validate + canonicalise + persist a /model <id> [default] switch."""
+    try:
+        parsed = parse_model_id(raw_model_id)
+    except InvalidModelId as exc:
+        return _MODEL_INVALID_MESSAGE.format(raw=raw_model_id, reason=str(exc))
+    entry = find(parsed)
+    if entry is None:
+        return _MODEL_UNKNOWN_MESSAGE.format(raw=raw_model_id)
 
     conversation = await get_or_create_telegram_conversation_full(
         user_id=pawrrtal_user_id,
@@ -82,8 +179,6 @@ async def handle_model_command(
         thread_id=sender.thread_id,
     )
 
-    # Store the canonical "host:vendor/model" form regardless of how
-    # the user typed it, so stored model_ids stay consistent.
     canonical_id = entry.id
     updated = await update_conversation_model(
         conversation_id=conversation.id,
@@ -98,15 +193,90 @@ async def handle_model_command(
         )
         return _MODEL_FAIL_MESSAGE
 
+    if make_default:
+        await set_user_default_model_id(
+            session=session,
+            user_id=pawrrtal_user_id,
+            model_id=canonical_id,
+        )
+
     logger.info(
-        "TELEGRAM_MODEL_SET user_id=%s conversation_id=%s model_id=%s",
+        "TELEGRAM_MODEL_SET user_id=%s conversation_id=%s model_id=%s default=%s",
         pawrrtal_user_id,
         conversation.id,
         canonical_id,
+        make_default,
     )
+
+    base_reply = _MODEL_OK_MESSAGE.format(model_id=canonical_id)
+    if make_default:
+        base_reply = base_reply + _MODEL_DEFAULT_SUFFIX
     return await maybe_append_model_switch_notice(
-        base_reply=_MODEL_OK_MESSAGE.format(model_id=canonical_id),
+        base_reply=base_reply,
         conversation_id=conversation.id,
         new_model_id=canonical_id,
         session=session,
     )
+
+
+async def _promote_current_to_default(
+    *,
+    sender: TelegramSender,
+    session: AsyncSession,
+    pawrrtal_user_id: uuid.UUID,
+) -> str:
+    """Handle the bare ``/model default`` shape.
+
+    Reads the conversation's current ``model_id`` and writes it to
+    ``UserPreferences.default_model_id``. Refuses when the
+    conversation hasn't been pinned to anything explicit yet — there
+    would be nothing meaningful to promote.
+    """
+    conversation = await get_or_create_telegram_conversation_full(
+        user_id=pawrrtal_user_id,
+        session=session,
+        thread_id=sender.thread_id,
+    )
+    current_id = conversation.model_id
+    if not current_id:
+        return _MODEL_DEFAULT_NO_CURRENT_MESSAGE
+
+    await set_user_default_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        model_id=current_id,
+    )
+    logger.info(
+        "TELEGRAM_DEFAULT_MODEL_SET user_id=%s model_id=%s",
+        pawrrtal_user_id,
+        current_id,
+    )
+    return _MODEL_DEFAULT_ONLY_MESSAGE.format(model_id=current_id)
+
+
+async def set_user_default_model_from_callback(
+    *,
+    sender: TelegramSender,
+    session: AsyncSession,
+    canonical_model_id: str,
+) -> bool:
+    """Persist the user's default model from a picker callback.
+
+    Returns ``True`` when the user was bound and the write succeeded;
+    ``False`` when the sender has no binding (the picker UI shouldn't
+    surface the button in that case, but we re-validate at the seam).
+    """
+    pawrrtal_user_id = await resolve_or_autolink_telegram_user(session=session, sender=sender)
+    if pawrrtal_user_id is None:
+        return False
+    await set_user_default_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        model_id=canonical_model_id,
+    )
+    logger.info(
+        "TELEGRAM_DEFAULT_MODEL_SET_VIA_PICKER user_id=%s model_id=%s",
+        pawrrtal_user_id,
+        canonical_model_id,
+    )
+    return True

--- a/backend/app/integrations/telegram/model_defaults.py
+++ b/backend/app/integrations/telegram/model_defaults.py
@@ -1,0 +1,75 @@
+"""Shared resolution helpers for Telegram model selection.
+
+Every Telegram surface that needs to know "which model is this
+conversation using right now" walks the same fallback chain:
+
+1. ``Conversation.model_id`` (per-conversation override set via the
+   picker, ``/model``, or the chat router).
+2. ``UserPreferences.default_model_id`` (user's pinned default,
+   written by ``/model ... default`` or the picker's "Set as
+   default" button).
+3. :func:`catalog.default_model` (system-wide fallback).
+
+Centralising the chain in one helper avoids the drift that surfaces
+when ``/thinking``, ``/compact``, ``/status``, and the chat path
+each open-code the resolution differently — a known footgun before
+this module existed.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.providers.catalog import default_model, find
+from app.core.providers.model_id import InvalidModelId, parse_model_id
+from app.crud.user_preferences import get_user_default_model_id
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_effective_model_id(
+    *,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    conversation_model_id: str | None,
+) -> str:
+    """Resolve the effective canonical model_id for a Telegram user.
+
+    Order: conversation override → user default → catalog default.
+
+    A user-default that's no longer in the catalog (e.g. catalog
+    rotation removed it) is treated as stale: we log
+    ``TELEGRAM_STALE_USER_DEFAULT`` and fall through to the catalog
+    default rather than handing a dead ID to the downstream chat path.
+    Operators reading the log can then prompt the user to re-pin.
+    """
+    if conversation_model_id:
+        return conversation_model_id
+
+    user_default = await get_user_default_model_id(
+        session=session,
+        user_id=user_id,
+    )
+    if user_default and _is_in_catalog(user_default):
+        return user_default
+
+    if user_default:
+        logger.warning(
+            "TELEGRAM_STALE_USER_DEFAULT user_id=%s stale_model_id=%s",
+            user_id,
+            user_default,
+        )
+
+    return default_model().id
+
+
+def _is_in_catalog(model_id: str) -> bool:
+    """Return whether ``model_id`` is structurally valid + catalog-known."""
+    try:
+        parsed = parse_model_id(model_id)
+    except InvalidModelId:
+        return False
+    return find(parsed) is not None

--- a/backend/app/integrations/telegram/model_picker.py
+++ b/backend/app/integrations/telegram/model_picker.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from html import escape
-from typing import Protocol
+from typing import Literal, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry, default_model
+from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry
 from app.core.providers.labels import host_label_from_slug, vendor_label_from_slug
 from app.crud.channel import get_or_create_telegram_conversation_full, get_user_id_for_external
 from app.crud.user_preferences import get_user_default_model_id
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
+
+ModelCallbackAction = Literal["providers", "vendors", "list", "select", "set_default"]
 
 PROVIDER = "telegram"
 MODEL_CALLBACK_PREFIX = "mdl:"
@@ -83,7 +86,7 @@ class ModelCallback:
     ``"select"``).
     """
 
-    action: str
+    action: ModelCallbackAction
     host: str | None = None
     provider: str | None = None  # vendor slug; name kept for runtime compatibility
     page: int = 1
@@ -113,12 +116,17 @@ async def get_model_picker_state(
         session=session,
         thread_id=sender.thread_id,
     )
+    current_model_id = await resolve_effective_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        conversation_model_id=conversation.model_id,
+    )
     user_default = await get_user_default_model_id(
         session=session,
         user_id=pawrrtal_user_id,
     )
     return ModelPickerState(
-        current_model_id=conversation.model_id or user_default or default_model().id,
+        current_model_id=current_model_id,
         user_default_model_id=user_default,
     )
 
@@ -280,28 +288,21 @@ def _parse_prefixed_callback(parts: list[str]) -> ModelCallback | None:
 
 
 def resolve_model_selection(callback: ModelCallback) -> ModelEntry | None:
-    """Resolve a ``select`` or ``set_default`` callback to a catalog entry.
+    """Resolve a ``select`` / ``set_default`` callback to a catalog entry.
 
     Returns ``None`` for stale catalog tokens or out-of-range indexes.
-    Both actions share the same ``(catalog_token, index)`` payload.
     """
     if callback.action not in ("select", "set_default"):
         return None
     if callback.catalog_token != _CATALOG_TOKEN:
         return None
-    if callback.index is None or callback.index < 0:
-        return None
-    if callback.index >= len(MODEL_CATALOG):
+    if callback.index is None or callback.index < 0 or callback.index >= len(MODEL_CATALOG):
         return None
     return MODEL_CATALOG[callback.index]
 
 
 def build_set_default_keyboard(*, model_id: str) -> list[list[ModelButton]] | None:
-    """Build the "⭐ Set as my default" row for the success message.
-
-    Returns ``None`` when ``model_id`` is not in the catalog (e.g. a
-    stale catalog-bump that's no longer resolvable).
-    """
+    """Build the "⭐ Set as my default" row, or ``None`` for stale catalog."""
     entry = _entry_by_id(model_id)
     if entry is None:
         return None
@@ -316,7 +317,7 @@ def build_set_default_keyboard(*, model_id: str) -> list[list[ModelButton]] | No
 
 
 def build_default_already_set_keyboard() -> list[list[ModelButton]]:
-    """Build an inert "⭐ Already your default" confirmation row."""
+    """Build the inert "⭐ Already your default" confirmation row."""
     return [[ModelButton(text=_DEFAULT_ALREADY_SET_TEXT, callback_data="mdl:noop")]]
 
 

--- a/backend/app/integrations/telegram/model_picker.py
+++ b/backend/app/integrations/telegram/model_picker.py
@@ -38,6 +38,8 @@ _PICKER_NOT_BOUND_MESSAGE = "Connect your account first before changing models."
 _PICKER_STALE_MESSAGE = "That model picker is out of date. Send /model again."
 _DEFAULT_BUTTON_TEXT = "⭐ Set as my default"
 _DEFAULT_ALREADY_SET_TEXT = "⭐ Already your default"
+# Inert callback used by the post-default badge so a second tap is a no-op.
+NOOP_CALLBACK = "mdl:noop"
 
 
 class TelegramSenderLike(Protocol):
@@ -64,27 +66,17 @@ class ModelButton:
 
 @dataclass(frozen=True)
 class ModelPickerState:
-    """Current catalog state for one Telegram conversation.
-
-    ``current_model_id`` is the conversation's resolved model.
-    ``user_default_model_id`` is the persisted per-user default (or
-    ``None``), used to decide whether to surface "set as default".
-    """
+    """Current catalog state for one Telegram conversation."""
 
     current_model_id: str
+    # Persisted per-user default (or ``None``) — drives whether the
+    # picker offers "set as default" affordances after a selection.
     user_default_model_id: str | None = None
 
 
 @dataclass(frozen=True)
 class ModelCallback:
-    """Parsed Telegram callback payload for the model picker.
-
-    ``action`` is one of: ``"providers"`` (root screen),
-    ``"vendors"`` (host's vendor list), ``"list"`` (paginated model
-    list), ``"select"`` (pick for this conversation), or
-    ``"set_default"`` (pin as user default; same payload shape as
-    ``"select"``).
-    """
+    """Parsed Telegram callback payload for the model picker."""
 
     action: ModelCallbackAction
     host: str | None = None
@@ -272,7 +264,8 @@ def parse_model_callback_data(data: str | None) -> ModelCallback | None:
 
 
 def _parse_prefixed_callback(parts: list[str]) -> ModelCallback | None:
-    """Dispatch a ``mdl:<tag>:...`` payload to the right parser."""
+    # Minimum length is `mdl:<tag>` (two parts); below that there's no
+    # tag byte to read and we'd index past the end.
     if len(parts) < _CALLBACK_MIN_PARTS:
         return None
     tag = parts[1]
@@ -318,7 +311,7 @@ def build_set_default_keyboard(*, model_id: str) -> list[list[ModelButton]] | No
 
 def build_default_already_set_keyboard() -> list[list[ModelButton]]:
     """Build the inert "⭐ Already your default" confirmation row."""
-    return [[ModelButton(text=_DEFAULT_ALREADY_SET_TEXT, callback_data="mdl:noop")]]
+    return [[ModelButton(text=_DEFAULT_ALREADY_SET_TEXT, callback_data=NOOP_CALLBACK)]]
 
 
 def picker_not_bound_message() -> str:
@@ -483,6 +476,7 @@ def _pagination_rows(
 
 __all__ = [
     "MODEL_CALLBACK_PREFIX",
+    "NOOP_CALLBACK",
     "ModelButton",
     "ModelCallback",
     "ModelPickerState",

--- a/backend/app/integrations/telegram/model_picker.py
+++ b/backend/app/integrations/telegram/model_picker.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry, default_model
 from app.core.providers.labels import host_label_from_slug, vendor_label_from_slug
 from app.crud.channel import get_or_create_telegram_conversation_full, get_user_id_for_external
+from app.crud.user_preferences import get_user_default_model_id
 
 PROVIDER = "telegram"
 MODEL_CALLBACK_PREFIX = "mdl:"
@@ -24,12 +25,16 @@ _CATALOG_TOKEN = CATALOG_ETAG[:8]
 _MODEL_PAGE_SIZE = 8
 _HOST_BUTTONS_PER_ROW = 2
 _VENDOR_BUTTONS_PER_ROW = 2
+_CALLBACK_MIN_PARTS = 2  # mdl:<tag>...
 _CALLBACK_VENDOR_PARTS = 3  # mdl:v:<host>
 _CALLBACK_LIST_PARTS = 5  # mdl:l:<host>:<vendor>:<page>
 _CALLBACK_SELECT_PARTS = 4  # mdl:s:<token>:<index>
+_CALLBACK_DEFAULT_PARTS = 4  # mdl:d:<token>:<index>
 
 _PICKER_NOT_BOUND_MESSAGE = "Connect your account first before changing models."
 _PICKER_STALE_MESSAGE = "That model picker is out of date. Send /model again."
+_DEFAULT_BUTTON_TEXT = "⭐ Set as my default"
+_DEFAULT_ALREADY_SET_TEXT = "⭐ Already your default"
 
 
 class TelegramSenderLike(Protocol):
@@ -56,14 +61,27 @@ class ModelButton:
 
 @dataclass(frozen=True)
 class ModelPickerState:
-    """Current catalog state for one Telegram conversation."""
+    """Current catalog state for one Telegram conversation.
+
+    ``current_model_id`` is the conversation's resolved model.
+    ``user_default_model_id`` is the persisted per-user default (or
+    ``None``), used to decide whether to surface "set as default".
+    """
 
     current_model_id: str
+    user_default_model_id: str | None = None
 
 
 @dataclass(frozen=True)
 class ModelCallback:
-    """Parsed Telegram callback payload for the model picker."""
+    """Parsed Telegram callback payload for the model picker.
+
+    ``action`` is one of: ``"providers"`` (root screen),
+    ``"vendors"`` (host's vendor list), ``"list"`` (paginated model
+    list), ``"select"`` (pick for this conversation), or
+    ``"set_default"`` (pin as user default; same payload shape as
+    ``"select"``).
+    """
 
     action: str
     host: str | None = None
@@ -78,7 +96,7 @@ async def get_model_picker_state(
     sender: TelegramSenderLike,
     session: AsyncSession,
 ) -> ModelPickerState | None:
-    """Resolve the current model for a Telegram sender.
+    """Resolve the current model + user default for a Telegram sender.
 
     Returns ``None`` when the Telegram sender is not bound to a user.
     """
@@ -95,7 +113,14 @@ async def get_model_picker_state(
         session=session,
         thread_id=sender.thread_id,
     )
-    return ModelPickerState(current_model_id=conversation.model_id or default_model().id)
+    user_default = await get_user_default_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+    )
+    return ModelPickerState(
+        current_model_id=conversation.model_id or user_default or default_model().id,
+        user_default_model_id=user_default,
+    )
 
 
 def build_host_keyboard() -> list[list[ModelButton]]:
@@ -190,10 +215,25 @@ def has_vendor_in_host(*, host: str, vendor: str) -> bool:
     return vendor in _host_to_vendors().get(host, {})
 
 
-def format_host_picker_text(current_model_id: str) -> str:
-    """Render the host picker message in Telegram HTML."""
+def format_host_picker_text(
+    current_model_id: str,
+    user_default_model_id: str | None = None,
+) -> str:
+    """Render the host picker message in Telegram HTML.
+
+    Surfaces a second "Default: …" line when the user has pinned a
+    default that differs from the conversation's current model.
+    """
     current = _display_name_for_model(current_model_id)
-    return f"Choose a provider for this Telegram conversation.\n\nCurrent: <b>{escape(current)}</b>"
+    lines = [
+        "Choose a provider for this Telegram conversation.",
+        "",
+        f"Current: <b>{escape(current)}</b>",
+    ]
+    if user_default_model_id and user_default_model_id != current_model_id:
+        default_name = _display_name_for_model(user_default_model_id)
+        lines.append(f"Default: <b>{escape(default_name)}</b> ⭐")
+    return "\n".join(lines)
 
 
 def format_vendor_picker_text(*, host: str) -> str:
@@ -220,27 +260,64 @@ def parse_model_callback_data(data: str | None) -> ModelCallback | None:
         return None
 
     parts = data.split(":")
-    if len(parts) == _CALLBACK_VENDOR_PARTS and parts[1] == "v":
+    return _parse_prefixed_callback(parts)
+
+
+def _parse_prefixed_callback(parts: list[str]) -> ModelCallback | None:
+    """Dispatch a ``mdl:<tag>:...`` payload to the right parser."""
+    if len(parts) < _CALLBACK_MIN_PARTS:
+        return None
+    tag = parts[1]
+    if len(parts) == _CALLBACK_VENDOR_PARTS and tag == "v":
         return ModelCallback(action="vendors", host=parts[2])
-    if len(parts) == _CALLBACK_LIST_PARTS and parts[1] == "l":
+    if len(parts) == _CALLBACK_LIST_PARTS and tag == "l":
         return _parse_list_callback(parts)
-    if len(parts) == _CALLBACK_SELECT_PARTS and parts[1] == "s":
+    if len(parts) == _CALLBACK_SELECT_PARTS and tag == "s":
         return _parse_select_callback(parts)
+    if len(parts) == _CALLBACK_DEFAULT_PARTS and tag == "d":
+        return _parse_set_default_callback(parts)
     return None
 
 
 def resolve_model_selection(callback: ModelCallback) -> ModelEntry | None:
-    """Resolve a parsed selection callback to a catalog entry.
+    """Resolve a ``select`` or ``set_default`` callback to a catalog entry.
 
     Returns ``None`` for stale catalog tokens or out-of-range indexes.
+    Both actions share the same ``(catalog_token, index)`` payload.
     """
-    if callback.action != "select" or callback.catalog_token != _CATALOG_TOKEN:
+    if callback.action not in ("select", "set_default"):
+        return None
+    if callback.catalog_token != _CATALOG_TOKEN:
         return None
     if callback.index is None or callback.index < 0:
         return None
     if callback.index >= len(MODEL_CATALOG):
         return None
     return MODEL_CATALOG[callback.index]
+
+
+def build_set_default_keyboard(*, model_id: str) -> list[list[ModelButton]] | None:
+    """Build the "⭐ Set as my default" row for the success message.
+
+    Returns ``None`` when ``model_id`` is not in the catalog (e.g. a
+    stale catalog-bump that's no longer resolvable).
+    """
+    entry = _entry_by_id(model_id)
+    if entry is None:
+        return None
+    return [
+        [
+            ModelButton(
+                text=_DEFAULT_BUTTON_TEXT,
+                callback_data=_set_default_callback(_catalog_index(entry)),
+            )
+        ]
+    ]
+
+
+def build_default_already_set_keyboard() -> list[list[ModelButton]]:
+    """Build an inert "⭐ Already your default" confirmation row."""
+    return [[ModelButton(text=_DEFAULT_ALREADY_SET_TEXT, callback_data="mdl:noop")]]
 
 
 def picker_not_bound_message() -> str:
@@ -306,6 +383,18 @@ def _select_callback(index: int) -> str:
     return f"mdl:s:{_CATALOG_TOKEN}:{index}"
 
 
+def _set_default_callback(index: int) -> str:
+    return f"mdl:d:{_CATALOG_TOKEN}:{index}"
+
+
+def _entry_by_id(model_id: str) -> ModelEntry | None:
+    """Look up a catalog entry by its canonical ``host:vendor/model`` ID."""
+    for entry in MODEL_CATALOG:
+        if entry.id == model_id:
+            return entry
+    return None
+
+
 def _parse_list_callback(parts: list[str]) -> ModelCallback | None:
     try:
         page = int(parts[4])
@@ -328,6 +417,18 @@ def _parse_select_callback(parts: list[str]) -> ModelCallback | None:
         return None
     return ModelCallback(
         action="select",
+        index=index,
+        catalog_token=parts[2],
+    )
+
+
+def _parse_set_default_callback(parts: list[str]) -> ModelCallback | None:
+    try:
+        index = int(parts[3])
+    except ValueError:
+        return None
+    return ModelCallback(
+        action="set_default",
         index=index,
         catalog_token=parts[2],
     )
@@ -385,8 +486,10 @@ __all__ = [
     "ModelCallback",
     "ModelPickerState",
     "TelegramSenderLike",
+    "build_default_already_set_keyboard",
     "build_host_keyboard",
     "build_models_keyboard",
+    "build_set_default_keyboard",
     "build_vendor_keyboard",
     "format_host_picker_text",
     "format_models_picker_text",

--- a/backend/app/integrations/telegram/model_picker_runtime.py
+++ b/backend/app/integrations/telegram/model_picker_runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import logging
+from typing import TYPE_CHECKING
 
 from app.db import async_session_maker
 from app.integrations.telegram.model_command import (
@@ -15,6 +16,7 @@ from app.integrations.telegram.model_picker import (
     MODEL_CALLBACK_PREFIX as MODEL_CALLBACK_PREFIX,  # noqa: PLC0414
 )
 from app.integrations.telegram.model_picker import (
+    NOOP_CALLBACK,
     ModelButton,
     ModelCallback,
     build_default_already_set_keyboard,
@@ -42,6 +44,8 @@ if TYPE_CHECKING:
         Message,
         ReplyParameters,
     )
+
+logger = logging.getLogger(__name__)
 
 
 async def answer_model_command(*, message: Message, model_arg: str) -> None:
@@ -82,7 +86,7 @@ async def answer_model_picker(*, message: Message) -> None:
 async def handle_model_picker_callback(*, callback: CallbackQuery) -> None:
     """Handle inline keyboard callbacks produced by the model picker."""
     # Inert confirmation button — no-op so a second tap doesn't error.
-    if callback.data == "mdl:noop":
+    if callback.data == NOOP_CALLBACK:
         await callback.answer()
         return
 
@@ -99,7 +103,6 @@ async def handle_model_picker_callback(*, callback: CallbackQuery) -> None:
 
 
 async def _handle_mutating_callback(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
-    """Dispatch to the right per-action mutation handler."""
     if parsed.action == "select":
         await _handle_model_select(callback=callback, parsed=parsed)
         return
@@ -163,10 +166,18 @@ async def _handle_model_select(*, callback: CallbackQuery, parsed: ModelCallback
         await message.edit_text(reply)
     else:
         default_keyboard = build_set_default_keyboard(model_id=entry.id)
-        await message.edit_text(
-            reply,
-            reply_markup=_inline_keyboard(default_keyboard) if default_keyboard else None,
-        )
+        if default_keyboard is None:
+            # Catalog rotated under us between the select callback and the
+            # success edit. The conversation switch already landed; we just
+            # can't offer the "Set as default" affordance for a model that's
+            # no longer in the catalog. Log so operators see the churn.
+            logger.warning(
+                "MODEL_PICKER_STALE_DEFAULT_KEYBOARD model_id=%s",
+                entry.id,
+            )
+            await message.edit_text(reply)
+        else:
+            await message.edit_text(reply, reply_markup=_inline_keyboard(default_keyboard))
     await callback.answer(f"Model set: {entry.short_name}")
 
 
@@ -308,7 +319,7 @@ def _callback_message(callback: CallbackQuery) -> Message | None:
         return None
     # ``callback.message`` is typed ``Message | InaccessibleMessage``; the
     # hasattr() guard above narrows to the accessible Message at runtime.
-    return cast("Message", message)
+    return message  # type: ignore[return-value]
 
 
 def _reply_parameters(message_id: int) -> ReplyParameters:

--- a/backend/app/integrations/telegram/model_picker_runtime.py
+++ b/backend/app/integrations/telegram/model_picker_runtime.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from app.db import async_session_maker
-from app.integrations.telegram.model_command import handle_model_command
+from app.integrations.telegram.model_command import (
+    handle_model_command,
+    set_user_default_model_from_callback,
+)
 
 # Re-exported so bot.py imports both via one module.
 from app.integrations.telegram.model_picker import (
@@ -14,8 +17,10 @@ from app.integrations.telegram.model_picker import (
 from app.integrations.telegram.model_picker import (
     ModelButton,
     ModelCallback,
+    build_default_already_set_keyboard,
     build_host_keyboard,
     build_models_keyboard,
+    build_set_default_keyboard,
     build_vendor_keyboard,
     format_host_picker_text,
     format_models_picker_text,
@@ -65,7 +70,10 @@ async def answer_model_picker(*, message: Message) -> None:
         return
 
     await message.answer(
-        format_host_picker_text(state.current_model_id),
+        format_host_picker_text(
+            state.current_model_id,
+            user_default_model_id=state.user_default_model_id,
+        ),
         reply_markup=_inline_keyboard(build_host_keyboard()),
         reply_parameters=_reply_parameters(message.message_id),
     )
@@ -73,15 +81,33 @@ async def answer_model_picker(*, message: Message) -> None:
 
 async def handle_model_picker_callback(*, callback: CallbackQuery) -> None:
     """Handle inline keyboard callbacks produced by the model picker."""
+    # Inert confirmation button — no-op so a second tap doesn't error.
+    if callback.data == "mdl:noop":
+        await callback.answer()
+        return
+
     parsed = parse_model_callback_data(callback.data)
     if parsed is None:
         await callback.answer(picker_stale_message(), show_alert=True)
         return
 
+    if parsed.action in ("select", "set_default"):
+        await _handle_mutating_callback(callback=callback, parsed=parsed)
+        return
+
+    await _handle_navigation_callback(callback=callback, parsed=parsed)
+
+
+async def _handle_mutating_callback(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
+    """Dispatch to the right per-action mutation handler."""
     if parsed.action == "select":
         await _handle_model_select(callback=callback, parsed=parsed)
         return
+    await _handle_set_default(callback=callback, parsed=parsed)
 
+
+async def _handle_navigation_callback(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
+    """Handle the back-button / drill-in screens (no DB mutation)."""
     sender = _sender_from_callback(callback)
     async with async_session_maker() as session:
         state = await get_model_picker_state(sender=sender, session=session)
@@ -98,7 +124,11 @@ async def handle_model_picker_callback(*, callback: CallbackQuery) -> None:
         )
         return
 
-    await _edit_host_list(callback=callback, current_model_id=state.current_model_id)
+    await _edit_host_list(
+        callback=callback,
+        current_model_id=state.current_model_id,
+        user_default_model_id=state.user_default_model_id,
+    )
 
 
 def _opens_picker(model_arg: str) -> bool:
@@ -106,6 +136,13 @@ def _opens_picker(model_arg: str) -> bool:
 
 
 async def _handle_model_select(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
+    """Persist a per-conversation model switch and offer "set as default".
+
+    The selection success message keeps a single inline button —
+    "⭐ Set as my default" — so the user can promote the just-picked
+    model to their personal default with a follow-up tap, without
+    typing the keyword.
+    """
     entry = resolve_model_selection(parsed)
     if entry is None:
         await callback.answer(picker_stale_message(), show_alert=True)
@@ -114,12 +151,49 @@ async def _handle_model_select(*, callback: CallbackQuery, parsed: ModelCallback
     sender = _sender_from_callback(callback)
     async with async_session_maker() as session:
         reply = await handle_model_command(sender=sender, model_arg=entry.id, session=session)
+        state = await get_model_picker_state(sender=sender, session=session)
+
     message = _callback_message(callback)
     if message is None:
         await callback.answer(picker_stale_message(), show_alert=True)
         return
-    await message.edit_text(reply)
+
+    already_default = state is not None and state.user_default_model_id == entry.id
+    if already_default:
+        await message.edit_text(reply)
+    else:
+        default_keyboard = build_set_default_keyboard(model_id=entry.id)
+        await message.edit_text(
+            reply,
+            reply_markup=_inline_keyboard(default_keyboard) if default_keyboard else None,
+        )
     await callback.answer(f"Model set: {entry.short_name}")
+
+
+async def _handle_set_default(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
+    """Persist the user's default model from the post-selection button."""
+    entry = resolve_model_selection(parsed)
+    if entry is None:
+        await callback.answer(picker_stale_message(), show_alert=True)
+        return
+
+    sender = _sender_from_callback(callback)
+    async with async_session_maker() as session:
+        success = await set_user_default_model_from_callback(
+            sender=sender,
+            session=session,
+            canonical_model_id=entry.id,
+        )
+    if not success:
+        await callback.answer(picker_not_bound_message(), show_alert=True)
+        return
+
+    message = _callback_message(callback)
+    if message is not None:
+        await message.edit_reply_markup(
+            reply_markup=_inline_keyboard(build_default_already_set_keyboard())
+        )
+    await callback.answer(f"⭐ Default set: {entry.short_name}")
 
 
 async def _edit_vendor_list(*, callback: CallbackQuery, parsed: ModelCallback) -> None:
@@ -170,13 +244,18 @@ async def _edit_model_list(
     await callback.answer()
 
 
-async def _edit_host_list(*, callback: CallbackQuery, current_model_id: str) -> None:
+async def _edit_host_list(
+    *,
+    callback: CallbackQuery,
+    current_model_id: str,
+    user_default_model_id: str | None = None,
+) -> None:
     message = _callback_message(callback)
     if message is None:
         await callback.answer(picker_stale_message(), show_alert=True)
         return
     await message.edit_text(
-        format_host_picker_text(current_model_id),
+        format_host_picker_text(current_model_id, user_default_model_id=user_default_model_id),
         reply_markup=_inline_keyboard(build_host_keyboard()),
     )
     await callback.answer()

--- a/backend/app/integrations/telegram/status.py
+++ b/backend/app/integrations/telegram/status.py
@@ -40,6 +40,7 @@ from app.integrations.telegram.compact_command import (
 from app.integrations.telegram.lcm_status import (
     handle_lcm_command as handle_lcm_command,  # noqa: PLC0414
 )
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
 
 
 class _TelegramSenderLike(Protocol):
@@ -222,9 +223,18 @@ def _render_status_message(
     run_active: bool,
     thread_id: int | None,
     now: datetime,
+    effective_model_id: str | None = None,
 ) -> str:
-    """Pure formatter used by ``handle_status_command`` and its tests."""
-    model_display, model_canonical, model_warning = _format_model_display(status.model_id)
+    """Pure formatter used by ``handle_status_command`` and its tests.
+
+    ``effective_model_id`` is the resolved canonical ID after walking
+    the conversation → user-default → catalog chain. Callers should
+    pre-resolve via :func:`resolve_effective_model_id`; if omitted,
+    the formatter falls back to ``status.model_id`` directly (used by
+    the existing test suite that doesn't model the user-default path).
+    """
+    rendered_model_id = effective_model_id if effective_model_id is not None else status.model_id
+    model_display, model_canonical, model_warning = _format_model_display(rendered_model_id)
     verbose_level, verbose_label = _resolve_verbose(status.verbose_level)
     # ``Conversation.created_at`` is a tz-naive DateTime column in the DB —
     # all timestamps in this app are written in UTC. Normalize so the
@@ -248,7 +258,7 @@ def _render_status_message(
             f"{_format_token_count(status.total_output_tokens)} out"
         )
 
-    reasoning_label = _resolve_reasoning_label(status.reasoning_effort, model_id=status.model_id)
+    reasoning_label = _resolve_reasoning_label(status.reasoning_effort, model_id=rendered_model_id)
     cost_line = _format_cost_usd(
         status.total_cost_usd, has_messages=has_messages, has_usage=has_usage
     )
@@ -315,10 +325,16 @@ async def handle_status_command(
         # unlikely but render the gateway-only view rather than crashing.
         return _STATUS_NO_CONVERSATION_MESSAGE.format(uptime=_format_duration(bot_uptime_seconds))
 
+    effective_model_id = await resolve_effective_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        conversation_model_id=status.model_id,
+    )
     return _render_status_message(
         bot_uptime_seconds=bot_uptime_seconds,
         status=status,
         run_active=is_chat_run_active(sender.chat_id),
         thread_id=sender.thread_id,
         now=_now_utc(),
+        effective_model_id=effective_model_id,
     )

--- a/backend/app/integrations/telegram/thinking_picker.py
+++ b/backend/app/integrations/telegram/thinking_picker.py
@@ -33,6 +33,7 @@ from app.crud.channel import (
     get_or_create_telegram_conversation_full,
     get_user_id_for_external,
 )
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
 
 PROVIDER = "telegram"
 THINKING_CALLBACK_PREFIX = "thk:"
@@ -135,7 +136,11 @@ async def get_thinking_picker_state(
         thread_id=sender.thread_id,
     )
 
-    model_id = conversation.model_id or default_model().id
+    model_id = await resolve_effective_model_id(
+        session=session,
+        user_id=pawrrtal_user_id,
+        conversation_model_id=conversation.model_id,
+    )
     entry = _resolve_entry(model_id) or default_model()
     return ThinkingPickerState(
         model_entry=entry,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -144,7 +144,10 @@ class UserPreferences(Base):
     )
     custom_instructions: Mapped[str | None] = mapped_column(Text, nullable=True)
     accent_color: Mapped[str | None] = mapped_column(String(7), nullable=True)
-    font_size: Mapped[int] = mapped_column()
+    # NULL = "use the UI default" — the frontend appearance settings
+    # own the canonical value, so seed-on-demand CRUD doesn't need to
+    # duplicate that literal in Python. Migration 022.
+    font_size: Mapped[int | None] = mapped_column(nullable=True)
     # User-level default model. When NULL, conversation model resolution
     # falls back to ``catalog.default_model()``. When set, this is the
     # canonical "host:vendor/model" form picked by the user via the

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -145,6 +145,12 @@ class UserPreferences(Base):
     custom_instructions: Mapped[str | None] = mapped_column(Text, nullable=True)
     accent_color: Mapped[str | None] = mapped_column(String(7), nullable=True)
     font_size: Mapped[int] = mapped_column()
+    # User-level default model. When NULL, conversation model resolution
+    # falls back to ``catalog.default_model()``. When set, this is the
+    # canonical "host:vendor/model" form picked by the user via the
+    # Telegram ``/model ... default`` command or the picker's "Set as
+    # default" button.
+    default_model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
 
 class UserPersonalization(Base):

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -515,8 +515,12 @@ class TestHandlePlainMessage:
                 new=AsyncMock(return_value=fake_conv),
             ),
             patch(
-                "app.integrations.telegram.handlers.get_user_default_model_id",
-                new=AsyncMock(return_value=None),
+                "app.integrations.telegram.handlers.resolve_effective_model_id",
+                new=AsyncMock(
+                    side_effect=lambda *, session, user_id, conversation_model_id: (
+                        conversation_model_id or "agent-sdk:anthropic/claude-sonnet-4-6"
+                    )
+                ),
             ),
         ):
             result = await handle_plain_message(sender=sender, text="what is RAG?", session=session)
@@ -547,8 +551,12 @@ class TestHandlePlainMessage:
                 new=AsyncMock(return_value=fake_conv),
             ),
             patch(
-                "app.integrations.telegram.handlers.get_user_default_model_id",
-                new=AsyncMock(return_value=None),
+                "app.integrations.telegram.handlers.resolve_effective_model_id",
+                new=AsyncMock(
+                    side_effect=lambda *, session, user_id, conversation_model_id: (
+                        conversation_model_id or "agent-sdk:anthropic/claude-sonnet-4-6"
+                    )
+                ),
             ),
         ):
             result = await handle_plain_message(sender=sender, text="hey", session=session)
@@ -582,7 +590,7 @@ class TestHandlePlainMessage:
                 new=AsyncMock(return_value=fake_conv),
             ),
             patch(
-                "app.integrations.telegram.handlers.get_user_default_model_id",
+                "app.integrations.telegram.handlers.resolve_effective_model_id",
                 new=AsyncMock(return_value="agent-sdk:anthropic/claude-opus-4-5"),
             ),
         ):
@@ -858,6 +866,9 @@ class TestHandleModelCommand:
         assert "✅" in reply
         assert "⭐" in reply
         assert canonical_id in reply
+        # The success-suffix copy is part of the contract — a regression
+        # that drops the descriptive text shouldn't pass on emoji alone.
+        assert "default for future conversations" in reply
         update_mock.assert_called_once()
         assert update_mock.call_args.kwargs["model_id"] == canonical_id
         set_default_mock.assert_called_once()
@@ -899,8 +910,13 @@ class TestHandleModelCommand:
                 session=session,
             )
 
+        canonical_id = "agent-sdk:anthropic/claude-sonnet-4-6"
         assert "⭐" in reply
+        assert canonical_id in reply
         set_default_mock.assert_called_once()
+        # Pin the contract: leading keyword form must persist the canonical
+        # ID, not the literal "default" word from the input.
+        assert set_default_mock.call_args.kwargs["model_id"] == canonical_id
 
     async def test_bare_default_keyword_promotes_current_conversation_model(self) -> None:
         """``/model default`` promotes the conversation's existing model_id."""
@@ -944,6 +960,43 @@ class TestHandleModelCommand:
         assert (
             set_default_mock.call_args.kwargs["model_id"] == "agent-sdk:anthropic/claude-sonnet-4-6"
         )
+
+    async def test_bare_default_with_stale_current_model_refuses(self) -> None:
+        """If the conversation's stored model is no longer in the catalog the
+        promotion is refused, so a stale ID can't silently become the user's
+        default and poison every future conversation.
+        """
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=10, chat_id=10, username="t", full_name="T")
+        session = AsyncMock()
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = "agent-sdk:anthropic/this-model-was-removed"
+
+        set_default_mock = AsyncMock(return_value=None)
+        with (
+            patch(
+                "app.integrations.telegram.model_command.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.set_user_default_model_id",
+                new=set_default_mock,
+            ),
+        ):
+            reply = await handle_model_command(
+                sender=sender,
+                model_arg="default",
+                session=session,
+            )
+
+        assert "no longer in the catalog" in reply
+        # Stale ID must not have been written as the user's default.
+        set_default_mock.assert_not_called()
 
     async def test_bare_default_without_current_model_returns_hint(self) -> None:
         """``/model default`` with no conversation model returns an explanation."""

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -514,6 +514,10 @@ class TestHandlePlainMessage:
                 "app.integrations.telegram.handlers.get_or_create_telegram_conversation_full",
                 new=AsyncMock(return_value=fake_conv),
             ),
+            patch(
+                "app.integrations.telegram.handlers.get_user_default_model_id",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             result = await handle_plain_message(sender=sender, text="what is RAG?", session=session)
 
@@ -542,11 +546,50 @@ class TestHandlePlainMessage:
                 "app.integrations.telegram.handlers.get_or_create_telegram_conversation_full",
                 new=AsyncMock(return_value=fake_conv),
             ),
+            patch(
+                "app.integrations.telegram.handlers.get_user_default_model_id",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             result = await handle_plain_message(sender=sender, text="hey", session=session)
 
         assert isinstance(result, TelegramTurnContext)
         assert result.model_id == "anthropic/claude-opus-4-5"
+
+    async def test_bound_user_falls_back_to_user_default_model(self) -> None:
+        """Without a conversation override, the user's persisted default wins.
+
+        The catalog default is the last-resort fallback; whenever the user
+        has pinned a default via ``/model ... default`` or the picker's
+        "Set as default" button, that ID should propagate into the turn
+        context.
+        """
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=99, chat_id=99, username="t", full_name="T")
+        session = AsyncMock()
+
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = None
+
+        with (
+            patch(
+                "app.integrations.telegram.handlers.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.handlers.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.handlers.get_user_default_model_id",
+                new=AsyncMock(return_value="agent-sdk:anthropic/claude-opus-4-5"),
+            ),
+        ):
+            result = await handle_plain_message(sender=sender, text="hey", session=session)
+
+        assert isinstance(result, TelegramTurnContext)
+        assert result.model_id == "agent-sdk:anthropic/claude-opus-4-5"
 
 
 # ---------------------------------------------------------------------------
@@ -775,6 +818,165 @@ class TestHandleModelCommand:
         assert "✅" in reply
         update_mock.assert_called_once()
         assert update_mock.call_args.kwargs["model_id"] == canonical_id
+
+    async def test_trailing_default_keyword_persists_user_default(self) -> None:
+        """``/model <id> default`` switches the chat AND pins the user default."""
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=6, chat_id=6, username="t", full_name="T")
+        session = AsyncMock()
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = None
+
+        update_mock = AsyncMock(return_value=True)
+        set_default_mock = AsyncMock(return_value=None)
+        with (
+            patch(
+                "app.integrations.telegram.model_command.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.update_conversation_model",
+                new=update_mock,
+            ),
+            patch(
+                "app.integrations.telegram.model_command.set_user_default_model_id",
+                new=set_default_mock,
+            ),
+        ):
+            reply = await handle_model_command(
+                sender=sender,
+                model_arg="anthropic/claude-sonnet-4-6 default",
+                session=session,
+            )
+
+        canonical_id = "agent-sdk:anthropic/claude-sonnet-4-6"
+        assert "✅" in reply
+        assert "⭐" in reply
+        assert canonical_id in reply
+        update_mock.assert_called_once()
+        assert update_mock.call_args.kwargs["model_id"] == canonical_id
+        set_default_mock.assert_called_once()
+        assert set_default_mock.call_args.kwargs["model_id"] == canonical_id
+        assert set_default_mock.call_args.kwargs["user_id"] == pawrrtal_uid
+
+    async def test_leading_default_keyword_also_works(self) -> None:
+        """``/model default <id>`` is equivalent to the trailing form."""
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=7, chat_id=7, username="t", full_name="T")
+        session = AsyncMock()
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = None
+
+        update_mock = AsyncMock(return_value=True)
+        set_default_mock = AsyncMock(return_value=None)
+        with (
+            patch(
+                "app.integrations.telegram.model_command.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.update_conversation_model",
+                new=update_mock,
+            ),
+            patch(
+                "app.integrations.telegram.model_command.set_user_default_model_id",
+                new=set_default_mock,
+            ),
+        ):
+            reply = await handle_model_command(
+                sender=sender,
+                model_arg="default anthropic/claude-sonnet-4-6",
+                session=session,
+            )
+
+        assert "⭐" in reply
+        set_default_mock.assert_called_once()
+
+    async def test_bare_default_keyword_promotes_current_conversation_model(self) -> None:
+        """``/model default`` promotes the conversation's existing model_id."""
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=8, chat_id=8, username="t", full_name="T")
+        session = AsyncMock()
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = "agent-sdk:anthropic/claude-sonnet-4-6"
+
+        update_mock = AsyncMock(return_value=True)
+        set_default_mock = AsyncMock(return_value=None)
+        with (
+            patch(
+                "app.integrations.telegram.model_command.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.update_conversation_model",
+                new=update_mock,
+            ),
+            patch(
+                "app.integrations.telegram.model_command.set_user_default_model_id",
+                new=set_default_mock,
+            ),
+        ):
+            reply = await handle_model_command(
+                sender=sender,
+                model_arg="default",
+                session=session,
+            )
+
+        assert "⭐" in reply
+        assert "agent-sdk:anthropic/claude-sonnet-4-6" in reply
+        update_mock.assert_not_called()  # No conversation-model write
+        set_default_mock.assert_called_once()
+        assert (
+            set_default_mock.call_args.kwargs["model_id"] == "agent-sdk:anthropic/claude-sonnet-4-6"
+        )
+
+    async def test_bare_default_without_current_model_returns_hint(self) -> None:
+        """``/model default`` with no conversation model returns an explanation."""
+        pawrrtal_uid = uuid.uuid4()
+        sender = TelegramSender(user_id=9, chat_id=9, username="t", full_name="T")
+        session = AsyncMock()
+        fake_conv = AsyncMock()
+        fake_conv.id = uuid.uuid4()
+        fake_conv.model_id = None
+
+        set_default_mock = AsyncMock(return_value=None)
+        with (
+            patch(
+                "app.integrations.telegram.model_command.resolve_or_autolink_telegram_user",
+                new=AsyncMock(return_value=pawrrtal_uid),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.get_or_create_telegram_conversation_full",
+                new=AsyncMock(return_value=fake_conv),
+            ),
+            patch(
+                "app.integrations.telegram.model_command.set_user_default_model_id",
+                new=set_default_mock,
+            ),
+        ):
+            reply = await handle_model_command(
+                sender=sender,
+                model_arg="default",
+                session=session,
+            )
+
+        assert "no current model" in reply.lower() or "switch" in reply.lower()
+        set_default_mock.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_compact_command.py
+++ b/backend/tests/test_telegram_compact_command.py
@@ -67,6 +67,10 @@ async def test_returns_nothing_to_compact_when_compactor_returns_false() -> None
             AsyncMock(return_value=fake_conversation),
         ),
         patch(
+            "app.integrations.telegram.compact_command.resolve_effective_model_id",
+            AsyncMock(return_value="agent-sdk:anthropic/claude-sonnet-4-6"),
+        ),
+        patch(
             "app.integrations.telegram.compact_command.compact_leaf_if_needed",
             AsyncMock(return_value=False),
         ),
@@ -107,6 +111,10 @@ async def test_returns_compacted_message_on_success() -> None:
         patch(
             "app.integrations.telegram.compact_command.get_or_create_telegram_conversation_full",
             AsyncMock(return_value=fake_conversation),
+        ),
+        patch(
+            "app.integrations.telegram.compact_command.resolve_effective_model_id",
+            AsyncMock(return_value="agent-sdk:anthropic/claude-sonnet-4-6"),
         ),
         patch(
             "app.integrations.telegram.compact_command.compact_leaf_if_needed",

--- a/backend/tests/test_telegram_model_command_args.py
+++ b/backend/tests/test_telegram_model_command_args.py
@@ -1,0 +1,76 @@
+"""Argument-parsing tests for :func:`_parse_model_args`.
+
+The helper is private but worth covering directly: the dispatcher in
+``handle_model_command`` is a thin branch over its output, so a
+regression in this single function silently changes how every
+``/model …`` shape is routed.
+
+The test set targets the edge cases the analyzer flagged as
+under-covered: uppercase ``DEFAULT``, double-``default``, extra
+whitespace, and mixed-case ``DEFault``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.integrations.telegram.model_command import _parse_model_args, _ParsedArgs
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Empty / whitespace-only → no parse.
+        ("", _ParsedArgs(model_id="", make_default=False)),
+        ("   ", _ParsedArgs(model_id="", make_default=False)),
+        # Plain ID — no keyword.
+        ("anthropic/claude-sonnet-4-6", _ParsedArgs("anthropic/claude-sonnet-4-6", False)),
+        # Trailing keyword (canonical typed form).
+        ("anthropic/claude-sonnet-4-6 default", _ParsedArgs("anthropic/claude-sonnet-4-6", True)),
+        # Leading keyword.
+        ("default anthropic/claude-sonnet-4-6", _ParsedArgs("anthropic/claude-sonnet-4-6", True)),
+        # Bare keyword (promote current).
+        ("default", _ParsedArgs("", True)),
+        # Case-insensitive matches both positions.
+        ("anthropic/claude-sonnet-4-6 DEFAULT", _ParsedArgs("anthropic/claude-sonnet-4-6", True)),
+        ("DEFAULT anthropic/claude-sonnet-4-6", _ParsedArgs("anthropic/claude-sonnet-4-6", True)),
+        ("DEFault", _ParsedArgs("", True)),
+        # Extra whitespace doesn't perturb the split — `.split()` collapses runs.
+        (
+            "   anthropic/claude-sonnet-4-6   default   ",
+            _ParsedArgs("anthropic/claude-sonnet-4-6", True),
+        ),
+    ],
+)
+def test_parse_model_args_shapes(raw: str, expected: _ParsedArgs) -> None:
+    """All accepted shapes parse to the expected (model_id, make_default) pair."""
+    assert _parse_model_args(raw) == expected
+
+
+def test_parse_model_args_keeps_second_default_as_model_token() -> None:
+    """Double-``default`` strips only one occurrence.
+
+    ``/model default default`` keeps the second word as a (catalog-invalid)
+    model token. Downstream the catalog lookup will reject it with the
+    standard "I don't have ... in the model catalog" message — which is
+    the right UX for a clearly-malformed input.
+    """
+    parsed = _parse_model_args("default default")
+    assert parsed.make_default is True
+    assert parsed.model_id == "default"
+
+
+def test_parse_model_args_strips_only_one_keyword_position() -> None:
+    """When ``default`` appears in both positions, the leading one wins.
+
+    Implementation detail captured here so a future refactor can't
+    silently flip the precedence — the structural form
+    ``/model default <id> default`` is rare but well-defined.
+    """
+    parsed = _parse_model_args("default anthropic/claude-sonnet-4-6 default")
+    # The leading "default" was stripped first. Whether the trailing
+    # one survived depends on the implementation; either way we end up
+    # with make_default=True and a non-empty model_id. Pin the contract:
+    # at minimum, make_default is True.
+    assert parsed.make_default is True
+    assert "anthropic/claude-sonnet-4-6" in parsed.model_id

--- a/backend/tests/test_telegram_model_defaults.py
+++ b/backend/tests/test_telegram_model_defaults.py
@@ -1,0 +1,115 @@
+"""Tests for :func:`app.integrations.telegram.model_defaults.resolve_effective_model_id`.
+
+The resolver owns the three-step fallback chain that every Telegram
+surface walks. Centralising it means every regression here is caught
+once; centralising it also means the breadcrumb logged for stale
+user-defaults must be exercised explicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+
+from app.core.providers.catalog import MODEL_CATALOG, default_model
+from app.db import User
+from app.integrations.telegram.model_defaults import resolve_effective_model_id
+
+
+@pytest.mark.anyio
+async def test_resolve_returns_conversation_override_when_set(db_session, test_user: User) -> None:
+    """Conversation override beats user default beats catalog default."""
+    pinned = MODEL_CATALOG[1].id
+    resolved = await resolve_effective_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        conversation_model_id=pinned,
+    )
+    assert resolved == pinned
+
+
+@pytest.mark.anyio
+async def test_resolve_falls_back_to_user_default_when_no_override(
+    db_session, test_user: User
+) -> None:
+    """When conversation has no override, the user's pinned default wins."""
+    from app.crud.user_preferences import set_user_default_model_id
+
+    user_default = MODEL_CATALOG[2].id
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id=user_default,
+    )
+    resolved = await resolve_effective_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        conversation_model_id=None,
+    )
+    assert resolved == user_default
+
+
+@pytest.mark.anyio
+async def test_resolve_falls_back_to_catalog_default_when_user_default_unset(
+    db_session, test_user: User
+) -> None:
+    """No conversation override + no user default → catalog default."""
+    resolved = await resolve_effective_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        conversation_model_id=None,
+    )
+    assert resolved == default_model().id
+
+
+@pytest.mark.anyio
+async def test_resolve_skips_stale_user_default_and_logs(
+    db_session,
+    test_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A user default removed from the catalog must fall through + log."""
+    from app.crud.user_preferences import set_user_default_model_id
+
+    stale = "agent-sdk:anthropic/this-was-removed"
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id=stale,
+    )
+    with caplog.at_level(logging.WARNING):
+        resolved = await resolve_effective_model_id(
+            session=db_session,
+            user_id=test_user.id,
+            conversation_model_id=None,
+        )
+    # Falls through to the catalog default rather than handing the
+    # stale ID to the downstream chat path.
+    assert resolved == default_model().id
+    # And leaves an operator breadcrumb so the user can be nudged.
+    assert any(
+        "TELEGRAM_STALE_USER_DEFAULT" in record.message and stale in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_resolve_does_not_log_when_no_user_default(
+    db_session,
+    test_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Falling through to catalog default for a user with no pref is silent."""
+    with caplog.at_level(logging.WARNING):
+        await resolve_effective_model_id(
+            session=db_session,
+            user_id=test_user.id,
+            conversation_model_id=None,
+        )
+    assert not any("TELEGRAM_STALE_USER_DEFAULT" in record.message for record in caplog.records)
+
+
+# Avoid unused-import warnings for fixtures referenced only by name.
+_ = uuid

--- a/backend/tests/test_telegram_model_picker.py
+++ b/backend/tests/test_telegram_model_picker.py
@@ -14,8 +14,10 @@ from app.core.providers.model_id import Host
 from app.integrations.telegram.model_picker import (
     ModelButton,
     ModelCallback,
+    build_default_already_set_keyboard,
     build_host_keyboard,
     build_models_keyboard,
+    build_set_default_keyboard,
     build_vendor_keyboard,
     format_host_picker_text,
     format_models_picker_text,
@@ -206,11 +208,44 @@ async def test_get_model_picker_state_reads_conversation_override() -> None:
             "app.integrations.telegram.model_picker.get_or_create_telegram_conversation_full",
             new=AsyncMock(return_value=conversation),
         ),
+        patch(
+            "app.integrations.telegram.model_picker.get_user_default_model_id",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         state = await get_model_picker_state(sender=sender, session=AsyncMock())
 
     assert state is not None
     assert state.current_model_id == override
+    assert state.user_default_model_id is None
+
+
+@pytest.mark.anyio
+async def test_get_model_picker_state_falls_back_to_user_default() -> None:
+    """When conversation has no override, the user's pinned default surfaces."""
+    sender = TelegramSender(user_id=3, chat_id=3, username=None, full_name=None)
+    user_default = MODEL_CATALOG[2].id
+    conversation = SimpleNamespace(model_id=None)
+
+    with (
+        patch(
+            "app.integrations.telegram.model_picker.get_user_id_for_external",
+            new=AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch(
+            "app.integrations.telegram.model_picker.get_or_create_telegram_conversation_full",
+            new=AsyncMock(return_value=conversation),
+        ),
+        patch(
+            "app.integrations.telegram.model_picker.get_user_default_model_id",
+            new=AsyncMock(return_value=user_default),
+        ),
+    ):
+        state = await get_model_picker_state(sender=sender, session=AsyncMock())
+
+    assert state is not None
+    assert state.current_model_id == user_default
+    assert state.user_default_model_id == user_default
 
 
 def test_parse_vendor_callback_round_trips_host() -> None:
@@ -253,6 +288,62 @@ def test_pagination_first_page_omits_prev_button(monkeypatch: pytest.MonkeyPatch
     labels = [b.text for b in _flatten(rows)]
     assert "< Prev" not in labels
     assert "Next >" in labels
+
+
+def test_host_picker_text_omits_default_line_when_user_default_matches_current() -> None:
+    """If current == default we suppress the second line to avoid noise."""
+    same = default_model().id
+    text = format_host_picker_text(same, user_default_model_id=same)
+    assert "Default:" not in text
+
+
+def test_host_picker_text_shows_default_line_when_distinct() -> None:
+    """A pinned default different from current must surface as its own line."""
+    current = MODEL_CATALOG[0].id
+    pinned = MODEL_CATALOG[1].id
+    text = format_host_picker_text(current, user_default_model_id=pinned)
+    assert "Default:" in text
+    assert MODEL_CATALOG[1].display_name in text
+
+
+def test_build_set_default_keyboard_emits_one_row_with_star() -> None:
+    """The success message gets one ⭐ row carrying the catalog-token payload."""
+    entry = MODEL_CATALOG[0]
+    rows = build_set_default_keyboard(model_id=entry.id)
+    assert rows is not None
+    assert len(rows) == 1
+    assert len(rows[0]) == 1
+    button = rows[0][0]
+    assert "⭐" in button.text
+    assert button.callback_data.startswith("mdl:d:")
+    # Round-trips through the parser as a set_default action.
+    parsed = parse_model_callback_data(button.callback_data)
+    assert parsed is not None
+    assert parsed.action == "set_default"
+
+
+def test_build_set_default_keyboard_returns_none_for_unknown_model() -> None:
+    assert build_set_default_keyboard(model_id="not-in-catalog") is None
+
+
+def test_build_default_already_set_keyboard_emits_inert_button() -> None:
+    rows = build_default_already_set_keyboard()
+    assert rows == [[ModelButton(text="⭐ Already your default", callback_data="mdl:noop")]]
+
+
+def test_parse_set_default_round_trips_to_catalog_entry() -> None:
+    """A set_default callback resolves to the same entry as a select callback."""
+    entry = MODEL_CATALOG[0]
+    rows = build_set_default_keyboard(model_id=entry.id)
+    assert rows is not None
+    parsed = parse_model_callback_data(rows[0][0].callback_data)
+    assert parsed is not None
+    assert resolve_model_selection(parsed) == entry
+
+
+def test_parse_set_default_rejects_stale_catalog_token() -> None:
+    stale = ModelCallback(action="set_default", index=0, catalog_token="deadbeef")
+    assert resolve_model_selection(stale) is None
 
 
 def test_pagination_last_page_omits_next_button(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_telegram_model_picker.py
+++ b/backend/tests/test_telegram_model_picker.py
@@ -212,6 +212,10 @@ async def test_get_model_picker_state_reads_conversation_override() -> None:
             "app.integrations.telegram.model_picker.get_user_default_model_id",
             new=AsyncMock(return_value=None),
         ),
+        patch(
+            "app.integrations.telegram.model_picker.resolve_effective_model_id",
+            new=AsyncMock(return_value=override),
+        ),
     ):
         state = await get_model_picker_state(sender=sender, session=AsyncMock())
 
@@ -238,6 +242,10 @@ async def test_get_model_picker_state_falls_back_to_user_default() -> None:
         ),
         patch(
             "app.integrations.telegram.model_picker.get_user_default_model_id",
+            new=AsyncMock(return_value=user_default),
+        ),
+        patch(
+            "app.integrations.telegram.model_picker.resolve_effective_model_id",
             new=AsyncMock(return_value=user_default),
         ),
     ):

--- a/backend/tests/test_telegram_model_picker.py
+++ b/backend/tests/test_telegram_model_picker.py
@@ -335,8 +335,10 @@ def test_build_set_default_keyboard_returns_none_for_unknown_model() -> None:
 
 
 def test_build_default_already_set_keyboard_emits_inert_button() -> None:
+    from app.integrations.telegram.model_picker import NOOP_CALLBACK
+
     rows = build_default_already_set_keyboard()
-    assert rows == [[ModelButton(text="⭐ Already your default", callback_data="mdl:noop")]]
+    assert rows == [[ModelButton(text="⭐ Already your default", callback_data=NOOP_CALLBACK)]]
 
 
 def test_parse_set_default_round_trips_to_catalog_entry() -> None:

--- a/backend/tests/test_telegram_model_picker_runtime.py
+++ b/backend/tests/test_telegram_model_picker_runtime.py
@@ -13,6 +13,7 @@ duck-typed objects with ``data``, ``from_user``, ``message``,
 
 from __future__ import annotations
 
+import logging
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -21,6 +22,7 @@ import pytest
 
 from app.core.providers.catalog import MODEL_CATALOG
 from app.integrations.telegram.model_picker import (
+    NOOP_CALLBACK,
     ModelPickerState,
     build_set_default_keyboard,
 )
@@ -55,7 +57,7 @@ class TestMdlNoopShortCircuit:
 
     async def test_mdl_noop_answers_without_alert(self) -> None:
         """A second tap on the inert badge must answer silently."""
-        callback = _make_callback(data="mdl:noop")
+        callback = _make_callback(data=NOOP_CALLBACK)
         await handle_model_picker_callback(callback=callback)
         callback.answer.assert_awaited_once_with()
         # No edits should happen — the badge stays put.
@@ -82,7 +84,7 @@ class TestHandleSetDefault:
         # The replacement keyboard's first button must be the inert badge.
         kwargs = callback.message.edit_reply_markup.await_args.kwargs
         inline_keyboard = kwargs["reply_markup"].inline_keyboard
-        assert inline_keyboard[0][0].callback_data == "mdl:noop"
+        assert inline_keyboard[0][0].callback_data == NOOP_CALLBACK
         callback.answer.assert_awaited_once()
         answer_text = callback.answer.await_args.args[0]
         assert entry.short_name in answer_text
@@ -149,6 +151,51 @@ class TestHandleModelSelectButtonBranching:
         callback.message.edit_text.assert_awaited_once()
         kwargs = callback.message.edit_text.await_args.kwargs
         assert "reply_markup" not in kwargs or kwargs.get("reply_markup") is None
+
+    async def test_stale_catalog_omits_button_and_logs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the catalog rotates between select + render, log + omit button.
+
+        The picker's select callback was emitted against a catalog
+        snapshot that no longer holds the picked entry by the time
+        the runtime tries to render its "Set as default" follow-up.
+        The conversation switch already succeeded — we just can't
+        offer the next-step affordance for a stale ID, so we log it
+        and edit the message without a keyboard.
+        """
+        entry = MODEL_CATALOG[0]
+        select_callback_data = f"mdl:s:{_catalog_token()}:0"
+        callback = _make_callback(data=select_callback_data)
+        state = ModelPickerState(
+            current_model_id=entry.id,
+            user_default_model_id=MODEL_CATALOG[1].id,
+        )
+        with (
+            patch(
+                "app.integrations.telegram.model_picker_runtime.handle_model_command",
+                new=AsyncMock(return_value="Model switched ✅"),
+            ),
+            patch(
+                "app.integrations.telegram.model_picker_runtime.get_model_picker_state",
+                new=AsyncMock(return_value=state),
+            ),
+            patch(
+                "app.integrations.telegram.model_picker_runtime.build_set_default_keyboard",
+                return_value=None,
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            await _handle_model_select(callback=callback, parsed=_select_callback_for_entry(0))
+        # Edit happens without a keyboard.
+        callback.message.edit_text.assert_awaited_once()
+        kwargs = callback.message.edit_text.await_args.kwargs
+        assert kwargs.get("reply_markup") is None
+        # And the operator gets a breadcrumb.
+        assert any(
+            "MODEL_PICKER_STALE_DEFAULT_KEYBOARD" in record.message
+            for record in caplog.records
+        )
 
     async def test_button_present_when_selection_is_new_default(self) -> None:
         """If the picked model differs from the user default, surface the button."""

--- a/backend/tests/test_telegram_model_picker_runtime.py
+++ b/backend/tests/test_telegram_model_picker_runtime.py
@@ -1,0 +1,200 @@
+"""Tests for the aiogram glue in :mod:`model_picker_runtime`.
+
+These exercise the orchestration that wires the picker keyboards to
+the CRUD layer — the seam where a regression silently makes the
+"Set as default" button stop working, or makes the inert
+"Already your default" button alert as a stale picker.
+
+Aiogram's ``CallbackQuery`` / ``Message`` are mocked with ``AsyncMock``
+to avoid the framework dependency; the runtime treats them purely as
+duck-typed objects with ``data``, ``from_user``, ``message``,
+``answer``, ``edit_text``, and ``edit_reply_markup`` attributes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.providers.catalog import MODEL_CATALOG
+from app.integrations.telegram.model_picker import (
+    ModelPickerState,
+    build_set_default_keyboard,
+)
+from app.integrations.telegram.model_picker_runtime import (
+    _handle_model_select,
+    _handle_set_default,
+    handle_model_picker_callback,
+)
+
+
+def _make_callback(*, data: str, with_message: bool = True) -> MagicMock:
+    """Build a minimal ``CallbackQuery`` mock used across these tests."""
+    callback = MagicMock()
+    callback.data = data
+    callback.answer = AsyncMock()
+    callback.from_user = SimpleNamespace(id=42, username="t", full_name="T")
+    if with_message:
+        message = MagicMock()
+        message.chat = SimpleNamespace(id=42)
+        message.message_thread_id = None
+        message.edit_text = AsyncMock()
+        message.edit_reply_markup = AsyncMock()
+        callback.message = message
+    else:
+        callback.message = None
+    return callback
+
+
+@pytest.mark.anyio
+class TestMdlNoopShortCircuit:
+    """`mdl:noop` is the inert callback on the post-default badge."""
+
+    async def test_mdl_noop_answers_without_alert(self) -> None:
+        """A second tap on the inert badge must answer silently."""
+        callback = _make_callback(data="mdl:noop")
+        await handle_model_picker_callback(callback=callback)
+        callback.answer.assert_awaited_once_with()
+        # No edits should happen — the badge stays put.
+        callback.message.edit_text.assert_not_called()
+        callback.message.edit_reply_markup.assert_not_called()
+
+
+@pytest.mark.anyio
+class TestHandleSetDefault:
+    """`_handle_set_default` persists the default and swaps the keyboard."""
+
+    async def test_success_replaces_keyboard_with_inert_badge(self) -> None:
+        """Happy path: user bound, model in catalog, button swap fires."""
+        entry = MODEL_CATALOG[0]
+        rows = build_set_default_keyboard(model_id=entry.id)
+        assert rows is not None
+        callback = _make_callback(data=rows[0][0].callback_data)
+        with patch(
+            "app.integrations.telegram.model_picker_runtime.set_user_default_model_from_callback",
+            new=AsyncMock(return_value=True),
+        ):
+            await handle_model_picker_callback(callback=callback)
+        callback.message.edit_reply_markup.assert_awaited_once()
+        # The replacement keyboard's first button must be the inert badge.
+        kwargs = callback.message.edit_reply_markup.await_args.kwargs
+        inline_keyboard = kwargs["reply_markup"].inline_keyboard
+        assert inline_keyboard[0][0].callback_data == "mdl:noop"
+        callback.answer.assert_awaited_once()
+        answer_text = callback.answer.await_args.args[0]
+        assert entry.short_name in answer_text
+
+    async def test_unbound_user_surfaces_not_bound_alert(self) -> None:
+        """When the seam returns False the runtime alerts not-bound."""
+        entry = MODEL_CATALOG[0]
+        rows = build_set_default_keyboard(model_id=entry.id)
+        assert rows is not None
+        callback = _make_callback(data=rows[0][0].callback_data)
+        with patch(
+            "app.integrations.telegram.model_picker_runtime.set_user_default_model_from_callback",
+            new=AsyncMock(return_value=False),
+        ):
+            await handle_model_picker_callback(callback=callback)
+        callback.answer.assert_awaited_once()
+        # The not-bound alert must be a show_alert call so the user sees it.
+        kwargs = callback.answer.await_args.kwargs
+        assert kwargs.get("show_alert") is True
+        callback.message.edit_reply_markup.assert_not_called()
+
+    async def test_stale_catalog_token_surfaces_stale_alert(self) -> None:
+        """A stale catalog token must reject before touching the DB."""
+        # Hand-craft a stale token payload — catalog index 0 with bad token.
+        callback = _make_callback(data="mdl:d:deadbeef:0")
+        set_default_mock = AsyncMock(return_value=True)
+        with patch(
+            "app.integrations.telegram.model_picker_runtime.set_user_default_model_from_callback",
+            new=set_default_mock,
+        ):
+            await handle_model_picker_callback(callback=callback)
+        set_default_mock.assert_not_called()
+        callback.answer.assert_awaited_once()
+        assert callback.answer.await_args.kwargs.get("show_alert") is True
+
+
+@pytest.mark.anyio
+class TestHandleModelSelectButtonBranching:
+    """`_handle_model_select` conditionally surfaces the "Set as default" button."""
+
+    async def test_button_omitted_when_selection_already_default(self) -> None:
+        """If the picked model is already the user's default, no extra button."""
+        entry = MODEL_CATALOG[0]
+        # Build the select-action callback that the picker would emit.
+        select_callback_data = f"mdl:s:{_catalog_token()}:0"
+        callback = _make_callback(data=select_callback_data)
+        # Pre-set state: user_default matches the entry the user just picked.
+        state = ModelPickerState(
+            current_model_id=entry.id,
+            user_default_model_id=entry.id,
+        )
+        with (
+            patch(
+                "app.integrations.telegram.model_picker_runtime.handle_model_command",
+                new=AsyncMock(return_value="Model switched ✅"),
+            ),
+            patch(
+                "app.integrations.telegram.model_picker_runtime.get_model_picker_state",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            await _handle_model_select(callback=callback, parsed=_select_callback_for_entry(0))
+        # edit_text must be called WITHOUT reply_markup.
+        callback.message.edit_text.assert_awaited_once()
+        kwargs = callback.message.edit_text.await_args.kwargs
+        assert "reply_markup" not in kwargs or kwargs.get("reply_markup") is None
+
+    async def test_button_present_when_selection_is_new_default(self) -> None:
+        """If the picked model differs from the user default, surface the button."""
+        entry = MODEL_CATALOG[0]
+        select_callback_data = f"mdl:s:{_catalog_token()}:0"
+        callback = _make_callback(data=select_callback_data)
+        # User has a *different* model as their default.
+        state = ModelPickerState(
+            current_model_id=entry.id,
+            user_default_model_id=MODEL_CATALOG[1].id,
+        )
+        with (
+            patch(
+                "app.integrations.telegram.model_picker_runtime.handle_model_command",
+                new=AsyncMock(return_value="Model switched ✅"),
+            ),
+            patch(
+                "app.integrations.telegram.model_picker_runtime.get_model_picker_state",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            await _handle_model_select(callback=callback, parsed=_select_callback_for_entry(0))
+        callback.message.edit_text.assert_awaited_once()
+        kwargs = callback.message.edit_text.await_args.kwargs
+        # The reply_markup must contain a "Set as my default" star button.
+        keyboard = kwargs["reply_markup"]
+        assert keyboard is not None
+        inline_keyboard = keyboard.inline_keyboard
+        button = inline_keyboard[0][0]
+        assert "⭐" in button.text
+        assert button.callback_data.startswith("mdl:d:")
+
+
+def _catalog_token() -> str:
+    """Return the current catalog token used by select/set_default callbacks."""
+    from app.core.providers.catalog import CATALOG_ETAG
+
+    return CATALOG_ETAG[:8]
+
+
+def _select_callback_for_entry(index: int):
+    """Build the ModelCallback object that the runtime would receive."""
+    from app.integrations.telegram.model_picker import ModelCallback
+
+    return ModelCallback(action="select", index=index, catalog_token=_catalog_token())
+
+
+# Suppress the unused-import warnings (kept for future use).
+_ = (uuid, _handle_set_default)

--- a/backend/tests/test_user_preferences_crud.py
+++ b/backend/tests/test_user_preferences_crud.py
@@ -1,0 +1,76 @@
+"""Tests for the ``app.crud.user_preferences`` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.crud.user_preferences import (
+    get_user_default_model_id,
+    set_user_default_model_id,
+)
+from app.db import User
+
+
+@pytest.mark.anyio
+async def test_get_default_model_id_returns_none_when_no_row(
+    db_session,
+    test_user: User,
+) -> None:
+    """A user without a preferences row reads back ``None``."""
+    result = await get_user_default_model_id(session=db_session, user_id=test_user.id)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_set_default_model_id_creates_row_on_first_write(
+    db_session,
+    test_user: User,
+) -> None:
+    """Writing the first preference creates the row on demand."""
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id="agent-sdk:anthropic/claude-sonnet-4-6",
+    )
+    persisted = await get_user_default_model_id(session=db_session, user_id=test_user.id)
+    assert persisted == "agent-sdk:anthropic/claude-sonnet-4-6"
+
+
+@pytest.mark.anyio
+async def test_set_default_model_id_updates_existing_row(
+    db_session,
+    test_user: User,
+) -> None:
+    """A second write updates the column in place, no duplicate row."""
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id="gemini-api:google/gemini-3-flash-preview",
+    )
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id="agent-sdk:anthropic/claude-sonnet-4-6",
+    )
+    persisted = await get_user_default_model_id(session=db_session, user_id=test_user.id)
+    assert persisted == "agent-sdk:anthropic/claude-sonnet-4-6"
+
+
+@pytest.mark.anyio
+async def test_set_default_model_id_clears_when_passed_none(
+    db_session,
+    test_user: User,
+) -> None:
+    """Passing ``None`` clears the override back to NULL."""
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id="agent-sdk:anthropic/claude-sonnet-4-6",
+    )
+    await set_user_default_model_id(
+        session=db_session,
+        user_id=test_user.id,
+        model_id=None,
+    )
+    result = await get_user_default_model_id(session=db_session, user_id=test_user.id)
+    assert result is None


### PR DESCRIPTION
## Summary

Lets a Telegram user pin a personal default model so future conversations inherit it instead of always falling back to the catalog default.

### CLI shapes

- `/model <id>` — switch this conversation only (existing behavior).
- `/model <id> default` — switch the conversation **and** pin the user default.
- `/model default <id>` — same as above (leading keyword form).
- `/model default` — promote the conversation's current model to the user default without switching to anything else.

### Picker UX

- **Host-picker entry** surfaces a second `Default: …` ⭐ line when the user's pinned default differs from the conversation's current model, so the contrast is visible at a glance.
- **Selection success message** now includes a single inline `⭐ Set as my default` button. One follow-up tap promotes the just-picked model to the user default. The button collapses to an inert `⭐ Already your default` badge once tapped (and is omitted entirely when the selection already matches the user's existing default).
- The mode toggle / per-row two-button alternatives were considered but rejected — the post-selection button keeps callback data minimal and the affordance discoverable without cluttering the keyboard.

### Storage

- New nullable `default_model_id` column on `user_preferences` (alembic migration `021_add_user_preferences_default_model_id`).
- Conversation model resolution now falls back through:
  `Conversation.model_id` → `UserPreferences.default_model_id` → `catalog.default_model()`.
- A new `app/crud/user_preferences.py` module owns the read/write surface and lazily creates the row on first write.

## Test plan

- [x] `backend/tests/test_user_preferences_crud.py` — get/set/clear, lazy row creation, idempotent re-writes.
- [x] `backend/tests/test_telegram_channel.py` — all three CLI shapes (`<id> default`, `default <id>`, bare `default`), the "no current model" hint, plus a new `handle_plain_message` test confirming the user-default fallback propagates into the turn context.
- [x] `backend/tests/test_telegram_model_picker.py` — `ModelPickerState` carries the user default, the host-picker text suppresses the second line when current == default, the new `build_set_default_keyboard` / `build_default_already_set_keyboard` builders round-trip, and `set_default` callbacks resolve like `select` callbacks (stale catalog tokens rejected).
- [x] Existing 1425 backend tests still pass.
- [x] `ruff check .` clean; `node scripts/check-file-lines.mjs` passes (model_picker.py at 489 lines, under the 500-line ceiling).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZh6gLVoscutWcvFyXe5Ei)_