### PR TITLE
feat(observability): test-injectable tracer for workshop spans (#352 L6)

### DIFF
--- a/backend/app/core/observability/workshop.py
+++ b/backend/app/core/observability/workshop.py
@@ -97,12 +97,53 @@ __all__ = [
     "ToolSpanRecorder",
     "TurnSpanRecorder",
     "llm_span",
+    "reset_tracer_for_tests",
+    "set_tracer_for_tests",
     "tool_span",
     "turn_span",
     "workshop_event_hook",
 ]
 
 _tracer = trace.get_tracer(TRACER_NAME, TRACER_VERSION)
+
+# Test-injectable tracer override (#352 L6). When non-``None``, every
+# span recorder reads spans through this tracer instead of the
+# global ``_tracer``. ``InMemorySpanExporter``-based tests inject
+# their own provider's tracer here, so the test never has to swap
+# the global ``trace.set_tracer_provider`` (which is one-shot per
+# process and produces order-dependent flakes in pytest fixtures).
+_tracer_override: trace.Tracer | None = None
+
+
+def _active_tracer() -> trace.Tracer:
+    """Return the test-injected tracer when set, otherwise the module tracer.
+
+    Every span context manager in this module reads through this
+    helper so the override is a single seam — there's no chance a
+    new code path forgets to consult it.
+    """
+    return _tracer_override if _tracer_override is not None else _tracer
+
+
+def set_tracer_for_tests(tracer: trace.Tracer) -> None:
+    """Install a test tracer so OTel assertions stay local to the test.
+
+    Pair with :func:`reset_tracer_for_tests` in a ``finally`` /
+    ``addfinalizer`` so the override doesn't leak across tests.
+
+    Args:
+        tracer: A tracer (typically built from a per-test
+            ``TracerProvider`` + ``InMemorySpanExporter``) that
+            captures spans into an exporter the test can read back.
+    """
+    global _tracer_override  # noqa: PLW0603 — test seam by design
+    _tracer_override = tracer
+
+
+def reset_tracer_for_tests() -> None:
+    """Clear the test tracer so subsequent spans use the module default."""
+    global _tracer_override  # noqa: PLW0603 — test seam by design
+    _tracer_override = None
 
 # Per-conversation memory of the previous turn's span context so
 # successive turns in the same conversation are linked.  OTel span
@@ -154,7 +195,7 @@ def turn_span(
     prev_ctx = _previous_turn.get(conv_key)
     links = [trace.Link(prev_ctx)] if prev_ctx is not None else None
 
-    with _tracer.start_as_current_span("pawrrtal.turn", links=links) as span:
+    with _active_tracer().start_as_current_span("pawrrtal.turn", links=links) as span:
         span.set_attribute(ATTR_CONVERSATION_ID, conv_key)
         span.set_attribute(ATTR_USER_ID, str(user_id))
         span.set_attribute(ATTR_SURFACE, surface)
@@ -206,7 +247,7 @@ def llm_span(
         An ``LLMSpanRecorder`` whose ``record_*`` methods accumulate
         streamed tokens and stamp final attributes on ``flush()``.
     """
-    with _tracer.start_as_current_span("pawrrtal.llm.chat") as span:
+    with _active_tracer().start_as_current_span("pawrrtal.llm.chat") as span:
         span.set_attribute(ATTR_TRACELOOP_KIND, KIND_LLM)
         span.set_attribute(ATTR_GENAI_OPERATION, "chat")
         span.set_attribute(ATTR_GENAI_REQUEST_MODEL, model_id)
@@ -259,7 +300,7 @@ def tool_span(
         A ``ToolSpanRecorder`` — call ``record_result`` (or
         ``record_error``) before the context exits to stamp the output.
     """
-    with _tracer.start_as_current_span(f"{name}.tool") as span:
+    with _active_tracer().start_as_current_span(f"{name}.tool") as span:
         span.set_attribute(ATTR_TRACELOOP_KIND, KIND_TOOL)
         span.set_attribute(ATTR_TRACELOOP_NAME, name)
         span.set_attribute(ATTR_TRACELOOP_INPUT, json_dumps(arguments))

--- a/backend/app/core/observability/workshop.py
+++ b/backend/app/core/observability/workshop.py
@@ -145,6 +145,7 @@ def reset_tracer_for_tests() -> None:
     global _tracer_override  # noqa: PLW0603 — test seam by design
     _tracer_override = None
 
+
 # Per-conversation memory of the previous turn's span context so
 # successive turns in the same conversation are linked.  OTel span
 # links are the standard way to connect traces without forcing them

--- a/backend/tests/test_workshop_tracer_injection.py
+++ b/backend/tests/test_workshop_tracer_injection.py
@@ -1,0 +1,100 @@
+"""Tests for the test-injectable tracer in workshop (#352 L6)."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from app.core.observability.workshop import (
+    reset_tracer_for_tests,
+    set_tracer_for_tests,
+    turn_span,
+)
+
+
+@pytest.fixture
+def in_memory_tracer() -> Iterator[tuple[trace.Tracer, InMemorySpanExporter]]:
+    """Per-test tracer + exporter so spans don't bleed across tests.
+
+    Returns the tracer (for ``set_tracer_for_tests``) and the
+    exporter (for reading recorded spans). The tracer provider is
+    discarded after the test — never installed globally — which is
+    exactly the property #352 L6 was designed to give us.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("pawrrtal-tests")
+    set_tracer_for_tests(tracer)
+    try:
+        yield tracer, exporter
+    finally:
+        reset_tracer_for_tests()
+        provider.shutdown()
+
+
+def test_turn_span_emits_through_injected_tracer(
+    in_memory_tracer: tuple[trace.Tracer, InMemorySpanExporter],
+) -> None:
+    """A turn_span recorded via the injected tracer lands in the exporter.
+
+    The matching production span (without the override) would land
+    on the configured OTLP collector. Reading back the
+    in-memory-exported span confirms ``_active_tracer()`` is the
+    seam the override flows through.
+    """
+    _, exporter = in_memory_tracer
+
+    with turn_span(
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        surface="telegram",
+        request_id="req-1",
+        model_id="agent-sdk:anthropic/claude-sonnet-4-6",
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "pawrrtal.turn"
+    assert span.attributes.get("pawrrtal.surface") == "telegram"
+
+
+def test_reset_tracer_for_tests_restores_module_default(
+    in_memory_tracer: tuple[trace.Tracer, InMemorySpanExporter],
+) -> None:
+    """After ``reset_tracer_for_tests``, the module tracer takes over again.
+
+    Without this guarantee, an override from a forgotten ``finally``
+    block in one test would pollute every subsequent test in the
+    suite. The fixture's ``finally`` exercises the reset path; the
+    assertion below confirms a second turn_span doesn't end up in
+    the test exporter.
+    """
+    _, exporter = in_memory_tracer
+
+    # Reset BEFORE the second span — this is the same code the
+    # fixture runs in its teardown; here we run it inline so the
+    # assertion isn't a tautology over the fixture's teardown.
+    reset_tracer_for_tests()
+
+    with turn_span(
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        surface="web",
+        request_id="req-2",
+        model_id=None,
+    ):
+        pass
+
+    # The exporter should NOT have recorded this span — after
+    # reset the module tracer (the no-op tracer in test envs
+    # without OTel configured) takes over.
+    assert not exporter.get_finished_spans()


### PR DESCRIPTION
## Closes #352 (L6 — final layer)

The issue text deferred L6 explicitly because `trace.set_tracer_provider`
is one-shot per process and swapping it from pytest fixtures
produces order-dependent flakes. The right way to test OTel
without touching globals is to inject a tracer at the seam — which
this PR adds.

## Refactor

- New **`set_tracer_for_tests(tracer)`** /
  **`reset_tracer_for_tests()`** helpers install / clear a
  module-local `_tracer_override`.
- All `start_as_current_span` call sites in `turn_span` /
  `llm_span` / `tool_span` now read through `_active_tracer()`,
  which prefers the override and falls back to the module tracer.
- The override **never touches the global `TracerProvider`** — the
  production OTLP collector is unaffected.

## Tests

`test_workshop_tracer_injection.py`:

- A `turn_span` recorded under the injected tracer lands in the
  per-test `InMemorySpanExporter` (confirms the override flows
  through `_active_tracer()`).
- After `reset_tracer_for_tests`, the exporter sees no further
  spans (confirms the override is torn down cleanly so it doesn't
  leak across tests).

## Status of #352 — every layer landed

| Layer | Status |
|-------|--------|
| L0 — `block_index` schema | ✅ #371 |
| L1 — Telegram dispatch unit tests | ✅ #371, #377 |
| L2 — Telegram channel integration | ✅ #393 |
| L3 — Hook ordering test | ✅ #377 |
| L4 — Per-provider translation tests | ✅ #393 |
| L5 — Catalog must-haves | ✅ #385 |
| **L6 — OTel integration** | **✅ This PR** |

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_