### PR TITLE
ui(tool): past-tense labels on terminal tool states (#360)

### DIFF
--- a/frontend/components/ai-elements/tool.test.tsx
+++ b/frontend/components/ai-elements/tool.test.tsx
@@ -28,4 +28,45 @@ describe('Tool', () => {
 		);
 		expect(getByText(/boom/)).toBeTruthy();
 	});
+
+	describe('ToolHeader status labels (#360)', () => {
+		// Past-tense labels on the terminal states so the transcript reads
+		// as a log of what happened, paired with the active verb ("Running"
+		// while in-flight, "Ran" once done).
+		it('shows "Ran" once a tool completes successfully', () => {
+			const { getByText } = render(
+				<Tool defaultOpen>
+					<ToolHeader state="output-available" type="tool-search" title="search-web" />
+				</Tool>
+			);
+			expect(getByText('Ran')).toBeTruthy();
+		});
+
+		it('shows "Failed" when a tool errors', () => {
+			const { getByText } = render(
+				<Tool defaultOpen>
+					<ToolHeader state="output-error" type="tool-search" title="search-web" />
+				</Tool>
+			);
+			expect(getByText('Failed')).toBeTruthy();
+		});
+
+		it('still shows "Running" while a tool is in flight', () => {
+			const { getByText } = render(
+				<Tool defaultOpen>
+					<ToolHeader state="input-available" type="tool-search" title="search-web" />
+				</Tool>
+			);
+			expect(getByText('Running')).toBeTruthy();
+		});
+
+		it('shows "Denied" when the user blocks a tool call', () => {
+			const { getByText } = render(
+				<Tool defaultOpen>
+					<ToolHeader state="output-denied" type="tool-search" title="search-web" />
+				</Tool>
+			);
+			expect(getByText('Denied')).toBeTruthy();
+		});
+	});
 });

--- a/frontend/components/ai-elements/tool.tsx
+++ b/frontend/components/ai-elements/tool.tsx
@@ -36,13 +36,16 @@ export type ToolHeaderProps = {
 };
 
 const getStatusBadge = (status: ToolUIPart['state']) => {
+	// Labels pair the active state's verb with its past-tense completion
+	// (Running → Ran, Failed, Denied) so the transcript reads as a log
+	// of what happened, not a snapshot of what is. Issue #360.
 	const labels: Record<ToolUIPart['state'], string> = {
 		'input-streaming': 'Pending',
 		'input-available': 'Running',
 		'approval-requested': 'Awaiting Approval',
 		'approval-responded': 'Responded',
-		'output-available': 'Completed',
-		'output-error': 'Error',
+		'output-available': 'Ran',
+		'output-error': 'Failed',
 		'output-denied': 'Denied',
 	};
 


### PR DESCRIPTION
## Summary
Fix #360 — switch the tool status badge labels on terminal states from "Completed"/"Error" to past-tense verbs paired with the active state's verb, so reading a transcript top-to-bottom is a log of what happened rather than a mix of "is happening" / "did happen".

- `output-available`: `Completed` → `Ran` (pairs with `Running`)
- `output-error`: `Error` → `Failed` (verb, not noun)
- `output-denied`: stays `Denied` (already past tense)
- `approval-responded`: stays `Responded` (already past tense)
- active states (`input-streaming` "Pending", `input-available` "Running", `approval-requested` "Awaiting Approval") unchanged.

## Why
A chat transcript scrolls top-to-bottom and is consumed as a log of past events. A row that says "Completed" sounds like the tool is in the process of completing — same with "Error" reading as a noun rather than an outcome. Switching to "Ran" / "Failed" matches the verb tense of the active labels ("Running" → "Ran") and reads as a log entry.

## Test plan
- [x] Added four new vitest cases in `tool.test.tsx` pinning the state→label map for `output-available`, `output-error`, `output-denied`, and `input-available` (the in-flight pair).
- [x] `npx @biomejs/biome check frontend/components/ai-elements/tool.tsx frontend/components/ai-elements/tool.test.tsx` — clean.
- [x] Frontend `bun install` requires workspace packages not present in this environment, so vitest could not be executed locally — CI's Frontend Vitest job is the canonical gate.
- [x] No backend changes, no design tokens touched, no `DESIGN.md` update needed.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_

## Summary by Sourcery

Align tool header status labels with past-tense terminal states for clearer transcript logs.

Bug Fixes:
- Ensure terminal tool states use past-tense verbs ("Ran", "Failed") to better reflect completed actions in transcripts.

Enhancements:
- Update tool header status label mapping to pair active verbs with their past-tense counterparts while keeping existing in-flight labels.
- Add tests covering the state-to-label mapping for running, successful, errored, and denied tool states.

Tests:
- Add vitest cases verifying the user-visible labels for terminal and in-flight tool header states.