### PR TITLE
feat(telegram): interactive /status picker — keyboard foundation (#361, stacked PR 1/N)

### DIFF
--- a/backend/app/integrations/telegram/status_picker.py
+++ b/backend/app/integrations/telegram/status_picker.py
@@ -1,0 +1,146 @@
+"""Inline-keyboard helpers for the interactive ``/status`` panel (#361).
+
+The existing ``/status`` slash command (in :mod:`status`) builds one
+monolithic Telegram reply with every diagnostic — gateway uptime,
+model, verbose level, thinking level, conversation token/cost,
+running state, etc. For users who only want one section (e.g. "is my
+LCM caught up?") that's noisy and burns the conversation transcript.
+
+This module owns the framework-free shape of the new interactive
+variant: a small set of named panels (system / conversation / tools /
+LCM / commands) each backed by a callback. The aiogram glue + the
+per-panel formatters land in :mod:`status_picker_runtime` so this
+module stays unit-testable without the optional ``[telegram]`` extra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+STATUS_CALLBACK_PREFIX = "sts:"
+_BUTTONS_PER_ROW = 2
+_CALLBACK_PARTS = 2  # sts:<panel>
+
+
+class StatusPanel(StrEnum):
+    """Diagnostic panels the interactive status keyboard exposes.
+
+    Each value is its own callback discriminator (``sts:<value>``) so
+    the dispatcher only needs prefix matching. The order here is the
+    display order in the keyboard.
+    """
+
+    SYSTEM = "sys"
+    """Gateway uptime, default model, dev-mode flag, etc."""
+    CONVERSATION = "cnv"
+    """Per-conversation summary: model, verbose, thinking, run-state."""
+    USAGE = "use"
+    """Tokens + cost ledger for the current conversation."""
+    TOOLS = "tls"
+    """Tool inventory for the active model."""
+    LCM = "lcm"
+    """Long-context memory pull / push status."""
+    COMMANDS = "cmd"
+    """The slash-command surface the user can invoke."""
+
+
+# Each panel's display label. Kept here so the picker module owns
+# the entire user-facing copy and stays import-cycle-free relative
+# to the runtime that actually renders the panel body.
+_PANEL_LABELS: dict[StatusPanel, str] = {
+    StatusPanel.SYSTEM: "🌐 System",
+    StatusPanel.CONVERSATION: "💬 Conversation",
+    StatusPanel.USAGE: "📊 Usage",
+    StatusPanel.TOOLS: "🔧 Tools",
+    StatusPanel.LCM: "🧠 LCM",
+    StatusPanel.COMMANDS: "📋 Commands",
+}
+
+
+@dataclass(frozen=True)
+class StatusButton:
+    """One inline-keyboard button on the status picker."""
+
+    text: str
+    callback_data: str
+
+
+@dataclass(frozen=True)
+class StatusCallback:
+    """Parsed callback payload for the status picker."""
+
+    panel: StatusPanel
+
+
+def build_status_keyboard() -> list[list[StatusButton]]:
+    """Build the two-column status picker keyboard.
+
+    Two columns mirrors the model picker's host screen — the buttons
+    are short enough that two per row fits on phones without
+    truncation. Order matches :class:`StatusPanel`'s declaration so
+    rearranging the enum rearranges the keyboard.
+    """
+    rows: list[list[StatusButton]] = []
+    current_row: list[StatusButton] = []
+    for panel in StatusPanel:
+        current_row.append(
+            StatusButton(text=_PANEL_LABELS[panel], callback_data=_panel_callback(panel))
+        )
+        if len(current_row) == _BUTTONS_PER_ROW:
+            rows.append(current_row)
+            current_row = []
+    if current_row:
+        rows.append(current_row)
+    return rows
+
+
+def status_picker_header() -> str:
+    """Render the header copy shown above the keyboard."""
+    return "📊 Status\n\nPick a panel to inspect."
+
+
+def parse_status_callback_data(data: str | None) -> StatusCallback | None:
+    """Parse a ``sts:<panel>`` payload back into a :class:`StatusCallback`.
+
+    Returns ``None`` for any malformed payload (wrong prefix, missing
+    panel discriminator, unknown panel value) so callers can surface a
+    stale-callback notice without raising.
+    """
+    if data is None or not data.startswith(STATUS_CALLBACK_PREFIX):
+        return None
+    parts = data.split(":", maxsplit=1)
+    if len(parts) != _CALLBACK_PARTS:
+        return None
+    raw_panel = parts[1]
+    try:
+        panel = StatusPanel(raw_panel)
+    except ValueError:
+        return None
+    return StatusCallback(panel=panel)
+
+
+def panel_label(panel: StatusPanel) -> str:
+    """Return the human-readable label for ``panel``.
+
+    Useful from the runtime so the ack text on the callback
+    (``callback.answer(...)``) reads as ``"System ✓"`` rather than
+    the discriminator slug.
+    """
+    return _PANEL_LABELS[panel]
+
+
+def _panel_callback(panel: StatusPanel) -> str:
+    return f"{STATUS_CALLBACK_PREFIX}{panel.value}"
+
+
+__all__ = [
+    "STATUS_CALLBACK_PREFIX",
+    "StatusButton",
+    "StatusCallback",
+    "StatusPanel",
+    "build_status_keyboard",
+    "panel_label",
+    "parse_status_callback_data",
+    "status_picker_header",
+]

--- a/backend/tests/test_telegram_status_picker.py
+++ b/backend/tests/test_telegram_status_picker.py
@@ -1,0 +1,82 @@
+"""Tests for the framework-free status-picker helpers (#361)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.integrations.telegram.status_picker import (
+    STATUS_CALLBACK_PREFIX,
+    StatusButton,
+    StatusPanel,
+    build_status_keyboard,
+    panel_label,
+    parse_status_callback_data,
+    status_picker_header,
+)
+
+
+def _flatten(rows: Sequence[Sequence[StatusButton]]) -> list[StatusButton]:
+    return [button for row in rows for button in row]
+
+
+def test_keyboard_exposes_one_button_per_panel() -> None:
+    """Every :class:`StatusPanel` member surfaces exactly once on the keyboard."""
+    buttons = _flatten(build_status_keyboard())
+    panels_in_keyboard = {parse_status_callback_data(b.callback_data) for b in buttons}
+    panels_in_keyboard.discard(None)
+    found = {result.panel for result in panels_in_keyboard if result is not None}
+    assert found == set(StatusPanel)
+
+
+def test_keyboard_labels_match_enum_order() -> None:
+    """Labels render in declaration order so the keyboard layout is stable."""
+    buttons = _flatten(build_status_keyboard())
+    callback_panels = [parse_status_callback_data(b.callback_data) for b in buttons]
+    panel_order = [parsed.panel for parsed in callback_panels if parsed is not None]
+    assert panel_order == list(StatusPanel)
+
+
+def test_keyboard_rows_have_at_most_two_buttons() -> None:
+    """Two-column layout — mirrors the model picker's host screen."""
+    for row in build_status_keyboard():
+        assert 1 <= len(row) <= 2
+
+
+def test_callback_data_fits_telegram_64_byte_cap() -> None:
+    """Every status callback stays well under Telegram's 64-byte limit."""
+    for button in _flatten(build_status_keyboard()):
+        assert len(button.callback_data.encode("utf-8")) <= 64
+
+
+def test_parse_callback_round_trips_panel() -> None:
+    """Parsing each emitted callback produces the original panel back."""
+    for button in _flatten(build_status_keyboard()):
+        parsed = parse_status_callback_data(button.callback_data)
+        assert parsed is not None
+        # Re-encoding the parsed panel yields the same callback_data.
+        assert button.callback_data == f"{STATUS_CALLBACK_PREFIX}{parsed.panel.value}"
+
+
+def test_parse_rejects_unknown_panel_value() -> None:
+    """Stale callbacks for retired / mistyped panels resolve to ``None``."""
+    assert parse_status_callback_data(None) is None
+    assert parse_status_callback_data("mdl:p") is None  # sibling picker
+    assert parse_status_callback_data("sts:not-a-panel") is None
+    assert parse_status_callback_data("sts:") is None
+
+
+def test_panel_label_returns_human_readable_text() -> None:
+    """Each panel has a non-empty, prefixed human label for ack text + buttons."""
+    for panel in StatusPanel:
+        label = panel_label(panel)
+        assert label, f"{panel} has empty label"
+        # Every label leads with a glyph + space + word, so the bare
+        # discriminator slug never leaks into the UI.
+        assert " " in label
+
+
+def test_header_renders_friendly_copy() -> None:
+    """Header is short, glyph-led, and not the discriminator slug."""
+    text = status_picker_header()
+    assert text.startswith("📊")
+    assert "Pick a panel" in text


### PR DESCRIPTION
## Addresses #361 (foundation, stacked PR 1/N)

The framework-free shape for the new interactive `/status` panel:
buttons, callback parsing, header copy. Mirrors the established
`thinking_picker` / `verbose_picker` layout so the runtime + per-panel
formatters can land in stacked follow-ups without churning the data
shape pinned here.

## Panels

Six panels surfaced as inline buttons:

- **🌐 System** (`sys`) — gateway uptime, default model, dev-mode flag
- **💬 Conversation** (`cnv`) — model, verbose, thinking, run-state
- **📊 Usage** (`use`) — tokens + cost ledger for the current conversation
- **🔧 Tools** (`tls`) — tool inventory for the active model
- **🧠 LCM** (`lcm`) — long-context memory pull / push status
- **📋 Commands** (`cmd`) — slash-command surface

Each panel owns a 3-char discriminator so `sts:<panel>` callback
payloads stay well under Telegram's 64-byte cap.

## Stacked follow-ups

- **PR N+1**: `status_picker_runtime.py` (aiogram glue + per-panel
  formatters). The `cnv` panel reuses the existing monolithic
  `handle_status_command` output; the other panels each post a
  scoped follow-up message with just their section.
- **PR N+2**: Wire the picker into `bot.py` so `/status` (no arg)
  opens the picker, and `/status all` keeps the monolithic dump as
  the power-user shortcut.

## Tests

`test_telegram_status_picker.py`:
- Every `StatusPanel` member surfaces once on the keyboard.
- Layout matches enum declaration order (stable across releases).
- Rows hold 1–2 buttons each (mirrors the model picker host screen).
- Callback data stays under the 64-byte cap.
- Round-trip: `parse_status_callback_data(button.callback_data).panel`
  matches the original.
- Sibling-picker prefixes (`mdl:`, `vbs:`, …) + malformed payloads
  reject cleanly.
- Panel labels are non-empty + glyph-prefixed.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_