### PR TITLE
feat(telegram): inline-keyboard picker for /verbose toggle (#343, #355)

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -98,6 +98,15 @@ from app.integrations.telegram.thinking_picker_runtime import (
     handle_thinking_picker_callback,
 )
 
+# ``VERBOSE_CALLBACK_PREFIX`` mirrors the other pickers — re-exported
+# from the runtime so bot.py picks up the callback prefix and the
+# entry-point handlers from one module.
+from app.integrations.telegram.verbose_picker_runtime import (
+    VERBOSE_CALLBACK_PREFIX,
+    answer_verbose_command,
+    handle_verbose_picker_callback,
+)
+
 if TYPE_CHECKING:
     from aiogram import Bot, Dispatcher
     from aiogram.types import CallbackQuery, Message, ReplyParameters, Update
@@ -618,6 +627,12 @@ def _register_telegram_command_handlers(dispatcher: Dispatcher) -> None:
         text = message.text or ""
         parts = text.strip().split(maxsplit=1)
         level_arg = parts[1].strip() if len(parts) > 1 else ""
+        # No argument → open the inline-keyboard picker. The power-user
+        # ``/verbose 0|1|2`` shortcut still resolves through the
+        # original handler so scripts and aliases keep working (#343).
+        if level_arg == "":
+            await answer_verbose_command(message=message)
+            return
         sender = _sender_from_message(message)
         async with async_session_maker() as session:
             reply = await handle_verbose_command(
@@ -668,6 +683,12 @@ def _register_telegram_callback_handlers(dispatcher: Dispatcher) -> None:
     )
     async def _on_thinking_picker(callback: CallbackQuery) -> None:
         await handle_thinking_picker_callback(callback=callback)
+
+    @dispatcher.callback_query(
+        lambda query: (query.data or "").startswith(VERBOSE_CALLBACK_PREFIX)
+    )
+    async def _on_verbose_picker(callback: CallbackQuery) -> None:
+        await handle_verbose_picker_callback(callback=callback)
 
 
 def _register_telegram_message_handler(dispatcher: Dispatcher) -> None:

--- a/backend/app/integrations/telegram/verbose_picker.py
+++ b/backend/app/integrations/telegram/verbose_picker.py
@@ -1,0 +1,225 @@
+"""Per-conversation verbose-level picker for the Telegram channel.
+
+Shape mirrors :mod:`app.integrations.telegram.thinking_picker` — pure
+formatter + button builder + callback parser. The aiogram glue lives
+in :mod:`app.integrations.telegram.verbose_picker_runtime` so this
+module stays framework-free and unit-testable.
+
+Three rungs total: ``quiet (0)``, ``normal (1)``, ``detailed (2)``.
+A trailing "Use default" button appears only when an override is
+currently set, so the picker stays minimal for users who haven't
+customised anything yet. The semantics of each level are documented
+in :func:`app.core.chat_aggregator.should_emit_event`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from html import escape
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.channel import (
+    get_or_create_telegram_conversation_full,
+    get_user_id_for_external,
+)
+
+PROVIDER = "telegram"
+VERBOSE_CALLBACK_PREFIX = "vbs:"
+_CALLBACK_SELECT_PARTS = 3  # vbs:s:<level>
+_CALLBACK_CLEAR_PARTS = 2  # vbs:c
+
+# ``_VERBOSE_LEVELS`` is the authoritative ordered list of rungs the
+# picker exposes. Mirrors :data:`app.integrations.telegram.status._VERBOSE_LABELS`
+# in coverage — kept independent here so the picker module stays free
+# of any cross-imports from the status / handlers surface.
+VERBOSE_LEVELS: tuple[int, ...] = (0, 1, 2)
+_VERBOSE_LABELS: dict[int, str] = {
+    0: "quiet",
+    1: "normal",
+    2: "detailed",
+}
+
+_NOT_BOUND_MESSAGE = "Connect your account first before changing verbose level."
+_STALE_MESSAGE = "That verbose picker is out of date. Open /verbose again."
+_PICKER_HEADER = (
+    "🔊 Verbose level\n\n"
+    "Pick what the assistant streams back to chat.\n"
+    "Current: <b>{current_label}</b>"
+)
+_DEFAULT_BUTTON_TEXT = "Use default (clear override)"
+_CURRENT_LABEL_DEFAULT_TEMPLATE = "default ({default_label})"
+
+
+class TelegramSenderLike(Protocol):
+    """Subset of ``TelegramSender`` used by the picker."""
+
+    user_id: int
+    thread_id: int | None
+
+
+@dataclass(frozen=True)
+class VerboseButton:
+    """One inline-keyboard button for the verbose picker."""
+
+    text: str
+    callback_data: str
+
+
+@dataclass(frozen=True)
+class VerbosePickerState:
+    """Resolved verbose state for one Telegram conversation.
+
+    Carries ``conversation_id`` + ``user_id`` so callback handlers can
+    persist the new override without a second user/conversation lookup —
+    the picker has already paid the cost to resolve both once.
+    ``default_level`` is the gateway-global default (read from
+    ``settings.telegram_verbose_default``) so the "Use default" copy
+    shows what clearing the override falls back to.
+    """
+
+    current_level: int | None
+    default_level: int
+    conversation_id: uuid.UUID
+    user_id: uuid.UUID
+
+
+@dataclass(frozen=True)
+class VerboseCallback:
+    """Parsed callback payload for the verbose picker."""
+
+    action: str
+    level: int | None = None
+
+
+async def get_verbose_picker_state(
+    *,
+    sender: TelegramSenderLike,
+    session: AsyncSession,
+    default_level: int,
+) -> VerbosePickerState | None:
+    """Resolve the per-conversation verbose level and identity for ``sender``.
+
+    Returns ``None`` when the Telegram sender isn't bound to a Pawrrtal
+    user yet (the caller should reply with the not-bound message).
+    """
+    pawrrtal_user_id = await get_user_id_for_external(
+        provider=PROVIDER,
+        external_user_id=str(sender.user_id),
+        session=session,
+    )
+    if pawrrtal_user_id is None:
+        return None
+
+    conversation = await get_or_create_telegram_conversation_full(
+        user_id=pawrrtal_user_id,
+        session=session,
+        thread_id=sender.thread_id,
+    )
+    return VerbosePickerState(
+        current_level=conversation.verbose_level,
+        default_level=default_level,
+        conversation_id=conversation.id,
+        user_id=pawrrtal_user_id,
+    )
+
+
+def build_verbose_keyboard(state: VerbosePickerState) -> list[list[VerboseButton]]:
+    """Build the keyboard rows for the picker.
+
+    One button per rung, in ladder order. The trailing "Use default"
+    button only appears when the row currently holds an override, so a
+    fresh conversation sees three buttons and a customised one sees
+    four.
+    """
+    rows: list[list[VerboseButton]] = [
+        [
+            VerboseButton(
+                text=_level_button_label(level, current=state.current_level),
+                callback_data=_select_callback(level),
+            )
+        ]
+        for level in VERBOSE_LEVELS
+    ]
+    if state.current_level is not None:
+        rows.append([VerboseButton(text=_DEFAULT_BUTTON_TEXT, callback_data=_clear_callback())])
+    return rows
+
+
+def format_picker_text(state: VerbosePickerState) -> str:
+    """Render the picker header in Telegram HTML."""
+    if state.current_level is None:
+        current_label = _CURRENT_LABEL_DEFAULT_TEMPLATE.format(
+            default_label=_VERBOSE_LABELS.get(state.default_level, str(state.default_level))
+        )
+    else:
+        current_label = (
+            f"{state.current_level} ({_VERBOSE_LABELS.get(state.current_level, 'unknown')})"
+        )
+    return _PICKER_HEADER.format(current_label=escape(current_label))
+
+
+def parse_verbose_callback_data(data: str | None) -> VerboseCallback | None:
+    """Parse Telegram callback data emitted by this picker."""
+    if data is None or not data.startswith(VERBOSE_CALLBACK_PREFIX):
+        return None
+    parts = data.split(":")
+    if len(parts) == _CALLBACK_SELECT_PARTS and parts[1] == "s":
+        try:
+            level = int(parts[2])
+        except ValueError:
+            return None
+        if level not in _VERBOSE_LABELS:
+            return None
+        return VerboseCallback(action="select", level=level)
+    if len(parts) == _CALLBACK_CLEAR_PARTS and parts[1] == "c":
+        return VerboseCallback(action="clear")
+    return None
+
+
+def picker_not_bound_message() -> str:
+    """Return the not-bound message for picker entry points."""
+    return _NOT_BOUND_MESSAGE
+
+
+def picker_stale_message() -> str:
+    """Return the stale-picker callback message."""
+    return _STALE_MESSAGE
+
+
+def verbose_label(level: int) -> str:
+    """Return the human-readable label for ``level`` (``"quiet"`` / ``"normal"`` / ``"detailed"``)."""
+    return _VERBOSE_LABELS.get(level, "unknown")
+
+
+def _level_button_label(level: int, *, current: int | None) -> str:
+    """Render a level button — marks the currently-selected level."""
+    prefix = "✓ " if level == current else ""
+    return f"{prefix}{level} ({_VERBOSE_LABELS[level]})"
+
+
+def _select_callback(level: int) -> str:
+    return f"vbs:s:{level}"
+
+
+def _clear_callback() -> str:
+    return "vbs:c"
+
+
+__all__ = [
+    "VERBOSE_CALLBACK_PREFIX",
+    "VERBOSE_LEVELS",
+    "TelegramSenderLike",
+    "VerboseButton",
+    "VerboseCallback",
+    "VerbosePickerState",
+    "build_verbose_keyboard",
+    "format_picker_text",
+    "get_verbose_picker_state",
+    "parse_verbose_callback_data",
+    "picker_not_bound_message",
+    "picker_stale_message",
+    "verbose_label",
+]

--- a/backend/app/integrations/telegram/verbose_picker_runtime.py
+++ b/backend/app/integrations/telegram/verbose_picker_runtime.py
@@ -1,0 +1,215 @@
+"""aiogram runtime glue for the Telegram verbose-level picker.
+
+Mirrors :mod:`app.integrations.telegram.thinking_picker_runtime` —
+keeps the picker module framework-free so it can be unit-tested
+without aiogram, while this file owns the aiogram-shaped IO.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.core.config import settings
+from app.crud.channel import update_conversation_verbose_level
+from app.db import async_session_maker
+from app.integrations.telegram.handlers import TelegramSender
+from app.integrations.telegram.verbose_picker import (
+    VERBOSE_CALLBACK_PREFIX,  # noqa: F401  # re-exported so bot.py imports both via one module
+    VerboseButton,
+    VerboseCallback,
+    VerbosePickerState,
+    build_verbose_keyboard,
+    format_picker_text,
+    get_verbose_picker_state,
+    parse_verbose_callback_data,
+    picker_not_bound_message,
+    picker_stale_message,
+    verbose_label,
+)
+
+if TYPE_CHECKING:
+    from aiogram.types import CallbackQuery, Message
+
+_CLEAR_NOTICE = "Verbose override cleared"
+
+
+async def answer_verbose_command(*, message: Message) -> None:
+    """Answer ``/verbose`` (no arg) with the per-conversation picker."""
+    sender = _sender_from_message(message)
+    async with async_session_maker() as session:
+        state = await get_verbose_picker_state(
+            sender=sender,
+            session=session,
+            default_level=settings.telegram_verbose_default,
+        )
+
+    if state is None:
+        await message.answer(
+            picker_not_bound_message(),
+            reply_parameters=_reply_parameters(message.message_id),
+        )
+        return
+
+    await message.answer(
+        format_picker_text(state),
+        reply_markup=_inline_keyboard(build_verbose_keyboard(state)),
+        reply_parameters=_reply_parameters(message.message_id),
+    )
+
+
+async def handle_verbose_picker_callback(*, callback: CallbackQuery) -> None:
+    """Handle inline-keyboard callbacks produced by the verbose picker."""
+    parsed = parse_verbose_callback_data(callback.data)
+    if parsed is None:
+        await callback.answer(picker_stale_message(), show_alert=True)
+        return
+
+    sender = _sender_from_callback(callback)
+    async with async_session_maker() as session:
+        state = await get_verbose_picker_state(
+            sender=sender,
+            session=session,
+            default_level=settings.telegram_verbose_default,
+        )
+    if state is None:
+        await callback.answer(picker_not_bound_message(), show_alert=True)
+        return
+
+    if parsed.action == "clear":
+        await _handle_clear(callback=callback, state=state)
+        return
+    if parsed.action == "select" and parsed.level is not None:
+        await _handle_select(callback=callback, parsed=parsed, state=state)
+        return
+    await callback.answer(picker_stale_message(), show_alert=True)
+
+
+async def _handle_select(
+    *,
+    callback: CallbackQuery,
+    parsed: VerboseCallback,
+    state: VerbosePickerState,
+) -> None:
+    """Apply a select callback, edit the message, ack the tap."""
+    if parsed.level is None:
+        await callback.answer(picker_stale_message(), show_alert=True)
+        return
+    await _persist_level(state=state, level=parsed.level)
+    await _refresh_picker(
+        callback=callback,
+        ack_text=f"Verbose: {parsed.level} ({verbose_label(parsed.level)})",
+    )
+
+
+async def _handle_clear(
+    *,
+    callback: CallbackQuery,
+    state: VerbosePickerState,
+) -> None:
+    """Clear the per-conversation override, edit the message, ack."""
+    # ``state`` is unused here today — the persist path doesn't need
+    # the previous value — but we keep the parameter so the function
+    # mirrors the select handler. Picker state is re-fetched inside
+    # ``_refresh_picker`` regardless.
+    del state
+    sender = _sender_from_callback(callback)
+    async with async_session_maker() as session:
+        refreshed = await get_verbose_picker_state(
+            sender=sender,
+            session=session,
+            default_level=settings.telegram_verbose_default,
+        )
+    if refreshed is None:
+        await callback.answer(picker_not_bound_message(), show_alert=True)
+        return
+    await _persist_level(state=refreshed, level=None)
+    await _refresh_picker(callback=callback, ack_text=_CLEAR_NOTICE)
+
+
+async def _refresh_picker(*, callback: CallbackQuery, ack_text: str) -> None:
+    """Re-fetch state + re-paint the keyboard so the new selection shows."""
+    sender = _sender_from_callback(callback)
+    message = _callback_message(callback)
+    if message is None:
+        await callback.answer(picker_stale_message(), show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        refreshed = await get_verbose_picker_state(
+            sender=sender,
+            session=session,
+            default_level=settings.telegram_verbose_default,
+        )
+    if refreshed is None:
+        await callback.answer(picker_not_bound_message(), show_alert=True)
+        return
+
+    await message.edit_text(
+        format_picker_text(refreshed),
+        reply_markup=_inline_keyboard(build_verbose_keyboard(refreshed)),
+    )
+    await callback.answer(ack_text)
+
+
+async def _persist_level(*, state: VerbosePickerState, level: int | None) -> None:
+    """Persist the new verbose level on the conversation."""
+    async with async_session_maker() as session:
+        await update_conversation_verbose_level(
+            conversation_id=state.conversation_id,
+            verbose_level=level,
+            session=session,
+        )
+
+
+def _inline_keyboard(rows: list[list[VerboseButton]]) -> object:
+    from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup  # noqa: PLC0415
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text=button.text, callback_data=button.callback_data)
+                for button in row
+            ]
+            for row in rows
+        ]
+    )
+
+
+def _sender_from_message(message: Message) -> TelegramSender:
+    user = message.from_user
+    if user is None:
+        raise RuntimeError("Telegram message has no from_user; refusing to dispatch.")
+    return TelegramSender(
+        user_id=user.id,
+        chat_id=message.chat.id,
+        username=user.username,
+        full_name=user.full_name,
+        thread_id=message.message_thread_id,
+    )
+
+
+def _sender_from_callback(callback: CallbackQuery) -> TelegramSender:
+    message = _callback_message(callback)
+    if message is None:
+        raise RuntimeError("Telegram callback has no accessible message.")
+    user = callback.from_user
+    return TelegramSender(
+        user_id=user.id,
+        chat_id=message.chat.id,
+        username=user.username,
+        full_name=user.full_name,
+        thread_id=message.message_thread_id,
+    )
+
+
+def _callback_message(callback: CallbackQuery) -> Message | None:
+    message = callback.message
+    if message is None or not hasattr(message, "edit_text"):
+        return None
+    return message
+
+
+def _reply_parameters(message_id: int) -> object:
+    from aiogram.types import ReplyParameters  # noqa: PLC0415
+
+    return ReplyParameters(message_id=message_id)

--- a/backend/tests/test_telegram_verbose_picker.py
+++ b/backend/tests/test_telegram_verbose_picker.py
@@ -1,0 +1,116 @@
+"""Tests for the Telegram ``/verbose`` inline-keyboard picker (#343 / #355)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.integrations.telegram.verbose_picker import (
+    VERBOSE_CALLBACK_PREFIX,
+    VERBOSE_LEVELS,
+    VerboseCallback,
+    VerbosePickerState,
+    build_verbose_keyboard,
+    format_picker_text,
+    parse_verbose_callback_data,
+    verbose_label,
+)
+
+_FAKE_CONVERSATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+_FAKE_USER_ID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+def _state(*, current: int | None = None, default: int = 1) -> VerbosePickerState:
+    return VerbosePickerState(
+        current_level=current,
+        default_level=default,
+        conversation_id=_FAKE_CONVERSATION_ID,
+        user_id=_FAKE_USER_ID,
+    )
+
+
+def test_keyboard_lists_one_button_per_level() -> None:
+    """The picker always exposes the three canonical levels (#343)."""
+    rows = build_verbose_keyboard(_state())
+    texts = [row[0].text for row in rows[: len(VERBOSE_LEVELS)]]
+    assert texts == ["0 (quiet)", "1 (normal)", "2 (detailed)"]
+
+
+def test_keyboard_marks_currently_selected_level() -> None:
+    """A check mark precedes the rung currently saved on the conversation."""
+    rows = build_verbose_keyboard(_state(current=2))
+    selected = next(row for row in rows if row[0].text.startswith("✓ "))
+    other = next(row for row in rows if row[0].text == "0 (quiet)")
+    assert selected[0].text == "✓ 2 (detailed)"
+    assert not other[0].text.startswith("✓ ")
+
+
+def test_clear_button_only_appears_when_override_is_set() -> None:
+    """Conversations on the default surface get three buttons; overridden get four."""
+    rows_default = build_verbose_keyboard(_state(current=None))
+    rows_override = build_verbose_keyboard(_state(current=0))
+    assert len(rows_default) == len(VERBOSE_LEVELS)
+    assert len(rows_override) == len(VERBOSE_LEVELS) + 1
+    assert "default" in rows_override[-1][0].text
+
+
+def test_select_callback_data_round_trips() -> None:
+    """Selecting a rung produces a parseable ``vbs:s:<level>`` callback."""
+    rows = build_verbose_keyboard(_state())
+    parsed_levels = [
+        parse_verbose_callback_data(row[0].callback_data) for row in rows[: len(VERBOSE_LEVELS)]
+    ]
+    actions = [callback.action for callback in parsed_levels if callback is not None]
+    levels = [callback.level for callback in parsed_levels if callback is not None]
+    assert actions == ["select", "select", "select"]
+    assert levels == list(VERBOSE_LEVELS)
+
+
+def test_clear_callback_data_round_trips() -> None:
+    """The clear button produces a parseable ``vbs:c`` callback."""
+    state = _state(current=1)
+    clear_button = build_verbose_keyboard(state)[-1][0]
+    parsed = parse_verbose_callback_data(clear_button.callback_data)
+    assert parsed is not None
+    assert parsed.action == "clear"
+    assert parsed.level is None
+
+
+def test_parse_rejects_unknown_callback_data() -> None:
+    """Stale / malformed callbacks resolve to ``None``."""
+    assert parse_verbose_callback_data(None) is None
+    assert parse_verbose_callback_data("mdl:p") is None  # other picker
+    assert parse_verbose_callback_data("vbs:s:42") is None  # out-of-range level
+    assert parse_verbose_callback_data("vbs:s:xyz") is None  # non-numeric
+    assert parse_verbose_callback_data("vbs:x") is None  # bogus action
+
+
+def test_format_picker_text_shows_current_level() -> None:
+    """The header surfaces the user's current rung in plain English."""
+    text_current = format_picker_text(_state(current=2))
+    assert "2 (detailed)" in text_current
+
+    text_default = format_picker_text(_state(current=None, default=1))
+    assert "default" in text_default
+    assert "normal" in text_default
+
+
+def test_callback_prefix_matches_runtime_dispatch() -> None:
+    """``VERBOSE_CALLBACK_PREFIX`` lines up with the data emitted by buttons."""
+    rows = build_verbose_keyboard(_state(current=0))
+    for row in rows:
+        assert row[0].callback_data.startswith(VERBOSE_CALLBACK_PREFIX)
+
+
+def test_verbose_label_resolves_known_levels() -> None:
+    """``verbose_label`` returns the human label for every valid rung."""
+    assert verbose_label(0) == "quiet"
+    assert verbose_label(1) == "normal"
+    assert verbose_label(2) == "detailed"
+    assert verbose_label(99) == "unknown"
+
+
+def test_verbose_callback_constructor_accepts_keyword_arguments() -> None:
+    """Sanity check: the dataclass is callable from the parser's perspective."""
+    callback = VerboseCallback(action="select", level=1)
+    assert callback.action == "select"
+    assert callback.level == 1


### PR DESCRIPTION
## Closes #343, closes #355

`/verbose` typed without an argument now opens an inline keyboard
matching the existing model / thinking picker pattern: three rungs
(`0 quiet`, `1 normal`, `2 detailed`), the currently selected one
marked with a check, plus a **"Use default"** button when an override
is set on the conversation. Tapping a rung persists via
`update_conversation_verbose_level` and re-paints the keyboard.

## Implementation

Mirrors the established `thinking_picker` layout:

- **`verbose_picker.py`** — framework-free helpers: keyboard builder,
  header copy, callback parsing, `VerbosePickerState` dataclass.
  Unit-testable without aiogram.
- **`verbose_picker_runtime.py`** — aiogram glue: opens the picker,
  handles select / clear callbacks, edits the message in place, acks
  the tap.
- **`bot.py`** — registers a new `callback_query` handler keyed on the
  `vbs:` prefix and routes the arg-less `/verbose` command to the
  picker. Power users keep their shortcut: `/verbose 0|1|2` still
  resolves through `handle_verbose_command` and writes the same row.

## Tests

`backend/tests/test_telegram_verbose_picker.py`:

- Keyboard shape (three rungs, one button per level).
- Currently-selected level prefixed with ✓.
- "Use default" button only when an override is set.
- Callback round-trip for both `select` and `clear`.
- Parser rejects stale / out-of-range / non-numeric / wrong-prefix
  payloads.
- Header copy reflects current level vs default.

## Out of scope

The user-facing copy mentions "thinking, tools, etc." in the issue
text — those are surfaced today as the rung labels (`detailed` adds
thinking, `normal` adds tool execution). Per-feature toggle
checkboxes (rather than three preset rungs) are a larger UX change
and stay deferred.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_