### PR TITLE
fix(gemini-cli): actionable error when session/new fails (#369)

### DIFF
--- a/backend/app/core/providers/gemini_cli/acp.py
+++ b/backend/app/core/providers/gemini_cli/acp.py
@@ -92,7 +92,26 @@ async def open_session(conn: ClientSideConnection, workspace_root: Path | None) 
             f"Gemini CLI did not respond to session/new within {_NEW_SESSION_TIMEOUT_SECONDS:.0f}s.",
         ) from exc
     except RequestError as exc:
-        raise AcpFatalError(f"Gemini CLI session/new failed: {exc}") from exc
+        # The gemini-cli binary frequently surfaces a bare "Internal
+        # error" RequestError on session/new when it can't reach the
+        # Google account / API key / Code Assist license configured on
+        # disk (#369). Bare "Internal error" reaches the user with no
+        # actionable hint, so log the structured RequestError fields
+        # alongside cwd for ops triage and surface a hint pointing at
+        # the most common cause.
+        logger.warning(
+            "GEMINI_CLI_NEW_SESSION_FAILED cwd=%s code=%s message=%s data=%s",
+            cwd,
+            getattr(exc, "code", "?"),
+            getattr(exc, "message", str(exc)),
+            getattr(exc, "data", None),
+        )
+        raise AcpFatalError(
+            f"Gemini CLI session/new failed: {exc}. "
+            f"This usually means the CLI can't reach its configured Google account, "
+            f"API key, or Code Assist license. Run `gemini` once in a shell to "
+            f"verify it can authenticate, or set GEMINI_API_KEY in the environment.",
+        ) from exc
 
     return session.session_id
 


### PR DESCRIPTION
## Addresses #369

The gemini-cli binary's `session/new` call frequently surfaces a bare
`RequestError("Internal error")` when it can't reach the Google
account / API key / Code Assist license configured on disk. That
opaque message reached the user as-is with no actionable hint —
operators had to run `gemini` interactively to figure out
authentication state.

## What changes

`backend/app/core/providers/gemini_cli/acp.py::open_session`:

- Log the structured `RequestError` fields (code, message, data)
  alongside the cwd as `WARNING` so ops triage has the full payload.
- Append a one-line hint to the user-facing `AcpFatalError`
  explaining the most common cause (authentication) and the two
  knobs that resolve it (run `gemini` once in a shell to verify the
  CLI authenticates, or set `GEMINI_API_KEY` in the environment).

The underlying `RequestError` is still chained as `__cause__` for
operators who want to inspect the original exception.

## Why not a deeper fix

The CLI's "Internal error" is an opaque payload from the upstream
binary — Pawrrtal can't read past it without changes to the gemini-cli
itself. Improving the surrounding diagnostic message (logs +
user-facing hint) is the smallest change that turns this from "no
reply" into "actionable error" without touching the protocol.

If the underlying cause turns out to be something other than
authentication (e.g. a bad model name the CLI rejects), the logged
RequestError code / data will let us narrow the hint in a follow-up.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_

## Summary by Sourcery

Improve diagnostics when Gemini CLI session creation fails by logging structured error details and surfacing an actionable user hint.

Bug Fixes:
- Provide a clearer, actionable error message to users when gemini-cli session/new fails with an opaque internal error.

Enhancements:
- Log structured RequestError details and working directory on gemini-cli session/new failures to aid operational triage.