### PR TITLE
feat(stt): swap api/stt.py over to resolve_xai_credentials (#372 impl 4/N)

### DIFF
--- a/backend/app/api/stt.py
+++ b/backend/app/api/stt.py
@@ -14,9 +14,9 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.keys import resolve_api_key
 from app.crud.workspace import get_default_workspace
 from app.db import User, get_async_session
+from app.integrations.xai import resolve_xai_credentials
 from app.users import get_allowed_user
 
 logger = logging.getLogger(__name__)
@@ -86,15 +86,16 @@ def get_stt_router() -> APIRouter:  # noqa: C901 — single cohesive STT route +
                 raise HTTPException(status_code=502, detail=str(exc)) from exc
             return JSONResponse(content={"text": text})
 
-        # STT runs against the user's default workspace's configured key —
-        # there's no concept of "STT for workspace X" in the UI yet, so the
-        # default is the only sensible choice.  `resolve_api_key` already
-        # falls back to `settings.xai_api_key`, so the caller doesn't need a
-        # manual `or settings.x` suffix.
+        # STT runs against the user's default workspace's configured
+        # credentials — there's no concept of "STT for workspace X" in
+        # the UI yet, so the default is the only sensible choice. The
+        # helper honours the OAuth access token (#372) when one is
+        # stored on the workspace, falls back to the workspace
+        # ``XAI_API_KEY``, then to the gateway-global
+        # ``settings.xai_api_key`` — no manual fallback needed here.
         workspace = await get_default_workspace(user.id, session)
-        api_key = (
-            resolve_api_key(Path(workspace.path), "XAI_API_KEY") if workspace is not None else None
-        )
+        workspace_root = Path(workspace.path) if workspace is not None else None
+        api_key = await resolve_xai_credentials(workspace_root)
         if not api_key:
             raise HTTPException(
                 status_code=503,

--- a/backend/tests/test_stt_route.py
+++ b/backend/tests/test_stt_route.py
@@ -1,0 +1,99 @@
+"""Tests for the speech-to-text proxy route (``api/stt.py``).
+
+The route used to call ``resolve_api_key("XAI_API_KEY")`` directly,
+falling through to ``settings.xai_api_key`` only when no workspace
+override was set. After #372 it funnels every credential lookup
+through :func:`resolve_xai_credentials` so the OAuth access token
+(refreshed transparently when near expiry) is preferred over the
+legacy long-lived API key.
+
+These tests pin the new contract: the route surfaces 503 when the
+helper resolves to ``None``, and forwards the resolved bearer token
+verbatim into the upstream ``Authorization`` header.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.anyio
+async def test_stt_route_503s_when_no_xai_credential_resolves(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    seeded_default_workspace: object,
+) -> None:
+    """When ``resolve_xai_credentials`` returns ``None`` the route surfaces 503.
+
+    Pins the swap (#372 follow-up): the legacy code had a two-step
+    "workspace key OR gateway key" fallback inline. The new code
+    delegates that to the helper, so a single ``None`` reply must
+    short-circuit the upstream call and the user sees the "not
+    configured" notice instead of a guaranteed 401 from xAI.
+    """
+    monkeypatch.setattr(
+        "app.api.stt.resolve_xai_credentials",
+        _async_return(None),
+    )
+    # Force the xAI path by disabling the alt-backend dispatch.
+    monkeypatch.setattr("app.integrations.voice.resolve_transcriber", lambda: None)
+
+    response = await client.post(
+        "/api/v1/stt",
+        files={"file": ("voice.webm", b"\x00\x01\x02", "audio/webm")},
+    )
+    assert response.status_code == 503
+    assert "Speech-to-text is not configured" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_stt_route_forwards_resolved_credential_to_xai(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    seeded_default_workspace: object,
+) -> None:
+    """The route forwards whatever ``resolve_xai_credentials`` returns.
+
+    This is the OAuth path's success case: the helper returns an
+    access token, and the route MUST put it in the
+    ``Authorization: Bearer <token>`` header without re-deriving it
+    from the legacy ``XAI_API_KEY`` setting. We mock the upstream
+    httpx call so we can inspect what header was sent.
+    """
+    seen_headers: dict[str, str] = {}
+
+    def _upstream(request: httpx.Request) -> httpx.Response:
+        seen_headers.update({k.lower(): v for k, v in request.headers.items()})
+        return httpx.Response(200, json={"text": "hello world", "duration": 1.2, "words": []})
+
+    transport = httpx.MockTransport(_upstream)
+    monkeypatch.setattr(
+        "httpx.AsyncClient",
+        lambda **_: httpx.AsyncClient(transport=transport),
+    )
+    monkeypatch.setattr(
+        "app.api.stt.resolve_xai_credentials",
+        _async_return("oauth-access-token-xyz"),
+    )
+    monkeypatch.setattr("app.integrations.voice.resolve_transcriber", lambda: None)
+
+    response = await client.post(
+        "/api/v1/stt",
+        files={"file": ("voice.webm", b"\x00\x01\x02", "audio/webm")},
+    )
+    assert response.status_code == 200
+    assert response.json()["text"] == "hello world"
+    assert seen_headers.get("authorization") == "Bearer oauth-access-token-xyz"
+
+
+def _async_return(value: object) -> Callable[..., Awaitable[object]]:
+    """Return an async callable that ignores its args and returns ``value``."""
+
+    async def _stub(*_args: object, **_kwargs: object) -> object:
+        return value
+
+    return _stub


### PR DESCRIPTION
## Summary

Closes the next gap in the #372 stack: the speech-to-text proxy now funnels credential resolution through the same `resolve_xai_credentials` helper the provider switched to in #405, so workspace OAuth access tokens are honoured by the web composer's voice path.

**Before:** `api/stt.py` called `resolve_api_key("XAI_API_KEY")` inline and hard-coded the workspace-key → `settings.xai_api_key` fallback.

**After:** `resolve_xai_credentials` owns the lookup order (workspace OAuth → workspace `XAI_API_KEY` → `settings.xai_api_key`) and refreshes the OAuth access token transparently when near expiry, exactly mirroring the provider's behaviour.

## Test plan

- [ ] Pytest: `test_stt_route_503s_when_no_xai_credential_resolves` — helper returns `None` → no upstream call, clean "not configured" notice.
- [ ] Pytest: `test_stt_route_forwards_resolved_credential_to_xai` — helper returns `"oauth-access-token-xyz"` → upstream `Authorization` header carries it verbatim. `httpx.MockTransport` pins the contract.
- [ ] Smoke: record a voice note in the web composer with the gateway-global `XAI_API_KEY` set — still transcribes.
- [ ] Smoke (once `/login xai` lands): record after authorising, confirm token refresh + transcription succeed.

## Follow-up (not in this PR)

- `XaiSttTranscriber` (lives on PR #383/#413) still reads `settings.xai_api_key` statically. Once that PR lands the transcriber should be swapped over too.

Stacked on #405 (`claude/feat-xai-provider-swap-372`).

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_