### PR TITLE
feat(dreaming): wire session-end trigger into turn_runner with throttle (#341 impl 4/N)

### DIFF
--- a/backend/app/channels/_turn_dreaming.py
+++ b/backend/app/channels/_turn_dreaming.py
@@ -1,0 +1,63 @@
+"""Dreaming trigger that fires after each turn's finalization (#341).
+
+Lives next to :mod:`turn_runner` instead of inside it so the runner
+stays under the 500-line budget. Pure side-effect helper: opens a
+session, calls the throttled scheduler, swallows errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import TYPE_CHECKING
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from app.channels.turn_runner import ChatTurnInput
+
+logger = logging.getLogger(__name__)
+
+SessionOpener = Callable[["ChatTurnInput"], AbstractAsyncContextManager[AsyncSession]]
+"""Shape of the runner's session context manager.
+
+Passed in so the helper doesn't import from
+:mod:`app.channels.turn_runner` and create a circular dependency
+— the runner already imports from this module.
+"""
+
+
+async def trigger_dreaming(
+    turn_input: ChatTurnInput,
+    open_session: SessionOpener,
+) -> None:
+    """Schedule a throttled dreaming pass for the just-finished turn.
+
+    Opens its own session via ``open_session`` and swallows any
+    errors so a dreaming-trigger failure can't break the user's
+    turn completion. The actual LLM call + memory writes happen on
+    the background task the throttled scheduler spawns.
+    """
+    # Lazy import so the dreaming package isn't a startup dependency
+    # for deployments running with ``dreaming_enabled=False``.
+    from app.core.dreaming import schedule_session_end_dream_if_idle  # noqa: PLC0415
+
+    try:
+        async with open_session(turn_input) as session:
+            await schedule_session_end_dream_if_idle(
+                session,
+                user_id=turn_input.user_id,
+                conversation_id=turn_input.conversation_id,
+            )
+    except Exception:
+        logger.exception(
+            "DREAMING_TRIGGER_ERR conversation_id=%s",
+            turn_input.conversation_id,
+        )
+
+
+__all__ = [
+    "SessionOpener",
+    "trigger_dreaming",
+]

--- a/backend/app/channels/turn_runner.py
+++ b/backend/app/channels/turn_runner.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.channels._turn_cost import record_turn_cost_if_enabled
+from app.channels._turn_dreaming import trigger_dreaming as _trigger_dreaming
 from app.channels._turn_runtime_context import system_prompt_for_turn
 from app.channels._turn_workspace import workspace_system_prompt
 from app.core.chat_aggregator import ChatTurnAggregator, should_emit_event
@@ -484,12 +485,13 @@ async def _finalize_turn(
             source=turn_input.log_tag.lower(),
         )
     )
-    # Fire-and-forget LCM leaf compaction.  Runs after the assistant row is
-    # finalized so the just-completed turn is eligible for compaction.
-    # The helper handles the ``settings.lcm_enabled`` gate, task-strong-ref
-    # bookkeeping, and exception suppression in one place.
+    # Fire-and-forget background passes after the assistant row is
+    # finalized. Each helper owns its own settings gate + task ref
+    # bookkeeping + error suppression.
     schedule_lcm_compaction(
         conversation_id=turn_input.conversation_id,
         user_id=turn_input.user_id,
         model_id=model_id or "",
     )
+    if settings.dreaming_enabled:
+        await _trigger_dreaming(turn_input, _turn_session)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -360,6 +360,10 @@ class Settings(BaseSettings):
     lcm_summary_model: str = ""
 
     # ── Dreaming (between-sessions reflection) ──────────────────────
+    # Master switch for the dreaming reflection pass (#341). Off by
+    # default so the rollout is gradual — the runner + scheduler are
+    # in place but no background LLM call fires until this is True.
+    dreaming_enabled: bool = False
     # Litellm model id used by the dreaming pass. Defaults to Gemini
     # Flash because the prompt is single-turn JSON-only — no need to
     # spend a premium model on it. See the ADR at

--- a/backend/app/core/dreaming/__init__.py
+++ b/backend/app/core/dreaming/__init__.py
@@ -27,6 +27,7 @@ from app.core.dreaming.scheduler import (
     DreamingScope,
     schedule_daily_rollup_dream,
     schedule_session_end_dream,
+    schedule_session_end_dream_if_idle,
 )
 from app.core.dreaming.schema import (
     ConsolidatedMemory,
@@ -48,4 +49,5 @@ __all__ = [
     "run_dreaming_job",
     "schedule_daily_rollup_dream",
     "schedule_session_end_dream",
+    "schedule_session_end_dream_if_idle",
 ]

--- a/backend/app/core/dreaming/scheduler.py
+++ b/backend/app/core/dreaming/scheduler.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dreaming.runner import DreamFn, SessionFactory, run_dreaming_job
@@ -43,6 +45,14 @@ DreamingScope = Literal["session_end", "daily_rollup"]
 # finalise them mid-loop. See app.core.lcm.background for the same
 # pattern + rationale.
 _DREAMING_TASKS: set[asyncio.Task[None]] = set()
+
+# How long to wait after a completed dreaming pass for the same
+# conversation before allowing another. Approximates the
+# "idle window" behaviour from the ADR without an actual delayed
+# scheduler: turns within this window count as the same session
+# and don't re-trigger reflection. 30 minutes is the same default
+# the ADR uses for the conceptual idle threshold.
+_SESSION_END_THROTTLE_MINUTES = 30
 
 
 async def schedule_session_end_dream(
@@ -69,6 +79,72 @@ async def schedule_session_end_dream(
         dream_fn=dream_fn,
         session_factory=session_factory,
     )
+
+
+async def schedule_session_end_dream_if_idle(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    workspace_id: uuid.UUID | None = None,
+    dream_fn: DreamFn | None = None,
+    session_factory: SessionFactory | None = None,
+    throttle_minutes: int = _SESSION_END_THROTTLE_MINUTES,
+) -> uuid.UUID | None:
+    """Schedule a session_end pass only if the conversation isn't recently reflected.
+
+    Approximates the "idle window" trigger from the ADR without an
+    actual delayed-task scheduler: the turn-runner fires this after
+    every turn, and the throttle keeps consecutive turns inside the
+    same session from spawning many redundant passes.
+
+    Returns the new job's id when a pass was scheduled, or ``None``
+    when the throttle filtered the call.
+    """
+    if await _has_recent_dreaming_pass(
+        session,
+        conversation_id=conversation_id,
+        throttle_minutes=throttle_minutes,
+    ):
+        logger.debug(
+            "DREAMING_TRIGGER_THROTTLED conversation_id=%s throttle_minutes=%s",
+            conversation_id,
+            throttle_minutes,
+        )
+        return None
+    return await schedule_session_end_dream(
+        session,
+        user_id=user_id,
+        conversation_id=conversation_id,
+        workspace_id=workspace_id,
+        dream_fn=dream_fn,
+        session_factory=session_factory,
+    )
+
+
+async def _has_recent_dreaming_pass(
+    session: AsyncSession,
+    *,
+    conversation_id: uuid.UUID,
+    throttle_minutes: int,
+) -> bool:
+    """Return whether a recent dreaming job exists for ``conversation_id``.
+
+    Both ``completed`` and any non-terminal status count — if a job
+    is already running for this conversation we don't want a second
+    racer in the same window.
+    """
+    cutoff = datetime.now(UTC) - timedelta(minutes=throttle_minutes)
+    stmt = (
+        select(DreamingJob.id)
+        .where(DreamingJob.conversation_id == conversation_id)
+        .where(DreamingJob.scope == "session_end")
+        .where(DreamingJob.created_at >= cutoff)
+        .order_by(desc(DreamingJob.created_at))
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none() is not None
 
 
 async def schedule_daily_rollup_dream(
@@ -140,4 +216,5 @@ __all__ = [
     "DreamingScope",
     "schedule_daily_rollup_dream",
     "schedule_session_end_dream",
+    "schedule_session_end_dream_if_idle",
 ]

--- a/backend/tests/test_dreaming_runner.py
+++ b/backend/tests/test_dreaming_runner.py
@@ -30,6 +30,7 @@ from app.core.dreaming import (
     run_dreaming_job,
     schedule_daily_rollup_dream,
     schedule_session_end_dream,
+    schedule_session_end_dream_if_idle,
 )
 from app.crud.memory import insert_memory
 from app.db import User
@@ -336,3 +337,82 @@ async def test_daily_rollup_scope_creates_a_pending_job_row(
     assert row.scope == "daily_rollup"
     assert row.conversation_id is None
     assert row.user_id == test_user.id
+
+
+@pytest.mark.anyio
+async def test_throttled_trigger_skips_when_recent_pass_exists(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The throttle suppresses a second trigger within the throttle window.
+
+    First call returns a job id (passes through to ``schedule_session_end_dream``).
+    Second call within ``throttle_minutes`` returns ``None`` and DOES NOT
+    add a new row.
+    """
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[("user", "hi")],
+    )
+    first = await schedule_session_end_dream_if_idle(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+    )
+    assert first is not None
+    second = await schedule_session_end_dream_if_idle(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+        throttle_minutes=60,
+    )
+    assert second is None
+
+    # Only one row exists for this conversation in the throttle window.
+    rows = list(
+        (
+            await db_session.execute(
+                select(DreamingJob).where(DreamingJob.conversation_id == conversation.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+@pytest.mark.anyio
+async def test_throttled_trigger_fires_when_window_elapsed(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """When the throttle is zero, the trigger always fires.
+
+    Simulates "idle window elapsed" so the second call gets a fresh
+    job row instead of being filtered out.
+    """
+    factory = _session_factory_for(db_session)
+    conversation = await _seed_conversation(
+        db_session,
+        user_id=test_user.id,
+        messages=[("user", "hi")],
+    )
+    first = await schedule_session_end_dream_if_idle(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+        throttle_minutes=0,
+    )
+    second = await schedule_session_end_dream_if_idle(
+        db_session,
+        user_id=test_user.id,
+        conversation_id=conversation.id,
+        session_factory=factory,
+        throttle_minutes=0,
+    )
+    assert first is not None
+    assert second is not None
+    assert first != second


### PR DESCRIPTION
## Summary

#420 added the runner + scheduler but nothing called them. This PR closes that gap so the dreaming pass actually fires.

### `scheduler.py`
- New `schedule_session_end_dream_if_idle` helper that wraps the base scheduler with a 30-minute (configurable) throttle. The throttle is enforced by querying `dreaming_jobs` for a recent `session_end` row on the same conversation and bailing early when one is found. Returns `None` on a throttled call.

### `_turn_dreaming.py` (new)
- `trigger_dreaming(turn_input, open_session)` opens a session via the runner's `_turn_session` context manager and calls the throttled scheduler. Errors are logged + swallowed so a dreaming-trigger failure can't break the user's turn.
- Lives in its own module to keep `turn_runner.py` under the 500-line budget. `SessionOpener` typedef so the helper doesn't import from `turn_runner` and create a circular dep.

### `turn_runner.py`
- `_finalize_turn` fires `trigger_dreaming` next to the existing LCM compaction call, gated on `settings.dreaming_enabled` (off by default for gradual rollout).
- LCM + dreaming comments collapsed so the file stays under budget after the new lines land.

### `config.py`
- `dreaming_enabled: bool = False` — master switch.

## Test plan
- [ ] `test_throttled_trigger_skips_when_recent_pass_exists` — second call within the window returns `None` and adds no new row.
- [ ] `test_throttled_trigger_fires_when_window_elapsed` — `throttle_minutes=0` always fires.
- [ ] Smoke (post-merge, with `DREAMING_ENABLED=true` + `DREAMING_MODEL_ID` set): send a Telegram turn, see a new `dreaming_jobs` row land + flip to `completed` within a few seconds. Second turn within 30m should NOT add another row.

## Follow-ups (not in this PR — scope guard)
- Daily cron entry point for the `daily_rollup` scope.
- Telegram "🌙 Pawrrtal dreamed" notice when a completed job is detected.
- Web composer xAI sign-in button.

Stacked on #420 (`claude/feat-dreaming-runner-341`).

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_