### PR TITLE
feat(telegram): /login xai command driving xAI device-code OAuth (#372 impl 5/N)

### DIFF
--- a/backend/app/integrations/telegram/bot.py
+++ b/backend/app/integrations/telegram/bot.py
@@ -86,6 +86,10 @@ from app.integrations.telegram.status import (
     handle_status_command,
 )
 
+# ``/login`` lives in its own module so the OAuth driver + reply
+# copy don't push bot.py past the structural ceiling.
+from app.integrations.telegram.login_command import handle_login_command
+
 # ``THINKING_CALLBACK_PREFIX`` is re-exported via
 # :mod:`thinking_picker_runtime` for the same fan-out reason.
 from app.integrations.telegram.thinking_picker_runtime import (
@@ -110,6 +114,7 @@ _TELEGRAM_COMMANDS: tuple[tuple[str, str], ...] = (
     ("status", "Show gateway + conversation status"),
     ("lcm", "Show LCM (long-context memory) status for this conversation"),
     ("compact", "Force an LCM leaf-compaction pass now"),
+    ("login", "Authorise a provider (currently: /login xai)"),
 )
 
 # Captured at module import so /status can report this worker's uptime
@@ -490,6 +495,38 @@ def _register_telegram_command_handlers(dispatcher: Dispatcher) -> None:
         await message.answer(reply)
 
     _register_telegram_lcm_command_handlers(dispatcher)
+    _register_telegram_login_command_handler(dispatcher)
+
+
+def _register_telegram_login_command_handler(dispatcher: Dispatcher) -> None:
+    """Register the ``/login`` slash-command handler.
+
+    Split out of :func:`_register_telegram_command_handlers` so that
+    function stays under the PLR0915 cap and so the auth surface
+    lives next to the rest of the OAuth driver
+    (:mod:`login_command`).
+    """
+    from aiogram.filters import Command  # noqa: PLC0415
+
+    @dispatcher.message(Command("login"))
+    async def _on_login(message: Message) -> None:
+        text = message.text or ""
+        parts = text.strip().split(maxsplit=1)
+        login_args = parts[1].strip() if len(parts) > 1 else ""
+        sender = _sender_from_message(message)
+        if message.bot is None:
+            await message.answer(
+                "Login requires a live bot connection — please try again in a moment."
+            )
+            return
+        async with async_session_maker() as session:
+            reply = await handle_login_command(
+                sender=sender,
+                bot=message.bot,
+                args=login_args,
+                session=session,
+            )
+        await message.answer(reply, parse_mode="HTML")
 
 
 def _register_telegram_lcm_command_handlers(dispatcher: Dispatcher) -> None:

--- a/backend/app/integrations/telegram/login_command.py
+++ b/backend/app/integrations/telegram/login_command.py
@@ -1,0 +1,261 @@
+"""``/login xai`` Telegram command — kicks off the xAI OAuth device flow (#372).
+
+The command surfaces xAI's RFC 8628 device-code flow to a Telegram user:
+
+1. Pawrrtal calls ``request_device_code`` and posts the
+   ``user_code`` + ``verification_uri`` back to the chat.
+2. A background task awaits ``poll_for_token`` until the user
+   authorises (or the device code expires) and writes the
+   resulting access + refresh tokens to the user's default
+   workspace ``.env``.
+3. On success the bot follows up with a "✅ Logged in" notice.
+   On failure (denied / expired / network) the user gets a
+   short reason.
+
+Why a separate module
+---------------------
+``bot.py`` is already at the structural ceiling. A new command
+that needs its own background-task helper and message templates
+belongs next to the other per-command modules
+(``compact_command.py``, ``lcm_status.py``, …) so each surface
+stays readable in isolation.
+
+Future surfaces (web composer "Sign in with xAI" button) can
+reuse the helper at the bottom (`drive_xai_device_flow`) — only
+the messaging is Telegram-specific.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.keys import load_workspace_env, save_workspace_env
+from app.crud.channel import get_user_id_for_external
+from app.crud.workspace import get_default_workspace
+from app.integrations.xai import (
+    DeviceCodeGrant,
+    DeviceCodeRequest,
+    OAuthError,
+    poll_for_token,
+    request_device_code,
+)
+from app.integrations.xai.credentials import (
+    ACCESS_TOKEN_KEY,
+    EXPIRES_AT_KEY,
+    REFRESH_TOKEN_KEY,
+)
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "telegram"
+
+# Retain references to the background poll tasks so the event loop
+# doesn't garbage-collect them mid-flight (asyncio holds only weak
+# references to scheduled tasks; without the strong reference here
+# the GC can finalise the task between iterations of its inner
+# polling loop and the user's login silently fails). The set
+# self-prunes via the done-callback below.
+_pending_poll_tasks: set[asyncio.Task[None]] = set()
+
+# Pawrrtal's chosen alias for the only positional sub-command. The
+# command surface is ``/login xai`` so other providers can plug in
+# without recompiling the dispatcher — but we only ship the xAI one
+# right now.
+LOGIN_XAI_SUBCOMMAND = "xai"
+
+# Bind the poll deadline to xAI's 15-minute device-code lifetime.
+# Slightly shorter cap here so the background task self-terminates
+# before the device code does, avoiding the corner case where the
+# poll succeeds against a code that the server has just expired.
+_POLL_DEADLINE_SECONDS = 870.0
+
+# Reply copy lifted out as constants so the test suite can pin
+# them and so localisation lives in one place.
+_NOT_BOUND_MESSAGE = "Connect your account first before running /login."
+_USAGE_MESSAGE = "Usage: /login xai"
+_NO_WORKSPACE_MESSAGE = "You don't have a default workspace yet — set one up in the web app first."
+_NOT_CONFIGURED_MESSAGE = (
+    "xAI OAuth is not enabled on this deployment (operator: set settings.xai_oauth_client_id)."
+)
+_REQUEST_FAILED_MESSAGE = "Couldn't reach xAI to start the login flow. Try again in a moment."
+_INSTRUCTIONS_TEMPLATE = (
+    "🔑 <b>Connect xAI</b>\n\n"
+    "1. Open: {verification_uri}\n"
+    "2. Enter the code: <code>{user_code}</code>\n\n"
+    "I'll let you know when authorization completes (expires in {minutes} min)."
+)
+_SUCCESS_MESSAGE = "✅ Connected to xAI — your workspace can now use OAuth-backed requests."
+_DENIED_MESSAGE = "❌ You denied the xAI login request."
+_EXPIRED_MESSAGE = "⌛ The xAI login code expired before you authorised it. Try /login xai again."
+_FAILED_MESSAGE = "❌ xAI login failed: {reason}. Try /login xai again."
+
+
+class _TelegramSenderLike(Protocol):
+    """Structural type for the subset of ``TelegramSender`` /login needs."""
+
+    user_id: int
+    chat_id: int
+
+
+async def handle_login_command(
+    *,
+    sender: _TelegramSenderLike,
+    bot: Bot,
+    args: str,
+    session: AsyncSession,
+) -> str:
+    """Drive the synchronous (kickoff) half of the ``/login xai`` flow.
+
+    Returns the reply the bot sends immediately. The polling half
+    runs as a background task so the bot doesn't block the Telegram
+    poll loop for 15 minutes; the task posts a follow-up message
+    via :meth:`Bot.send_message` when it finishes.
+
+    Args:
+        sender: Normalized sender identity (Telegram numeric user
+            id + chat id used by the follow-up message).
+        bot: Live aiogram ``Bot`` for the follow-up message.
+        args: Whatever followed ``/login`` (trim'd). Only
+            ``"xai"`` is currently recognised — anything else
+            surfaces a one-liner usage hint.
+        session: Async DB session for the user binding + workspace
+            lookups.
+    """
+    if args.strip() != LOGIN_XAI_SUBCOMMAND:
+        return _USAGE_MESSAGE
+
+    pawrrtal_user_id = await get_user_id_for_external(
+        provider=_PROVIDER,
+        external_user_id=str(sender.user_id),
+        session=session,
+    )
+    if pawrrtal_user_id is None:
+        return _NOT_BOUND_MESSAGE
+
+    if not settings.xai_oauth_client_id:
+        return _NOT_CONFIGURED_MESSAGE
+
+    workspace = await get_default_workspace(pawrrtal_user_id, session)
+    if workspace is None:
+        return _NO_WORKSPACE_MESSAGE
+
+    try:
+        device_request = await request_device_code(client_id=settings.xai_oauth_client_id)
+    except OAuthError as exc:
+        logger.warning(
+            "XAI_LOGIN_REQUEST_FAILED user_id=%s code=%s",
+            pawrrtal_user_id,
+            exc.code,
+        )
+        return _REQUEST_FAILED_MESSAGE
+
+    # Background task: own the polling loop + the on-success env
+    # write. We pin a name on the task so it shows up in repr/log
+    # output and so the test suite can find it; we also pin a
+    # strong reference in ``_pending_poll_tasks`` so asyncio's GC
+    # doesn't finalise the task between polling iterations.
+    poll_task = asyncio.create_task(
+        _drive_poll_and_persist(
+            bot=bot,
+            chat_id=sender.chat_id,
+            workspace_root=Path(workspace.path),
+            device_request=device_request,
+        ),
+        name=f"xai-login-poll-{pawrrtal_user_id}",
+    )
+    _pending_poll_tasks.add(poll_task)
+    poll_task.add_done_callback(_pending_poll_tasks.discard)
+
+    minutes = max(1, device_request.expires_in // 60)
+    return _INSTRUCTIONS_TEMPLATE.format(
+        verification_uri=device_request.verification_uri,
+        user_code=device_request.user_code,
+        minutes=minutes,
+    )
+
+
+async def _drive_poll_and_persist(
+    *,
+    bot: Bot,
+    chat_id: int,
+    workspace_root: Path,
+    device_request: DeviceCodeRequest,
+) -> None:
+    """Poll until xAI grants a token, then write it to the workspace env."""
+    try:
+        grant = await poll_for_token(
+            client_id=settings.xai_oauth_client_id,
+            device_code=device_request.device_code,
+            interval=device_request.interval,
+            deadline_seconds=_POLL_DEADLINE_SECONDS,
+        )
+    except OAuthError as exc:
+        reply = _format_failure(exc.code)
+        logger.warning(
+            "XAI_LOGIN_POLL_FAILED workspace=%s code=%s",
+            workspace_root,
+            exc.code,
+        )
+        await _safe_followup(bot, chat_id, reply)
+        return
+
+    persist_xai_oauth_grant(workspace_root, grant)
+    await _safe_followup(bot, chat_id, _SUCCESS_MESSAGE)
+
+
+def persist_xai_oauth_grant(workspace_root: Path, grant: DeviceCodeGrant) -> None:
+    """Write the OAuth grant to the workspace ``.env`` in the canonical key shape.
+
+    The keys mirror what :func:`resolve_xai_credentials` reads back.
+    Exposed as a public helper so the future web-composer flow can
+    persist the same shape without re-implementing the key names.
+    """
+    env = load_workspace_env(workspace_root)
+    env[ACCESS_TOKEN_KEY] = grant.access_token
+    if grant.refresh_token is not None:
+        env[REFRESH_TOKEN_KEY] = grant.refresh_token
+    expires_at = datetime.now(UTC) + timedelta(seconds=grant.expires_in)
+    env[EXPIRES_AT_KEY] = expires_at.isoformat()
+    save_workspace_env(workspace_root, env)
+
+
+def _format_failure(code: str | None) -> str:
+    """Map an :class:`OAuthError` code to user-facing copy."""
+    if code == "access_denied":
+        return _DENIED_MESSAGE
+    if code == "expired_token":
+        return _EXPIRED_MESSAGE
+    return _FAILED_MESSAGE.format(reason=code or "unknown")
+
+
+async def _safe_followup(bot: Bot, chat_id: int, text: str) -> None:
+    """Post the closing message; swallow Telegram errors so the task can't crash the loop."""
+    # ``aiogram``'s exception classes are imported lazily here for the
+    # same reason :mod:`telegram_delivery` does: aiogram is optional
+    # in non-Telegram pytest runs.
+    from aiogram.exceptions import (  # noqa: PLC0415
+        TelegramAPIError,
+        TelegramNetworkError,
+    )
+
+    with contextlib.suppress(TelegramAPIError, TelegramNetworkError):
+        await bot.send_message(chat_id=chat_id, text=text, parse_mode="HTML")
+
+
+# Re-exported via __all__ so the import surface stays small.
+__all__ = [
+    "LOGIN_XAI_SUBCOMMAND",
+    "handle_login_command",
+    "persist_xai_oauth_grant",
+]

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -137,6 +137,7 @@ async def test_refresh_telegram_commands_sets_current_command_menu() -> None:
         "status",
         "lcm",
         "compact",
+        "login",
     ]
     assert all(command.description for command in commands)
 

--- a/backend/tests/test_telegram_login_command.py
+++ b/backend/tests/test_telegram_login_command.py
@@ -1,0 +1,235 @@
+"""Tests for the Telegram ``/login xai`` command (#372)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.integrations.telegram.login_command import (
+    LOGIN_XAI_SUBCOMMAND,
+    handle_login_command,
+    persist_xai_oauth_grant,
+)
+from app.integrations.xai import DeviceCodeGrant, DeviceCodeRequest, OAuthError
+from app.integrations.xai.credentials import (
+    ACCESS_TOKEN_KEY,
+    EXPIRES_AT_KEY,
+    REFRESH_TOKEN_KEY,
+)
+
+
+def _sender(*, user_id: int = 42, chat_id: int = 42) -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, chat_id=chat_id)
+
+
+@pytest.mark.anyio
+async def test_usage_message_when_subcommand_missing() -> None:
+    """``/login`` without a sub-command surfaces a one-liner usage hint.
+
+    Prevents an empty kickoff (no device code requested) from
+    burning xAI quota on a typo.
+    """
+    reply = await handle_login_command(
+        sender=_sender(),
+        bot=AsyncMock(),
+        args="",
+        session=AsyncMock(),
+    )
+    assert "Usage" in reply
+    assert LOGIN_XAI_SUBCOMMAND in reply
+
+
+@pytest.mark.anyio
+async def test_not_bound_when_user_has_no_telegram_binding() -> None:
+    """Unbound Telegram users see the ``/start`` nudge before logging in."""
+    with patch(
+        "app.integrations.telegram.login_command.get_user_id_for_external",
+        AsyncMock(return_value=None),
+    ):
+        reply = await handle_login_command(
+            sender=_sender(),
+            bot=AsyncMock(),
+            args="xai",
+            session=AsyncMock(),
+        )
+    assert "Connect your account" in reply
+
+
+@pytest.mark.anyio
+async def test_not_configured_when_oauth_client_id_unset() -> None:
+    """Operator misconfiguration surfaces a clean operator hint, no OAuth call."""
+    fake_user = uuid.uuid4()
+    fake_settings = SimpleNamespace(xai_oauth_client_id="")
+    request_spy = AsyncMock()
+    with (
+        patch(
+            "app.integrations.telegram.login_command.get_user_id_for_external",
+            AsyncMock(return_value=fake_user),
+        ),
+        patch("app.integrations.telegram.login_command.settings", fake_settings),
+        patch(
+            "app.integrations.telegram.login_command.request_device_code",
+            request_spy,
+        ),
+    ):
+        reply = await handle_login_command(
+            sender=_sender(),
+            bot=AsyncMock(),
+            args="xai",
+            session=AsyncMock(),
+        )
+    assert "not enabled" in reply
+    assert request_spy.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_no_workspace_message_when_user_has_no_default_workspace() -> None:
+    """Users without a default workspace are bounced before kicking off the flow."""
+    fake_user = uuid.uuid4()
+    fake_settings = SimpleNamespace(xai_oauth_client_id="pawrrtal-client")
+    with (
+        patch(
+            "app.integrations.telegram.login_command.get_user_id_for_external",
+            AsyncMock(return_value=fake_user),
+        ),
+        patch("app.integrations.telegram.login_command.settings", fake_settings),
+        patch(
+            "app.integrations.telegram.login_command.get_default_workspace",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        reply = await handle_login_command(
+            sender=_sender(),
+            bot=AsyncMock(),
+            args="xai",
+            session=AsyncMock(),
+        )
+    assert "default workspace" in reply
+
+
+@pytest.mark.anyio
+async def test_kickoff_posts_user_code_and_spawns_poll_task(tmp_path: Path) -> None:
+    """The happy path returns the user code + verification URI and launches the poller."""
+    fake_user = uuid.uuid4()
+    fake_workspace = SimpleNamespace(path=str(tmp_path / "ws"))
+    fake_settings = SimpleNamespace(xai_oauth_client_id="pawrrtal-client")
+    device_request = DeviceCodeRequest(
+        device_code="DEV-abc",
+        user_code="ABCD-1234",
+        verification_uri="https://x.ai/device",
+        expires_in=600,
+        interval=5,
+    )
+    # poll_for_token never returns here — we want the kickoff message
+    # only, not the success branch. Cancel the task afterwards.
+    poll_event = asyncio.Event()
+
+    async def _hang(**_kw: object) -> DeviceCodeGrant:
+        await poll_event.wait()
+        return DeviceCodeGrant(access_token="x", refresh_token=None, expires_in=1, scope=None)
+
+    with (
+        patch(
+            "app.integrations.telegram.login_command.get_user_id_for_external",
+            AsyncMock(return_value=fake_user),
+        ),
+        patch("app.integrations.telegram.login_command.settings", fake_settings),
+        patch(
+            "app.integrations.telegram.login_command.get_default_workspace",
+            AsyncMock(return_value=fake_workspace),
+        ),
+        patch(
+            "app.integrations.telegram.login_command.request_device_code",
+            AsyncMock(return_value=device_request),
+        ),
+        patch("app.integrations.telegram.login_command.poll_for_token", _hang),
+    ):
+        reply = await handle_login_command(
+            sender=_sender(),
+            bot=AsyncMock(),
+            args="xai",
+            session=AsyncMock(),
+        )
+
+    assert "ABCD-1234" in reply
+    assert "https://x.ai/device" in reply
+    # A background task is named ``xai-login-poll-<user-id>`` —
+    # finding it tells us the kickoff actually scheduled the poll.
+    tasks = [t for t in asyncio.all_tasks() if t.get_name().startswith("xai-login-poll-")]
+    assert len(tasks) == 1, "expected exactly one xai-login-poll-* task"
+    # Tear down so the hung task doesn't leak between tests.
+    poll_event.set()
+    for task in tasks:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.anyio
+async def test_request_failed_message_when_device_endpoint_errs() -> None:
+    """xAI device-code endpoint errors surface as a retry hint, not the user code."""
+    fake_user = uuid.uuid4()
+    fake_workspace = SimpleNamespace(path="/tmp/ws")
+    fake_settings = SimpleNamespace(xai_oauth_client_id="pawrrtal-client")
+    with (
+        patch(
+            "app.integrations.telegram.login_command.get_user_id_for_external",
+            AsyncMock(return_value=fake_user),
+        ),
+        patch("app.integrations.telegram.login_command.settings", fake_settings),
+        patch(
+            "app.integrations.telegram.login_command.get_default_workspace",
+            AsyncMock(return_value=fake_workspace),
+        ),
+        patch(
+            "app.integrations.telegram.login_command.request_device_code",
+            AsyncMock(side_effect=OAuthError("upstream borked", code="500")),
+        ),
+    ):
+        reply = await handle_login_command(
+            sender=_sender(),
+            bot=AsyncMock(),
+            args="xai",
+            session=AsyncMock(),
+        )
+    assert "Couldn't reach xAI" in reply
+
+
+def test_persist_xai_oauth_grant_writes_canonical_keys(tmp_path: Path) -> None:
+    """The grant lands under the three canonical workspace .env keys."""
+    workspace_root = tmp_path / "ws"
+    workspace_root.mkdir()
+    grant = DeviceCodeGrant(
+        access_token="access-1",
+        refresh_token="refresh-1",
+        expires_in=3600,
+        scope="chat:read",
+    )
+
+    captured: dict[str, str] = {}
+
+    def _save(_root: Path, env: dict[str, str]) -> None:
+        captured.update(env)
+
+    with (
+        patch(
+            "app.integrations.telegram.login_command.load_workspace_env",
+            MagicMock(return_value={}),
+        ),
+        patch(
+            "app.integrations.telegram.login_command.save_workspace_env",
+            _save,
+        ),
+    ):
+        persist_xai_oauth_grant(workspace_root, grant)
+
+    assert captured[ACCESS_TOKEN_KEY] == "access-1"
+    assert captured[REFRESH_TOKEN_KEY] == "refresh-1"
+    # ISO-8601 UTC string with a +00:00 offset, no trailing whitespace.
+    assert captured[EXPIRES_AT_KEY].endswith("+00:00")


### PR DESCRIPTION
## Summary

The `/login xai` command lifts the OAuth device-code primitives shipped in #397/#402/#405 into a user-reachable Telegram action.

**Flow**
1. `/login xai` posts the `user_code` + `verification_uri` in chat.
2. A background `asyncio.Task` polls `poll_for_token` until the user authorises (or the code expires).
3. On success the access + refresh tokens land in the workspace `.env` under the same `XAI_OAUTH_*` keys `resolve_xai_credentials` reads back. The bot follows up with a "✅ Connected to xAI" notice.
4. On failure (denied / expired / unknown) the bot surfaces a short reason so the user can retry.

`login_command.py` owns the OAuth driver + reply copy. `bot.py` gets ~37 lines of wiring (one new dispatcher handler + inclusion in `_TELEGRAM_COMMANDS`). Matches the `/compact` and `/lcm` shape.

The background task's strong-ref set (`_pending_poll_tasks`) prevents asyncio's task GC from finalising the poll mid-flight; without it long-lived background tasks can be collected between iterations of their inner loop and silently disappear.

## Test plan

- [ ] `test_usage_message_when_subcommand_missing`
- [ ] `test_not_bound_when_user_has_no_telegram_binding`
- [ ] `test_not_configured_when_oauth_client_id_unset`
- [ ] `test_no_workspace_message_when_user_has_no_default_workspace`
- [ ] `test_kickoff_posts_user_code_and_spawns_poll_task`
- [ ] `test_request_failed_message_when_device_endpoint_errs`
- [ ] `test_persist_xai_oauth_grant_writes_canonical_keys`
- [ ] Updated channel `test_refresh_telegram_commands_sets_current_command_menu` for `/login`.
- [ ] Smoke: set `XAI_OAUTH_CLIENT_ID`, run `/login xai`, authorise on the device page, watch the chat post the success notice and the workspace `.env` pick up the three keys.

## Follow-ups (not in this PR — scope guard)

- Web composer "Sign in with xAI" button — reuse `persist_xai_oauth_grant` + the same OAuth helpers.
- Surface OAuth login status in `/status` output.

Stacked on #405 (`claude/feat-xai-provider-swap-372`).

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_