### PR TITLE
feat(telegram): wire ChatMessageQueueDispatcher into bot.py (#357 impl 2/N, stacked on #388)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -325,6 +325,13 @@ class Settings(BaseSettings):
     # for animated streaming. Falls back to ``editMessageText`` when
     # aiogram doesn't expose the binding.
     telegram_use_draft_streaming: bool = False
+    # When True, the Telegram bot uses a per-chat FIFO turn queue
+    # (``ChatMessageQueueDispatcher``) instead of the legacy
+    # "cancel previous task" behaviour. Mid-turn user messages
+    # queue up and run serially rather than clobbering the
+    # in-flight reply (#357). Default off until the dispatcher has
+    # baked in a deployment.
+    telegram_chat_queue_enabled: bool = False
 
     # ── Voice transcription (PR 14) ──────────────────────────────────────
     # Selects which STT backend the voice handler routes to. The

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -51,6 +51,10 @@ from app.integrations.telegram.bot_provider_resolution import (
 # imports it from :mod:`sender`) so bot.py imports both
 # ``handle_plain_message`` and ``TelegramSender`` from the same module
 # — keeps bot.py under sentrux's ``no_god_files`` fan-out budget.
+from app.integrations.telegram.message_queue import (
+    ChatMessageQueueDispatcher,
+    QueuedTurn,
+)
 from app.integrations.telegram.handlers import (
     TelegramSender,
     TelegramTurnContext,
@@ -124,7 +128,14 @@ def get_bot_uptime_seconds() -> float:
 
 
 def is_chat_run_active(chat_id: int) -> bool:
-    """Return whether an agent run is in flight for ``chat_id`` on this worker."""
+    """Return whether an agent run is in flight for ``chat_id`` on this worker.
+
+    When the FIFO dispatcher is enabled (``settings.telegram_chat_queue_enabled``),
+    delegates to :meth:`ChatMessageQueueDispatcher.is_running`; otherwise
+    reads the legacy ``_running_tasks`` dict.
+    """
+    if settings.telegram_chat_queue_enabled:
+        return _get_chat_queue_dispatcher().is_running(chat_id)
     task = _running_tasks.get(chat_id)
     return task is not None and not task.done()
 
@@ -138,7 +149,96 @@ def is_chat_run_active(chat_id: int) -> bool:
 # cannot cancel a task running on worker B.  This is correct for the current
 # single-worker deployment; promote to a shared store (e.g. Redis pub/sub)
 # before running multiple uvicorn workers.
+#
+# When ``settings.telegram_chat_queue_enabled`` is True the dispatcher
+# from :mod:`message_queue` owns this state instead (#357).
 _running_tasks: dict[int, asyncio.Task[None]] = {}
+
+
+# Singleton :class:`ChatMessageQueueDispatcher` for the per-chat FIFO
+# turn queue (#357). Built lazily on first access so processes that
+# never enable the dispatcher (the default) pay zero overhead.
+_CHAT_QUEUE_DISPATCHER: ChatMessageQueueDispatcher | None = None
+
+
+def _get_chat_queue_dispatcher() -> ChatMessageQueueDispatcher:
+    """Return the process-wide chat-queue dispatcher, building on first use."""
+    global _CHAT_QUEUE_DISPATCHER  # noqa: PLW0603 — singleton accessor pattern
+    if _CHAT_QUEUE_DISPATCHER is None:
+        _CHAT_QUEUE_DISPATCHER = ChatMessageQueueDispatcher(consumer=_chat_queue_consumer)
+    return _CHAT_QUEUE_DISPATCHER
+
+
+async def _chat_queue_consumer(turn: QueuedTurn) -> None:
+    """Default consumer — runs the turn payload that ``_run_llm_turn`` enqueued.
+
+    The payload is the bound coroutine factory ``_run_llm_turn`` would
+    have invoked synchronously; the consumer awaits it under the
+    dispatcher's per-chat serialised worker so messages arriving
+    mid-turn queue up instead of clobbering the in-flight reply.
+    """
+    coro_factory = turn.payload
+    if not callable(coro_factory):
+        logger.warning(
+            "TELEGRAM_CHAT_QUEUE_BAD_PAYLOAD chat_id=%s type=%s",
+            turn.chat_id,
+            type(coro_factory).__name__,
+        )
+        return
+    await coro_factory()
+
+
+async def _execute_turn_body(
+    *,
+    message: Message,
+    turn_input: ChatTurnInput,
+    user_text: str,
+    context: TelegramTurnContext,
+) -> None:
+    """Run the typing + stream + auto-title block under the FIFO dispatcher.
+
+    Extracted from :func:`_run_llm_turn` so the dispatcher's consumer
+    has a clean callable to await. The legacy non-FIFO path still
+    inlines this logic (with the extra ``_running_tasks`` bookkeeping
+    the dispatcher does on its own).
+    """
+    chat_id = message.chat.id
+    typing_task = asyncio.create_task(
+        _maintain_typing_indicator(message.bot, chat_id, context.thread_id),
+        name=f"telegram-typing-{chat_id}",
+    )
+    try:
+        async for _ in run_turn(turn_input):
+            pass
+    except asyncio.CancelledError:
+        logger.info("TELEGRAM_STREAM_CANCELLED chat_id=%s", chat_id)
+        raise
+    finally:
+        typing_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await typing_task
+
+    try:
+        await _maybe_set_auto_title(
+            bot=message.bot,
+            conversation_id=context.conversation_id,
+            user_text=user_text,
+            chat_id=chat_id,
+            thread_id=context.thread_id,
+        )
+    except Exception:
+        logger.warning("TELEGRAM_AUTO_TITLE_FAILED", exc_info=True)
+
+
+async def shutdown_chat_queue_dispatcher() -> None:
+    """Cancel every per-chat worker on bot shutdown.
+
+    Called from the bot's lifespan teardown so a clean ``SIGTERM``
+    doesn't leak dispatcher task references. No-op when the
+    dispatcher was never constructed.
+    """
+    if _CHAT_QUEUE_DISPATCHER is not None:
+        await _CHAT_QUEUE_DISPATCHER.shutdown()
 
 
 async def _send_one_typing_action(
@@ -332,8 +432,36 @@ async def _run_llm_turn(
         async for _ in run_turn(turn_input):
             pass
 
-    # Cancel any previous stream for this chat before starting the new one.
     chat_id = message.chat.id
+
+    if settings.telegram_chat_queue_enabled:
+        # FIFO mode (#357): enqueue the rest of the turn body and
+        # return. The dispatcher's per-chat worker drains the queue
+        # serially so a second message arriving here gets appended
+        # to the same worker's queue instead of clobbering the
+        # in-flight turn. The typing indicator + run_turn + auto-
+        # title block below is bound into a coroutine factory and
+        # handed to the dispatcher as the payload.
+        async def _enqueued_body() -> None:
+            await _execute_turn_body(
+                message=message,
+                turn_input=turn_input,
+                user_text=user_text,
+                context=context,
+            )
+
+        await _get_chat_queue_dispatcher().enqueue(
+            QueuedTurn(
+                chat_id=chat_id,
+                payload=_enqueued_body,
+                enqueued_at_monotonic=asyncio.get_event_loop().time(),
+            )
+        )
+        return
+
+    # Legacy "cancel previous task" path. Kept until the FIFO mode
+    # has baked in a production deployment, then this branch can be
+    # deleted and the helper inlined.
     old_task = _running_tasks.pop(chat_id, None)
     if old_task is not None and not old_task.done():
         old_task.cancel()
@@ -441,10 +569,13 @@ def _register_telegram_command_handlers(dispatcher: Dispatcher) -> None:
     @dispatcher.message(Command("stop"))
     async def _on_stop(message: Message) -> None:
         chat_id = message.chat.id
-        task = _running_tasks.pop(chat_id, None)
-        was_running = task is not None and not task.done()
-        if was_running:
-            task.cancel()  # type: ignore[union-attr]
+        if settings.telegram_chat_queue_enabled:
+            was_running = await _get_chat_queue_dispatcher().stop_chat(chat_id)
+        else:
+            task = _running_tasks.pop(chat_id, None)
+            was_running = task is not None and not task.done()
+            if was_running:
+                task.cancel()  # type: ignore[union-attr]
         # handle_stop_command is a plain sync function — no await.
         reply = handle_stop_command(was_running=was_running)
         await message.answer(reply)

--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -46,15 +46,6 @@ from app.db import async_session_maker
 from app.integrations.telegram.bot_provider_resolution import (
     resolve_provider_with_auto_clear,
 )
-
-# ``TelegramSender`` is re-exported via :mod:`handlers` (which already
-# imports it from :mod:`sender`) so bot.py imports both
-# ``handle_plain_message`` and ``TelegramSender`` from the same module
-# — keeps bot.py under sentrux's ``no_god_files`` fan-out budget.
-from app.integrations.telegram.message_queue import (
-    ChatMessageQueueDispatcher,
-    QueuedTurn,
-)
 from app.integrations.telegram.handlers import (
     TelegramSender,
     TelegramTurnContext,
@@ -65,6 +56,15 @@ from app.integrations.telegram.handlers import (
     handle_start_command,
     handle_stop_command,
     handle_verbose_command,
+)
+
+# ``TelegramSender`` is re-exported via :mod:`handlers` (which already
+# imports it from :mod:`sender`) so bot.py imports both
+# ``handle_plain_message`` and ``TelegramSender`` from the same module
+# — keeps bot.py under sentrux's ``no_god_files`` fan-out budget.
+from app.integrations.telegram.message_queue import (
+    ChatMessageQueueDispatcher,
+    QueuedTurn,
 )
 
 # ``MODEL_CALLBACK_PREFIX`` is re-exported via
@@ -905,6 +905,7 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
     try:
         yield service
     finally:
+        await shutdown_chat_queue_dispatcher()
         if service.polling_task is not None:
             service.polling_task.cancel()
             # The task either finishes cleanly (CancelledError) or surfaces

--- a/backend/app/integrations/telegram/message_queue.py
+++ b/backend/app/integrations/telegram/message_queue.py
@@ -1,0 +1,187 @@
+"""Per-chat FIFO queue dispatcher for Telegram turn processing (#357).
+
+The Telegram bot currently cancels the in-flight stream when a new
+user message arrives in the same chat — last-one-wins. That's fine
+for the "user notices the model is going wrong and corrects mid-turn"
+case but trashes the common case where the user fires off a
+second message a second after the first ("oh, also: …"). The second
+message clobbers the first and the first's reply is lost.
+
+This module owns the FIFO replacement: every Telegram message hands
+the bot a :class:`QueuedTurn` payload, which is appended to a
+per-chat :class:`asyncio.Queue`. A single worker task per chat
+drains the queue serially so each turn runs to completion before the
+next one starts.
+
+The dispatcher is framework-free — the aiogram glue that builds the
+``QueuedTurn`` payload and calls :func:`enqueue` lives in
+:mod:`bot.py` once this lands behind a feature flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# How many seconds the worker waits for the next item before tearing
+# itself down. Without this, an idle chat keeps a worker task alive
+# forever (small but bounded leak). Workers re-spawn on demand when
+# the next message arrives, so the user-visible behaviour is
+# unchanged.
+_WORKER_IDLE_TIMEOUT_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class QueuedTurn:
+    """One pending turn for a single Telegram chat.
+
+    ``payload`` is opaque to the dispatcher — the consumer (bot.py)
+    decides what to put in it. Today it's the inbound aiogram
+    ``Message`` object; future producers can wrap any shape the
+    consumer recognises (e.g. a regenerate request from issue #368).
+    """
+
+    chat_id: int
+    payload: Any
+    enqueued_at_monotonic: float
+
+
+# A consumer is the async function the dispatcher invokes for each
+# queued turn. It must run the turn to completion (or raise to surface
+# the failure) before the next turn starts.
+TurnConsumer = Callable[[QueuedTurn], Coroutine[Any, Any, None]]
+
+
+@dataclass
+class ChatMessageQueueDispatcher:
+    """One worker task per chat, draining a FIFO queue of pending turns.
+
+    Lifecycle:
+
+    * :meth:`enqueue` appends to the per-chat queue and ensures a
+      worker is running. Idempotent — calling it from any task is safe.
+    * :meth:`stop_chat` cancels the in-flight turn AND drops queued
+      items. Used by ``/stop``.
+    * :meth:`shutdown` cancels every chat's worker — called from the
+      bot's lifespan on shutdown.
+
+    The dispatcher uses one consumer callable supplied at construction
+    time so the worker doesn't have to fan out by message shape — the
+    consumer is whatever ``bot.py`` wires up.
+    """
+
+    consumer: TurnConsumer
+    """The callable invoked once per queued turn."""
+
+    _queues: dict[int, asyncio.Queue[QueuedTurn]] = field(default_factory=dict)
+    _workers: dict[int, asyncio.Task[None]] = field(default_factory=dict)
+    _active_turns: dict[int, asyncio.Task[None]] = field(default_factory=dict)
+
+    async def enqueue(self, turn: QueuedTurn) -> None:
+        """Append ``turn`` to the chat's queue, spawning a worker on first use.
+
+        Returns immediately; the turn runs in the background. The
+        worker drains its queue serially so callers can rely on
+        order-of-arrival being order-of-execution.
+        """
+        queue = self._queues.setdefault(turn.chat_id, asyncio.Queue())
+        await queue.put(turn)
+        if self._workers.get(turn.chat_id) is None or self._workers[turn.chat_id].done():
+            self._workers[turn.chat_id] = asyncio.create_task(
+                self._drain(turn.chat_id, queue),
+                name=f"telegram-chat-worker-{turn.chat_id}",
+            )
+
+    def is_running(self, chat_id: int) -> bool:
+        """Return whether a turn is currently in flight for ``chat_id``.
+
+        Used by ``/status`` to decide between "running" / "idle".
+        Mirrors the existing ``is_chat_run_active`` API on the legacy
+        ``_running_tasks`` dict.
+        """
+        task = self._active_turns.get(chat_id)
+        return task is not None and not task.done()
+
+    def pending_count(self, chat_id: int) -> int:
+        """Return the number of turns sitting behind the in-flight one.
+
+        Useful for the ``/status`` panel — if the user is wondering
+        why their reply hasn't arrived, surfacing the backlog size
+        gives them an honest answer.
+        """
+        queue = self._queues.get(chat_id)
+        return queue.qsize() if queue is not None else 0
+
+    async def stop_chat(self, chat_id: int) -> bool:
+        """Cancel the in-flight turn and drop every queued turn for ``chat_id``.
+
+        Returns ``True`` when something was actually cancelled,
+        ``False`` when the chat had nothing running and nothing
+        queued.  Mirrors the bool the legacy ``/stop`` path returns.
+        """
+        cancelled_anything = False
+
+        active = self._active_turns.get(chat_id)
+        if active is not None and not active.done():
+            active.cancel()
+            cancelled_anything = True
+
+        queue = self._queues.get(chat_id)
+        if queue is not None:
+            while not queue.empty():
+                queue.get_nowait()
+                queue.task_done()
+                cancelled_anything = True
+
+        return cancelled_anything
+
+    async def shutdown(self) -> None:
+        """Cancel every worker — called from the bot's lifespan teardown."""
+        for chat_id, worker in list(self._workers.items()):
+            worker.cancel()
+            try:
+                await worker
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("CHAT_WORKER_SHUTDOWN_ERR chat_id=%s", chat_id)
+        self._workers.clear()
+        self._active_turns.clear()
+        self._queues.clear()
+
+    async def _drain(self, chat_id: int, queue: asyncio.Queue[QueuedTurn]) -> None:
+        """Pop + run turns until the queue idles for the timeout window."""
+        while True:
+            try:
+                turn = await asyncio.wait_for(
+                    queue.get(),
+                    timeout=_WORKER_IDLE_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                logger.debug("CHAT_WORKER_IDLE_EXIT chat_id=%s", chat_id)
+                return
+
+            active = asyncio.create_task(self.consumer(turn), name=f"telegram-turn-{chat_id}")
+            self._active_turns[chat_id] = active
+            try:
+                await active
+            except asyncio.CancelledError:
+                logger.info("CHAT_TURN_CANCELLED chat_id=%s", chat_id)
+            except Exception:
+                logger.exception("CHAT_TURN_ERR chat_id=%s", chat_id)
+            finally:
+                self._active_turns.pop(chat_id, None)
+                queue.task_done()
+
+
+__all__ = [
+    "ChatMessageQueueDispatcher",
+    "QueuedTurn",
+    "TurnConsumer",
+]

--- a/backend/tests/test_telegram_message_queue.py
+++ b/backend/tests/test_telegram_message_queue.py
@@ -1,0 +1,198 @@
+"""Tests for the per-chat FIFO turn dispatcher (#357)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from app.integrations.telegram.message_queue import (
+    ChatMessageQueueDispatcher,
+    QueuedTurn,
+)
+
+
+def _turn(*, chat_id: int, payload: object) -> QueuedTurn:
+    return QueuedTurn(
+        chat_id=chat_id,
+        payload=payload,
+        enqueued_at_monotonic=time.monotonic(),
+    )
+
+
+@pytest.mark.anyio
+async def test_dispatcher_runs_turns_in_arrival_order() -> None:
+    """Two messages on the same chat run FIFO, not concurrently (#357)."""
+    completed: list[object] = []
+    in_flight = 0
+    max_in_flight = 0
+
+    async def consumer(turn: QueuedTurn) -> None:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            # Short sleep simulates a turn doing real work; without
+            # this the test couldn't observe concurrency violations.
+            await asyncio.sleep(0.02)
+            completed.append(turn.payload)
+        finally:
+            in_flight -= 1
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    await dispatcher.enqueue(_turn(chat_id=1, payload="first"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="second"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="third"))
+
+    # Wait long enough for the worker to drain all three.
+    for _ in range(50):
+        if len(completed) == 3:
+            break
+        await asyncio.sleep(0.01)
+
+    assert completed == ["first", "second", "third"], (
+        "FIFO order violated — second message ran before first finished"
+    )
+    assert max_in_flight == 1, (
+        f"Concurrency budget broken — saw {max_in_flight} turns running at once"
+    )
+
+    await dispatcher.shutdown()
+
+
+@pytest.mark.anyio
+async def test_separate_chats_run_independently() -> None:
+    """Two different chats each get their own worker; one's queue doesn't block the other."""
+    started: list[tuple[int, str]] = []
+
+    async def consumer(turn: QueuedTurn) -> None:
+        started.append((turn.chat_id, turn.payload))
+        # Slow turn on chat 1 must not delay chat 2.
+        if turn.chat_id == 1:
+            await asyncio.sleep(0.05)
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    await dispatcher.enqueue(_turn(chat_id=1, payload="slow"))
+    await dispatcher.enqueue(_turn(chat_id=2, payload="fast"))
+
+    # Wait until chat 2 has at least started; chat 1's slow turn
+    # should not have blocked chat 2.
+    for _ in range(50):
+        if any(chat_id == 2 for chat_id, _ in started):
+            break
+        await asyncio.sleep(0.01)
+
+    chat_ids_started = [chat_id for chat_id, _ in started]
+    assert 1 in chat_ids_started
+    assert 2 in chat_ids_started
+
+    await dispatcher.shutdown()
+
+
+@pytest.mark.anyio
+async def test_is_running_and_pending_count_track_state() -> None:
+    """``is_running`` flips while a turn is in flight; ``pending_count`` reflects backlog."""
+    gate = asyncio.Event()
+    seen_running: list[bool] = []
+
+    async def consumer(turn: QueuedTurn) -> None:
+        seen_running.append(True)
+        await gate.wait()
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    assert dispatcher.is_running(chat_id=1) is False
+    assert dispatcher.pending_count(chat_id=1) == 0
+
+    await dispatcher.enqueue(_turn(chat_id=1, payload="first"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="second"))
+
+    # Yield long enough for the worker to pop the first item and call
+    # the consumer; the second stays behind in the queue.
+    for _ in range(50):
+        if dispatcher.is_running(chat_id=1):
+            break
+        await asyncio.sleep(0.01)
+    assert dispatcher.is_running(chat_id=1) is True
+    assert dispatcher.pending_count(chat_id=1) == 1
+
+    gate.set()
+    for _ in range(50):
+        if not dispatcher.is_running(chat_id=1) and dispatcher.pending_count(chat_id=1) == 0:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatcher.is_running(chat_id=1) is False
+    assert dispatcher.pending_count(chat_id=1) == 0
+    assert seen_running == [True, True]
+
+    await dispatcher.shutdown()
+
+
+@pytest.mark.anyio
+async def test_stop_chat_cancels_in_flight_and_drops_queue() -> None:
+    """``/stop`` semantics: cancel the running turn and clear pending ones."""
+    started: list[object] = []
+    cancelled = asyncio.Event()
+
+    async def consumer(turn: QueuedTurn) -> None:
+        started.append(turn.payload)
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    await dispatcher.enqueue(_turn(chat_id=1, payload="running"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="queued-1"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="queued-2"))
+
+    # Wait until the first turn started.
+    for _ in range(50):
+        if started:
+            break
+        await asyncio.sleep(0.01)
+
+    cancelled_anything = await dispatcher.stop_chat(chat_id=1)
+    assert cancelled_anything is True
+
+    # Wait for the cancel to propagate.
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+    assert started == ["running"], "Stop didn't drop queued turns"
+
+    await dispatcher.shutdown()
+
+
+@pytest.mark.anyio
+async def test_stop_chat_returns_false_when_idle() -> None:
+    """Nothing running, nothing queued → ``stop_chat`` reports ``False``."""
+
+    async def consumer(turn: QueuedTurn) -> None:
+        return None
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    assert await dispatcher.stop_chat(chat_id=99) is False
+    await dispatcher.shutdown()
+
+
+@pytest.mark.anyio
+async def test_consumer_exception_does_not_kill_the_worker() -> None:
+    """A failed turn must not stop the worker from running the next one."""
+    seen: list[object] = []
+
+    async def consumer(turn: QueuedTurn) -> None:
+        seen.append(turn.payload)
+        if turn.payload == "boom":
+            raise RuntimeError("consumer exploded")
+
+    dispatcher = ChatMessageQueueDispatcher(consumer=consumer)
+    await dispatcher.enqueue(_turn(chat_id=1, payload="boom"))
+    await dispatcher.enqueue(_turn(chat_id=1, payload="after"))
+
+    for _ in range(50):
+        if "after" in seen:
+            break
+        await asyncio.sleep(0.01)
+
+    assert seen == ["boom", "after"]
+    await dispatcher.shutdown()


### PR DESCRIPTION
## Closes #357 (implementation slice 2/N — wire-up)

**Stacked on PR #388** (the dispatcher module). Integrates the
per-chat FIFO turn queue into the Telegram bot **behind a feature
flag** so the new behaviour rolls out per-deployment without
regressing the legacy cancel-on-arrival path.

## Wire points

- `settings.telegram_chat_queue_enabled` (default **False**) opts in.
- `_get_chat_queue_dispatcher()` returns a process-wide singleton
  built lazily — the off-by-default path pays zero overhead.
- `_chat_queue_consumer` unpacks the queued payload (a bound
  coroutine factory) and awaits it; the per-chat worker draining
  the queue runs each turn to completion before the next starts.
- `_execute_turn_body` extracts the typing + `run_turn` +
  auto-title block from `_run_llm_turn` so the dispatcher has a
  clean callable to await. The legacy non-FIFO branch still
  inlines this logic (with the extra `_running_tasks` bookkeeping
  the dispatcher does on its own).
- `is_chat_run_active` and the `/stop` handler consult the
  dispatcher when the flag is on; legacy path preserved when off.
- `shutdown_chat_queue_dispatcher()` exposed so the bot's lifespan
  teardown can cancel every per-chat worker on SIGTERM.

## Rollout plan

1. **This PR**: flag-gated wire-up lands; default off.
2. Operator flips the flag on a staging deployment, exercises mid-
   turn messages, verifies FIFO behaviour.
3. Flag flipped on for production.
4. Follow-up PR deletes the legacy branch + `_running_tasks` and
   inlines `_execute_turn_body` since it has only one caller left.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_