### PR TITLE
feat(xai): surface grok-4.3's no-thinking mode in the /thinking picker (#373)

### DIFF
--- a/backend/app/core/providers/_catalog_entries.py
+++ b/backend/app/core/providers/_catalog_entries.py
@@ -231,6 +231,11 @@ XAI_ENTRIES: tuple[ModelEntry, ...] = (
         is_default=False,
         cost_per_mtok_in_usd=_GROK_4_3_IN_USD,
         cost_per_mtok_out_usd=_GROK_4_3_OUT_USD,
-        supports_reasoning=("low", "high"),
+        # xAI added an explicit no-thinking mode on grok-4.3 (#373).
+        # ``minimal`` maps to ``EFFORT_NONE`` inside the provider so
+        # the user can pick "no reasoning" without clearing the
+        # override entirely; ``low`` / ``high`` continue to map onto
+        # xAI's two-level enum.
+        supports_reasoning=("minimal", "low", "high"),
     ),
 )

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -118,18 +118,23 @@ def _map_reasoning_effort(
 ) -> chat_pb2.ReasoningEffort | None:
     """Map Pawrrtal's five-level UI knob onto xAI's proto enum.
 
-    Grok 4.3 accepts ``EFFORT_LOW`` or ``EFFORT_HIGH``
-    (https://docs.x.ai/docs/models/grok-4-3) and 400s on anything
-    else, including ``EFFORT_MEDIUM`` and ``EFFORT_NONE``.  The
-    Pawrrtal UI surfaces ``minimal | low | medium | high | extra-high``
-    — we collapse the lower three to ``EFFORT_LOW`` and the upper two
-    to ``EFFORT_HIGH`` so the user gets a meaningful difference
-    without overshooting xAI's schema.  ``None`` means "let xAI pick
-    the model default" and the field is omitted from the request.
+    Grok 4.3 historically accepted only ``EFFORT_LOW`` and
+    ``EFFORT_HIGH``. xAI added explicit no-thinking support on
+    grok-4.3 (#373); the request now accepts ``EFFORT_NONE`` to
+    disable reasoning entirely. The Pawrrtal UI surfaces
+    ``minimal | low | medium | high | extra-high`` — we map
+    ``minimal`` onto ``EFFORT_NONE`` (the new no-thinking mode),
+    collapse ``low / medium`` to ``EFFORT_LOW``, and collapse
+    ``high / extra-high`` to ``EFFORT_HIGH`` so the user gets a
+    meaningful difference without overshooting xAI's schema.
+    ``None`` (no override) means "let xAI pick the model default"
+    and the field is omitted from the request entirely.
     """
     if effort is None:
         return None
-    if effort in ("minimal", "low", "medium"):
+    if effort == "minimal":
+        return chat_pb2.ReasoningEffort.EFFORT_NONE
+    if effort in ("low", "medium"):
         return chat_pb2.ReasoningEffort.EFFORT_LOW
     return chat_pb2.ReasoningEffort.EFFORT_HIGH
 

--- a/backend/tests/test_telegram_thinking_picker.py
+++ b/backend/tests/test_telegram_thinking_picker.py
@@ -99,9 +99,15 @@ def test_claude_haiku_no_adaptive_thinking() -> None:
     assert _entry(Host.agent_sdk, "claude-haiku-4-5").supports_reasoning == ()
 
 
-def test_grok_collapses_to_two_levels() -> None:
-    """xai_provider._map_reasoning_effort folds four levels into two."""
-    assert _entry(Host.xai, "grok-4.3").supports_reasoning == ("low", "high")
+def test_grok_exposes_minimal_low_high_after_no_thinking_addition() -> None:
+    """xAI added ``EFFORT_NONE`` to grok-4.3; the picker now surfaces 3 rungs (#373).
+
+    ``minimal`` maps to ``EFFORT_NONE`` (no thinking), ``low`` and
+    ``medium`` collapse to ``EFFORT_LOW``, ``high`` and ``extra-high``
+    collapse to ``EFFORT_HIGH``. The picker shows the three distinct
+    rungs the user can meaningfully select.
+    """
+    assert _entry(Host.xai, "grok-4.3").supports_reasoning == ("minimal", "low", "high")
 
 
 def test_gemini_3_flash_models_expose_all_four_levels() -> None:

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -332,9 +332,16 @@ def test_resolve_api_key_workspace_override(
 # ---------------------------------------------------------------------------
 
 
-def test_map_reasoning_effort_collapses_four_levels_to_two() -> None:
-    """Pawrrtal's four-level UI knob → grok-4.3's two-level proto enum."""
+def test_map_reasoning_effort_collapses_five_levels_to_three() -> None:
+    """Pawrrtal's five-level UI knob → grok-4.3's three-level proto enum.
+
+    xAI added ``EFFORT_NONE`` for grok-4.3's no-thinking mode (#373);
+    we surface that via the ``minimal`` rung. ``low / medium`` collapse
+    to ``EFFORT_LOW`` and ``high / extra-high`` collapse to
+    ``EFFORT_HIGH`` — three rungs total at the wire layer.
+    """
     assert _map_reasoning_effort(None) is None
+    assert _map_reasoning_effort("minimal") == chat_pb2.ReasoningEffort.EFFORT_NONE
     assert _map_reasoning_effort("low") == chat_pb2.ReasoningEffort.EFFORT_LOW
     assert _map_reasoning_effort("medium") == chat_pb2.ReasoningEffort.EFFORT_LOW
     assert _map_reasoning_effort("high") == chat_pb2.ReasoningEffort.EFFORT_HIGH


### PR DESCRIPTION
## Closes #373

xAI added explicit no-thinking support on grok-4.3 — `EFFORT_NONE`
on the `chat_pb2.ReasoningEffort` enum is now accepted (the request
historically 400'd on it, and the comment in `_map_reasoning_effort`
still said as much). Surface the new rung in the `/thinking` picker.

## What changes

- `_catalog_entries.XAI_ENTRIES` — grok-4.3's `supports_reasoning`
  goes from `("low", "high")` to `("minimal", "low", "high")`, so
  the picker shows three meaningful rungs.
- `xai_provider._map_reasoning_effort` — `"minimal"` maps to
  `chat_pb2.ReasoningEffort.EFFORT_NONE` (the new no-thinking mode).
  `"low" / "medium"` still collapse to `EFFORT_LOW` and
  `"high" / "extra-high"` to `EFFORT_HIGH` — three rungs total on
  the wire, matching xAI's enum without overshooting.

## Tests

- `test_xai_provider_translation::test_map_reasoning_effort_collapses_five_levels_to_three`
  pins the new mapping including `EFFORT_NONE`.
- `test_telegram_thinking_picker::test_grok_exposes_minimal_low_high_after_no_thinking_addition`
  pins the picker contract.

## Verification

- `python3 -c "ast.parse(...)"` clean on every modified file.
- Tests updated to reflect the new contract; the existing
  `test_grok_collapses_to_two_levels` was renamed to reflect the new
  three-rung surface.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_