### PR TITLE
fix(telegram): transcribe voice notes via xAI by default (#374)

### DIFF
--- a/backend/app/integrations/telegram/_attachments.py
+++ b/backend/app/integrations/telegram/_attachments.py
@@ -325,7 +325,13 @@ async def _transcribe_audio(audio_bytes: bytes) -> str | None:
         resolve_transcriber,
     )
 
-    transcriber = resolve_transcriber()
+    # ``include_xai=True`` flips the default behaviour for the xAI
+    # backend (the gateway's most common setting). The web composer
+    # has its own workspace-aware ``api/stt.py`` route; Telegram
+    # voice notes don't reach that route, so without this flag a
+    # default ``voice_provider=xai`` deployment silently dropped every
+    # voice note with the "ask the user to retype" annotation (#374).
+    transcriber = resolve_transcriber(include_xai=True)
     if transcriber is None:
         return None
     try:

--- a/backend/app/integrations/voice/__init__.py
+++ b/backend/app/integrations/voice/__init__.py
@@ -2,14 +2,14 @@
 
 Selected by ``settings.voice_provider`` — one of:
 
-* ``xai`` (default; existing ``api/stt.py`` proxy stays the route)
+* ``xai`` (default; HTTP STT endpoint shared with ``api/stt.py``)
 * ``mistral`` (Voxtral)
 * ``openai`` (Whisper)
 * ``local`` (whisper.cpp via ffmpeg subprocess)
 
-The non-xAI backends share the :class:`Transcriber` Protocol so the
-``api/stt.py`` route can dispatch on ``settings.voice_provider``
-without knowing which backend is wired up.
+All four backends share the :class:`Transcriber` Protocol so both
+``api/stt.py`` (web composer) and Telegram voice ingestion can
+dispatch uniformly without knowing which backend is wired up (#374).
 """
 
 from app.integrations.voice.transcriber import (
@@ -18,6 +18,7 @@ from app.integrations.voice.transcriber import (
     OpenAIWhisperTranscriber,
     Transcriber,
     TranscriptionError,
+    XaiSttTranscriber,
     resolve_transcriber,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "OpenAIWhisperTranscriber",
     "Transcriber",
     "TranscriptionError",
+    "XaiSttTranscriber",
     "resolve_transcriber",
 ]

--- a/backend/app/integrations/voice/transcriber.py
+++ b/backend/app/integrations/voice/transcriber.py
@@ -43,6 +43,68 @@ class Transcriber(Protocol):
         ...
 
 
+# xAI's documented STT endpoint. Mirrors the constant in
+# ``app.api.stt`` — kept independent here so the transcriber path
+# doesn't import from the FastAPI router module.
+_XAI_STT_URL = "https://api.x.ai/v1/stt"
+
+# Cap on the xAI STT request. Tuned for the typical 30-60s voice note;
+# longer recordings can still get through but won't hang the bot for
+# minutes if xAI is slow.
+_XAI_STT_TIMEOUT_SECONDS = 60.0
+
+
+class XaiSttTranscriber:
+    """Transcription via xAI's hosted STT endpoint.
+
+    The ``api/stt.py`` proxy that powers the web composer used to be
+    the only consumer of this endpoint; Telegram voice notes silently
+    fell through ``resolve_transcriber()`` (which returned ``None``
+    for ``voice_provider == "xai"``) and surfaced as "Transcription
+    is not available on this surface yet — ask the user to retype
+    the relevant bits." (#374). The transcriber below exposes the
+    same HTTP call as a :class:`Transcriber` so Telegram can use the
+    operator's existing ``XAI_API_KEY`` without additional config.
+    """
+
+    def __init__(self, api_key: str, *, url: str = _XAI_STT_URL) -> None:
+        self._api_key = api_key
+        self._url = url
+
+    async def transcribe(self, audio_bytes: bytes) -> str:
+        """Return the plain-text transcription of ``audio_bytes``."""
+        # ``httpx`` is a hard dependency of the gateway, so no lazy
+        # import gate is required — every deployment already has it.
+        import httpx  # noqa: PLC0415
+
+        try:
+            async with httpx.AsyncClient(timeout=_XAI_STT_TIMEOUT_SECONDS) as client:
+                response = await client.post(
+                    self._url,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    data={"format": "true"},
+                    files={"file": ("voice.ogg", audio_bytes, "audio/ogg")},
+                )
+        except httpx.TimeoutException as exc:
+            logger.warning("XAI_TRANSCRIBE_TIMEOUT after=%ss", _XAI_STT_TIMEOUT_SECONDS)
+            raise TranscriptionError("xAI transcription timed out.") from exc
+        except httpx.RequestError as exc:
+            logger.warning("XAI_TRANSCRIBE_REQUEST_FAIL error=%s", exc)
+            raise TranscriptionError("xAI transcription provider unreachable.") from exc
+
+        if response.status_code >= 400:
+            logger.warning(
+                "XAI_TRANSCRIBE_HTTP_ERROR status=%s body=%s",
+                response.status_code,
+                response.text[:200],
+            )
+            raise TranscriptionError(f"xAI transcription returned {response.status_code}.")
+        text = (response.json().get("text") or "").strip()
+        if not text:
+            raise TranscriptionError("xAI returned an empty transcription.")
+        return text
+
+
 class MistralVoxtralTranscriber:
     """Voxtral transcription via the Mistral SDK (lazy import)."""
 
@@ -229,12 +291,27 @@ class LocalWhisperCppTranscriber:
         return stdout.decode()
 
 
-def resolve_transcriber() -> Transcriber | None:
-    """Build the configured backend.  Returns ``None`` for ``xai`` (legacy path).
+def resolve_transcriber(*, include_xai: bool = False) -> Transcriber | None:
+    """Build the configured backend.
 
-    The xAI proxy lives in ``api/stt.py`` and is the historical path.
-    The other three backends are returned as :class:`Transcriber`
-    instances the route can call uniformly.
+    Args:
+        include_xai: When ``True`` (Telegram and other surfaces without
+            their own xAI route), the xAI path returns a
+            :class:`XaiSttTranscriber` so voice notes get transcribed
+            via the gateway's ``XAI_API_KEY`` (#374). When ``False``
+            (the default — kept for the ``api/stt.py`` web composer
+            route), the xAI path returns ``None`` so the route's own
+            workspace-aware ``XAI_API_KEY`` resolution continues to
+            run. Other backends ignore the flag.
+
+    The xAI proxy ``api/stt.py`` historically handled the web composer
+    directly without going through this function — Telegram, which
+    *does* call this function for voice notes, then got ``None`` back
+    on the default ``voice_provider == "xai"`` deployment and fell
+    through to the "transcription not available — please retype"
+    annotation. ``include_xai=True`` is the seam Telegram uses to
+    pick up the gateway-global key without touching the web composer
+    contract.
     """
     provider = settings.voice_provider
     if provider == "mistral":
@@ -250,4 +327,8 @@ def resolve_transcriber() -> Transcriber | None:
             binary_path=settings.voice_whisper_cpp_binary or None,
             model_path=settings.voice_whisper_cpp_model,
         )
+    if provider == "xai" and include_xai:
+        if not settings.xai_api_key:
+            return None
+        return XaiSttTranscriber(api_key=settings.xai_api_key)
     return None

--- a/backend/tests/test_voice_transcriber.py
+++ b/backend/tests/test_voice_transcriber.py
@@ -1,0 +1,69 @@
+"""Tests for the pluggable voice-transcription backends (#374).
+
+Specifically covers the seam ``resolve_transcriber(include_xai=...)``
+introduced for the Telegram voice-note path so a default
+``voice_provider=xai`` deployment actually transcribes rather than
+silently dropping voice notes with "ask the user to retype".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.integrations.voice import (
+    XaiSttTranscriber,
+    resolve_transcriber,
+)
+
+
+def test_resolve_transcriber_returns_none_for_xai_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backwards-compatible default: the api/stt.py web route keeps its own xAI path.
+
+    ``include_xai=False`` (the default) preserves the historical
+    contract — the web composer route owns the xAI call so it can
+    resolve a workspace-level ``XAI_API_KEY`` override.
+    """
+    monkeypatch.setattr(settings, "voice_provider", "xai")
+    monkeypatch.setattr(settings, "xai_api_key", "test-xai-key")
+    assert resolve_transcriber() is None
+
+
+def test_resolve_transcriber_returns_xai_when_include_xai_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Telegram opts in via ``include_xai=True`` so voice notes transcribe (#374)."""
+    monkeypatch.setattr(settings, "voice_provider", "xai")
+    monkeypatch.setattr(settings, "xai_api_key", "test-xai-key")
+    transcriber = resolve_transcriber(include_xai=True)
+    assert isinstance(transcriber, XaiSttTranscriber)
+
+
+def test_resolve_transcriber_returns_none_with_include_xai_when_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``include_xai=True`` still respects the missing-key gate.
+
+    Without a configured ``XAI_API_KEY`` the gateway can't transcribe,
+    so the caller must fall back to the metadata-only annotation
+    rather than build a transcriber that will 401 on every call.
+    """
+    monkeypatch.setattr(settings, "voice_provider", "xai")
+    monkeypatch.setattr(settings, "xai_api_key", "")
+    assert resolve_transcriber(include_xai=True) is None
+
+
+def test_resolve_transcriber_ignores_include_xai_for_other_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag is meaningless when another backend is configured.
+
+    ``mistral`` / ``openai`` / ``local`` have always returned through
+    ``resolve_transcriber``; ``include_xai`` only flips the xAI default.
+    """
+    monkeypatch.setattr(settings, "voice_provider", "mistral")
+    monkeypatch.setattr(settings, "voice_mistral_api_key", "")
+    assert resolve_transcriber() is None
+    assert resolve_transcriber(include_xai=True) is None


### PR DESCRIPTION
## Closes #374

The default `voice_provider == "xai"` deployment had no working
voice-transcription path on Telegram: `resolve_transcriber()`
returned `None` for `xai` (the web composer's `api/stt.py` route
handles xAI directly so it can honour workspace-level `XAI_API_KEY`
overrides), and Telegram silently fell through to the *"transcription
is not available on this surface yet — ask the user to retype"*
annotation — exactly the symptom in #374.

## What changes

- **New `XaiSttTranscriber`** that posts to the same
  `https://api.x.ai/v1/stt` endpoint as the web route, behind the
  existing `Transcriber` protocol.
- **`resolve_transcriber(*, include_xai=False)`** — opt-in flag for
  callers that should resolve the xAI path:
  - `api/stt.py` keeps the default (`include_xai=False`), so its
    workspace-aware key resolution + multipart pass-through remain
    unchanged.
  - `telegram/_attachments.py::_transcribe_audio` passes
    `include_xai=True`, picking up the gateway-global `XAI_API_KEY`.
- When `XAI_API_KEY` is empty the helper still returns `None` so
  Telegram surfaces the existing metadata-only annotation rather
  than attempting a guaranteed-401 call.

## Tests

`backend/tests/test_voice_transcriber.py` pins each branch:
- Default returns `None` for `xai` (web composer contract intact).
- `include_xai=True` returns an `XaiSttTranscriber` instance.
- `include_xai=True` still returns `None` when the key is empty.
- Other backends ignore the flag.

## Out of scope

The `api/stt.py` route still has its own inline xAI HTTP call —
this PR doesn't try to deduplicate it, because the route uses
workspace-level key resolution that the gateway-only transcriber
doesn't yet honour. Threading workspace context through the
transcriber is a follow-up.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_