### PR TITLE
feat(dreaming): runner + scheduler that drive DreamingJob end-to-end (#341 impl 3/N)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -359,6 +359,13 @@ class Settings(BaseSettings):
     # cheap models, wasteful for premium ones.
     lcm_summary_model: str = ""
 
+    # ── Dreaming (between-sessions reflection) ──────────────────────
+    # Litellm model id used by the dreaming pass. Defaults to Gemini
+    # Flash because the prompt is single-turn JSON-only — no need to
+    # spend a premium model on it. See the ADR at
+    # ``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``.
+    dreaming_model_id: str = "gemini/gemini-flash-latest"
+
     @property
     def claude_sandbox_excluded_commands_list(self) -> list[str]:
         """Parsed view of ``claude_sandbox_excluded_commands``."""

--- a/backend/app/core/dreaming/__init__.py
+++ b/backend/app/core/dreaming/__init__.py
@@ -14,14 +14,20 @@ Public surface:
   output the model returns.
 - :func:`parse_dreaming_output` — robust parser that accepts the
   model's raw JSON / Markdown-fenced JSON / partial outputs.
-
-The actual job runner + scheduler integration lives in
-:mod:`app.core.dreaming.runner` (added in a stacked follow-up); this
-module owns the pure types + prompt so they're unit-testable without
-the LCM background scheduler in scope.
+- :func:`run_dreaming_job` — drive one job from pending →
+  completed/failed (used by the scheduler + cron entry points).
+- :func:`schedule_session_end_dream` /
+  :func:`schedule_daily_rollup_dream` — create a job and fire its
+  background runner.
 """
 
 from app.core.dreaming.prompt import DREAMING_PROMPT
+from app.core.dreaming.runner import DreamFn, run_dreaming_job
+from app.core.dreaming.scheduler import (
+    DreamingScope,
+    schedule_daily_rollup_dream,
+    schedule_session_end_dream,
+)
 from app.core.dreaming.schema import (
     ConsolidatedMemory,
     DreamingOutput,
@@ -31,10 +37,15 @@ from app.core.dreaming.schema import (
 )
 
 __all__ = [
-    "ConsolidatedMemory",
     "DREAMING_PROMPT",
+    "ConsolidatedMemory",
+    "DreamFn",
     "DreamingOutput",
     "DreamingPattern",
+    "DreamingScope",
     "Followup",
     "parse_dreaming_output",
+    "run_dreaming_job",
+    "schedule_daily_rollup_dream",
+    "schedule_session_end_dream",
 ]

--- a/backend/app/core/dreaming/runner.py
+++ b/backend/app/core/dreaming/runner.py
@@ -1,0 +1,326 @@
+"""Dreaming-pass runner — drives one :class:`DreamingJob` end-to-end (#341).
+
+Per the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``,
+each pass:
+
+1. Reads the chat history window the job points at
+   (``session_end`` → last N messages on the conversation;
+   ``daily_rollup`` → last 24h across all of the user's conversations).
+2. Renders the dreaming prompt and asks the reasoning model for a
+   single structured response.
+3. Parses the response with :func:`parse_dreaming_output`.
+4. Writes each :class:`ConsolidatedMemory` into the ``memories``
+   table with ``source="dreaming"`` and ``provenance_job_id``
+   pointing back at the job row, so every dreaming-derived memory
+   can be traced to the pass that produced it.
+5. Updates the job row with the output counts, the session summary,
+   and the terminal status (``completed`` / ``failed``).
+
+The LLM call is dependency-injected via the ``dream_fn`` argument
+so tests run without a live provider. The default implementation
+(``_default_dream_fn``) shells out to the configured dreaming model
+via litellm — same dependency the LCM compaction summariser uses.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dreaming.prompt import DREAMING_PROMPT
+from app.core.dreaming.schema import (
+    DreamingOutput,
+    parse_dreaming_output,
+)
+from app.crud.memory import find_similar_memories, insert_memory
+from app.db import async_session_maker
+from app.models import ChatMessage, Conversation, DreamingJob
+
+logger = logging.getLogger(__name__)
+
+
+# Window sizes for the two scopes. Tuned so a single pass fits in
+# a 32k-token context window even with verbose tool turns.
+_SESSION_END_MESSAGE_LIMIT = 50
+_DAILY_ROLLUP_HOURS = 24
+_DAILY_ROLLUP_MESSAGE_LIMIT = 200
+
+# Per-input token cap so a runaway message thread can't blow the
+# prompt budget. Tokens are estimated as roughly 4 chars / token,
+# which is the same approximation LCM uses for its leaf chunks.
+_CHARS_PER_TOKEN = 4
+_MAX_INPUT_CHARS = 24_000 * _CHARS_PER_TOKEN
+
+DreamFn = Callable[[str], Awaitable[str]]
+"""Signature for the dreaming-prompt LLM call.
+
+Takes the rendered prompt; returns the model's raw string output.
+Injectable so tests can swap in a deterministic stub instead of a
+network round-trip.
+"""
+
+
+SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+"""Factory shape callers can swap in to redirect the runner to a test DB.
+
+Defaults to :data:`app.db.async_session_maker` — pytest fixtures
+that need to assert against in-memory state pass their own
+sessionmaker so the runner reads/writes through the same engine
+as the test's setup.
+"""
+
+
+async def run_dreaming_job(
+    job_id: uuid.UUID,
+    *,
+    dream_fn: DreamFn | None = None,
+    session_factory: SessionFactory | None = None,
+) -> None:
+    """Drive one dreaming pass from ``pending`` to ``completed`` or ``failed``.
+
+    Idempotent on the ``status`` column: if the job has already run
+    (``status != "pending"``) the function short-circuits without
+    touching the row. Callers can safely retry on transient errors
+    by clearing ``error_text`` + setting ``status="pending"`` before
+    invoking this again.
+
+    Args:
+        job_id: Primary key of the :class:`DreamingJob` to run.
+        dream_fn: Optional override for the LLM call seam — lets
+            tests inject a deterministic response without a provider.
+            When ``None``, the default impl uses litellm via
+            :func:`_default_dream_fn`.
+        session_factory: Optional override for the session maker.
+            Defaults to :data:`async_session_maker`; tests pass
+            their own factory so the runner reads/writes through
+            the same in-memory SQLite engine as the test setup.
+    """
+    effective_fn = dream_fn or _default_dream_fn
+    factory = session_factory or async_session_maker
+    async with factory() as session:
+        job = await _claim_pending_job(session, job_id)
+        if job is None:
+            return
+        try:
+            input_text = await _build_input_window(session, job)
+            raw_response = await effective_fn(_render_prompt(input_text))
+            parsed = parse_dreaming_output(raw_response)
+            memories_written = await _persist_outputs(session, job, parsed)
+            await _mark_completed(
+                session,
+                job,
+                parsed,
+                memories_written=memories_written,
+                input_chars=len(input_text),
+                raw_chars=len(raw_response),
+            )
+        except (OSError, RuntimeError, ValueError, TimeoutError) as exc:
+            logger.exception("DREAMING_RUN_ERR job_id=%s", job_id)
+            await _mark_failed(session, job, error=str(exc))
+
+
+async def _claim_pending_job(session: AsyncSession, job_id: uuid.UUID) -> DreamingJob | None:
+    """Flip ``pending`` → ``running`` + set ``started_at``; return ``None`` otherwise."""
+    job = await session.get(DreamingJob, job_id)
+    if job is None:
+        logger.warning("DREAMING_JOB_MISSING job_id=%s", job_id)
+        return None
+    if job.status != "pending":
+        logger.info(
+            "DREAMING_JOB_SKIP_NONPENDING job_id=%s status=%s",
+            job_id,
+            job.status,
+        )
+        return None
+    job.status = "running"
+    job.started_at = datetime.now(UTC)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def _build_input_window(session: AsyncSession, job: DreamingJob) -> str:
+    """Pull the messages the dreaming pass should reflect on."""
+    if job.scope == "session_end" and job.conversation_id is not None:
+        rows = await _last_n_messages_in_conversation(
+            session,
+            conversation_id=job.conversation_id,
+            limit=_SESSION_END_MESSAGE_LIMIT,
+        )
+    else:
+        rows = await _last_24h_messages_for_user(
+            session,
+            user_id=job.user_id,
+            limit=_DAILY_ROLLUP_MESSAGE_LIMIT,
+        )
+    return _format_input(rows)
+
+
+async def _last_n_messages_in_conversation(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    limit: int,
+) -> list[ChatMessage]:
+    """Return the most recent ``limit`` messages in ``conversation_id``, oldest first."""
+    stmt = (
+        select(ChatMessage)
+        .where(ChatMessage.conversation_id == conversation_id)
+        .order_by(desc(ChatMessage.ordinal))
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    rows.reverse()
+    return rows
+
+
+async def _last_24h_messages_for_user(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    limit: int,
+) -> list[ChatMessage]:
+    """Return ``user_id``'s messages from the last 24h, oldest first."""
+    cutoff = datetime.now(UTC) - timedelta(hours=_DAILY_ROLLUP_HOURS)
+    stmt = (
+        select(ChatMessage)
+        .join(Conversation, Conversation.id == ChatMessage.conversation_id)
+        .where(Conversation.user_id == user_id)
+        .where(ChatMessage.created_at >= cutoff)
+        .order_by(desc(ChatMessage.created_at))
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    rows.reverse()
+    return rows
+
+
+def _format_input(rows: list[ChatMessage]) -> str:
+    """Render messages as a plain transcript, capped at ``_MAX_INPUT_CHARS``.
+
+    Plain text keeps the dreaming prompt token-efficient — tool
+    metadata + provider-specific block types from the live history
+    don't help the reflection pass. We tag each line with the role
+    so the model can tell user input apart from assistant output.
+    """
+    lines: list[str] = []
+    total = 0
+    for row in rows:
+        line = f"[{row.role}] {row.content or ''}"
+        if total + len(line) > _MAX_INPUT_CHARS:
+            lines.append("[truncated: input window exceeded]")
+            break
+        lines.append(line)
+        total += len(line) + 1  # +1 for the newline
+    return "\n".join(lines)
+
+
+def _render_prompt(input_text: str) -> str:
+    """Combine the static dreaming prompt and the chat transcript window."""
+    return f"{DREAMING_PROMPT}\n\n# Recent activity\n\n{input_text}"
+
+
+async def _persist_outputs(
+    session: AsyncSession,
+    job: DreamingJob,
+    parsed: DreamingOutput,
+) -> int:
+    """Write each consolidated memory; return the count actually written.
+
+    Dedupe pre-check: for each candidate memory we run
+    :func:`find_similar_memories` first and skip when the substring
+    match returns anything — the model often re-states the same
+    fact across runs and we don't want a memory list that doubles
+    every night.
+    """
+    written = 0
+    for entry in parsed.consolidated_memories:
+        existing = await find_similar_memories(
+            session,
+            job.user_id,
+            text=entry.text,
+            kind=entry.kind,
+        )
+        if existing:
+            continue
+        await insert_memory(
+            session,
+            job.user_id,
+            kind=entry.kind,
+            text=entry.text,
+            source="dreaming",
+            workspace_id=job.workspace_id,
+            conversation_id=job.conversation_id,
+            provenance_job_id=job.id,
+        )
+        written += 1
+    return written
+
+
+async def _mark_completed(
+    session: AsyncSession,
+    job: DreamingJob,
+    parsed: DreamingOutput,
+    *,
+    memories_written: int,
+    input_chars: int,
+    raw_chars: int,
+) -> None:
+    """Stamp the job row with the run's results."""
+    job.status = "completed"
+    job.completed_at = datetime.now(UTC)
+    job.memories_written = memories_written
+    job.patterns_written = len(parsed.patterns)
+    job.followups_written = len(parsed.followups)
+    job.session_summary = parsed.session_summary or None
+    # Char-based estimate matches the LCM convention; the dedicated
+    # tokeniser comes online when the provider seam stabilises.
+    job.input_token_count = input_chars // _CHARS_PER_TOKEN
+    job.output_token_count = raw_chars // _CHARS_PER_TOKEN
+    await session.commit()
+
+
+async def _mark_failed(session: AsyncSession, job: DreamingJob, *, error: str) -> None:
+    """Stamp the job row as failed with a truncated error message."""
+    job.status = "failed"
+    job.completed_at = datetime.now(UTC)
+    job.error_text = error[:1000]
+    await session.commit()
+
+
+async def _default_dream_fn(prompt: str) -> str:
+    """Default dreaming-call implementation — lazy litellm wrapper.
+
+    Kept narrow on purpose: a dreaming pass is a one-shot text
+    completion, not a streaming agent loop, so going through the
+    full provider seam would be overkill. ``litellm.acompletion``
+    is the same dependency the LCM summariser uses, so we inherit
+    its provider routing for free.
+    """
+    # ``litellm`` is a hard dep of the gateway; lazy import keeps the
+    # module load cost low when the dreaming runner is never invoked.
+    import litellm  # noqa: PLC0415
+
+    from app.core.config import settings  # noqa: PLC0415
+
+    response = await litellm.acompletion(
+        model=settings.dreaming_model_id,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+    return str(response.choices[0].message.content or "")
+
+
+__all__ = [
+    "DreamFn",
+    "run_dreaming_job",
+]

--- a/backend/app/core/dreaming/scheduler.py
+++ b/backend/app/core/dreaming/scheduler.py
@@ -1,0 +1,143 @@
+"""Fire-and-forget scheduler for dreaming passes (#341).
+
+The two trigger entry points the rest of the codebase calls are:
+
+- :func:`schedule_session_end_dream` — fired by the per-turn finalizer
+  when a conversation has been idle long enough to look like the
+  user has wrapped up that thread.
+- :func:`schedule_daily_rollup_dream` — fired by the daily cron (a
+  follow-up to this PR) once per user, 24 h after the last rollup.
+
+Both helpers create a :class:`DreamingJob` row in the
+``pending`` state and launch the runner as a background task. The
+runner takes over from there: it transitions the row through
+``running`` → ``completed`` / ``failed`` and writes any new
+memories. No locking is needed because the scope of each job is
+(user_id, conversation_id) for ``session_end`` and (user_id,
+24-hour window) for ``daily_rollup`` — concurrent runs at the
+same scope would write the same dedupe-checked memories and the
+classifier's substring filter swallows duplicates.
+
+The strong-ref task set follows the same pattern as
+:mod:`app.core.lcm.background` so background tasks aren't GC'd
+mid-flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dreaming.runner import DreamFn, SessionFactory, run_dreaming_job
+from app.models import DreamingJob
+
+logger = logging.getLogger(__name__)
+
+DreamingScope = Literal["session_end", "daily_rollup"]
+
+# Strong references to in-flight tasks so asyncio's GC doesn't
+# finalise them mid-loop. See app.core.lcm.background for the same
+# pattern + rationale.
+_DREAMING_TASKS: set[asyncio.Task[None]] = set()
+
+
+async def schedule_session_end_dream(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    workspace_id: uuid.UUID | None = None,
+    dream_fn: DreamFn | None = None,
+    session_factory: SessionFactory | None = None,
+) -> uuid.UUID:
+    """Create a session_end dreaming job and launch its runner.
+
+    Returns the new job's id so the caller can correlate later
+    log entries with it (e.g. surfacing "🌙 Pawrrtal dreamed about
+    this conversation" in Telegram once the row hits ``completed``).
+    """
+    return await _create_and_schedule(
+        session,
+        user_id=user_id,
+        scope="session_end",
+        conversation_id=conversation_id,
+        workspace_id=workspace_id,
+        dream_fn=dream_fn,
+        session_factory=session_factory,
+    )
+
+
+async def schedule_daily_rollup_dream(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    workspace_id: uuid.UUID | None = None,
+    dream_fn: DreamFn | None = None,
+    session_factory: SessionFactory | None = None,
+) -> uuid.UUID:
+    """Create a daily_rollup dreaming job and launch its runner."""
+    return await _create_and_schedule(
+        session,
+        user_id=user_id,
+        scope="daily_rollup",
+        conversation_id=None,
+        workspace_id=workspace_id,
+        dream_fn=dream_fn,
+        session_factory=session_factory,
+    )
+
+
+async def _create_and_schedule(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    scope: DreamingScope,
+    conversation_id: uuid.UUID | None,
+    workspace_id: uuid.UUID | None,
+    dream_fn: DreamFn | None,
+    session_factory: SessionFactory | None,
+) -> uuid.UUID:
+    """Insert the job row and spawn the background runner.
+
+    The job is committed before the task is launched so the runner
+    can re-load it via its primary key — necessary because the
+    runner opens its own session (life-cycle independent of the
+    caller's).
+    """
+    job = DreamingJob(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+        scope=scope,
+        status="pending",
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    job_id = job.id
+
+    task = asyncio.create_task(
+        run_dreaming_job(job_id, dream_fn=dream_fn, session_factory=session_factory),
+        name=f"dreaming-{scope}-{job_id}",
+    )
+    _DREAMING_TASKS.add(task)
+    task.add_done_callback(_DREAMING_TASKS.discard)
+    logger.info(
+        "DREAMING_JOB_SCHEDULED job_id=%s scope=%s user_id=%s conversation_id=%s",
+        job_id,
+        scope,
+        user_id,
+        conversation_id,
+    )
+    return job_id
+
+
+__all__ = [
+    "DreamingScope",
+    "schedule_daily_rollup_dream",
+    "schedule_session_end_dream",
+]

--- a/backend/tests/test_dreaming_runner.py
+++ b/backend/tests/test_dreaming_runner.py
@@ -1,0 +1,338 @@
+"""Tests for the dreaming runner + scheduler (#341).
+
+Uses a stubbed ``dream_fn`` so the pass runs without a live LLM —
+exactly the pattern the agent-loop tests follow with
+``ScriptedStreamFn``. The real persistence layer (SQLAlchemy +
+SQLite) runs in the test DB so the lifecycle transitions
+(``pending`` → ``running`` → ``completed`` / ``failed``), memory
+inserts, and dedupe checks all exercise the production code path.
+
+Each test passes a ``session_factory`` keyed to the test's
+in-memory engine so the runner's own session reads the same data
+the test seeded. Without that override the runner's
+``async_session_maker`` would open a session against the
+production engine and the test data would be invisible.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.dreaming import (
+    run_dreaming_job,
+    schedule_daily_rollup_dream,
+    schedule_session_end_dream,
+)
+from app.crud.memory import insert_memory
+from app.db import User
+from app.models import ChatMessage, Conversation, DreamingJob, Memory
+
+
+def _scripted_fn(payload: dict[str, object]) -> Callable[[str], Awaitable[str]]:
+    """Return a ``DreamFn`` stub that always replies with ``payload`` as JSON."""
+    encoded = json.dumps(payload)
+
+    async def _stub(_prompt: str) -> str:
+        return encoded
+
+    return _stub
+
+
+def _session_factory_for(db_session: AsyncSession):
+    """Build a session factory bound to the test's in-memory engine.
+
+    The runner's default factory is ``app.db.async_session_maker``,
+    which targets the production engine. Tests rebind so the
+    runner reads/writes through the same engine the fixture sets
+    up; otherwise the runner would open an empty production
+    session and see none of the seeded data.
+    """
+    engine = db_session.bind  # AsyncEngine attached to the test session
+    test_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def _factory() -> AsyncIterator[AsyncSession]:
+        async with test_session_maker() as session:
+            yield session
+
+    return _factory
+
+
+async def _seed_conversation(
+    db_session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    messages: list[tuple[str, str]],
+) -> Conversation:
+    """Insert a conversation + ordered messages and return the conversation row."""
+    now = datetime.now(UTC)
+    conversation = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        title="Test conversation",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(conversation)
+    await db_session.commit()
+    for ordinal, (role, content) in enumerate(messages):
+        db_session.add(
+            ChatMessage(
+                id=uuid.uuid4(),
+                conversation_id=conversation.id,
+                user_id=user_id,
+                ordinal=ordinal,
+                role=role,
+                content=content,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    await db_session.commit()
+    return conversation
+
+
+@pytest.mark.anyio
+async def test_session_end_pass_writes_memories_and_completes(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """Happy path: session_end pass writes consolidated memories + flips the job to completed."""
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[
+            ("user", "I always prefer concise replies."),
+            ("assistant", "Noted — I'll keep responses short."),
+        ],
+    )
+    payload = {
+        "consolidated_memories": [
+            {"kind": "user", "text": "Prefers concise replies."},
+        ],
+        "patterns": [{"text": "Repeated brevity request"}],
+        "followups": [],
+        "session_summary": "Short turn discussing response style.",
+    }
+    job_id = await schedule_session_end_dream(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        dream_fn=_scripted_fn(payload),
+        session_factory=factory,
+    )
+
+    # ``schedule_session_end_dream`` spawns a background task that
+    # may already have run before the next line lands. The runner
+    # is idempotent on the ``status`` column — calling it again
+    # against a row that's already ``completed`` is a no-op. We
+    # call explicitly here so the test doesn't race the bg task
+    # for the assertion phase.
+    await run_dreaming_job(
+        job_id,
+        dream_fn=_scripted_fn(payload),
+        session_factory=factory,
+    )
+
+    # Refresh from the same session that seeded the row so we
+    # don't read a stale snapshot from before the runner committed.
+    await db_session.commit()
+    refreshed = await db_session.get(DreamingJob, job_id)
+    await db_session.refresh(refreshed) if refreshed is not None else None
+    assert refreshed is not None
+    assert refreshed.status == "completed"
+    assert refreshed.memories_written == 1
+    assert refreshed.patterns_written == 1
+    assert refreshed.session_summary == "Short turn discussing response style."
+    assert refreshed.completed_at is not None
+
+    memories = list(
+        (await db_session.execute(select(Memory).where(Memory.user_id == test_user.id)))
+        .scalars()
+        .all()
+    )
+    assert len(memories) == 1
+    assert memories[0].text == "Prefers concise replies."
+    assert memories[0].source == "dreaming"
+    assert memories[0].provenance_job_id == job_id
+
+
+@pytest.mark.anyio
+async def test_dedupe_skips_substring_duplicate(db_session: AsyncSession, test_user: User) -> None:
+    """A consolidated memory whose substring already exists isn't re-inserted."""
+    await insert_memory(
+        db_session,
+        test_user.id,
+        kind="user",
+        text="Prefers concise replies.",
+        source="classifier",
+    )
+
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[("user", "Remember I want short answers.")],
+    )
+    job_id = await schedule_session_end_dream(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+        dream_fn=_scripted_fn(
+            {
+                "consolidated_memories": [
+                    {"kind": "user", "text": "Prefers concise replies."},
+                ],
+                "patterns": [],
+                "followups": [],
+                "session_summary": "",
+            }
+        ),
+    )
+    await run_dreaming_job(
+        job_id,
+        dream_fn=_scripted_fn(
+            {
+                "consolidated_memories": [
+                    {"kind": "user", "text": "Prefers concise replies."},
+                ],
+                "patterns": [],
+                "followups": [],
+                "session_summary": "",
+            }
+        ),
+        session_factory=factory,
+    )
+
+    await db_session.commit()
+    refreshed = await db_session.get(DreamingJob, job_id)
+    await db_session.refresh(refreshed) if refreshed is not None else None
+    assert refreshed is not None
+    assert refreshed.status == "completed"
+    assert refreshed.memories_written == 0  # dedupe filtered the only candidate
+
+    rows = list(
+        (await db_session.execute(select(Memory).where(Memory.user_id == test_user.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1  # only the pre-seeded classifier memory
+
+
+@pytest.mark.anyio
+async def test_runner_marks_job_failed_on_dream_fn_error(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """When the dream_fn raises, the job is marked failed with truncated error_text."""
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[("user", "hi")],
+    )
+    job_id = await schedule_session_end_dream(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+    )
+
+    async def _exploding(_prompt: str) -> str:
+        raise RuntimeError("LLM provider unreachable")
+
+    await run_dreaming_job(job_id, dream_fn=_exploding, session_factory=factory)
+
+    await db_session.commit()
+    refreshed = await db_session.get(DreamingJob, job_id)
+    await db_session.refresh(refreshed) if refreshed is not None else None
+    assert refreshed is not None
+    assert refreshed.status == "failed"
+    assert refreshed.error_text is not None
+    assert "LLM provider unreachable" in refreshed.error_text
+
+
+@pytest.mark.anyio
+async def test_runner_is_idempotent_on_already_completed_job(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A second call against a completed job is a no-op (no double-insert).
+
+    Important: schedule_*_dream spawns its own background task. If
+    the test event loop runs the task before our explicit run, the
+    explicit run must observe the terminal state and bail without
+    re-writing memories.
+    """
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[("user", "test")],
+    )
+    job_id = await schedule_session_end_dream(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+    )
+    await run_dreaming_job(
+        job_id,
+        dream_fn=_scripted_fn(
+            {
+                "consolidated_memories": [{"kind": "user", "text": "Likes tests."}],
+                "patterns": [],
+                "followups": [],
+                "session_summary": "",
+            }
+        ),
+        session_factory=factory,
+    )
+    # Second call: status is already "completed", so the runner
+    # should short-circuit and the memory count stays at 1.
+    await run_dreaming_job(
+        job_id,
+        dream_fn=_scripted_fn(
+            {
+                "consolidated_memories": [{"kind": "user", "text": "Different text."}],
+                "patterns": [],
+                "followups": [],
+                "session_summary": "",
+            }
+        ),
+        session_factory=factory,
+    )
+
+    rows = list(
+        (await db_session.execute(select(Memory).where(Memory.user_id == test_user.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].text == "Likes tests."
+
+
+@pytest.mark.anyio
+async def test_daily_rollup_scope_creates_a_pending_job_row(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The daily-rollup scheduler stamps the row with scope='daily_rollup'."""
+    factory = _session_factory_for(db_session)
+    job_id = await schedule_daily_rollup_dream(
+        db_session,
+        user_id=test_user.id,
+        dream_fn=_scripted_fn({"consolidated_memories": []}),
+        session_factory=factory,
+    )
+    row = await db_session.get(DreamingJob, job_id)
+    assert row is not None
+    assert row.scope == "daily_rollup"
+    assert row.conversation_id is None
+    assert row.user_id == test_user.id


### PR DESCRIPTION
## Summary

Closes the dreaming-handler gap. The lifecycle now actually moves from `pending` → `running` → `completed`/`failed` with memories landing in the right table.

### `runner.py`
- `run_dreaming_job(job_id)` loads a pending row, claims it (`status='running'`, `started_at=now`), fetches the message window appropriate for the scope (`session_end`: last 50 messages on the conversation; `daily_rollup`: last 24h of the user's messages), renders the `DREAMING_PROMPT`, calls the model, parses the output via `parse_dreaming_output`, dedupes against existing memories via `find_similar_memories`, inserts each survivor through `insert_memory` with `source='dreaming'` + `provenance_job_id`, and stamps the row with output counts + `session_summary`.
- The LLM call is dependency-injected via `DreamFn` so tests run without a network round-trip. The default `_default_dream_fn` uses litellm against `settings.dreaming_model_id` (default `gemini/gemini-flash-latest` — single-turn JSON, no premium model needed).
- The session opener is dependency-injected via `SessionFactory` for the same reason: tests pass their in-memory engine's sessionmaker so the runner reads/writes through the same DB the test seeded.
- Idempotent on status: a second call against a `completed` job short-circuits.
- `OSError` / `RuntimeError` / `ValueError` / `TimeoutError` become `status='failed'` + `error_text`. Other classes propagate (real bugs shouldn't be silently swallowed).

### `scheduler.py`
- `schedule_session_end_dream(session, user_id, conversation_id)` and `schedule_daily_rollup_dream(session, user_id)` insert the job row + launch the runner as a background `asyncio.Task` with a stable name (`dreaming-<scope>-<job_id>`) for log grep-ability.
- Strong-ref task set matches the LCM background pattern so the GC doesn't finalise long-running tasks mid-loop.

### Tests
- Happy-path `session_end` pass writes one memory + completes.
- Substring dedupe filters out a re-stated memory.
- Runner marks the job failed with truncated `error_text` when the `dream_fn` raises.
- Second run against a `completed` job is a no-op.
- `daily_rollup` scope creates the right row shape.

## Test plan

- [ ] Backend pytest passes the five new dreaming runner tests.
- [ ] No new lint or nesting failures.
- [ ] Smoke (post-wire): trigger session_end manually via Python REPL, watch the row transition + see a `memories` row land with `source='dreaming'`.

## Follow-ups (not in this PR — scope guard)

- Wire `schedule_session_end_dream` into the per-turn finalizer in `turn_runner` so the bg pass actually fires.
- Daily cron entry point (24h sweep).
- Telegram "🌙 Pawrrtal dreamed" follow-up message when the job completes (correlates via the returned `job_id`).
- Embedding-aware dedupe — substring is the cheap pre-filter per the ADR.

Stacked on #406 (`claude/feat-dreaming-reflection-341`).

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_