### PR TITLE
fix(telegram, observability): legacy text path drops chunks + workshop hooks filtered (#346, #347)

### DIFF
--- a/backend/app/channels/_telegram_dispatch.py
+++ b/backend/app/channels/_telegram_dispatch.py
@@ -368,10 +368,15 @@ async def dispatch_text_delta(
         )
         return text_buffer, text_message_id, chars_since_edit, last_edit_at, True
 
-    # Legacy editMessageText path: only open / continue an interleaved text
-    # message on a block transition. Pure-text or same-block deltas keep
-    # accumulating into ``answer_text`` for the closing reply.
-    if previous_block_kind in (None, "text"):
+    # Legacy editMessageText path: only open an interleaved text
+    # message on a block transition. Pure-text turns (no prior block)
+    # keep accumulating into ``answer_text`` for the closing reply.
+    # ``previous_block_kind == "text"`` now FALLS THROUGH so subsequent
+    # same-block deltas EXTEND the open interleaved message instead of
+    # being dropped (#346): the previous short-circuit on ``"text"``
+    # caused only the first chunk to render whenever text followed a
+    # thinking / tools block.
+    if previous_block_kind is None:
         return text_buffer, text_message_id, chars_since_edit, last_edit_at, False
     if previous_block_kind != "text":
         text_message_id = None

--- a/backend/app/channels/_telegram_finalize.py
+++ b/backend/app/channels/_telegram_finalize.py
@@ -71,8 +71,14 @@ async def finalize_turn_delivery(
             placeholder_message_id,
         )
 
-    if text_message_id is not None and text_buffer:
-        await safe_edit(bot, chat_id, text_message_id, text_buffer)
+    # Prefer ``final_text`` (the caller's authoritative ``answer_text``)
+    # over ``text_buffer`` when both diverge — defence in depth against
+    # the #346 regression class where ``text_buffer`` lagged the live
+    # accumulator. ``text_buffer`` is the fallback for callers that
+    # opened an interleaved message without producing a separate
+    # ``final_text`` for the closing reply.
+    if text_message_id is not None and (final_text or text_buffer):
+        await safe_edit(bot, chat_id, text_message_id, final_text or text_buffer)
         return
 
     if final_text:

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -272,12 +272,21 @@ async def _guarded_stream(
             permission_check=turn_input.permission_check,
             images=turn_input.images,
         ):
+            # Hooks fire BEFORE the verbose filter so observability sees
+            # every provider event — including thinking-deltas at
+            # ``verbose_level < 2``, which the filter would otherwise
+            # drop before the Workshop span recorder ever sees them
+            # (#347). The hook contract for ``workshop_event_hook``
+            # returns ``[]`` (side-effects only); extras from any
+            # future hook stay behind the filter so /verbose still
+            # gates what the channel renders.
+            extras = list(_expand_hook_events(event, hooks))
             if not _should_deliver_event(event, turn_input.verbose_level):
                 continue
             counter.record(event)
             aggregator.apply(event)
             yield event
-            for extra in _expand_hook_events(event, hooks):
+            for extra in extras:
                 counter.record(extra)
                 aggregator.apply(extra)
                 yield extra

--- a/backend/tests/test_telegram_dispatch_text_path.py
+++ b/backend/tests/test_telegram_dispatch_text_path.py
@@ -1,0 +1,102 @@
+"""Unit tests for the legacy text-path same-block extend behaviour (#346).
+
+When ``telegram_use_draft_streaming=False`` (the legacy edit-message
+streaming path), ``dispatch_text_delta`` must EXTEND the open
+interleaved text message on subsequent same-block deltas instead of
+short-circuiting on ``previous_block_kind == "text"``. The previous
+implementation returned ``rendered=False`` on every same-block delta
+after the first chunk landed, which the channel layer treated as
+"don't append" — so any text following a thinking or tools block
+rendered only its first chunk.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.channels._telegram_dispatch import dispatch_text_delta
+
+
+def _make_bot() -> AsyncMock:
+    bot = AsyncMock()
+    bot.edit_message_text = AsyncMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
+    return bot
+
+
+@pytest.mark.anyio
+async def test_dispatch_text_delta_extends_interleaved_text_on_same_block() -> None:
+    """A second delta with ``previous_block_kind="text"`` appends to the buffer.
+
+    Reproduces the #346 regression: after a tools or thinking block,
+    the first text delta opens an interleaved message, and every
+    subsequent delta in the same text block must extend that message.
+    The bug was a short-circuit that returned ``rendered=False`` on
+    ``"text"`` and never appended chunks 2..N.
+    """
+    bot = _make_bot()
+
+    # First delta after a tools block — opens the interleaved message.
+    text_buffer, text_message_id, chars_since_edit, last_edit_at, rendered = (
+        await dispatch_text_delta(
+            chunk="Hello",
+            previous_block_kind="tools",
+            bot=bot,
+            chat_id=1,
+            text_buffer="",
+            text_message_id=None,
+            chars_since_edit=0,
+            last_edit_at=0.0,
+            reply_to_message_id=None,
+            message_thread_id=None,
+        )
+    )
+    assert rendered is True
+    assert text_buffer == "Hello"
+    assert text_message_id == 99
+
+    # Second delta — same block. Must EXTEND the buffer, not short-circuit.
+    text_buffer, _, _, _, rendered = await dispatch_text_delta(
+        chunk=" world",
+        previous_block_kind="text",
+        bot=bot,
+        chat_id=1,
+        text_buffer=text_buffer,
+        text_message_id=text_message_id,
+        chars_since_edit=chars_since_edit,
+        last_edit_at=last_edit_at,
+        reply_to_message_id=None,
+        message_thread_id=None,
+    )
+    assert rendered is True
+    assert text_buffer == "Hello world"
+
+
+@pytest.mark.anyio
+async def test_dispatch_text_delta_pure_text_turn_still_short_circuits() -> None:
+    """``previous_block_kind=None`` (pure-text turn) still returns rendered=False.
+
+    Pure-text turns continue to accumulate into ``answer_text`` and
+    only flush via the closing reply — we must not start opening
+    interleaved messages for them.
+    """
+    bot = _make_bot()
+    text_buffer, text_message_id, _, _, rendered = await dispatch_text_delta(
+        chunk="Hello",
+        previous_block_kind=None,
+        bot=bot,
+        chat_id=1,
+        text_buffer="",
+        text_message_id=None,
+        chars_since_edit=0,
+        last_edit_at=0.0,
+        reply_to_message_id=None,
+        message_thread_id=None,
+    )
+    assert rendered is False
+    assert text_buffer == ""
+    assert text_message_id is None
+    bot.send_message.assert_not_called()

--- a/backend/tests/test_turn_runner_hook_ordering.py
+++ b/backend/tests/test_turn_runner_hook_ordering.py
@@ -1,0 +1,122 @@
+"""Hook-ordering tests for ``_guarded_stream`` (#347 / #352 L3).
+
+The verbose filter is a channel rendering concern; observability hooks
+(Workshop / OTel span recorders) must see every event regardless of
+``verbose_level``. The previous implementation ran the filter first,
+short-circuiting before the hook fan-out — so thinking deltas at
+``verbose_level=1`` (Telegram's default) were invisible to the LLM
+span.
+
+These tests pin the new order at the unit seam (``_guarded_stream``)
+so the regression can't ship silently again.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.channels.turn_runner import ChatTurnInput, _guarded_stream
+from app.core.chat_aggregator import ChatTurnAggregator
+from app.core.providers.base import StreamEvent
+
+
+class _ScriptedProvider:
+    """Minimal ``AILLM`` stand-in that yields a hard-coded event sequence."""
+
+    def __init__(self, events: list[StreamEvent]) -> None:
+        self._events = events
+
+    def stream(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[StreamEvent]:
+        for event in self._events:
+            yield event
+
+
+def _make_turn_input(provider: _ScriptedProvider, *, verbose_level: int) -> ChatTurnInput:
+    """Build a ``ChatTurnInput`` with the minimum surface ``_guarded_stream`` reads."""
+    # ``_guarded_stream`` only touches a narrow subset of the dataclass
+    # (provider, question, IDs, tools, verbose_level); other fields are
+    # stubs that satisfy the dataclass without exercising real types.
+    return ChatTurnInput(
+        conversation_id=MagicMock(),
+        user_id=MagicMock(),
+        question="hi",
+        provider=provider,  # type: ignore[arg-type]
+        channel=MagicMock(),
+        channel_message=MagicMock(),
+        workspace_root=None,
+        tools=[],
+        images=None,
+        permission_check=None,
+        log_tag="TEST",
+        log_extras={},
+        verbose_level=verbose_level,
+        reasoning_effort=None,
+    )
+
+
+class _Counter:
+    """Stand-in for the private ``_EventCounter`` used by ``_guarded_stream``."""
+
+    def __init__(self) -> None:
+        self.value = 0
+        self.by_type: dict[str, int] = {}
+
+    def record(self, event: StreamEvent) -> None:
+        self.value += 1
+        etype = event.get("type", "")
+        self.by_type[etype] = self.by_type.get(etype, 0) + 1
+
+
+@pytest.mark.anyio
+async def test_hooks_observe_thinking_at_verbose_normal() -> None:
+    """Verbose=1 hides thinking from the channel but hooks still see it (#347).
+
+    With ``verbose_level=1`` (Telegram's default) the filter drops
+    ``thinking`` events before they reach the channel — but the
+    Workshop hook lives in the same ``hooks`` list and must observe
+    every event so the LLM span gets ``gen_ai.thinking.delta`` entries.
+    """
+    seen_events: list[StreamEvent] = []
+
+    def recording_hook(event: StreamEvent) -> list[StreamEvent]:
+        seen_events.append(event)
+        return []
+
+    provider = _ScriptedProvider(
+        [
+            {"type": "thinking", "content": "let me think..."},
+            {"type": "delta", "content": "Hello."},
+        ]
+    )
+    turn_input = _make_turn_input(provider, verbose_level=1)
+    aggregator = ChatTurnAggregator()
+    counter = _Counter()
+
+    delivered = [
+        e
+        async for e in _guarded_stream(
+            turn_input=turn_input,
+            history=[],
+            system_prompt=None,
+            aggregator=aggregator,
+            counter=counter,  # type: ignore[arg-type]
+            hooks=[recording_hook],
+        )
+    ]
+
+    # The hook observed BOTH events, even though only the delta was delivered.
+    assert any(e.get("type") == "thinking" for e in seen_events)
+    assert any(e.get("type") == "delta" for e in seen_events)
+    # The channel saw only the delta — the filter still gates rendering.
+    assert [e.get("type") for e in delivered] == ["delta"]


### PR DESCRIPTION
## Closes #346, #347

Two related backend fixes — both deferred from #352's plan, both
narrow.

### #346 — Telegram legacy text path: only first chunk shows when text follows thinking/tools

`dispatch_text_delta` short-circuited on
`previous_block_kind in (None, "text")`, returning `rendered=False` on
every same-block delta after the first chunk landed. The channel layer
treated that as "don't append," so any text following a thinking or
tool block rendered only its first chunk — typically a single word.

Fix the short-circuit to fire only on `previous_block_kind is None`
(pure-text turns) so `"text"` falls through and `handle_text_delta`
extends the open interleaved message. Also hardened
`finalize_turn_delivery` to prefer the caller's authoritative
`final_text` over the dispatch's `text_buffer` when both are set —
defence in depth against the same class of regression.

### #347 — Workshop: thinking events filtered out before observability hook can record them

In `_guarded_stream`, the verbose filter ran before the hook fan-out.
Telegram's default is `verbose_level=1`, which drops every `thinking`
event — so the Workshop span recorder never saw a single
`gen_ai.thinking.delta`. Move the hook fan-out *before*
`_should_deliver_event` so observability always sees full fidelity.
Extras from any hook that does return events stay behind the filter so
`/verbose` still gates what the channel renders.

## Tests

- `backend/tests/test_telegram_dispatch_text_path.py` — same-block
  extend regression test (L1 layer in #352).
- `backend/tests/test_turn_runner_hook_ordering.py` — hooks observe
  thinking events at `verbose_level=1` (L3 layer in #352).

## Verification

- `python3 -c "ast.parse(...)"` clean on every modified file.
- New tests pin the exact transition each fix targets; failure
  messages reference the regression directly.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_