### PR TITLE
refactor(exporters): take ConversationLike/MessageLike protocols, drop direct ORM dependency

### DIFF
--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -58,9 +58,11 @@ layers =
 ; the api/crud layer) in a follow-up. Pattern mirrors `EXEMPT_FUNCTIONS` in
 ; `scripts/check-nesting.py`.
 ignore_imports =
-    app.core.exporters.markdown_export -> app.models
-    app.core.exporters.html_export -> app.models
-    app.core.exporters.json_export -> app.models
+    ; Exporters (markdown / html / json) previously imported the
+    ; ``Conversation`` + ``ChatMessage`` ORM rows directly. They now
+    ; take ``ConversationLike`` + ``MessageLike`` Protocols from
+    ; ``app.core.exporters.types`` and stay layer-pure. (Cluster A
+    ; flatten — exporters → models — has landed.)
     app.core.governance.audit -> app.models
     app.core.governance.cost_tracker -> app.models
     app.core.scheduler.scheduler -> app.models

--- a/backend/app/core/exporters/html_export.py
+++ b/backend/app/core/exporters/html_export.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from html import escape
 from typing import Any
 
-from app.models import ChatMessage, Conversation
+from app.core.exporters.types import ConversationLike, MessageLike
 
 _STYLE = """
 body { font-family: 'Inter', system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #222; }
@@ -31,8 +31,8 @@ pre { background: #f6f8fa; padding: 0.75rem; border-radius: 6px; overflow-x: aut
 
 def render_html(
     *,
-    conversation: Conversation,
-    messages: Sequence[ChatMessage],
+    conversation: ConversationLike,
+    messages: Sequence[MessageLike],
 ) -> str:
     """Return a self-contained HTML document for the conversation."""
     title = escape(conversation.title or "Conversation")
@@ -59,7 +59,7 @@ def render_html(
     return "\n".join(parts)
 
 
-def _render_message(message: ChatMessage) -> str:
+def _render_message(message: MessageLike) -> str:
     """Render one message as an HTML block."""
     role = escape(message.role)
     label = "You" if message.role == "user" else "Assistant"

--- a/backend/app/core/exporters/json_export.py
+++ b/backend/app/core/exporters/json_export.py
@@ -17,13 +17,13 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
-from app.models import ChatMessage, Conversation
+from app.core.exporters.types import ConversationLike, MessageLike
 
 
 def render_json(
     *,
-    conversation: Conversation,
-    messages: Sequence[ChatMessage],
+    conversation: ConversationLike,
+    messages: Sequence[MessageLike],
 ) -> str:
     """Return a pretty-printed JSON export of the conversation."""
     payload: dict[str, Any] = {
@@ -33,7 +33,7 @@ def render_json(
     return json.dumps(payload, indent=2, sort_keys=True, default=str)
 
 
-def _serialize_conversation(conversation: Conversation) -> dict[str, Any]:
+def _serialize_conversation(conversation: ConversationLike) -> dict[str, Any]:
     return {
         "id": str(conversation.id),
         "user_id": str(conversation.user_id),
@@ -48,7 +48,7 @@ def _serialize_conversation(conversation: Conversation) -> dict[str, Any]:
     }
 
 
-def _serialize_message(message: ChatMessage) -> dict[str, Any]:
+def _serialize_message(message: MessageLike) -> dict[str, Any]:
     return {
         "id": str(message.id),
         "ordinal": message.ordinal,

--- a/backend/app/core/exporters/markdown_export.py
+++ b/backend/app/core/exporters/markdown_export.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
-from app.models import ChatMessage, Conversation
+from app.core.exporters.types import ConversationLike, MessageLike
 
 # Truncate long tool-call results to keep the export readable.
 # Anything longer is replaced with the head + an ellipsis.
@@ -25,8 +25,8 @@ _TOOL_RESULT_PREVIEW_CHARS = 200
 
 def render_markdown(
     *,
-    conversation: Conversation,
-    messages: Sequence[ChatMessage],
+    conversation: ConversationLike,
+    messages: Sequence[MessageLike],
 ) -> str:
     """Return a self-contained Markdown export of the conversation."""
     lines: list[str] = []
@@ -50,7 +50,7 @@ def render_markdown(
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _render_message(message: ChatMessage) -> list[str]:
+def _render_message(message: MessageLike) -> list[str]:
     """Render one message as a Markdown block."""
     role_label = "You" if message.role == "user" else "Assistant"
     timestamp = _fmt_dt(message.created_at)

--- a/backend/app/core/exporters/types.py
+++ b/backend/app/core/exporters/types.py
@@ -1,0 +1,70 @@
+"""Structural protocols that conversation exporters consume.
+
+The exporters render a conversation + its messages into Markdown / HTML
+/ JSON.  They never need to write back to the database — they're pure
+projections.  Defining the input shape as a :class:`typing.Protocol`
+instead of taking the SQLAlchemy ORM classes directly lets the
+exporters stay at the ``app.core`` layer without importing
+``app.models``, which would violate the layered architecture contract
+(``models`` lives below ``core`` in the sentrux / import-linter
+ordering).
+
+The ``app.models.Conversation`` and ``app.models.ChatMessage`` ORM
+rows satisfy these Protocols structurally — every attribute matches —
+so call sites in the API layer just pass the ORM rows directly. The
+seam is type-only: at runtime nothing changes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Protocol
+
+
+class ConversationLike(Protocol):
+    """The conversation-shaped subset of attributes exporters read.
+
+    Mirrors the public surface of :class:`app.models.Conversation` that
+    the exporters touch — title, identity, timestamps, optional model
+    ID, plus the JSON-export-only fields (``user_id``, ``is_archived``,
+    ``is_flagged``, ``labels``, ``origin_channel``). Adding a new
+    exporter field means adding it here too.
+    """
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    title: str
+    created_at: datetime
+    updated_at: datetime
+    model_id: str | None
+    is_archived: bool
+    is_flagged: bool
+    labels: list[str]
+    origin_channel: str | None
+
+
+class MessageLike(Protocol):
+    """The message-shaped subset of attributes exporters read.
+
+    Mirrors the public surface of :class:`app.models.ChatMessage` —
+    role + body + the auxiliary fields the renderers fan out into
+    (thinking text, tool calls, an optional attachment path) plus the
+    JSON-export-only metadata (``id``, ``ordinal``, ``timeline``,
+    ``thinking_duration_seconds``, ``assistant_status``,
+    ``updated_at``).
+    """
+
+    id: uuid.UUID
+    ordinal: int
+    role: str
+    created_at: datetime
+    updated_at: datetime
+    content: str
+    thinking: str | None
+    thinking_duration_seconds: int | None
+    tool_calls: list[dict[str, Any]] | None
+    timeline: list[dict[str, Any]] | None
+    assistant_status: str | None
+    attachment: str | None
+    attachment_mime: str | None


### PR DESCRIPTION
## Summary

The three conversation exporters (`markdown_export`, `html_export`, `json_export`) imported `Conversation` + `ChatMessage` ORM rows directly. That sat in `app.core.*` reading from `app.models`, violating the layered architecture — `core` is at the bottom of the sentrux ordering and must not depend on `models`. The violation was grandfathered with three `ignore_imports` entries.

Replace direct ORM imports with structural `typing.Protocol`s in a new `app/core/exporters/types.py`:
- `ConversationLike` — every conversation attr the exporters touch
- `MessageLike` — every message attr the exporters touch

Both Protocols mirror the ORM's public attribute types verbatim, so existing ORM rows satisfy them structurally — zero conversion layer, zero caller changes in `app.api.exports`. The type seam lives in `app.core.exporters` instead of `app.models`.

`backend/.importlinter` lost three `ignore_imports` entries (one per exporter); the cluster A flatten (exporters → models) is done. The remaining LCM/governance/event_bus clusters stay grandfathered for their own follow-up PRs.

## Test plan

- [x] `cd backend && uv run mypy` — 0 errors / 341 files
- [x] `cd backend && uv run ruff check .` — clean
- [x] `cd backend && uv run ruff format --check .` — 342 files already formatted
- [x] `cd backend && uv run lint-imports --config .importlinter` — 3 contracts kept, 0 broken (one fewer grandfathered entry)
- [x] `pytest tests/test_exporters.py` — 6 passed

Branched off PR #375. Will rebase onto `development` once #375 merges.

https://claude.ai/code/session_01PQUJULmmdMPpiqNT2aqFKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQUJULmmdMPpiqNT2aqFKk)_