### PR TITLE
feat(memory): memory_query tool + chat-router wiring (#340 impl 2/N, stacked on #395)

### DIFF
--- a/backend/alembic/versions/021_add_memories_table.py
+++ b/backend/alembic/versions/021_add_memories_table.py
@@ -1,0 +1,111 @@
+"""Add the ``memories`` table for proactive memory writes (#340).
+
+Per the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-proactive-memory-updates.mdx``,
+the chat router runs a post-turn classifier that captures user
+preferences, project decisions, and explicit feedback as typed
+memory rows.  Those rows live on this table.
+
+The dreaming pass (#341) writes into the same table — the
+``source`` column distinguishes per-turn classifier writes from
+the dreaming consolidation pass, and ``provenance_job_id`` lets a
+reviewer trace any dreaming-written row back to the job that
+produced it.
+
+Embeddings are stored as opaque bytes (the existing
+``backend/app/core/lcm/embeddings.py`` pipeline does its own
+serialisation per provider). A future migration can promote the
+column to ``pgvector`` once the operator deployment confirms the
+extension is installed.
+
+Revision ID: 021_add_memories_table
+Revises: 020_add_conversation_reasoning_effort
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "021_add_memories_table"
+down_revision = "020_add_conversation_reasoning_effort"
+branch_labels = None
+depends_on = None
+
+# Allowed values for the ``kind`` discriminator. Mirrors the literal
+# union the application layer uses; pinned via CHECK so an out-of-tree
+# script or admin SQL session can't write a garbage value.
+_KIND_VALUES = ("feedback", "project", "user")
+
+# Allowed values for the ``source`` provenance flag. ``classifier``
+# is the per-turn writer from this ADR; ``dreaming`` is the
+# between-sessions consolidation pass (#341); ``user`` is for the
+# rare case the user adds a memory manually via the (future) CLI.
+_SOURCE_VALUES = ("classifier", "dreaming", "user")
+
+
+def upgrade() -> None:
+    """Create the memories table and supporting indexes."""
+    op.create_table(
+        "memories",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("conversation_id", sa.Uuid(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False, server_default="classifier"),
+        sa.Column("provenance_job_id", sa.Uuid(), nullable=True),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("embedding", sa.LargeBinary(), nullable=True),
+        sa.Column("source_message_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("last_referenced_at", sa.DateTime(timezone=True), nullable=True),
+        # fastapi-users names the user table ``user`` (singular) — not
+        # ``users`` — so every cross-table FK uses that. Workspace
+        # uses ``workspaces``; see ``__tablename__`` in models.py.
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_message_id"],
+            ["chat_messages.id"],
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            f"kind IN ({', '.join(repr(v) for v in _KIND_VALUES)})",
+            name="ck_memories_kind_valid",
+        ),
+        sa.CheckConstraint(
+            f"source IN ({', '.join(repr(v) for v in _SOURCE_VALUES)})",
+            name="ck_memories_source_valid",
+        ),
+    )
+    # Reading top-K memories by (user, kind) is the hot path for the
+    # system-prompt assembler — one composite index gets us both
+    # filters at once.
+    op.create_index(
+        "ix_memories_user_kind",
+        "memories",
+        ["user_id", "kind"],
+    )
+    op.create_index(
+        "ix_memories_conversation_id",
+        "memories",
+        ["conversation_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the memories table and its indexes."""
+    op.drop_index("ix_memories_conversation_id", table_name="memories")
+    op.drop_index("ix_memories_user_kind", table_name="memories")
+    op.drop_table("memories")

--- a/backend/app/core/agent_tools.py
+++ b/backend/app/core/agent_tools.py
@@ -46,6 +46,7 @@ from app.core.tools.lcm_agents import (
     make_lcm_search_tool,
 )
 from app.core.tools.markitdown_convert import make_markitdown_tool
+from app.core.tools.memory_query import make_memory_query_tool
 from app.core.tools.now import (
     build_external_mcp_tools,
     make_add_task_tool,
@@ -266,6 +267,16 @@ def build_agent_tools(
                     model_id=expand_model_id,
                 )
             )
+
+    # Proactive memory (#340) — give the agent on-demand access to
+    # the long tail of user preferences / project decisions /
+    # feedback the post-turn classifier wrote. Gated on a configured
+    # user_id (the closure embeds the authorisation gate) and the
+    # ``memories_enabled`` master switch from the ADR plan; the
+    # default-off rollout means existing deployments don't see the
+    # new tool until they opt in.
+    if settings.memories_enabled and user_id is not None:
+        tools.append(make_memory_query_tool(user_id=user_id))
 
     # Plugin-contributed tools.  Additive only — core tools above are
     # unaffected.  Extracted into a helper so the main composition body

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -319,6 +319,12 @@ class Settings(BaseSettings):
     # for animated streaming. Falls back to ``editMessageText`` when
     # aiogram doesn't expose the binding.
     telegram_use_draft_streaming: bool = False
+    # Master switch for proactive memory writes (#340) + the
+    # ``memory_query`` tool. Default off so deployments roll out
+    # the new chat-surface acknowledgment line ("📝 Saved feedback")
+    # per-user rather than big-bang. See
+    # ``frontend/content/docs/handbook/decisions/2026-05-20-proactive-memory-updates.mdx``.
+    memories_enabled: bool = False
 
     # ── Voice transcription (PR 14) ──────────────────────────────────────
     # Selects which STT backend the voice handler routes to. The

--- a/backend/app/core/tools/memory_query.py
+++ b/backend/app/core/tools/memory_query.py
@@ -1,0 +1,138 @@
+"""``memory_query`` AgentTool — read top-K proactive memories (#340).
+
+Lets the agent pull the long tail of user preferences / project
+decisions / feedback that the post-turn classifier wrote to the
+``memories`` table. The system-prompt assembler already surfaces
+the freshest top-N as context; this tool covers the cases where
+the agent wants something older, narrower, or kind-filtered.
+
+The tool is read-only — writes happen in the classifier hook.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from app.core.agent_loop.types import AgentTool
+from app.crud.memory import (
+    MemoryKind,
+    list_memories_for_user,
+    mark_memory_referenced,
+)
+from app.db import async_session_maker
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT = 5
+_MAX_LIMIT = 20
+_ALLOWED_KINDS: tuple[MemoryKind, ...] = ("feedback", "project", "user")
+
+
+def make_memory_query_tool(*, user_id: uuid.UUID) -> AgentTool:
+    """Return the ``memory_query`` AgentTool bound to ``user_id``.
+
+    The chat router builds one of these per turn (the user id is
+    known once a request lands), then appends it to the agent's
+    tool list. The tool ignores requests for memories belonging to
+    other users — the binding here is the authorisation gate.
+
+    Args:
+        user_id: Authenticated Pawrrtal user the memory rows belong
+            to. Stored in the closure so the model can never read
+            another user's memories.
+
+    Returns:
+        An :class:`AgentTool` the agent can call mid-turn to pull
+        the long tail of proactive memories the classifier wrote.
+    """
+
+    async def execute(tool_call_id: str, **kwargs: Any) -> str:
+        kind_arg = kwargs.get("kind")
+        kind: MemoryKind | None
+        if isinstance(kind_arg, str) and kind_arg in _ALLOWED_KINDS:
+            kind = kind_arg  # type: ignore[assignment]
+        else:
+            kind = None
+
+        raw_limit = kwargs.get("limit", _DEFAULT_LIMIT)
+        try:
+            limit = max(1, min(_MAX_LIMIT, int(raw_limit)))
+        except (TypeError, ValueError):
+            limit = _DEFAULT_LIMIT
+
+        async with async_session_maker() as session:
+            rows = await list_memories_for_user(
+                session,
+                user_id,
+                kind=kind,
+                limit=limit,
+            )
+            for row in rows:
+                # Mark each surfaced row as referenced so cleanup
+                # jobs keep hot memories around. Fire-and-forget
+                # within the same session — no separate commit.
+                await mark_memory_referenced(session, row.id)
+
+        if not rows:
+            return _empty_response(kind=kind)
+        return _format_memories(rows, kind=kind)
+
+    return AgentTool(
+        name="memory_query",
+        description=(
+            "Read the user's saved memories — user preferences, project "
+            "decisions, and feedback the Paw kept from past turns. Use "
+            "this when the user references something they told you "
+            "earlier but it's not in the immediate context, or when "
+            "you want to verify the user's standing preference before "
+            "making an assumption."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": list(_ALLOWED_KINDS),
+                    "description": (
+                        "Filter by memory kind: ``feedback`` "
+                        "(corrections / preferences on the Paw's "
+                        "behaviour), ``project`` (architectural / "
+                        "product decisions), or ``user`` (durable "
+                        "user context). Omit to return all kinds."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_LIMIT,
+                    "description": (
+                        f"Maximum number of memories to return. "
+                        f"Default {_DEFAULT_LIMIT}, capped at {_MAX_LIMIT}."
+                    ),
+                },
+            },
+            "required": [],
+        },
+        execute=execute,
+    )
+
+
+def _format_memories(rows: list[Any], *, kind: MemoryKind | None) -> str:
+    """Render the memory rows as a model-readable bulleted list."""
+    header = (
+        f"Saved memories ({kind})" if kind is not None else "Saved memories (all kinds)"
+    )
+    lines = [header]
+    for row in rows:
+        timestamp = row.created_at.strftime("%Y-%m-%d") if row.created_at else "?"
+        lines.append(f"- [{row.kind} · {timestamp}] {row.text}")
+    return "\n".join(lines)
+
+
+def _empty_response(*, kind: MemoryKind | None) -> str:
+    """Render the "no memories yet" reply."""
+    if kind is None:
+        return "No saved memories yet."
+    return f"No saved memories of kind '{kind}' yet."

--- a/backend/app/crud/memory.py
+++ b/backend/app/crud/memory.py
@@ -1,0 +1,135 @@
+"""CRUD operations for proactive memory rows (#340).
+
+The schema lives in migration 021 and the ORM model in
+:mod:`app.models`. This module owns the small surface every
+consumer (the post-turn classifier hook, the ``memory_query``
+tool, the system-prompt assembler) shares: insert with dedupe,
+read top-K for system-prompt grounding, mark a memory as
+referenced when the model actually used it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Memory
+
+MemoryKind = Literal["feedback", "project", "user"]
+MemorySource = Literal["classifier", "dreaming", "user"]
+
+
+async def insert_memory(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    kind: MemoryKind,
+    text: str,
+    source: MemorySource = "classifier",
+    workspace_id: uuid.UUID | None = None,
+    conversation_id: uuid.UUID | None = None,
+    source_message_id: uuid.UUID | None = None,
+    provenance_job_id: uuid.UUID | None = None,
+    embedding: bytes | None = None,
+) -> Memory:
+    """Persist a new memory row and return the saved ORM instance.
+
+    The caller is expected to have already checked for duplicates
+    (see :func:`find_similar_memories`). The dedupe step lives in
+    the classifier / dreaming pipelines, not here, so each consumer
+    can pick its own similarity threshold.
+    """
+    row = Memory(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+        kind=kind,
+        source=source,
+        provenance_job_id=provenance_job_id,
+        text=text,
+        embedding=embedding,
+        source_message_id=source_message_id,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def list_memories_for_user(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    kind: MemoryKind | None = None,
+    limit: int = 20,
+) -> list[Memory]:
+    """Read recent memories for ``user_id``, newest first.
+
+    Used by the system-prompt assembler to surface top-K rows. The
+    ``kind`` filter lets the assembler pull the three buckets
+    separately so they can be formatted differently in the prompt
+    (preferences as bullet points, project decisions as inline
+    statements, etc.).
+    """
+    stmt = (
+        select(Memory)
+        .where(Memory.user_id == user_id)
+        .order_by(Memory.created_at.desc())
+        .limit(limit)
+    )
+    if kind is not None:
+        stmt = stmt.where(Memory.kind == kind)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def find_similar_memories(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    text: str,
+    kind: MemoryKind,
+    limit: int = 5,
+) -> list[Memory]:
+    """Return memories whose text matches ``text`` via case-insensitive substring.
+
+    This is the cheap pre-dedupe filter — full embedding cosine
+    similarity lives in a separate helper to be added by the
+    classifier PR. For now, substring covers the most common
+    "I just wrote the same observation" case (the classifier tends
+    to emit short, deterministic statements that share substrings
+    when restating the same fact).
+    """
+    stmt = (
+        select(Memory)
+        .where(Memory.user_id == user_id)
+        .where(Memory.kind == kind)
+        .where(Memory.text.ilike(f"%{text[:120]}%"))
+        .order_by(Memory.created_at.desc())
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def mark_memory_referenced(
+    session: AsyncSession,
+    memory_id: uuid.UUID,
+) -> None:
+    """Touch ``last_referenced_at`` so future cleanup jobs can keep hot rows.
+
+    Called by the ``memory_query`` tool whenever the model actually
+    surfaces a memory in its turn. Pure timestamp write; the row
+    object isn't returned because every caller today is
+    fire-and-forget.
+    """
+    row = await session.get(Memory, memory_id)
+    if row is None:
+        return
+    row.last_referenced_at = datetime.now(UTC)
+    await session.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -520,6 +520,57 @@ class NotionOperationLog(Base):
     )
 
 
+class Memory(Base):
+    """A typed proactive memory written by the post-turn classifier or dreaming pass.
+
+    Per the ADR at
+    ``frontend/content/docs/handbook/decisions/2026-05-20-proactive-memory-updates.mdx``,
+    the chat router runs a post-turn classifier that captures user
+    preferences, project decisions, and explicit feedback. Each
+    captured signal becomes a row here, typed by ``kind``.
+
+    The dreaming pass (#341) reuses the same table — ``source`` is
+    the provenance discriminator (``classifier`` / ``dreaming`` /
+    ``user``) and ``provenance_job_id`` ties dreaming-written rows
+    back to the job that wrote them.
+    """
+
+    __tablename__ = "memories"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
+    )
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=True
+    )
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    # One of ``feedback`` / ``project`` / ``user``. Pinned to that
+    # set by ``ck_memories_kind_valid`` in migration 021.
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # ``classifier`` (per-turn) | ``dreaming`` (between-sessions) |
+    # ``user`` (manual). Pinned by ``ck_memories_source_valid``.
+    source: Mapped[str] = mapped_column(String(16), nullable=False, default="classifier")
+    # Set when ``source == "dreaming"`` — ties the row back to the
+    # ``DreamingJob`` that wrote it (table introduced by #341).
+    provenance_job_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, nullable=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    # Opaque bytes; the existing ``lcm/embeddings.py`` pipeline does
+    # the per-provider serialisation. Promoted to ``pgvector`` later.
+    embedding: Mapped[bytes | None] = mapped_column(nullable=True)
+    source_message_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("chat_messages.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    last_referenced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 __all__ = [
     "AuditEvent",
     "ChannelBinding",
@@ -532,6 +583,7 @@ __all__ = [
     "LCMSummary",
     "LCMSummarySource",
     "McpServer",
+    "Memory",
     "NotionOperationLog",
     "Project",
     "ScheduledJob",

--- a/backend/tests/test_crud_memory.py
+++ b/backend/tests/test_crud_memory.py
@@ -1,0 +1,134 @@
+"""Tests for the memory CRUD surface (#340)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.memory import (
+    find_similar_memories,
+    insert_memory,
+    list_memories_for_user,
+    mark_memory_referenced,
+)
+from app.db import User
+from app.models import Memory
+
+
+@pytest.mark.anyio
+async def test_insert_memory_persists_with_defaults(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Default source is ``classifier``; default workspace / conversation NULL."""
+    row = await insert_memory(
+        db_session,
+        test_user.id,
+        kind="feedback",
+        text="User prefers concise replies.",
+    )
+    assert row.kind == "feedback"
+    assert row.source == "classifier"
+    assert row.workspace_id is None
+    assert row.conversation_id is None
+    assert row.user_id == test_user.id
+
+
+@pytest.mark.anyio
+async def test_insert_memory_records_dreaming_source(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Dreaming-written rows carry the right provenance flag (#341 dependency)."""
+    job_id = uuid.uuid4()
+    row = await insert_memory(
+        db_session,
+        test_user.id,
+        kind="project",
+        text="Postgres for the cost ledger.",
+        source="dreaming",
+        provenance_job_id=job_id,
+    )
+    assert row.source == "dreaming"
+    assert row.provenance_job_id == job_id
+
+
+@pytest.mark.anyio
+async def test_list_memories_returns_newest_first(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The system-prompt assembler always wants the freshest top-K rows."""
+    await insert_memory(db_session, test_user.id, kind="feedback", text="older")
+    await insert_memory(db_session, test_user.id, kind="feedback", text="newer")
+    rows = await list_memories_for_user(db_session, test_user.id, kind="feedback")
+    assert [r.text for r in rows] == ["newer", "older"]
+
+
+@pytest.mark.anyio
+async def test_list_memories_filters_by_kind(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The three kinds map to three distinct downstream consumers — keep them separable."""
+    await insert_memory(db_session, test_user.id, kind="feedback", text="feedback row")
+    await insert_memory(db_session, test_user.id, kind="project", text="project row")
+    await insert_memory(db_session, test_user.id, kind="user", text="user row")
+
+    feedback_rows = await list_memories_for_user(db_session, test_user.id, kind="feedback")
+    assert {r.text for r in feedback_rows} == {"feedback row"}
+    project_rows = await list_memories_for_user(db_session, test_user.id, kind="project")
+    assert {r.text for r in project_rows} == {"project row"}
+
+
+@pytest.mark.anyio
+async def test_find_similar_returns_matching_substring(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The cheap dedupe filter catches restatements via substring."""
+    await insert_memory(
+        db_session,
+        test_user.id,
+        kind="feedback",
+        text="User prefers concise replies under 5 sentences.",
+    )
+    matches = await find_similar_memories(
+        db_session,
+        test_user.id,
+        text="User prefers concise replies",
+        kind="feedback",
+    )
+    assert len(matches) == 1
+
+
+@pytest.mark.anyio
+async def test_find_similar_respects_kind_partition(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """A ``project`` row with the same text doesn't dedupe a ``feedback`` write."""
+    await insert_memory(db_session, test_user.id, kind="project", text="rate limit")
+    matches = await find_similar_memories(
+        db_session,
+        test_user.id,
+        text="rate limit",
+        kind="feedback",
+    )
+    assert matches == []
+
+
+@pytest.mark.anyio
+async def test_mark_memory_referenced_updates_timestamp(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The ``memory_query`` tool calls this whenever it surfaces a row."""
+    row = await insert_memory(db_session, test_user.id, kind="user", text="prefers Pacific time")
+    assert row.last_referenced_at is None
+    await mark_memory_referenced(db_session, row.id)
+    refreshed = await db_session.get(Memory, row.id)
+    assert refreshed is not None
+    assert refreshed.last_referenced_at is not None


### PR DESCRIPTION
## Closes #340 (implementation slice 2/N)

**Stacked on PR #395** (the schema + CRUD). Adds the
`memory_query` AgentTool the agent can call mid-turn to read the
long tail of proactive memories the post-turn classifier wrote.

## New surface

- **`backend/app/core/tools/memory_query.py`** —
  `make_memory_query_tool(user_id)` returns an `AgentTool` with an
  optional `kind` filter (`feedback` / `project` / `user`) and a
  `limit` capped at 20. The `user_id` is captured in the closure
  as the authorisation gate — the model can never read another
  user's memories.
- **`backend/app/core/agent_tools.py`** — appended next to the LCM
  family, gated on `settings.memories_enabled` + a configured user
  id.
- **`backend/app/core/config.py`** — new
  `memories_enabled: bool = False` master switch matching the
  ADR's per-user rollout plan.

Each returned row is touched (`last_referenced_at`) so the future
cleanup job can keep hot memories around and archive cold ones.

## Stacked follow-ups (per ADR)

- Post-turn classifier hook that writes new rows on `TurnEndEvent`.
- System-prompt assembler surfaces top-K rows on every turn.
- Inline "📝 Saved feedback" acknowledgment after the assistant
  reply when the classifier wrote something.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_