### PR TITLE
feat(telegram): register regenerate-callback handler in bot.py (#368 impl 3/N, stacked on #408)

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -94,6 +94,15 @@ from app.integrations.telegram.thinking_picker_runtime import (
     handle_thinking_picker_callback,
 )
 
+# Regenerate-keyboard runtime (#368) — re-exports the callback prefix
+# so bot.py imports both the registration prefix + handler from one
+# module, keeping the fan-out under the sentrux ``no_god_files``
+# budget. Same trick as the model / thinking / verbose pickers.
+from app.integrations.telegram.regenerate_runtime import (
+    REGEN_CALLBACK_PREFIX,
+    handle_regenerate_callback,
+)
+
 if TYPE_CHECKING:
     from aiogram import Bot, Dispatcher
     from aiogram.types import CallbackQuery, Message, Update
@@ -532,6 +541,12 @@ def _register_telegram_callback_handlers(dispatcher: Dispatcher) -> None:
     )
     async def _on_thinking_picker(callback: CallbackQuery) -> None:
         await handle_thinking_picker_callback(callback=callback)
+
+    @dispatcher.callback_query(
+        lambda query: (query.data or "").startswith(REGEN_CALLBACK_PREFIX)
+    )
+    async def _on_regenerate(callback: CallbackQuery) -> None:
+        await handle_regenerate_callback(callback=callback)
 
 
 def _register_telegram_message_handler(dispatcher: Dispatcher) -> None:

--- a/backend/app/integrations/telegram/regenerate_keyboard.py
+++ b/backend/app/integrations/telegram/regenerate_keyboard.py
@@ -1,0 +1,90 @@
+"""Inline-keyboard helpers for the per-turn ``Regenerate`` button (#368).
+
+After every assistant reply the Telegram channel attaches a small
+inline keyboard with a single ``🔄 Regenerate`` button. Tapping the
+button hands the conversation back to the turn pipeline with the
+same user input that produced the (now stale) answer, so the user
+can ask the model to try again without retyping the prompt.
+
+The framework-free shape mirrors :mod:`thinking_picker` and
+:mod:`verbose_picker` — pure dataclasses + callback parsing here,
+aiogram glue in :mod:`regenerate_runtime`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+REGEN_CALLBACK_PREFIX = "rgn:"
+_REGEN_BUTTON_TEXT = "🔄 Regenerate"
+_CALLBACK_PARTS = 2  # rgn:<conversation_id>
+
+
+@dataclass(frozen=True)
+class RegenerateButton:
+    """One inline-keyboard button for the regenerate row."""
+
+    text: str
+    callback_data: str
+
+
+@dataclass(frozen=True)
+class RegenerateCallback:
+    """Parsed callback payload for the regenerate button.
+
+    ``conversation_id`` is the only payload the button carries — the
+    runtime resolves the latest user message in that conversation
+    from the database, so we don't need to encode the message text
+    or assistant message id in callback_data (Telegram caps callback
+    data at 64 bytes).
+    """
+
+    conversation_id: uuid.UUID
+
+
+def regenerate_button_for(conversation_id: uuid.UUID) -> RegenerateButton:
+    """Build the lone inline button rendered under each assistant reply.
+
+    Args:
+        conversation_id: The conversation the reply belongs to. The
+            callback uses this to find the most recent user message
+            and re-run the turn pipeline against it.
+
+    Returns:
+        A single :class:`RegenerateButton` ready to drop into a
+        Telegram ``InlineKeyboardMarkup`` row.
+    """
+    return RegenerateButton(
+        text=_REGEN_BUTTON_TEXT,
+        callback_data=f"{REGEN_CALLBACK_PREFIX}{conversation_id}",
+    )
+
+
+def parse_regenerate_callback_data(data: str | None) -> RegenerateCallback | None:
+    """Parse a ``rgn:<uuid>`` payload back into a :class:`RegenerateCallback`.
+
+    Returns ``None`` for any malformed payload (wrong prefix, missing
+    UUID, unparseable UUID) so callers can surface a stale-callback
+    notice without an exception.
+    """
+    if data is None or not data.startswith(REGEN_CALLBACK_PREFIX):
+        return None
+    parts = data.split(":", maxsplit=1)
+    if len(parts) != _CALLBACK_PARTS:
+        return None
+    raw_uuid = parts[1]
+    try:
+        conversation_id = uuid.UUID(raw_uuid)
+    except ValueError:
+        return None
+    return RegenerateCallback(conversation_id=conversation_id)
+
+
+__all__ = [
+    "REGEN_CALLBACK_PREFIX",
+    "RegenerateButton",
+    "RegenerateCallback",
+    "parse_regenerate_callback_data",
+    "regenerate_button_for",
+]

--- a/backend/app/integrations/telegram/regenerate_runtime.py
+++ b/backend/app/integrations/telegram/regenerate_runtime.py
@@ -1,0 +1,215 @@
+"""aiogram runtime for the regenerate-keyboard callback (#368).
+
+The runtime answers a callback (``rgn:<conversation-id>``) by
+fetching the latest user message in that conversation from the
+``chat_messages`` table and posting it back into the chat so the
+existing message handler picks it up — driving the standard turn
+pipeline without the runtime having to duplicate any of it.
+
+The bot's regular message handler ignores messages from itself, so
+"post the user's last message verbatim" via ``bot.send_message``
+won't work. Instead this runtime sends a short "🔄 Regenerating…"
+notice and stores the regen state, then drives the turn directly
+through the legacy ``_run_llm_turn`` import (resolved lazily to
+avoid a circular import).
+
+Ownership / authorisation: the callback verifies that
+``callback.from_user.id`` matches the user who owns
+``conversation_id`` before touching anything. A different Telegram
+user (e.g. one who got the chat link forwarded) tapping the button
+gets a stale-callback message.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.channel import get_user_id_for_external
+from app.db import async_session_maker
+from app.integrations.telegram.regenerate_keyboard import (
+    REGEN_CALLBACK_PREFIX,  # noqa: F401  # re-exported for bot.py one-stop import
+    RegenerateCallback,
+    parse_regenerate_callback_data,
+)
+from app.models import ChatMessage, Conversation
+
+if TYPE_CHECKING:
+    from aiogram.types import CallbackQuery, Message
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_PROVIDER = "telegram"
+_STALE_MESSAGE = "That regenerate button is out of date. Send the message again."
+_NOT_OWNER_MESSAGE = "Only the conversation owner can regenerate."
+_NO_USER_MESSAGE_MESSAGE = "No previous user message to regenerate from."
+_REGENERATING_NOTICE = "🔄 Regenerating…"
+
+
+async def handle_regenerate_callback(*, callback: CallbackQuery) -> None:
+    """Handle a ``rgn:<conversation-id>`` callback tap.
+
+    Validates ownership, looks up the conversation's most recent
+    user message, and replays it as if the user had sent it again.
+    Each step that fails surfaces a callback-answer alert so the
+    user knows what happened.
+    """
+    parsed = parse_regenerate_callback_data(callback.data)
+    if parsed is None:
+        await callback.answer(_STALE_MESSAGE, show_alert=True)
+        return
+
+    sender = callback.from_user
+    if sender is None:
+        await callback.answer(_STALE_MESSAGE, show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        owner_user_id = await get_user_id_for_external(
+            provider=_TELEGRAM_PROVIDER,
+            external_user_id=str(sender.id),
+            session=session,
+        )
+        if owner_user_id is None:
+            await callback.answer(_STALE_MESSAGE, show_alert=True)
+            return
+
+        if not await _user_owns_conversation(
+            session=session,
+            conversation_id=parsed.conversation_id,
+            user_id=owner_user_id,
+        ):
+            await callback.answer(_NOT_OWNER_MESSAGE, show_alert=True)
+            return
+
+        last_user_text = await _last_user_message_text(
+            session=session,
+            conversation_id=parsed.conversation_id,
+        )
+
+    if last_user_text is None:
+        await callback.answer(_NO_USER_MESSAGE_MESSAGE, show_alert=True)
+        return
+
+    message = _callback_message(callback)
+    if message is None:
+        await callback.answer(_STALE_MESSAGE, show_alert=True)
+        return
+
+    await message.answer(_REGENERATING_NOTICE)
+    await callback.answer("Regenerating…")
+
+    # Drive the turn pipeline directly. Imported lazily to avoid a
+    # ``bot ↔ regenerate_runtime`` circular import (bot.py imports
+    # this module to register the callback handler; this module
+    # needs bot.py's ``_run_llm_turn`` helper to re-fire the turn).
+    from app.integrations.telegram.bot import (  # noqa: PLC0415 — see docstring
+        _run_llm_turn,
+    )
+    from app.integrations.telegram.handlers import (  # noqa: PLC0415
+        TelegramTurnContext,
+    )
+
+    # Synthesise a turn context from the resolved conversation. The
+    # caller is the original owner so verbose settings carry over
+    # verbatim from the row; ``model_id`` is left to the runner's
+    # standard lookup so an empty value works.
+    turn_context = TelegramTurnContext(
+        pawrrtal_user_id=owner_user_id,
+        conversation_id=parsed.conversation_id,
+        model_id="",  # runner resolves the persisted model
+        thread_id=message.message_thread_id,
+        verbose_level=None,
+    )
+
+    # The message argument is the picker message — its ``answer``
+    # method is what posts the assistant reply. The turn runner
+    # reads ``message.text`` only when building the initial user
+    # turn, so we monkey-set it to the last user text we resolved
+    # from the database via a lightweight wrapper.
+    await _run_llm_turn(
+        message=_RegenerateMessageView(
+            original=message,
+            user_text=last_user_text,
+        ),  # type: ignore[arg-type]
+        context=turn_context,
+        images=None,
+        text_annotations=None,
+    )
+
+
+async def _user_owns_conversation(
+    *,
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Check that ``user_id`` owns ``conversation_id``."""
+    stmt = select(Conversation.user_id).where(Conversation.id == conversation_id)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    return row == user_id
+
+
+async def _last_user_message_text(
+    *,
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+) -> str | None:
+    """Return the latest user message text for ``conversation_id`` or None."""
+    stmt = (
+        select(ChatMessage.content)
+        .where(ChatMessage.conversation_id == conversation_id)
+        .where(ChatMessage.role == "user")
+        .order_by(desc(ChatMessage.ordinal))
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if not row:
+        return None
+    return str(row)
+
+
+def _callback_message(callback: CallbackQuery) -> Message | None:
+    message = callback.message
+    if message is None or not hasattr(message, "answer"):
+        return None
+    return message
+
+
+class _RegenerateMessageView:
+    """Minimal :class:`Message`-shaped wrapper for the regenerated turn.
+
+    ``_run_llm_turn`` reads only a handful of attributes off the
+    aiogram message it receives (``text``, ``caption``, ``bot``,
+    ``chat``, ``message_id``, ``message_thread_id``, ``answer``).
+    Building a real aiogram ``Message`` object is overkill; this
+    proxy carries the values we need and forwards the rest to the
+    original picker message.
+    """
+
+    def __init__(self, original: Message, user_text: str) -> None:
+        self._original = original
+        self._user_text = user_text
+
+    @property
+    def text(self) -> str:
+        return self._user_text
+
+    @property
+    def caption(self) -> None:
+        return None
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._original, name)
+
+
+__all__ = [
+    "REGEN_CALLBACK_PREFIX",
+    "handle_regenerate_callback",
+]

--- a/backend/tests/test_telegram_regenerate_keyboard.py
+++ b/backend/tests/test_telegram_regenerate_keyboard.py
@@ -1,0 +1,59 @@
+"""Tests for the regenerate-keyboard helpers (#368)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.integrations.telegram.regenerate_keyboard import (
+    REGEN_CALLBACK_PREFIX,
+    parse_regenerate_callback_data,
+    regenerate_button_for,
+)
+
+
+def test_regenerate_button_carries_conversation_uuid() -> None:
+    """The button payload encodes the conversation id behind the standard prefix."""
+    conversation_id = uuid.UUID("01234567-89ab-cdef-0123-456789abcdef")
+    button = regenerate_button_for(conversation_id)
+    assert button.text == "🔄 Regenerate"
+    assert button.callback_data == f"{REGEN_CALLBACK_PREFIX}{conversation_id}"
+
+
+def test_regenerate_callback_data_fits_telegram_64_byte_cap() -> None:
+    """A UUID-payload callback stays under Telegram's 64-byte callback_data cap.
+
+    ``rgn:`` (4) + UUID stringified (36) = 40 bytes — well under 64.
+    """
+    button = regenerate_button_for(uuid.uuid4())
+    assert len(button.callback_data.encode("utf-8")) <= 64
+
+
+def test_parse_regenerate_callback_round_trips_uuid() -> None:
+    """Parsing the emitted payload yields the original UUID back."""
+    conversation_id = uuid.uuid4()
+    button = regenerate_button_for(conversation_id)
+    parsed = parse_regenerate_callback_data(button.callback_data)
+    assert parsed is not None
+    assert parsed.conversation_id == conversation_id
+
+
+def test_parse_rejects_other_picker_callbacks() -> None:
+    """Callbacks from sibling pickers must resolve to ``None``.
+
+    Each picker owns a distinct prefix (``mdl:``, ``thk:``, ``vbs:``,
+    ``rgn:``) so the dispatcher can fan out by prefix. Anything that
+    doesn't start with the regen prefix must be rejected so it
+    doesn't get routed to the regen handler by mistake.
+    """
+    assert parse_regenerate_callback_data(None) is None
+    assert parse_regenerate_callback_data("mdl:p") is None
+    assert parse_regenerate_callback_data("vbs:c") is None
+    assert parse_regenerate_callback_data("thk:c:deadbeef") is None
+
+
+def test_parse_rejects_malformed_uuid() -> None:
+    """A non-UUID tail resolves to ``None`` so stale buttons get a clean stale-message reply."""
+    assert parse_regenerate_callback_data("rgn:not-a-uuid") is None
+    assert parse_regenerate_callback_data("rgn:") is None
+    # Wrong length / shape still rejected
+    assert parse_regenerate_callback_data("rgn:1234") is None


### PR DESCRIPTION
## Closes #368 (implementation slice 3/N)

**Stacked on PRs #384 (keyboard) + #408 (runtime).** Registers
the `rgn:` callback handler on the aiogram dispatcher so tapping
the regenerate button actually fires `handle_regenerate_callback`
and drives a new turn.

## Wire point

Mirrors the `THINKING_CALLBACK_PREFIX` / `STATUS_CALLBACK_PREFIX`
registration pattern in this file so future picker callbacks slot
in next to it.

```python
@dispatcher.callback_query(
    lambda query: (query.data or "").startswith(REGEN_CALLBACK_PREFIX)
)
async def _on_regenerate(callback: CallbackQuery) -> None:
    await handle_regenerate_callback(callback=callback)
```

## End-to-end state

With this PR landing, the full path from "user taps regenerate"
to "new turn streams a reply" is functional. The remaining
stacked PR attaches the regen keyboard to the assistant's final
reply via `finalize_turn_delivery` so the button is reachable
through the UI without manual `bot.send_message` injection.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_