### PR TITLE
feat(telegram): regenerate-keyboard foundation (#368, stacked PR 1/N)

### DIFF
--- a/backend/app/integrations/telegram/regenerate_keyboard.py
+++ b/backend/app/integrations/telegram/regenerate_keyboard.py
@@ -6,9 +6,9 @@ button hands the conversation back to the turn pipeline with the
 same user input that produced the (now stale) answer, so the user
 can ask the model to try again without retyping the prompt.
 
-The framework-free shape mirrors :mod:`thinking_picker` and
-:mod:`verbose_picker` — pure dataclasses + callback parsing here,
-aiogram glue in :mod:`regenerate_runtime`.
+The framework-free shape mirrors :mod:`thinking_picker` — pure
+dataclasses + callback parsing here, aiogram glue in
+:mod:`regenerate_runtime`.
 """
 
 from __future__ import annotations

--- a/backend/app/integrations/telegram/regenerate_keyboard.py
+++ b/backend/app/integrations/telegram/regenerate_keyboard.py
@@ -1,0 +1,90 @@
+"""Inline-keyboard helpers for the per-turn ``Regenerate`` button (#368).
+
+After every assistant reply the Telegram channel attaches a small
+inline keyboard with a single ``🔄 Regenerate`` button. Tapping the
+button hands the conversation back to the turn pipeline with the
+same user input that produced the (now stale) answer, so the user
+can ask the model to try again without retyping the prompt.
+
+The framework-free shape mirrors :mod:`thinking_picker` and
+:mod:`verbose_picker` — pure dataclasses + callback parsing here,
+aiogram glue in :mod:`regenerate_runtime`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+REGEN_CALLBACK_PREFIX = "rgn:"
+_REGEN_BUTTON_TEXT = "🔄 Regenerate"
+_CALLBACK_PARTS = 2  # rgn:<conversation_id>
+
+
+@dataclass(frozen=True)
+class RegenerateButton:
+    """One inline-keyboard button for the regenerate row."""
+
+    text: str
+    callback_data: str
+
+
+@dataclass(frozen=True)
+class RegenerateCallback:
+    """Parsed callback payload for the regenerate button.
+
+    ``conversation_id`` is the only payload the button carries — the
+    runtime resolves the latest user message in that conversation
+    from the database, so we don't need to encode the message text
+    or assistant message id in callback_data (Telegram caps callback
+    data at 64 bytes).
+    """
+
+    conversation_id: uuid.UUID
+
+
+def regenerate_button_for(conversation_id: uuid.UUID) -> RegenerateButton:
+    """Build the lone inline button rendered under each assistant reply.
+
+    Args:
+        conversation_id: The conversation the reply belongs to. The
+            callback uses this to find the most recent user message
+            and re-run the turn pipeline against it.
+
+    Returns:
+        A single :class:`RegenerateButton` ready to drop into a
+        Telegram ``InlineKeyboardMarkup`` row.
+    """
+    return RegenerateButton(
+        text=_REGEN_BUTTON_TEXT,
+        callback_data=f"{REGEN_CALLBACK_PREFIX}{conversation_id}",
+    )
+
+
+def parse_regenerate_callback_data(data: str | None) -> RegenerateCallback | None:
+    """Parse a ``rgn:<uuid>`` payload back into a :class:`RegenerateCallback`.
+
+    Returns ``None`` for any malformed payload (wrong prefix, missing
+    UUID, unparseable UUID) so callers can surface a stale-callback
+    notice without an exception.
+    """
+    if data is None or not data.startswith(REGEN_CALLBACK_PREFIX):
+        return None
+    parts = data.split(":", maxsplit=1)
+    if len(parts) != _CALLBACK_PARTS:
+        return None
+    raw_uuid = parts[1]
+    try:
+        conversation_id = uuid.UUID(raw_uuid)
+    except ValueError:
+        return None
+    return RegenerateCallback(conversation_id=conversation_id)
+
+
+__all__ = [
+    "REGEN_CALLBACK_PREFIX",
+    "RegenerateButton",
+    "RegenerateCallback",
+    "parse_regenerate_callback_data",
+    "regenerate_button_for",
+]

--- a/backend/tests/test_telegram_regenerate_keyboard.py
+++ b/backend/tests/test_telegram_regenerate_keyboard.py
@@ -1,0 +1,59 @@
+"""Tests for the regenerate-keyboard helpers (#368)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.integrations.telegram.regenerate_keyboard import (
+    REGEN_CALLBACK_PREFIX,
+    parse_regenerate_callback_data,
+    regenerate_button_for,
+)
+
+
+def test_regenerate_button_carries_conversation_uuid() -> None:
+    """The button payload encodes the conversation id behind the standard prefix."""
+    conversation_id = uuid.UUID("01234567-89ab-cdef-0123-456789abcdef")
+    button = regenerate_button_for(conversation_id)
+    assert button.text == "🔄 Regenerate"
+    assert button.callback_data == f"{REGEN_CALLBACK_PREFIX}{conversation_id}"
+
+
+def test_regenerate_callback_data_fits_telegram_64_byte_cap() -> None:
+    """A UUID-payload callback stays under Telegram's 64-byte callback_data cap.
+
+    ``rgn:`` (4) + UUID stringified (36) = 40 bytes — well under 64.
+    """
+    button = regenerate_button_for(uuid.uuid4())
+    assert len(button.callback_data.encode("utf-8")) <= 64
+
+
+def test_parse_regenerate_callback_round_trips_uuid() -> None:
+    """Parsing the emitted payload yields the original UUID back."""
+    conversation_id = uuid.uuid4()
+    button = regenerate_button_for(conversation_id)
+    parsed = parse_regenerate_callback_data(button.callback_data)
+    assert parsed is not None
+    assert parsed.conversation_id == conversation_id
+
+
+def test_parse_rejects_other_picker_callbacks() -> None:
+    """Callbacks from sibling pickers must resolve to ``None``.
+
+    Each picker owns a distinct prefix (``mdl:``, ``thk:``, ``vbs:``,
+    ``rgn:``) so the dispatcher can fan out by prefix. Anything that
+    doesn't start with the regen prefix must be rejected so it
+    doesn't get routed to the regen handler by mistake.
+    """
+    assert parse_regenerate_callback_data(None) is None
+    assert parse_regenerate_callback_data("mdl:p") is None
+    assert parse_regenerate_callback_data("vbs:c") is None
+    assert parse_regenerate_callback_data("thk:c:deadbeef") is None
+
+
+def test_parse_rejects_malformed_uuid() -> None:
+    """A non-UUID tail resolves to ``None`` so stale buttons get a clean stale-message reply."""
+    assert parse_regenerate_callback_data("rgn:not-a-uuid") is None
+    assert parse_regenerate_callback_data("rgn:") is None
+    # Wrong length / shape still rejected
+    assert parse_regenerate_callback_data("rgn:1234") is None


### PR DESCRIPTION
## Addresses #368 (foundation)

Adds the framework-free shape for the per-turn "🔄 Regenerate"
inline button — callback prefix, button dataclass, callback parser
— mirroring the established `thinking_picker` / `verbose_picker`
pattern. This is the **first PR in a stack**; runtime glue, button
attachment, and the actual re-dispatch logic land in stacked
follow-ups.

## What's in this PR

- `regenerate_keyboard.py` — pure helpers, no aiogram dependency
  (so it unit-tests cleanly without the optional `[telegram]` extra).
- Callback payload: `rgn:<conversation_id>` (40 bytes, well under
  Telegram's 64-byte `callback_data` cap). UUID is the only payload —
  the runtime resolves the most recent user message in that
  conversation from the DB on tap, so we don't need to encode the
  prompt text on the wire.

## Stacked follow-ups

- **PR N+1**: `regenerate_runtime.py` (aiogram glue) + dispatcher
  registration.
- **PR N+2**: Refactor `_run_llm_turn` to expose a helper that takes
  `(user_text, context)` directly so the callback can re-fire the
  turn without faking a `Message` object.
- **PR N+3**: Wire the button into `finalize_turn_delivery` so it
  shows up under each assistant reply.

Each follow-up is independent; the data shape pinned here is what
they'll consume.

## Tests

`test_telegram_regenerate_keyboard.py`:
- Button text + payload encoding.
- 64-byte Telegram cap.
- Callback parser round-trip.
- Rejection of sibling picker prefixes (`mdl:`, `vbs:`, `thk:`).
- Rejection of malformed / empty UUIDs.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_