### PR TITLE
feat(telegram): filter unauthenticated providers from /model picker (#370)

### DIFF
--- a/backend/app/integrations/telegram/model_auth.py
+++ b/backend/app/integrations/telegram/model_auth.py
@@ -1,0 +1,48 @@
+"""Gateway-global host authentication checks for the Telegram model picker.
+
+Centralises the mapping from host slugs to their required ``settings``
+attribute so that :mod:`model_picker` can filter unauthenticated hosts
+without pulling in ``app.core.config`` directly.
+"""
+
+from __future__ import annotations
+
+from app.core.config import settings
+
+# Host → settings field that must be non-empty for the host to appear in
+# the picker (#370). Hosts that don't require a gateway API key
+# (``gemini-cli`` uses a local subprocess) are absent from this map and
+# always shown.
+_HOST_AUTH_SETTING: dict[str, str] = {
+    "agent-sdk": "claude_code_oauth_token",
+    "google-ai": "google_api_key",
+    "litellm": "openai_api_key",
+    "opencode-go": "opencode_api_key",
+    "xai": "xai_api_key",
+}
+
+
+def is_host_authenticated(host_slug: str) -> bool:
+    """Return whether the gateway-global config has the credentials for ``host_slug``.
+
+    Used by the picker to hide hosts whose credentials aren't configured
+    so the user doesn't pick a model that will immediately fail. Per-
+    workspace overrides aren't consulted here — the picker runs in the
+    chat surface (not the workspace), and a host that only some
+    workspaces have keys for is still better hidden than shown with a
+    failing default. When a workspace lands real per-user picker
+    filtering, that work threads workspace_root through this seam.
+
+    Hosts absent from :data:`_HOST_AUTH_SETTING` (e.g. ``gemini-cli``,
+    which runs a local subprocess rather than calling out to a managed
+    gateway) are always considered authenticated.
+    """
+    setting_name = _HOST_AUTH_SETTING.get(host_slug)
+    if setting_name is None:
+        return True
+    return bool(getattr(settings, setting_name, "") or "")
+
+
+__all__ = [
+    "is_host_authenticated",
+]

--- a/backend/app/integrations/telegram/model_picker.py
+++ b/backend/app/integrations/telegram/model_picker.py
@@ -14,6 +14,7 @@ from typing import Literal, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry
 from app.core.providers.labels import host_label_from_slug, vendor_label_from_slug
 from app.crud.channel import get_or_create_telegram_conversation_full, get_user_id_for_external
@@ -40,6 +41,39 @@ _DEFAULT_BUTTON_TEXT = "⭐ Set as my default"
 _DEFAULT_ALREADY_SET_TEXT = "⭐ Already your default"
 # Inert callback used by the post-default badge so a second tap is a no-op.
 NOOP_CALLBACK = "mdl:noop"
+
+# Host → settings field that must be non-empty for the host to appear in
+# the picker (#370). Hosts that don't require a gateway API key
+# (``gemini-cli`` uses a local subprocess) are absent from this map and
+# always shown.
+_HOST_AUTH_SETTING: dict[str, str] = {
+    "agent-sdk": "claude_code_oauth_token",
+    "google-ai": "google_api_key",
+    "litellm": "openai_api_key",
+    "opencode-go": "opencode_api_key",
+    "xai": "xai_api_key",
+}
+
+
+def is_host_authenticated(host_slug: str) -> bool:
+    """Return whether the gateway-global config has the credentials for ``host_slug``.
+
+    Used by the picker to hide hosts whose credentials aren't configured
+    so the user doesn't pick a model that will immediately fail. Per-
+    workspace overrides aren't consulted here — the picker runs in the
+    chat surface (not the workspace), and a host that only some
+    workspaces have keys for is still better hidden than shown with a
+    failing default. When a workspace lands real per-user picker
+    filtering, that work threads workspace_root through this seam.
+
+    Hosts absent from :data:`_HOST_AUTH_SETTING` (e.g. ``gemini-cli``,
+    which runs a local subprocess rather than calling out to a managed
+    gateway) are always considered authenticated.
+    """
+    setting_name = _HOST_AUTH_SETTING.get(host_slug)
+    if setting_name is None:
+        return True
+    return bool(getattr(settings, setting_name, "") or "")
 
 
 class TelegramSenderLike(Protocol):
@@ -327,12 +361,17 @@ def picker_stale_message() -> str:
 def _host_to_vendors() -> dict[str, dict[str, list[ModelEntry]]]:
     """Group the catalog as ``{host_slug: {vendor_slug: [entries]}}``.
 
-    Both layers preserve a stable, alphabetised order so the keyboards
-    are deterministic.
+    Hosts whose gateway-global API key is absent are filtered out so
+    the picker only shows providers the user can actually invoke
+    (#370). Both layers preserve a stable, alphabetised order so the
+    keyboards are deterministic.
     """
     grouped: dict[str, dict[str, list[ModelEntry]]] = {}
     for entry in MODEL_CATALOG:
-        host_bucket = grouped.setdefault(entry.host.value, {})
+        host_slug = entry.host.value
+        if not is_host_authenticated(host_slug):
+            continue
+        host_bucket = grouped.setdefault(host_slug, {})
         host_bucket.setdefault(entry.vendor.value, []).append(entry)
     return {host: dict(sorted(vendors.items())) for host, vendors in sorted(grouped.items())}
 
@@ -492,6 +531,7 @@ __all__ = [
     "get_model_picker_state",
     "has_host",
     "has_vendor_in_host",
+    "is_host_authenticated",
     "parse_model_callback_data",
     "picker_not_bound_message",
     "picker_stale_message",

--- a/backend/app/integrations/telegram/model_picker.py
+++ b/backend/app/integrations/telegram/model_picker.py
@@ -1,8 +1,6 @@
 """Catalog-backed Telegram model picker helpers.
 
-The picker is a three-level walk: provider (host) → vendor → models.
-Hosts that serve a single vendor collapse to two levels (host → models),
-because forcing a single-button vendor screen is just an extra tap.
+Three-level walk: host → vendor → models (single-vendor hosts collapse to two levels).
 """
 
 from __future__ import annotations
@@ -14,11 +12,11 @@ from typing import Literal, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
 from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry
 from app.core.providers.labels import host_label_from_slug, vendor_label_from_slug
 from app.crud.channel import get_or_create_telegram_conversation_full, get_user_id_for_external
 from app.crud.user_preferences import get_user_default_model_id
+from app.integrations.telegram.model_auth import is_host_authenticated
 from app.integrations.telegram.model_defaults import resolve_effective_model_id
 
 ModelCallbackAction = Literal["providers", "vendors", "list", "select", "set_default"]
@@ -41,39 +39,6 @@ _DEFAULT_BUTTON_TEXT = "⭐ Set as my default"
 _DEFAULT_ALREADY_SET_TEXT = "⭐ Already your default"
 # Inert callback used by the post-default badge so a second tap is a no-op.
 NOOP_CALLBACK = "mdl:noop"
-
-# Host → settings field that must be non-empty for the host to appear in
-# the picker (#370). Hosts that don't require a gateway API key
-# (``gemini-cli`` uses a local subprocess) are absent from this map and
-# always shown.
-_HOST_AUTH_SETTING: dict[str, str] = {
-    "agent-sdk": "claude_code_oauth_token",
-    "google-ai": "google_api_key",
-    "litellm": "openai_api_key",
-    "opencode-go": "opencode_api_key",
-    "xai": "xai_api_key",
-}
-
-
-def is_host_authenticated(host_slug: str) -> bool:
-    """Return whether the gateway-global config has the credentials for ``host_slug``.
-
-    Used by the picker to hide hosts whose credentials aren't configured
-    so the user doesn't pick a model that will immediately fail. Per-
-    workspace overrides aren't consulted here — the picker runs in the
-    chat surface (not the workspace), and a host that only some
-    workspaces have keys for is still better hidden than shown with a
-    failing default. When a workspace lands real per-user picker
-    filtering, that work threads workspace_root through this seam.
-
-    Hosts absent from :data:`_HOST_AUTH_SETTING` (e.g. ``gemini-cli``,
-    which runs a local subprocess rather than calling out to a managed
-    gateway) are always considered authenticated.
-    """
-    setting_name = _HOST_AUTH_SETTING.get(host_slug)
-    if setting_name is None:
-        return True
-    return bool(getattr(settings, setting_name, "") or "")
 
 
 class TelegramSenderLike(Protocol):
@@ -178,12 +143,7 @@ def build_host_keyboard() -> list[list[ModelButton]]:
 
 
 def build_vendor_keyboard(*, host: str) -> list[list[ModelButton]]:
-    """Build the vendor keyboard for a host that has multiple vendors.
-
-    For single-vendor hosts the caller should jump straight to
-    :func:`build_models_keyboard`; this function still works in that
-    case but produces a one-button screen.
-    """
+    """Build the vendor keyboard for a host with multiple vendors."""
     vendors = _host_to_vendors().get(host, {})
     rows: list[list[ModelButton]] = []
     current_row: list[ModelButton] = []
@@ -390,10 +350,8 @@ def _model_label(entry: ModelEntry, current_model_id: str) -> str:
 
 
 def _display_name_for_model(model_id: str) -> str:
-    for entry in MODEL_CATALOG:
-        if entry.id == model_id:
-            return entry.display_name
-    return model_id
+    entry = _entry_by_id(model_id)
+    return entry.display_name if entry else model_id
 
 
 def _catalog_index(entry: ModelEntry) -> int:
@@ -531,7 +489,6 @@ __all__ = [
     "get_model_picker_state",
     "has_host",
     "has_vendor_in_host",
-    "is_host_authenticated",
     "parse_model_callback_data",
     "picker_not_bound_message",
     "picker_stale_message",

--- a/backend/tests/test_telegram_model_picker.py
+++ b/backend/tests/test_telegram_model_picker.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.core.config import settings
 from app.core.providers.catalog import MODEL_CATALOG, default_model
 from app.core.providers.model_id import Host
 from app.integrations.telegram.model_picker import (
@@ -25,10 +26,28 @@ from app.integrations.telegram.model_picker import (
     get_model_picker_state,
     has_host,
     has_vendor_in_host,
+    is_host_authenticated,
     parse_model_callback_data,
     resolve_model_selection,
 )
 from app.integrations.telegram.sender import TelegramSender
+
+
+@pytest.fixture(autouse=True)
+def _all_providers_authenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set every gateway API key so the picker shows every host (#370).
+
+    The picker filters out hosts whose credentials are missing
+    (:func:`is_host_authenticated`). Most tests in this file exercise
+    the full keyboard, so we default every key to a placeholder; the
+    filter behaviour itself has dedicated tests below that opt out by
+    overriding individual settings on top of this fixture.
+    """
+    monkeypatch.setattr(settings, "google_api_key", "test-google-key")
+    monkeypatch.setattr(settings, "claude_code_oauth_token", "test-claude-token")
+    monkeypatch.setattr(settings, "xai_api_key", "test-xai-key")
+    monkeypatch.setattr(settings, "openai_api_key", "test-openai-key")
+    monkeypatch.setattr(settings, "opencode_api_key", "test-opencode-key")
 
 
 def _flatten(rows: Sequence[Sequence[ModelButton]]) -> list[ModelButton]:
@@ -155,6 +174,43 @@ def test_stale_model_selection_is_rejected() -> None:
 def test_has_host_and_has_vendor_in_host_guards() -> None:
     assert has_host(Host.agent_sdk.value) is True
     assert has_host("totally-fake") is False
+
+
+def test_is_host_authenticated_reports_gateway_key_presence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``is_host_authenticated`` reflects the gateway-global setting (#370)."""
+    monkeypatch.setattr(settings, "opencode_api_key", "")
+    assert is_host_authenticated(Host.opencode_go.value) is False
+
+    monkeypatch.setattr(settings, "opencode_api_key", "real-key")
+    assert is_host_authenticated(Host.opencode_go.value) is True
+
+
+def test_is_host_authenticated_returns_true_for_hosts_without_gateway_key() -> None:
+    """``gemini-cli`` runs a local subprocess, so it never needs a gateway key."""
+    assert is_host_authenticated(Host.gemini_cli.value) is True
+
+
+def test_host_keyboard_hides_unauthenticated_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an API key is missing the host is hidden from the picker (#370).
+
+    Reproduces the symptom the issue described: OpenCode Go was shown
+    even when no ``OPENCODE_API_KEY`` was configured, so users picked a
+    model that immediately failed.
+    """
+    monkeypatch.setattr(settings, "opencode_api_key", "")
+    monkeypatch.setattr(settings, "xai_api_key", "")
+
+    labels = [button.text for button in _flatten(build_host_keyboard())]
+
+    assert not any("OpenCode Go" in label for label in labels)
+    assert not any(label.startswith("xAI") for label in labels)
+    # Hosts that DO have keys configured stay visible.
+    assert any("Gemini API" in label for label in labels)
+    assert any("Anthropic Agent SDK" in label for label in labels)
     assert has_vendor_in_host(host=Host.opencode_go.value, vendor="zai") is True
     assert has_vendor_in_host(host=Host.opencode_go.value, vendor="anthropic") is False
 

--- a/backend/tests/test_telegram_model_picker.py
+++ b/backend/tests/test_telegram_model_picker.py
@@ -12,6 +12,7 @@ import pytest
 from app.core.config import settings
 from app.core.providers.catalog import MODEL_CATALOG, default_model
 from app.core.providers.model_id import Host
+from app.integrations.telegram.model_auth import is_host_authenticated
 from app.integrations.telegram.model_picker import (
     ModelButton,
     ModelCallback,
@@ -26,7 +27,6 @@ from app.integrations.telegram.model_picker import (
     get_model_picker_state,
     has_host,
     has_vendor_in_host,
-    is_host_authenticated,
     parse_model_callback_data,
     resolve_model_selection,
 )
@@ -174,6 +174,8 @@ def test_stale_model_selection_is_rejected() -> None:
 def test_has_host_and_has_vendor_in_host_guards() -> None:
     assert has_host(Host.agent_sdk.value) is True
     assert has_host("totally-fake") is False
+    assert has_vendor_in_host(host=Host.opencode_go.value, vendor="zai") is True
+    assert has_vendor_in_host(host=Host.opencode_go.value, vendor="anthropic") is False
 
 
 def test_is_host_authenticated_reports_gateway_key_presence(
@@ -211,8 +213,6 @@ def test_host_keyboard_hides_unauthenticated_providers(
     # Hosts that DO have keys configured stay visible.
     assert any("Gemini API" in label for label in labels)
     assert any("Anthropic Agent SDK" in label for label in labels)
-    assert has_vendor_in_host(host=Host.opencode_go.value, vendor="zai") is True
-    assert has_vendor_in_host(host=Host.opencode_go.value, vendor="anthropic") is False
 
 
 def test_host_picker_text_displays_known_model_name() -> None:


### PR DESCRIPTION
## Closes #370

The `/model` picker walked the full `MODEL_CATALOG` regardless of
which gateway API keys were configured, so users picked models that
immediately failed with "OpenCode API key not configured" or similar.
The most visible symptom was OpenCode Go appearing on every
deployment, including ones where `OPENCODE_API_KEY` was left at its
empty default.

## What changes

- New `is_host_authenticated(host_slug)` helper reads the gateway-
  global `settings` field paired with each host:
  - `agent-sdk` → `claude_code_oauth_token`
  - `google-ai` → `google_api_key`
  - `litellm` → `openai_api_key`
  - `opencode-go` → `opencode_api_key`
  - `xai` → `xai_api_key`
- `gemini-cli` runs a local subprocess and is absent from the map, so
  it always shows.
- `_host_to_vendors` skips hosts that return `False` before the
  keyboard is built — header counts (vendor counts, single- vs
  multi-vendor handling) all stay consistent because they derive from
  the same filtered map.

## Tests

- Autouse fixture in `test_telegram_model_picker.py` sets every key so
  the existing 30+ tests keep exercising the full keyboard.
- `test_is_host_authenticated_reports_gateway_key_presence` pins the
  helper contract.
- `test_host_keyboard_hides_unauthenticated_providers` reproduces the
  reported symptom (OpenCode Go visible with no key) and pins the fix.

## Out of scope

Per-workspace key overrides are deliberately not consulted yet — the
picker runs in the chat surface, not the workspace, and a host that
only some workspaces have keys for is better hidden than shown with a
failing default. When per-user picker filtering lands, that work
threads `workspace_root` through this seam.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_