### PR TITLE
db: add CHECK constraint on conversations.reasoning_effort (#367)

### DIFF
--- a/backend/alembic/versions/021_conversation_reasoning_effort_check.py
+++ b/backend/alembic/versions/021_conversation_reasoning_effort_check.py
@@ -1,0 +1,44 @@
+"""Pin ``conversations.reasoning_effort`` to the literal value set (#367).
+
+The column was added by 020 as a nullable ``VARCHAR(16)`` with no value
+constraint, but every legitimate writer goes through the
+``ReasoningEffort`` literal (``"minimal" | "low" | "medium" | "high" |
+"extra-high"``).  The CRUD setter still accepts ``str | None``, which
+means a typo or stale enum value would silently land in the database and
+break provider resolution at request time.
+
+This migration adds a CHECK constraint that mirrors the literal so the
+DB rejects bad values at write time.  NULL is explicitly allowed (SQL
+CHECK treats NULL as passing, which matches the "let the provider pick"
+sentinel the column already documents).
+
+Revision ID: 021_conversation_reasoning_effort_check
+Revises: 020_add_conversation_reasoning_effort
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "021_conversation_reasoning_effort_check"
+down_revision = "020_add_conversation_reasoning_effort"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT_NAME = "ck_conversations_reasoning_effort_values"
+_ALLOWED_VALUES = ("minimal", "low", "medium", "high", "extra-high")
+
+
+def upgrade() -> None:
+    """Add the CHECK constraint pinning ``reasoning_effort`` values."""
+    values_sql = ", ".join(f"'{v}'" for v in _ALLOWED_VALUES)
+    op.create_check_constraint(
+        _CONSTRAINT_NAME,
+        "conversations",
+        f"reasoning_effort IN ({values_sql})",
+    )
+
+
+def downgrade() -> None:
+    """Drop the CHECK constraint."""
+    op.drop_constraint(_CONSTRAINT_NAME, "conversations", type_="check")

--- a/backend/alembic/versions/021_conversation_reasoning_effort_check.py
+++ b/backend/alembic/versions/021_conversation_reasoning_effort_check.py
@@ -7,10 +7,20 @@ constraint, but every legitimate writer goes through the
 means a typo or stale enum value would silently land in the database and
 break provider resolution at request time.
 
-This migration adds a CHECK constraint that mirrors the literal so the
-DB rejects bad values at write time.  NULL is explicitly allowed (SQL
-CHECK treats NULL as passing, which matches the "let the provider pick"
-sentinel the column already documents).
+This migration:
+
+1. Backfills any pre-existing rows whose ``reasoning_effort`` is outside
+   the literal set to NULL. Without this PostgreSQL's immediate validation
+   of the new CHECK would abort ``alembic upgrade`` on a single stale row
+   from the unconstrained window between 020 and 021.
+2. Adds a CHECK constraint that mirrors the literal so the DB rejects
+   bad values at write time going forward.
+
+NULL is explicitly allowed (SQL CHECK treats NULL as passing, which
+matches the "let the provider pick" sentinel the column already documents).
+``op.batch_alter_table`` is used so the constraint addition succeeds on
+SQLite as well as Postgres — SQLite does not support ``ALTER TABLE ADD
+CONSTRAINT`` directly and needs Alembic's table-recreate fallback.
 
 Revision ID: 021_conversation_reasoning_effort_check
 Revises: 020_add_conversation_reasoning_effort
@@ -26,19 +36,42 @@ branch_labels = None
 depends_on = None
 
 _CONSTRAINT_NAME = "ck_conversations_reasoning_effort_values"
+# NOTE: must stay in sync with the ``ReasoningEffort`` literal in
+# ``app/core/providers/base.py`` and ``_REASONING_EFFORT_VALUES`` on the
+# ``Conversation`` model in ``app/models.py``. Migrations can't import
+# application code, so the values are intentionally duplicated here —
+# adding a new literal value means touching all three sites.
 _ALLOWED_VALUES = ("minimal", "low", "medium", "high", "extra-high")
 
 
+def _values_in_sql() -> str:
+    """Return the SQL ``IN (...)`` body for the allowed value set."""
+    return ", ".join(f"'{v}'" for v in _ALLOWED_VALUES)
+
+
 def upgrade() -> None:
-    """Add the CHECK constraint pinning ``reasoning_effort`` values."""
-    values_sql = ", ".join(f"'{v}'" for v in _ALLOWED_VALUES)
-    op.create_check_constraint(
-        _CONSTRAINT_NAME,
-        "conversations",
-        f"reasoning_effort IN ({values_sql})",
+    """Backfill stale rows then add the CHECK constraint."""
+    values_sql = _values_in_sql()
+    # 1) Clear any value that already drifted outside the literal set
+    #    so the new CHECK doesn't abort on existing rows. NULL is the
+    #    documented "let the provider pick" sentinel and is the only
+    #    safe fallback that doesn't pretend to know the user's intent.
+    op.execute(
+        f"UPDATE conversations SET reasoning_effort = NULL "
+        f"WHERE reasoning_effort IS NOT NULL "
+        f"AND reasoning_effort NOT IN ({values_sql})"
     )
+    # 2) Add the constraint inside a batch block so Alembic recreates
+    #    the table on SQLite (which can't ALTER ADD CONSTRAINT) and
+    #    runs a plain ALTER on Postgres.
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.create_check_constraint(
+            _CONSTRAINT_NAME,
+            f"reasoning_effort IN ({values_sql})",
+        )
 
 
 def downgrade() -> None:
     """Drop the CHECK constraint."""
-    op.drop_constraint(_CONSTRAINT_NAME, "conversations", type_="check")
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_constraint(_CONSTRAINT_NAME, type_="check")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,17 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, Uuid
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Text
 
@@ -34,6 +44,9 @@ class SenderType(Enum):
     USER = "user"
 
 
+_REASONING_EFFORT_VALUES = ("minimal", "low", "medium", "high", "extra-high")
+
+
 class Conversation(Base):
     """Conversation metadata stored in the application database.
 
@@ -42,6 +55,18 @@ class Conversation(Base):
     """
 
     __tablename__ = "conversations"
+    __table_args__ = (
+        # Pin ``reasoning_effort`` to the ``ReasoningEffort`` literal values
+        # (or NULL). The setter in ``app.crud.channel`` accepts ``str | None``,
+        # so without this constraint a typo or stale enum value could land in
+        # the DB and silently break provider resolution. SQL ``CHECK`` allows
+        # NULL by default, which is what we want for "let the provider pick".
+        # Issue #367.
+        CheckConstraint(
+            "reasoning_effort IN (" + ", ".join(f"'{v}'" for v in _REASONING_EFFORT_VALUES) + ")",
+            name="ck_conversations_reasoning_effort_values",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("user.id", ondelete="CASCADE"))
@@ -82,10 +107,12 @@ class Conversation(Base):
     # settings.telegram_verbose_default (or 1 if unset).
     verbose_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Per-conversation reasoning depth. One of the ReasoningEffort literal
-    # values ("low" | "medium" | "high" | "extra-high") or NULL to let the
-    # provider pick its default. Mirrors verbose_level's plumbing: a chat
-    # request may still override per-turn, but absent that the persisted
-    # value is what the turn runner forwards to the provider.
+    # values ("minimal" | "low" | "medium" | "high" | "extra-high") or NULL
+    # to let the provider pick its default. Pinned by the
+    # ``ck_conversations_reasoning_effort_values`` CHECK constraint above
+    # so bad enum strings never make it to the DB. Mirrors verbose_level's
+    # plumbing: a chat request may still override per-turn, but absent that
+    # the persisted value is what the turn runner forwards to the provider.
     reasoning_effort: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
 

--- a/backend/tests/test_conversation_crud.py
+++ b/backend/tests/test_conversation_crud.py
@@ -1,8 +1,11 @@
 """CRUD service tests for conversations."""
 
+import uuid
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.conversation import (
@@ -15,6 +18,7 @@ from app.crud.conversation import (
     update_conversation_title,
 )
 from app.db import User
+from app.models import Conversation
 from app.schemas import ConversationCreate, ConversationUpdate
 
 
@@ -214,3 +218,54 @@ async def test_delete_conversation_removes_owned_row(
 
     assert deleted is True
     assert await get_conversation(test_user.id, db_session, conversation.id) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "value",
+    ["minimal", "low", "medium", "high", "extra-high", None],
+)
+async def test_reasoning_effort_accepts_literal_values(
+    db_session: AsyncSession, test_user: User, value: str | None
+) -> None:
+    """Every ``ReasoningEffort`` literal value (and NULL) survives a round-trip.
+
+    The CHECK constraint added in migration 021 (#367) must not reject any
+    of the documented literal values, including NULL for "let the provider
+    pick its default".
+    """
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        title="reasoning",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        reasoning_effort=value,
+    )
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+    assert conv.reasoning_effort == value
+
+
+@pytest.mark.anyio
+async def test_reasoning_effort_rejects_unknown_value(
+    db_session: AsyncSession, test_user: User
+) -> None:
+    """The DB-level CHECK constraint blocks values outside the literal set.
+
+    Regression for #367 — without this gate, a typo or stale enum string
+    from the CRUD setter would silently land in the column and only blow
+    up later during provider resolution.
+    """
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        title="bad effort",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        reasoning_effort="ultra-mega-high",  # not in the literal
+    )
+    db_session.add(conv)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()


### PR DESCRIPTION
## Summary
Fix #367 — pin `conversations.reasoning_effort` to the `ReasoningEffort` literal (`"minimal" | "low" | "medium" | "high" | "extra-high"`) at the DB layer.

- Add `CheckConstraint` via `__table_args__` on the SQLAlchemy `Conversation` model so test schemas (`Base.metadata.create_all` against SQLite) pick it up.
- Add alembic migration `021_conversation_reasoning_effort_check.py` so live Postgres databases get the same constraint.
- Refresh the stale column comment — the literal has had `"minimal"` since the xAI / Anthropic provider work but the docstring still listed only four values.

NULL is explicitly allowed (SQL `CHECK` treats NULL as passing, matching the "let the provider pick its default" semantics the column already documents).

## Why
The setter in `app/crud/channel.py::update_conversation_reasoning_effort` accepts `reasoning_effort: str | None` — not the `Literal`. A typo or a stale value from `resolve_reasoning_effort` (e.g. an enum renamed across providers) would silently land in the column and only blow up later during provider resolution. A DB-level CHECK is the right belt-and-braces gate; it's cheap and it surfaces the bug at the write site instead of the next chat turn.

## Test plan
- [x] `pytest tests/test_conversation_crud.py` — 17 passed (10 existing + 7 new: 5 literal values × parametrize + NULL + 1 invalid-value test asserting `IntegrityError`).
- [x] `pytest tests/test_conversation_api.py tests/test_conversation_read.py tests/test_conversation_helpers.py tests/test_models_api.py tests/test_lcm_schema.py tests/test_reasoning_resolver.py` — 69 passed (no regressions in neighbouring conversation/reasoning paths).
- [x] `ruff check` + `ruff format --check` green on all three changed files.
- [x] `node scripts/check-file-lines.mjs` — no overflow.
- [x] `python3 scripts/check-nesting.py` — no functions over depth 3.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_

## Summary by Sourcery

Enforce valid reasoning effort values for conversations at the database level and verify the constraint with tests.

Bug Fixes:
- Prevent invalid or stale reasoning_effort strings from being persisted by constraining the column to the documented literal set.

Enhancements:
- Add a CHECK constraint on the conversations.reasoning_effort column in the SQLAlchemy model to align persisted values with the ReasoningEffort literal and update its documentation comment.
- Introduce an Alembic migration to apply the reasoning_effort CHECK constraint to existing databases.

Tests:
- Add CRUD tests to confirm reasoning_effort accepts all allowed literals and NULL while rejecting unknown values with an IntegrityError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for conversation reasoning effort settings to ensure only valid values are persisted in the database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OctavianTocan/Pawrrtal-AI/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->