### PR TITLE
refactor(dev): centralise the dev-port contract (#342)

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -1,9 +1,17 @@
 /**
  * Dev orchestrator: runs the Next.js frontend and FastAPI backend side-by-side
- * on plain localhost. Frontend on :3001, backend on :8000. No proxies, no HTTPS,
- * no special routing — just the two processes.
+ * on plain localhost. Frontend / backend ports come from `scripts/dev-ports.ts`,
+ * the single source of truth shared with the Electrobun shell and the
+ * frontend's package.json `dev` script. No proxies, no HTTPS, no special
+ * routing — just the two processes.
  */
 import { $ } from 'bun';
+import {
+	DEV_BACKEND_PORT,
+	DEV_BACKEND_URL,
+	DEV_FRONTEND_PORT,
+	DEV_FRONTEND_URL,
+} from './scripts/dev-ports';
 
 const SQLITE_DB_FILENAME_PREFIX = 'pawrrtal';
 const MAX_BRANCH_FILENAME_LENGTH = 80;
@@ -30,8 +38,8 @@ async function sqliteDbFilenameForBranch(): Promise<string | null> {
 
 // Free up dev ports before starting (handles ghost processes from previous runs).
 // `.nothrow()` keeps the script running even if no process is bound to the port.
-await $`lsof -ti:3001 | xargs kill -9`.quiet().nothrow();
-await $`lsof -ti:8000 | xargs kill -9`.quiet().nothrow();
+await $`lsof -ti:${DEV_FRONTEND_PORT} | xargs kill -9`.quiet().nothrow();
+await $`lsof -ti:${DEV_BACKEND_PORT} | xargs kill -9`.quiet().nothrow();
 
 // Clear Next.js dev lock to avoid the "Unable to acquire lock" error on restart.
 await $`rm -rf frontend/.next/dev/lock`.quiet().nothrow();
@@ -49,7 +57,7 @@ if (!process.env.SQLITE_DB_FILENAME) {
 }
 
 console.log(
-	'Starting dev servers — frontend on http://localhost:3001, backend on http://localhost:8000'
+	`Starting dev servers — frontend on ${DEV_FRONTEND_URL}, backend on ${DEV_BACKEND_URL}`
 );
 
 // Frontend: plain Next.js dev server. Workspace package, run via bun --filter.
@@ -58,7 +66,7 @@ const frontendPromise = $`bun --filter pawrrtal dev`.quiet(false);
 // Backend: explicit ASGI target via uvicorn. `main.app` is wrapped in CORS
 // middleware, so FastAPI CLI discovery cannot treat it as a raw FastAPI instance.
 const backendPromise =
-	$`uv run --project backend uvicorn main:app --app-dir backend --host 127.0.0.1 --port 8000 --reload --reload-dir backend`.quiet(
+	$`uv run --project backend uvicorn main:app --app-dir backend --host 127.0.0.1 --port ${DEV_BACKEND_PORT} --reload --reload-dir backend`.quiet(
 		false
 	);
 

--- a/electrobun/src/bun/server.ts
+++ b/electrobun/src/bun/server.ts
@@ -16,14 +16,17 @@
 
 import { createServer } from 'node:net';
 import path from 'node:path';
+import { DEV_FRONTEND_PORT } from '../../../scripts/dev-ports';
 
 export interface StartedServer {
 	url: string;
 	stop: () => Promise<void>;
 }
 
-/** Must match `frontend/package.json` → `scripts.dev` --port value. */
-const DEV_FRONTEND_PORT = 3001;
+// ``DEV_FRONTEND_PORT`` is the canonical shared constant — imported from
+// the monorepo's ``scripts/dev-ports.ts`` so this shell, dev.ts, and any
+// future consumer agree on the value without having to keep three
+// literal copies in sync.
 
 // ---------------------------------------------------------------------------
 // Port helpers

--- a/scripts/check-dev-port-contract.ts
+++ b/scripts/check-dev-port-contract.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+/**
+ * Verify the dev-port contract is intact.
+ *
+ * Reads `frontend/package.json` and asserts its `scripts.dev` still
+ * references the canonical `DEV_FRONTEND_PORT` from `scripts/dev-ports.ts`.
+ * Run from CI or a pre-commit hook to catch drift between the shared
+ * constant and the package-script literal (#342).
+ *
+ * Exit codes:
+ *   0 — contract intact.
+ *   1 — package.json missing or port mismatched.
+ */
+import { resolve } from 'node:path';
+
+import { assertFrontendPortMatchesPackageJson } from './dev-ports';
+
+const repoRoot = resolve(import.meta.dir, '..');
+const packageJsonPath = resolve(repoRoot, 'frontend', 'package.json');
+
+const file = Bun.file(packageJsonPath);
+if (!(await file.exists())) {
+	console.error(`check-dev-port-contract: ${packageJsonPath} does not exist`);
+	process.exit(1);
+}
+
+try {
+	assertFrontendPortMatchesPackageJson(await file.text());
+	console.log('check-dev-port-contract: OK');
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(`check-dev-port-contract: ${message}`);
+	process.exit(1);
+}

--- a/scripts/dev-ports.ts
+++ b/scripts/dev-ports.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared dev-port contract for the monorepo.
+ *
+ * The frontend dev server port and backend dev server port are a
+ * cross-process contract (referenced from `dev.ts`, the Electrobun
+ * shell's lifecycle module, comments in handbook docs, etc.). Owning
+ * the literal values here gives every consumer one canonical import
+ * and stops drift between repo root, frontend, and desktop shell.
+ *
+ * The frontend dev port also appears in `frontend/package.json`
+ * (`scripts.dev`: `next dev --port 3001`). That value must stay in
+ * sync with {@link DEV_FRONTEND_PORT}; the verification helper below
+ * is the gate for that constraint — call it from CI or pre-commit if
+ * needed.
+ *
+ * @see frontend/package.json
+ * @see dev.ts
+ * @see electrobun/src/bun/server.ts
+ * @see electron/src/server.ts (if present)
+ */
+
+/**
+ * Port the Next.js dev server listens on locally.
+ *
+ * Must match the `--port` flag in `frontend/package.json` → `scripts.dev`.
+ * Verified by {@link assertFrontendPortMatchesPackageJson}.
+ */
+export const DEV_FRONTEND_PORT = 3001;
+
+/**
+ * Port the FastAPI dev server listens on locally.
+ *
+ * Driven from `dev.ts`'s uvicorn invocation; the value isn't currently
+ * embedded in any other file but lives here so the same export pattern
+ * applies to both ports.
+ */
+export const DEV_BACKEND_PORT = 8000;
+
+/**
+ * URL the desktop shell points at when running against `bun run dev`.
+ *
+ * Centralised so the dev shell + status log + any future
+ * health-probe consumer all read the same string.
+ */
+export const DEV_FRONTEND_URL = `http://localhost:${DEV_FRONTEND_PORT}`;
+
+/**
+ * URL the backend exposes during `bun run dev`.
+ *
+ * Mirrors {@link DEV_FRONTEND_URL} for symmetry; the backend stays on
+ * `127.0.0.1` to match what uvicorn binds inside `dev.ts`.
+ */
+export const DEV_BACKEND_URL = `http://127.0.0.1:${DEV_BACKEND_PORT}`;
+
+/**
+ * Verify that `frontend/package.json` still encodes the canonical
+ * frontend dev port.
+ *
+ * This is the assertion side of the package.json escape hatch:
+ * package-script command strings can't easily import this module, so
+ * the check lives here and any consumer (a pre-push hook, a CI step)
+ * calls it to fail fast on drift.
+ *
+ * @param packageJsonText - The textual contents of `frontend/package.json`.
+ *   The function intentionally takes the raw string rather than a parsed
+ *   shape so callers can read it once with `Bun.file().text()` /
+ *   `fs.readFileSync` without picking a JSON schema.
+ * @returns `true` when the file references the canonical port via
+ *   `next dev --port <DEV_FRONTEND_PORT>`. Throws an `Error` describing
+ *   the mismatch when the port literal is missing or differs.
+ */
+export function assertFrontendPortMatchesPackageJson(packageJsonText: string): true {
+	const expected = `next dev --port ${DEV_FRONTEND_PORT}`;
+	if (!packageJsonText.includes(expected)) {
+		throw new Error(
+			`frontend/package.json does not reference the canonical dev port. ` +
+				`Expected the substring '${expected}' in scripts.dev; update package.json ` +
+				`or scripts/dev-ports.ts so the two match.`
+		);
+	}
+	return true;
+}


### PR DESCRIPTION
## Closes #342

The frontend (3001) and backend (8000) dev-server ports were spread
across raw literals in `dev.ts`, the Electrobun shell's lifecycle
module, and `frontend/package.json`. The package.json + scripts
copies were kept in sync only by comments and memory — when the port
changes in one place the other consumers go quietly stale.

## What changes

- **`scripts/dev-ports.ts`** — single source of truth exporting
  `DEV_FRONTEND_PORT`, `DEV_BACKEND_PORT`, and the matching URL
  constants. Also exposes
  `assertFrontendPortMatchesPackageJson(text)` for the
  package.json-substring check.
- **`dev.ts`** — imports the shared constants for the `lsof -ti`
  cleanup, the startup log, and the uvicorn `--port` flag.
- **`electrobun/src/bun/server.ts`** — replaces its local
  `const DEV_FRONTEND_PORT = 3001` with an import from the shared
  module.
- **`scripts/check-dev-port-contract.ts`** — narrow Bun script that
  reads `frontend/package.json` and asserts its `scripts.dev` still
  references the canonical port. Wire into CI or a pre-commit hook
  to fail fast on drift; runs in <100 ms.

## Verification

```bash
$ bun run scripts/check-dev-port-contract.ts
check-dev-port-contract: OK
```

## Out of scope

- Re-orchestrating dev startup or changing the port values themselves.
- Touching production server allocation (Electrobun still allocates a
  free port via `allocateFreePort`).
- Adding the check to CI here — the script is in place so a follow-up
  can wire it without touching this PR.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_