### PR TITLE
🎨 Palette: Add `ariaLabel` support to `AppEmptyState` action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 ## 2024-05-18 - Loading States on Async Form Submissions
 **Learning:** Auth forms with multiple backend steps (register + immediate login) can cause a noticeable delay before redirection. Without visual feedback, users may click submit multiple times or assume the application is frozen. Adding disabled states with explicit loading spinners and text changes (e.g. "Creating Account...") provides crucial reassurance during these async multi-step operations.
 **Action:** Always add loading spinners (`Loader2Icon` or similar) inside submit buttons and disable the button while `isSubmitting` is true on critical user-blocking forms.
+
+## 2025-02-23 - AppEmptyState CTA ARIA Labels
+**Learning:** Shared UI primitives for empty states (`AppEmptyState`) that abstract away button labels often render `<button>` elements with generic text like "Create". When these components lack the ability to accept `aria-label` overrides, it forces screen readers into relying on surrounding context, degrading accessibility for core conversion actions (CTAs).
+**Action:** When designing primitive layout components that render interactive elements (buttons, links), ensure the API surface exposes necessary ARIA attributes (like `ariaLabel`) alongside visible labels.

--- a/frontend/components/ui/app-empty-state.tsx
+++ b/frontend/components/ui/app-empty-state.tsx
@@ -33,6 +33,8 @@ export interface AppEmptyStateProps {
 		onClick: () => void;
 		/** Button label for default layouts; omit when using `inlineCta`. */
 		label?: string;
+		/** Optional ARIA label for accessibility. */
+		ariaLabel?: string;
 	};
 	/**
 	 * `inlineCta` renders a single sidebar row button (e.g. “Create your first project”).
@@ -63,6 +65,7 @@ export function AppEmptyState({
 		}
 		return (
 			<button
+				aria-label={action.ariaLabel}
 				className={cn(
 					'flex cursor-pointer items-center gap-1.5 rounded-control px-2 py-1.5 text-left text-sm text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground',
 					className
@@ -112,6 +115,7 @@ export function AppEmptyState({
 					) : null}
 					{action?.label ? (
 						<button
+							aria-label={action.ariaLabel}
 							className="mt-2 inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-full bg-foreground px-4 text-[13px] font-medium text-background transition-colors duration-150 ease-out hover:bg-foreground/90"
 							onClick={action.onClick}
 							type="button"
@@ -142,6 +146,7 @@ export function AppEmptyState({
 					) : null}
 					{action?.label ? (
 						<button
+							aria-label={action.ariaLabel}
 							className="mt-2 inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-full bg-foreground px-4 text-[13px] font-medium text-background transition-[background-color,transform] duration-150 ease-out hover:bg-foreground/90 active:scale-[0.98] motion-reduce:transition-none"
 							onClick={action.onClick}
 							type="button"
@@ -174,6 +179,7 @@ export function AppEmptyState({
 			) : null}
 			{action?.label ? (
 				<button
+					aria-label={action.ariaLabel}
 					className="mt-4 inline-flex h-7 items-center rounded-soft bg-background px-3 text-xs font-medium shadow-minimal transition-colors hover:bg-foreground/[0.03]"
 					onClick={action.onClick}
 					type="button"


### PR DESCRIPTION
💡 What: Added an optional `ariaLabel` property to the `action` prop of the `AppEmptyState` component. It is applied to the `<button>` tags rendered within the empty state layout variations.
🎯 Why: Empty states frequently use succinct, context-dependent language (e.g. "Create"). Without an ARIA label, screen readers only announce the generic text, making it harder for users relying on assistive tech to understand the button's explicit purpose.
♿ Accessibility: Improved screen reader support for the primary call-to-action on empty pages, cards, and sidebar sections across the application.

---
*PR created automatically by Jules for task [10881199843349891277](https://jules.google.com/task/10881199843349891277) started by @OctavianTocan*

## Summary by Sourcery

Add accessibility support for AppEmptyState call-to-action buttons by allowing ARIA labels to be specified.

New Features:
- Allow AppEmptyState actions to provide an optional ariaLabel applied to rendered buttons for improved accessibility.

Documentation:
- Document the accessibility consideration and guidance for exposing ARIA attributes on primitive layout components in the Palette playbook.