### PR TITLE
feat(dreaming): Telegram "🌙 Pawrrtal dreamed" notice on completed pass (#341 impl 5/N)

### DIFF
--- a/backend/app/core/dreaming/runner.py
+++ b/backend/app/core/dreaming/runner.py
@@ -275,7 +275,7 @@ async def _mark_completed(
     input_chars: int,
     raw_chars: int,
 ) -> None:
-    """Stamp the job row with the run's results."""
+    """Stamp the job row with the run's results and publish the completion event."""
     job.status = "completed"
     job.completed_at = datetime.now(UTC)
     job.memories_written = memories_written
@@ -287,6 +287,7 @@ async def _mark_completed(
     job.input_token_count = input_chars // _CHARS_PER_TOKEN
     job.output_token_count = raw_chars // _CHARS_PER_TOKEN
     await session.commit()
+    await _publish_completion(job)
 
 
 async def _mark_failed(session: AsyncSession, job: DreamingJob, *, error: str) -> None:
@@ -295,6 +296,36 @@ async def _mark_failed(session: AsyncSession, job: DreamingJob, *, error: str) -
     job.completed_at = datetime.now(UTC)
     job.error_text = error[:1000]
     await session.commit()
+    await _publish_completion(job)
+
+
+async def _publish_completion(job: DreamingJob) -> None:
+    """Publish a :class:`DreamingCompletedEvent` for downstream subscribers.
+
+    Lazy imports keep the event-bus dependency outside the
+    runner's hot path — important because the runner runs in
+    background tasks where a top-level import would force every
+    deployment to pay the bus's startup cost regardless of whether
+    dreaming is enabled.
+    """
+    from app.core.event_bus import (  # noqa: PLC0415
+        DreamingCompletedEvent,
+        publish_if_available,
+    )
+
+    await publish_if_available(
+        DreamingCompletedEvent(
+            job_id=job.id,
+            user_id=job.user_id,
+            conversation_id=job.conversation_id,
+            scope=job.scope,
+            status=job.status,
+            memories_written=job.memories_written,
+            patterns_written=job.patterns_written,
+            followups_written=job.followups_written,
+            session_summary=job.session_summary,
+        )
+    )
 
 
 async def _default_dream_fn(prompt: str) -> str:

--- a/backend/app/core/event_bus/__init__.py
+++ b/backend/app/core/event_bus/__init__.py
@@ -29,6 +29,7 @@ from app.core.event_bus.global_bus import publish_if_available
 from app.core.event_bus.handlers import AgentHandler, NotificationService
 from app.core.event_bus.types import (
     AgentResponseEvent,
+    DreamingCompletedEvent,
     ScheduledEvent,
     TurnCompletedEvent,
     TurnStartedEvent,
@@ -38,6 +39,7 @@ from app.core.event_bus.types import (
 __all__ = [
     "AgentHandler",
     "AgentResponseEvent",
+    "DreamingCompletedEvent",
     "Event",
     "EventBus",
     "EventHandler",

--- a/backend/app/core/event_bus/types.py
+++ b/backend/app/core/event_bus/types.py
@@ -133,3 +133,30 @@ class AgentResponseEvent(Event):
     text: str = ""
     originating_event_id: str | None = None
     source: str = "agent"
+
+
+@dataclass
+class DreamingCompletedEvent(Event):
+    """A background dreaming pass landed on a terminal status (#341).
+
+    Emitted from :func:`app.core.dreaming.runner.run_dreaming_job`
+    when it stamps a row as ``completed`` (or ``failed``). Telegram
+    subscribers surface the "🌙 Pawrrtal dreamed" notice;
+    observability subscribers can record per-user reflection
+    metrics.
+
+    The integer counts mirror the columns the runner just wrote to
+    ``dreaming_jobs`` so subscribers don't need a follow-up DB
+    round-trip.
+    """
+
+    job_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
+    conversation_id: uuid.UUID | None = None
+    scope: str = ""
+    status: str = ""
+    memories_written: int = 0
+    patterns_written: int = 0
+    followups_written: int = 0
+    session_summary: str | None = None
+    source: str = "dreaming"

--- a/backend/app/integrations/telegram/dreaming_notify.py
+++ b/backend/app/integrations/telegram/dreaming_notify.py
@@ -1,0 +1,125 @@
+"""Telegram subscriber for :class:`DreamingCompletedEvent` (#341).
+
+Posts a brief "🌙 Pawrrtal dreamed" notice in the user's DM whenever
+a dreaming pass lands in the ``completed`` state and produced at
+least one new memory. Failed jobs are deliberately silent — the
+user shouldn't be paged when a background pass errors; the runner
+already records the failure on the row's ``error_text`` column for
+the operator to inspect.
+
+The handler is registered from the FastAPI lifespan alongside
+:class:`NotificationService`. It looks up the user's Telegram
+binding via the existing ``channel_bindings`` table; users without
+a Telegram binding get no notification, by design — they'll see
+the consolidated memories on their next session through the
+existing ``memory_query`` tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from app.core.event_bus import DreamingCompletedEvent, Event
+from app.db import async_session_maker
+from app.models import ChannelBinding
+
+if TYPE_CHECKING:
+    from app.core.event_bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_PROVIDER = "telegram"
+_NOTICE_TEMPLATE = (
+    "🌙 Pawrrtal dreamed about your recent conversation.\n{memories_line}{summary_line}"
+)
+
+
+class DreamingNotificationService:
+    """Bus subscriber that posts a Telegram notice on completed dreaming passes.
+
+    Held by the FastAPI app state (alongside ``NotificationService``)
+    so the lifespan can pass the live aiogram ``Bot`` at construction
+    time without the dreaming runner taking a Telegram dependency.
+    """
+
+    def __init__(self, *, telegram_bot: Any | None) -> None:
+        self._bot = telegram_bot
+
+    def register(self, bus: EventBus) -> None:
+        """Attach the dreaming-completion handler to the bus."""
+        bus.subscribe(DreamingCompletedEvent, self.handle_completion)
+
+    async def handle_completion(self, event: Event) -> None:
+        """Post the dreaming notice to the user's Telegram DM if one exists."""
+        if not isinstance(event, DreamingCompletedEvent):
+            return
+        if self._bot is None or event.user_id is None:
+            return
+        if event.status != "completed":
+            return
+        # Don't page on no-op runs — substring dedupe sometimes
+        # filters every candidate out and the user wouldn't notice
+        # a difference anyway.
+        if event.memories_written == 0:
+            return
+
+        external_id = await _lookup_telegram_external_user_id(event.user_id)
+        if external_id is None:
+            return
+
+        notice = _format_notice(event)
+        try:
+            await self._bot.send_message(chat_id=int(external_id), text=notice)
+        except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
+            logger.warning(
+                "DREAMING_NOTIFY_FAILED user_id=%s job_id=%s error=%s",
+                event.user_id,
+                event.job_id,
+                exc,
+            )
+
+
+async def _lookup_telegram_external_user_id(user_id: object) -> str | None:
+    """Read the user's Telegram external_user_id from ``channel_bindings``.
+
+    For DMs, the external_user_id equals the chat_id — Telegram
+    treats a 1:1 conversation's chat_id as the user's numeric id.
+    Groups have their own chat_id which the dreaming notifier
+    deliberately doesn't post into (the dreaming pass is
+    user-scoped, not chat-scoped).
+    """
+    async with async_session_maker() as session:
+        stmt = (
+            select(ChannelBinding.external_user_id)
+            .where(ChannelBinding.user_id == user_id)
+            .where(ChannelBinding.provider == _TELEGRAM_PROVIDER)
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+
+def _format_notice(event: DreamingCompletedEvent) -> str:
+    """Render the body of the Telegram notice from the event payload."""
+    if event.memories_written == 1:
+        memories_line = "Captured one new memory."
+    else:
+        memories_line = f"Captured {event.memories_written} new memories."
+    # Summary is optional — only inline it when the model produced
+    # something. Keeps the notice compact when the prompt focused
+    # on memory extraction only.
+    summary_line = ""
+    if event.session_summary:
+        summary_line = f"\n\n{event.session_summary}"
+    return _NOTICE_TEMPLATE.format(
+        memories_line=memories_line,
+        summary_line=summary_line,
+    )
+
+
+__all__ = [
+    "DreamingNotificationService",
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,7 @@ from app.core.scheduler import JobScheduler
 from app.core.telemetry import setup_tracing, shutdown_tracing
 from app.db import create_db_and_tables
 from app.integrations.telegram import telegram_lifespan
+from app.integrations.telegram.dreaming_notify import DreamingNotificationService
 from app.integrations.webhooks import get_webhooks_router
 from app.logger_setup import (
     configure_logging,  # Set up logging configuration (this should be done before any loggers are used)
@@ -146,6 +147,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             telegram_bot=telegram_service.bot if telegram_service is not None else None
         )
         notification_service.register(event_bus)
+        # Dreaming completion notice (#341): posts "🌙 Pawrrtal dreamed"
+        # in the user's Telegram DM whenever a background reflection
+        # pass finishes with at least one new memory. No-op when the
+        # bot is down or dreaming is disabled.
+        dreaming_notify = DreamingNotificationService(
+            telegram_bot=telegram_service.bot if telegram_service is not None else None
+        )
+        dreaming_notify.register(event_bus)
         try:
             yield
         finally:

--- a/backend/tests/test_dreaming_notify.py
+++ b/backend/tests/test_dreaming_notify.py
@@ -1,0 +1,167 @@
+"""Tests for the Telegram dreaming-completion notifier (#341)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.event_bus import DreamingCompletedEvent
+from app.db import User
+from app.integrations.telegram.dreaming_notify import DreamingNotificationService
+from app.models import ChannelBinding
+
+
+async def _seed_telegram_binding(
+    db_session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    external_user_id: str,
+) -> None:
+    """Insert a telegram binding row for ``user_id``."""
+    db_session.add(
+        ChannelBinding(
+            id=uuid4(),
+            user_id=user_id,
+            provider="telegram",
+            external_user_id=external_user_id,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+
+
+@pytest.mark.anyio
+async def test_completed_event_with_memories_sends_telegram_dm(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A completed pass that wrote memories pushes a notice to the bound Telegram DM."""
+    await _seed_telegram_binding(db_session, user_id=test_user.id, external_user_id="987654")
+    bot = AsyncMock()
+    service = DreamingNotificationService(telegram_bot=bot)
+    event = DreamingCompletedEvent(
+        job_id=uuid4(),
+        user_id=test_user.id,
+        conversation_id=uuid4(),
+        scope="session_end",
+        status="completed",
+        memories_written=2,
+        patterns_written=1,
+        followups_written=0,
+        session_summary="Brief reflection on the recent conversation.",
+    )
+
+    with patch(
+        "app.integrations.telegram.dreaming_notify.async_session_maker",
+        _session_factory_returning(db_session),
+    ):
+        await service.handle_completion(event)
+
+    bot.send_message.assert_awaited_once()
+    call = bot.send_message.await_args
+    assert call.kwargs["chat_id"] == 987654
+    text = call.kwargs["text"]
+    assert "Pawrrtal dreamed" in text
+    assert "2 new memories" in text
+    assert "Brief reflection" in text
+
+
+@pytest.mark.anyio
+async def test_failed_event_does_not_notify(db_session: AsyncSession, test_user: User) -> None:
+    """Failed jobs are silent — the user shouldn't be paged on a background error."""
+    await _seed_telegram_binding(db_session, user_id=test_user.id, external_user_id="987654")
+    bot = AsyncMock()
+    service = DreamingNotificationService(telegram_bot=bot)
+    event = DreamingCompletedEvent(
+        job_id=uuid4(),
+        user_id=test_user.id,
+        scope="session_end",
+        status="failed",
+        memories_written=0,
+    )
+
+    with patch(
+        "app.integrations.telegram.dreaming_notify.async_session_maker",
+        _session_factory_returning(db_session),
+    ):
+        await service.handle_completion(event)
+
+    assert bot.send_message.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_completed_event_with_zero_memories_does_not_notify(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """A pass where dedupe filtered every candidate stays silent."""
+    await _seed_telegram_binding(db_session, user_id=test_user.id, external_user_id="987654")
+    bot = AsyncMock()
+    service = DreamingNotificationService(telegram_bot=bot)
+    event = DreamingCompletedEvent(
+        job_id=uuid4(),
+        user_id=test_user.id,
+        scope="session_end",
+        status="completed",
+        memories_written=0,
+        patterns_written=2,
+    )
+
+    with patch(
+        "app.integrations.telegram.dreaming_notify.async_session_maker",
+        _session_factory_returning(db_session),
+    ):
+        await service.handle_completion(event)
+
+    assert bot.send_message.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_unbound_user_does_not_notify(db_session: AsyncSession, test_user: User) -> None:
+    """Users without a Telegram binding don't see the notice (by design)."""
+    bot = AsyncMock()
+    service = DreamingNotificationService(telegram_bot=bot)
+    event = DreamingCompletedEvent(
+        job_id=uuid4(),
+        user_id=test_user.id,
+        scope="session_end",
+        status="completed",
+        memories_written=1,
+    )
+
+    with patch(
+        "app.integrations.telegram.dreaming_notify.async_session_maker",
+        _session_factory_returning(db_session),
+    ):
+        await service.handle_completion(event)
+
+    assert bot.send_message.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_no_bot_handle_is_a_silent_noop() -> None:
+    """Without a bot instance the handler returns cleanly — no exception, no work."""
+    service = DreamingNotificationService(telegram_bot=None)
+    event = DreamingCompletedEvent(
+        job_id=uuid4(),
+        user_id=uuid4(),
+        status="completed",
+        memories_written=3,
+    )
+    # No DB lookup, no send_message call, no raise — pure no-op.
+    await service.handle_completion(event)
+
+
+def _session_factory_returning(session: AsyncSession):
+    """Return a callable that yields the given session via an async context manager."""
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _factory():
+        yield session
+
+    return _factory


### PR DESCRIPTION
## Summary

After a dreaming pass lands in `completed`, the bound Telegram DM gets a brief notice with the new-memory count and the optional session summary the model produced.

### `event_bus/types.py`
- `DreamingCompletedEvent` — emitted from `runner._mark_completed` and `runner._mark_failed`. Carries the `user_id`, `scope`, `status`, output counts, and `session_summary` so subscribers don't need a DB round-trip.

### `dreaming/runner.py`
- `_mark_completed` and `_mark_failed` publish via `publish_if_available`. Lazy import keeps the event bus out of the runner's hot path.

### `integrations/telegram/dreaming_notify.py` (new)
- `DreamingNotificationService` subscribes to `DreamingCompletedEvent`.
- Silent on: failed jobs (error_text is enough for ops), zero-memories runs (dedupe filtered everything), unbound users (no DM target), missing bot (Telegram disabled).
- Looks up the chat_id from `channel_bindings` — for DMs this equals `external_user_id`.

### `main.py`
- Registers `DreamingNotificationService` alongside the existing `NotificationService`. No-op when the bot is down.

## Test plan
- [ ] `test_completed_event_with_memories_sends_telegram_dm`
- [ ] `test_failed_event_does_not_notify`
- [ ] `test_completed_event_with_zero_memories_does_not_notify`
- [ ] `test_unbound_user_does_not_notify`
- [ ] `test_no_bot_handle_is_a_silent_noop`
- [ ] Smoke: with `DREAMING_ENABLED=true`, trigger a turn, watch the "🌙 Pawrrtal dreamed" message arrive in the bound Telegram DM after the bg pass completes.

## Follow-ups (not in this PR)
- Daily cron entry point for the `daily_rollup` scope.
- Web composer xAI sign-in button.

Stacked on #421 (`claude/feat-dreaming-trigger-341`).

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_