### PR TITLE
feat(dreaming): reflection prompt + output schema + parser (#341 impl 2/N, stacked on #396)

### DIFF
--- a/backend/alembic/versions/021_add_memories_table.py
+++ b/backend/alembic/versions/021_add_memories_table.py
@@ -1,0 +1,111 @@
+"""Add the ``memories`` table for proactive memory writes (#340).
+
+Per the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-proactive-memory-updates.mdx``,
+the chat router runs a post-turn classifier that captures user
+preferences, project decisions, and explicit feedback as typed
+memory rows.  Those rows live on this table.
+
+The dreaming pass (#341) writes into the same table — the
+``source`` column distinguishes per-turn classifier writes from
+the dreaming consolidation pass, and ``provenance_job_id`` lets a
+reviewer trace any dreaming-written row back to the job that
+produced it.
+
+Embeddings are stored as opaque bytes (the existing
+``backend/app/core/lcm/embeddings.py`` pipeline does its own
+serialisation per provider). A future migration can promote the
+column to ``pgvector`` once the operator deployment confirms the
+extension is installed.
+
+Revision ID: 021_add_memories_table
+Revises: 020_add_conversation_reasoning_effort
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "021_add_memories_table"
+down_revision = "020_add_conversation_reasoning_effort"
+branch_labels = None
+depends_on = None
+
+# Allowed values for the ``kind`` discriminator. Mirrors the literal
+# union the application layer uses; pinned via CHECK so an out-of-tree
+# script or admin SQL session can't write a garbage value.
+_KIND_VALUES = ("feedback", "project", "user")
+
+# Allowed values for the ``source`` provenance flag. ``classifier``
+# is the per-turn writer from this ADR; ``dreaming`` is the
+# between-sessions consolidation pass (#341); ``user`` is for the
+# rare case the user adds a memory manually via the (future) CLI.
+_SOURCE_VALUES = ("classifier", "dreaming", "user")
+
+
+def upgrade() -> None:
+    """Create the memories table and supporting indexes."""
+    op.create_table(
+        "memories",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("conversation_id", sa.Uuid(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False, server_default="classifier"),
+        sa.Column("provenance_job_id", sa.Uuid(), nullable=True),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("embedding", sa.LargeBinary(), nullable=True),
+        sa.Column("source_message_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("last_referenced_at", sa.DateTime(timezone=True), nullable=True),
+        # fastapi-users names the user table ``user`` (singular) — not
+        # ``users`` — so every cross-table FK uses that. Workspace
+        # uses ``workspaces``; see ``__tablename__`` in models.py.
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_message_id"],
+            ["chat_messages.id"],
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            f"kind IN ({', '.join(repr(v) for v in _KIND_VALUES)})",
+            name="ck_memories_kind_valid",
+        ),
+        sa.CheckConstraint(
+            f"source IN ({', '.join(repr(v) for v in _SOURCE_VALUES)})",
+            name="ck_memories_source_valid",
+        ),
+    )
+    # Reading top-K memories by (user, kind) is the hot path for the
+    # system-prompt assembler — one composite index gets us both
+    # filters at once.
+    op.create_index(
+        "ix_memories_user_kind",
+        "memories",
+        ["user_id", "kind"],
+    )
+    op.create_index(
+        "ix_memories_conversation_id",
+        "memories",
+        ["conversation_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the memories table and its indexes."""
+    op.drop_index("ix_memories_conversation_id", table_name="memories")
+    op.drop_index("ix_memories_user_kind", table_name="memories")
+    op.drop_table("memories")

--- a/backend/alembic/versions/022_add_dreaming_jobs_table.py
+++ b/backend/alembic/versions/022_add_dreaming_jobs_table.py
@@ -1,0 +1,102 @@
+"""Add the ``dreaming_jobs`` table for between-sessions reflection (#341).
+
+Per the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``,
+the dreaming pass runs in two modes (session-end + daily cron),
+both writing to the same ``DreamingJob`` row. The row records what
+the pass was given as input, what the pass produced, and how long
+it took — enough to grep operator logs, replay a failed pass, and
+trace any memory row back to the pass that created it via
+``memories.provenance_job_id``.
+
+Revision ID: 022_add_dreaming_jobs_table
+Revises: 021_add_memories_table
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "022_add_dreaming_jobs_table"
+down_revision = "021_add_memories_table"
+branch_labels = None
+depends_on = None
+
+# Allowed values for the ``scope`` discriminator.
+# ``session_end`` runs on a single conversation after it goes idle;
+# ``daily_rollup`` runs on the user's prior 24h across conversations.
+_SCOPE_VALUES = ("session_end", "daily_rollup")
+
+# Allowed values for the ``status`` field.
+# ``pending`` — created but not yet started.
+# ``running`` — actively reflecting.
+# ``completed`` — wrote its outputs successfully.
+# ``failed`` — terminal failure (logged + surfaced in /status).
+_STATUS_VALUES = ("pending", "running", "completed", "failed")
+
+
+def upgrade() -> None:
+    """Create the dreaming_jobs table and supporting indexes."""
+    op.create_table(
+        "dreaming_jobs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("conversation_id", sa.Uuid(), nullable=True),
+        sa.Column("scope", sa.String(length=24), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+        # Model used for the reflection. Stored verbatim so a future
+        # change to ``settings.dreaming_model`` doesn't rewrite the
+        # historical record.
+        sa.Column("model_id", sa.String(length=128), nullable=True),
+        # Token-bound window the pass actually read. Useful when the
+        # 24h dump exceeded the cap and the truncated tail mattered.
+        sa.Column("input_token_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_token_count", sa.Integer(), nullable=False, server_default="0"),
+        # Counts per output category — match the four bucket names
+        # from the ADR (consolidated_memories / patterns / followups /
+        # session_summary). Stored individually so /status can
+        # surface "🌙 last night: 3 memories, 1 follow-up".
+        sa.Column("memories_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("patterns_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("followups_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("session_summary", sa.Text(), nullable=True),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            f"scope IN ({', '.join(repr(v) for v in _SCOPE_VALUES)})",
+            name="ck_dreaming_jobs_scope_valid",
+        ),
+        sa.CheckConstraint(
+            f"status IN ({', '.join(repr(v) for v in _STATUS_VALUES)})",
+            name="ck_dreaming_jobs_status_valid",
+        ),
+    )
+    # /status panel asks "what was the last dreaming pass for this
+    # user?" — index by (user, created_at desc) to make that cheap.
+    op.create_index(
+        "ix_dreaming_jobs_user_created_at",
+        "dreaming_jobs",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the dreaming_jobs table and its index."""
+    op.drop_index("ix_dreaming_jobs_user_created_at", table_name="dreaming_jobs")
+    op.drop_table("dreaming_jobs")

--- a/backend/app/core/dreaming/__init__.py
+++ b/backend/app/core/dreaming/__init__.py
@@ -1,0 +1,40 @@
+"""Background reflection pass that consolidates memories between sessions (#341).
+
+Designed in the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``.
+The pass runs in two modes (session-end + daily cron), both feeding
+the same :class:`DreamingJob` lifecycle and writing through the
+shared dedupe pipeline that :mod:`app.crud.memory` exposes.
+
+Public surface:
+
+- :data:`DREAMING_PROMPT` — the reflection prompt template the
+  reasoning model sees on every pass.
+- :class:`DreamingOutput` — Pydantic schema for the structured
+  output the model returns.
+- :func:`parse_dreaming_output` — robust parser that accepts the
+  model's raw JSON / Markdown-fenced JSON / partial outputs.
+
+The actual job runner + scheduler integration lives in
+:mod:`app.core.dreaming.runner` (added in a stacked follow-up); this
+module owns the pure types + prompt so they're unit-testable without
+the LCM background scheduler in scope.
+"""
+
+from app.core.dreaming.prompt import DREAMING_PROMPT
+from app.core.dreaming.schema import (
+    ConsolidatedMemory,
+    DreamingOutput,
+    DreamingPattern,
+    Followup,
+    parse_dreaming_output,
+)
+
+__all__ = [
+    "ConsolidatedMemory",
+    "DREAMING_PROMPT",
+    "DreamingOutput",
+    "DreamingPattern",
+    "Followup",
+    "parse_dreaming_output",
+]

--- a/backend/app/core/dreaming/prompt.py
+++ b/backend/app/core/dreaming/prompt.py
@@ -1,0 +1,76 @@
+"""The reflection prompt the dreaming pass sends to the reasoning model.
+
+Held in its own module so the prompt text — load-bearing for the
+quality of the dreaming output — can be tuned without touching the
+runner. Mirrors the pattern used by
+:mod:`app.core.lcm.condense` (compaction prompt) and
+:mod:`app.core.lcm.planner` (focused-recall prompt).
+
+The prompt asks for four structured outputs documented in the
+dreaming ADR:
+
+* ``consolidated_memories`` — typed feedback/project/user
+  statements distilled from repetition.
+* ``patterns`` — recurring themes across turns.
+* ``followups`` — deferred work the user mentioned but the Paw
+  didn't act on.
+* ``session_summary`` — one-paragraph "what I learned" line.
+"""
+
+from __future__ import annotations
+
+DREAMING_PROMPT = (
+    "You are Pawrrtal's between-sessions reflection pass.\n"
+    "You read a conversation transcript (or a roll-up of the last 24h "
+    "of conversations) and produce four structured outputs that "
+    "Pawrrtal stores for future turns.\n"
+    "\n"
+    "Do NOT speak directly to the user. Your output is consumed by an "
+    "internal pipeline. Return a SINGLE JSON object matching this "
+    "schema exactly:\n"
+    "\n"
+    "{\n"
+    '  "consolidated_memories": [\n'
+    '    {"kind": "feedback" | "project" | "user", "text": "..."}\n'
+    "  ],\n"
+    '  "patterns": [\n'
+    '    {"text": "..."}\n'
+    "  ],\n"
+    '  "followups": [\n'
+    '    {"text": "...", "priority": "high" | "normal" | "low"}\n'
+    "  ],\n"
+    '  "session_summary": "..."\n'
+    "}\n"
+    "\n"
+    "Guidance:\n"
+    "- ``feedback`` memories capture how the user wants the Paw to "
+    "behave (e.g. 'user prefers concise replies', 'user dislikes "
+    "emoji in technical answers').\n"
+    "- ``project`` memories capture architectural / product / scope "
+    "decisions (e.g. 'cost ledger lives in Postgres, not Redis').\n"
+    "- ``user`` memories capture durable personal context "
+    "(e.g. 'user lives in Madrid', 'user is dyslexic — wall-of-text "
+    "replies are hard for them').\n"
+    "- ``patterns`` are observations that span multiple turns or "
+    "multiple conversations (e.g. 'this user always edits the Paw's "
+    "code before running it — bias toward fewer auto-runs').\n"
+    "- ``followups`` are concrete TODO items the user mentioned but "
+    "did not finish. Each becomes a bean / task.\n"
+    "- ``session_summary`` is one short paragraph (<=400 chars) "
+    "summarising what you learned this session — read by the next "
+    "session's context-assembler.\n"
+    "\n"
+    "If a category has nothing worth writing, return an empty list / "
+    "empty string. Never write a memory just to fill the field.\n"
+    "\n"
+    "Do NOT wrap the JSON in Markdown code fences. Do NOT prefix it "
+    "with prose. Return JSON only."
+)
+"""The full reflection prompt as a single string.
+
+Stored as a module-level constant so the runner imports it once
+per process and the prompt-text diff lands in a single review-able
+unit when it changes."""
+
+
+__all__ = ["DREAMING_PROMPT"]

--- a/backend/app/core/dreaming/schema.py
+++ b/backend/app/core/dreaming/schema.py
@@ -1,0 +1,144 @@
+"""Pydantic output schema + parser for the dreaming pass (#341).
+
+Decouples the reflection prompt's output shape from the runner that
+consumes it. The runner imports :func:`parse_dreaming_output` and
+trusts the parsed values; the prompt is in the sibling
+:mod:`prompt` module.
+
+The parser is intentionally robust:
+
+* Accepts raw JSON.
+* Accepts Markdown-fenced JSON (``"```json\\n{...}\\n```"``) — some
+  reasoning models won't follow the "no fences" instruction.
+* Trims leading / trailing whitespace + accidental prose lines that
+  precede the JSON.
+* Returns an empty :class:`DreamingOutput` rather than raising when
+  the model returns invalid JSON entirely — the runner records the
+  failure on the ``DreamingJob.error_text`` column instead of
+  crashing the cron.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+MemoryKind = Literal["feedback", "project", "user"]
+FollowupPriority = Literal["high", "normal", "low"]
+
+
+class ConsolidatedMemory(BaseModel):
+    """One typed memory the dreaming pass wants to persist."""
+
+    kind: MemoryKind
+    text: str = Field(min_length=1)
+
+
+class DreamingPattern(BaseModel):
+    """One recurring theme the pass noticed across the input window."""
+
+    text: str = Field(min_length=1)
+
+
+class Followup(BaseModel):
+    """One deferred TODO the user mentioned but didn't finish."""
+
+    text: str = Field(min_length=1)
+    priority: FollowupPriority = "normal"
+
+
+class DreamingOutput(BaseModel):
+    """Full structured output the reflection prompt returns."""
+
+    consolidated_memories: list[ConsolidatedMemory] = Field(default_factory=list)
+    patterns: list[DreamingPattern] = Field(default_factory=list)
+    followups: list[Followup] = Field(default_factory=list)
+    session_summary: str = ""
+
+
+# Match a Markdown JSON fence ``...```json\n{...}\n```...`` and
+# extract just the inner body. Non-greedy so the ``````` close
+# matches the FIRST closing fence, not the last one in the buffer.
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*\n(?P<body>.*?)\n\s*```", re.DOTALL)
+
+
+def parse_dreaming_output(raw: str) -> DreamingOutput:
+    """Parse the model's raw output into a :class:`DreamingOutput`.
+
+    Robustness contract:
+
+    * Tolerates Markdown JSON fences.
+    * Tolerates leading prose like ``"Sure! Here's the JSON:"``.
+    * Returns an empty :class:`DreamingOutput` on any parse / schema
+      failure so the runner can record the failure without
+      bringing down the cron.
+
+    Args:
+        raw: The model's complete response string.
+
+    Returns:
+        A populated :class:`DreamingOutput`, or an empty one if the
+        raw output couldn't be parsed.
+    """
+    candidate = _extract_json_payload(raw)
+    if candidate is None:
+        logger.warning("DREAMING_PARSE_NO_JSON raw_preview=%r", raw[:200])
+        return DreamingOutput()
+
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "DREAMING_PARSE_JSON_DECODE_ERR error=%s candidate_preview=%r",
+            exc,
+            candidate[:200],
+        )
+        return DreamingOutput()
+
+    try:
+        return DreamingOutput.model_validate(payload)
+    except ValidationError as exc:
+        logger.warning("DREAMING_PARSE_SCHEMA_INVALID errors=%s", exc.errors())
+        return DreamingOutput()
+
+
+def _extract_json_payload(raw: str) -> str | None:
+    """Return the candidate JSON substring, or ``None`` if none found.
+
+    Tries (in order):
+
+    1. The interior of the first Markdown JSON fence, if present.
+    2. The substring from the first ``{`` to the matching last
+       ``}``. Naive but covers "reasoning model added a one-liner
+       intro before the JSON" cases.
+    3. ``None`` when neither shape produced anything.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return None
+
+    fenced = _FENCED_JSON_RE.search(stripped)
+    if fenced is not None:
+        return fenced.group("body").strip()
+
+    open_idx = stripped.find("{")
+    close_idx = stripped.rfind("}")
+    if open_idx == -1 or close_idx <= open_idx:
+        return None
+    return stripped[open_idx : close_idx + 1]
+
+
+__all__ = [
+    "ConsolidatedMemory",
+    "DreamingOutput",
+    "DreamingPattern",
+    "Followup",
+    "parse_dreaming_output",
+]

--- a/backend/app/crud/memory.py
+++ b/backend/app/crud/memory.py
@@ -1,0 +1,135 @@
+"""CRUD operations for proactive memory rows (#340).
+
+The schema lives in migration 021 and the ORM model in
+:mod:`app.models`. This module owns the small surface every
+consumer (the post-turn classifier hook, the ``memory_query``
+tool, the system-prompt assembler) shares: insert with dedupe,
+read top-K for system-prompt grounding, mark a memory as
+referenced when the model actually used it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Memory
+
+MemoryKind = Literal["feedback", "project", "user"]
+MemorySource = Literal["classifier", "dreaming", "user"]
+
+
+async def insert_memory(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    kind: MemoryKind,
+    text: str,
+    source: MemorySource = "classifier",
+    workspace_id: uuid.UUID | None = None,
+    conversation_id: uuid.UUID | None = None,
+    source_message_id: uuid.UUID | None = None,
+    provenance_job_id: uuid.UUID | None = None,
+    embedding: bytes | None = None,
+) -> Memory:
+    """Persist a new memory row and return the saved ORM instance.
+
+    The caller is expected to have already checked for duplicates
+    (see :func:`find_similar_memories`). The dedupe step lives in
+    the classifier / dreaming pipelines, not here, so each consumer
+    can pick its own similarity threshold.
+    """
+    row = Memory(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+        kind=kind,
+        source=source,
+        provenance_job_id=provenance_job_id,
+        text=text,
+        embedding=embedding,
+        source_message_id=source_message_id,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def list_memories_for_user(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    kind: MemoryKind | None = None,
+    limit: int = 20,
+) -> list[Memory]:
+    """Read recent memories for ``user_id``, newest first.
+
+    Used by the system-prompt assembler to surface top-K rows. The
+    ``kind`` filter lets the assembler pull the three buckets
+    separately so they can be formatted differently in the prompt
+    (preferences as bullet points, project decisions as inline
+    statements, etc.).
+    """
+    stmt = (
+        select(Memory)
+        .where(Memory.user_id == user_id)
+        .order_by(Memory.created_at.desc())
+        .limit(limit)
+    )
+    if kind is not None:
+        stmt = stmt.where(Memory.kind == kind)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def find_similar_memories(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    text: str,
+    kind: MemoryKind,
+    limit: int = 5,
+) -> list[Memory]:
+    """Return memories whose text matches ``text`` via case-insensitive substring.
+
+    This is the cheap pre-dedupe filter — full embedding cosine
+    similarity lives in a separate helper to be added by the
+    classifier PR. For now, substring covers the most common
+    "I just wrote the same observation" case (the classifier tends
+    to emit short, deterministic statements that share substrings
+    when restating the same fact).
+    """
+    stmt = (
+        select(Memory)
+        .where(Memory.user_id == user_id)
+        .where(Memory.kind == kind)
+        .where(Memory.text.ilike(f"%{text[:120]}%"))
+        .order_by(Memory.created_at.desc())
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def mark_memory_referenced(
+    session: AsyncSession,
+    memory_id: uuid.UUID,
+) -> None:
+    """Touch ``last_referenced_at`` so future cleanup jobs can keep hot rows.
+
+    Called by the ``memory_query`` tool whenever the model actually
+    surfaces a memory in its turn. Pure timestamp write; the row
+    object isn't returned because every caller today is
+    fire-and-forget.
+    """
+    row = await session.get(Memory, memory_id)
+    if row is None:
+        return
+    row.last_referenced_at = datetime.now(UTC)
+    await session.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -520,6 +520,57 @@ class NotionOperationLog(Base):
     )
 
 
+class Memory(Base):
+    """A typed proactive memory written by the post-turn classifier or dreaming pass.
+
+    Per the ADR at
+    ``frontend/content/docs/handbook/decisions/2026-05-20-proactive-memory-updates.mdx``,
+    the chat router runs a post-turn classifier that captures user
+    preferences, project decisions, and explicit feedback. Each
+    captured signal becomes a row here, typed by ``kind``.
+
+    The dreaming pass (#341) reuses the same table — ``source`` is
+    the provenance discriminator (``classifier`` / ``dreaming`` /
+    ``user``) and ``provenance_job_id`` ties dreaming-written rows
+    back to the job that wrote them.
+    """
+
+    __tablename__ = "memories"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
+    )
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=True
+    )
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    # One of ``feedback`` / ``project`` / ``user``. Pinned to that
+    # set by ``ck_memories_kind_valid`` in migration 021.
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # ``classifier`` (per-turn) | ``dreaming`` (between-sessions) |
+    # ``user`` (manual). Pinned by ``ck_memories_source_valid``.
+    source: Mapped[str] = mapped_column(String(16), nullable=False, default="classifier")
+    # Set when ``source == "dreaming"`` — ties the row back to the
+    # ``DreamingJob`` that wrote it (table introduced by #341).
+    provenance_job_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, nullable=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    # Opaque bytes; the existing ``lcm/embeddings.py`` pipeline does
+    # the per-provider serialisation. Promoted to ``pgvector`` later.
+    embedding: Mapped[bytes | None] = mapped_column(nullable=True)
+    source_message_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("chat_messages.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    last_referenced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 __all__ = [
     "AuditEvent",
     "ChannelBinding",
@@ -532,6 +583,7 @@ __all__ = [
     "LCMSummary",
     "LCMSummarySource",
     "McpServer",
+    "Memory",
     "NotionOperationLog",
     "Project",
     "ScheduledJob",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -520,6 +520,60 @@ class NotionOperationLog(Base):
     )
 
 
+class DreamingJob(Base):
+    """One run of the between-sessions reflection pass (#341).
+
+    Per the ADR at
+    ``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``,
+    the pass runs in two modes:
+
+    * ``session_end`` — single conversation after idle window.
+    * ``daily_rollup`` — user-scoped reflection over prior 24h.
+
+    Each row records the inputs (model, token counts), the outputs
+    (counts per category + session_summary), and the lifecycle
+    (status + timestamps + error_text). The dreaming pass writes
+    memory rows with ``source="dreaming"`` and
+    ``provenance_job_id=<this row's id>`` so any consolidated
+    memory can be traced back to the pass that produced it.
+    """
+
+    __tablename__ = "dreaming_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
+    )
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=True
+    )
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
+    # ``session_end`` | ``daily_rollup``. Pinned by
+    # ``ck_dreaming_jobs_scope_valid`` in migration 022.
+    scope: Mapped[str] = mapped_column(String(24), nullable=False)
+    # ``pending`` | ``running`` | ``completed`` | ``failed``.
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    input_token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    patterns_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    followups_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    session_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 class Memory(Base):
     """A typed proactive memory written by the post-turn classifier or dreaming pass.
 
@@ -578,6 +632,7 @@ __all__ = [
     "ChatMessage",
     "Conversation",
     "CostLedger",
+    "DreamingJob",
     "LCMContextItem",
     "LCMEmbedding",
     "LCMSummary",

--- a/backend/tests/test_crud_memory.py
+++ b/backend/tests/test_crud_memory.py
@@ -1,0 +1,134 @@
+"""Tests for the memory CRUD surface (#340)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.memory import (
+    find_similar_memories,
+    insert_memory,
+    list_memories_for_user,
+    mark_memory_referenced,
+)
+from app.db import User
+from app.models import Memory
+
+
+@pytest.mark.anyio
+async def test_insert_memory_persists_with_defaults(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Default source is ``classifier``; default workspace / conversation NULL."""
+    row = await insert_memory(
+        db_session,
+        test_user.id,
+        kind="feedback",
+        text="User prefers concise replies.",
+    )
+    assert row.kind == "feedback"
+    assert row.source == "classifier"
+    assert row.workspace_id is None
+    assert row.conversation_id is None
+    assert row.user_id == test_user.id
+
+
+@pytest.mark.anyio
+async def test_insert_memory_records_dreaming_source(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """Dreaming-written rows carry the right provenance flag (#341 dependency)."""
+    job_id = uuid.uuid4()
+    row = await insert_memory(
+        db_session,
+        test_user.id,
+        kind="project",
+        text="Postgres for the cost ledger.",
+        source="dreaming",
+        provenance_job_id=job_id,
+    )
+    assert row.source == "dreaming"
+    assert row.provenance_job_id == job_id
+
+
+@pytest.mark.anyio
+async def test_list_memories_returns_newest_first(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The system-prompt assembler always wants the freshest top-K rows."""
+    await insert_memory(db_session, test_user.id, kind="feedback", text="older")
+    await insert_memory(db_session, test_user.id, kind="feedback", text="newer")
+    rows = await list_memories_for_user(db_session, test_user.id, kind="feedback")
+    assert [r.text for r in rows] == ["newer", "older"]
+
+
+@pytest.mark.anyio
+async def test_list_memories_filters_by_kind(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The three kinds map to three distinct downstream consumers — keep them separable."""
+    await insert_memory(db_session, test_user.id, kind="feedback", text="feedback row")
+    await insert_memory(db_session, test_user.id, kind="project", text="project row")
+    await insert_memory(db_session, test_user.id, kind="user", text="user row")
+
+    feedback_rows = await list_memories_for_user(db_session, test_user.id, kind="feedback")
+    assert {r.text for r in feedback_rows} == {"feedback row"}
+    project_rows = await list_memories_for_user(db_session, test_user.id, kind="project")
+    assert {r.text for r in project_rows} == {"project row"}
+
+
+@pytest.mark.anyio
+async def test_find_similar_returns_matching_substring(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The cheap dedupe filter catches restatements via substring."""
+    await insert_memory(
+        db_session,
+        test_user.id,
+        kind="feedback",
+        text="User prefers concise replies under 5 sentences.",
+    )
+    matches = await find_similar_memories(
+        db_session,
+        test_user.id,
+        text="User prefers concise replies",
+        kind="feedback",
+    )
+    assert len(matches) == 1
+
+
+@pytest.mark.anyio
+async def test_find_similar_respects_kind_partition(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """A ``project`` row with the same text doesn't dedupe a ``feedback`` write."""
+    await insert_memory(db_session, test_user.id, kind="project", text="rate limit")
+    matches = await find_similar_memories(
+        db_session,
+        test_user.id,
+        text="rate limit",
+        kind="feedback",
+    )
+    assert matches == []
+
+
+@pytest.mark.anyio
+async def test_mark_memory_referenced_updates_timestamp(
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """The ``memory_query`` tool calls this whenever it surfaces a row."""
+    row = await insert_memory(db_session, test_user.id, kind="user", text="prefers Pacific time")
+    assert row.last_referenced_at is None
+    await mark_memory_referenced(db_session, row.id)
+    refreshed = await db_session.get(Memory, row.id)
+    assert refreshed is not None
+    assert refreshed.last_referenced_at is not None

--- a/backend/tests/test_dreaming_schema.py
+++ b/backend/tests/test_dreaming_schema.py
@@ -1,0 +1,87 @@
+"""Tests for the dreaming output schema + parser (#341)."""
+
+from __future__ import annotations
+
+from app.core.dreaming import parse_dreaming_output
+
+
+def test_parse_clean_json_returns_populated_output() -> None:
+    """The happy path: model returns clean JSON, parser populates every field."""
+    raw = (
+        '{"consolidated_memories": [{"kind": "feedback", "text": "user prefers concise"}],'
+        ' "patterns": [{"text": "edits code before running"}],'
+        ' "followups": [{"text": "write tests for X", "priority": "high"}],'
+        ' "session_summary": "User shipped feature Y today."}'
+    )
+    out = parse_dreaming_output(raw)
+    assert len(out.consolidated_memories) == 1
+    assert out.consolidated_memories[0].kind == "feedback"
+    assert len(out.patterns) == 1
+    assert out.followups[0].priority == "high"
+    assert "feature Y" in out.session_summary
+
+
+def test_parse_strips_markdown_json_fence() -> None:
+    """Reasoning models often wrap JSON in a ```json fence — parser tolerates it."""
+    raw = (
+        "Sure, here's the reflection:\n"
+        "```json\n"
+        '{"consolidated_memories": [], "patterns": [], "followups": [], '
+        '"session_summary": "Quiet session."}\n'
+        "```"
+    )
+    out = parse_dreaming_output(raw)
+    assert out.session_summary == "Quiet session."
+    assert out.consolidated_memories == []
+
+
+def test_parse_handles_leading_prose_without_fence() -> None:
+    """A reasoning model that ignores the no-prose instruction still parses.
+
+    The parser falls back to "first '{' to last '}'" extraction
+    so a 'Here you go:' preface doesn't break the pipeline.
+    """
+    raw = (
+        "Here is what I noticed:\n"
+        '{"consolidated_memories": [{"kind": "user", "text": "user is in Madrid"}], '
+        '"patterns": [], "followups": [], "session_summary": ""}'
+    )
+    out = parse_dreaming_output(raw)
+    assert out.consolidated_memories[0].text == "user is in Madrid"
+
+
+def test_parse_returns_empty_output_on_invalid_json() -> None:
+    """A model that returns garbage doesn't crash the runner.
+
+    The runner records the failure on ``DreamingJob.error_text``
+    and the pass logs at WARNING — the cron keeps running.
+    """
+    out = parse_dreaming_output("not json at all { broken")
+    assert out.consolidated_memories == []
+    assert out.session_summary == ""
+
+
+def test_parse_rejects_unknown_kind() -> None:
+    """An invalid ``kind`` value drops the entire output (schema validation)."""
+    raw = '{"consolidated_memories": [{"kind": "not-a-kind", "text": "x"}]}'
+    out = parse_dreaming_output(raw)
+    # Validation failure → empty output (the runner records the
+    # failure but doesn't write half-broken rows).
+    assert out.consolidated_memories == []
+
+
+def test_parse_handles_missing_fields_gracefully() -> None:
+    """Partial output is fine — empty defaults for absent fields."""
+    raw = '{"consolidated_memories": [{"kind": "user", "text": "owns a Mac"}]}'
+    out = parse_dreaming_output(raw)
+    assert out.consolidated_memories[0].text == "owns a Mac"
+    assert out.patterns == []
+    assert out.followups == []
+    assert out.session_summary == ""
+
+
+def test_parse_empty_string_returns_empty_output() -> None:
+    """An empty model response shouldn't blow up."""
+    out = parse_dreaming_output("")
+    assert out.consolidated_memories == []
+    assert out.session_summary == ""


### PR DESCRIPTION
## Closes #341 (implementation slice 2/N)

**Stacked on PR #396** (the `dreaming_jobs` schema). Adds the
purely-functional core of the dreaming pass: the reflection prompt,
the Pydantic output schema, and the robust parser the future runner
calls. Decoupled from the LCM background scheduler so the types +
prompt unit-test without it.

## Modules (`backend/app/core/dreaming/`)

- **`prompt.py`** — single `DREAMING_PROMPT` constant carrying the
  full reflection prompt. Lives alone so prompt tuning lands in a
  single review-able diff.
- **`schema.py`** — `DreamingOutput` + `ConsolidatedMemory` +
  `DreamingPattern` + `Followup` pydantic models. The four bucket
  names match the `dreaming_jobs` columns from PR #396.
- **`schema.parse_dreaming_output(raw)`** — robust parser that
  tolerates Markdown JSON fences, leading prose, partial output,
  and invalid JSON. Returns an empty `DreamingOutput` on any
  failure so the runner can log + record on `DreamingJob.error_text`
  instead of crashing the cron.

## Tests

`test_dreaming_schema.py`:
- Clean JSON → populated output (happy path).
- Markdown `\`\`\`json` fence → stripped, JSON parses.
- Leading prose ("Sure, here's:") → fallback `{...}` extraction.
- Invalid JSON / invalid `kind` enum → empty output, no crash.
- Missing fields → defaults populate gracefully.
- Empty string → empty output.

## Stacked follow-ups (per ADR)

- `runner.py` — fetches the input window, calls the model with
  `DREAMING_PROMPT`, parses + writes through `app.crud.memory`.
- `DreamingJob` handler on the LCM background scheduler.
- Bean writer for the `followups` output.
- Optional Telegram notice + `/status` row.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_