### PR TITLE
xai(grok-4.3): surface the new no-thinking tier (#373)

### DIFF
--- a/backend/app/core/providers/_catalog_entries.py
+++ b/backend/app/core/providers/_catalog_entries.py
@@ -231,6 +231,12 @@ XAI_ENTRIES: tuple[ModelEntry, ...] = (
         is_default=False,
         cost_per_mtok_in_usd=_GROK_4_3_IN_USD,
         cost_per_mtok_out_usd=_GROK_4_3_OUT_USD,
-        supports_reasoning=("low", "high"),
+        # xAI added a "no thinking" tier to Grok 4.3 (issue #373).
+        # ``"minimal"`` is Pawrrtal's canonical "lightest possible
+        # reasoning" sentinel, and for Grok it maps to the new
+        # ``EFFORT_NONE`` proto value (see ``_map_reasoning_effort``).
+        # ``"low"`` and ``"high"`` are Grok's two actual reasoning
+        # tiers; everything in between collapses to ``"low"``.
+        supports_reasoning=("minimal", "low", "high"),
     ),
 )

--- a/backend/app/core/providers/_catalog_entries.py
+++ b/backend/app/core/providers/_catalog_entries.py
@@ -216,8 +216,8 @@ GOOGLE_ENTRIES: tuple[ModelEntry, ...] = (
     ),
 )
 
-# xAI's SDK exposes two reasoning levels; ``_map_reasoning_effort`` in
-# xai_provider.py collapses pawrrtal's four levels into these two
+# xAI's SDK exposes three reasoning tiers; ``_map_reasoning_effort`` in
+# xai_provider.py collapses pawrrtal's five levels into these three
 # before the call, so the picker should match what the model actually
 # honours.
 XAI_ENTRIES: tuple[ModelEntry, ...] = (

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -170,7 +170,7 @@ def make_xai_stream_fn(
             StreamFn per request so the workspace-assembled prompt
             (SOUL.md + AGENTS.md + skills) is what the model sees.
         reasoning_effort: Optional reasoning-depth knob for grok-4.3.
-            Mapped onto xAI's two-level proto enum via
+            Mapped onto xAI's three-tier proto enum via
             :func:`_map_reasoning_effort`.  ``None`` lets xAI pick the
             model default.
         usage_sink: Optional mutable :class:`UsageAccumulator` the
@@ -333,7 +333,7 @@ class XaiLLM:
                 back to :data:`DEFAULT_AGENT_SYSTEM_PROMPT` so bare
                 unit tests still work.
             reasoning_effort: Optional reasoning-depth knob.  Mapped
-                onto grok-4.3's two-level enum via
+                onto grok-4.3's three-tier enum via
                 :func:`_map_reasoning_effort` and passed to xai-sdk.
                 The model's chain-of-thought streams back as
                 ``reasoning_content`` deltas and surfaces as

--- a/backend/app/core/providers/xai_provider.py
+++ b/backend/app/core/providers/xai_provider.py
@@ -26,10 +26,12 @@ Design parity with :mod:`app.core.providers.gemini_provider`:
 xAI-specific surface this provider drives natively (via typed
 proto / SDK fields, not ``extra_body``):
 
-* ``reasoning_effort`` — Pawrrtal's four-level UI knob
-  (``low | medium | high | extra-high``) is collapsed to xAI's
-  two-level enum via :func:`_map_reasoning_effort`.  Grok 4.3 400s on
-  anything else (https://docs.x.ai/docs/models/grok-4-3).
+* ``reasoning_effort`` — Pawrrtal's five-level UI knob
+  (``minimal | low | medium | high | extra-high``) is collapsed to
+  xAI's three-tier enum via :func:`_map_reasoning_effort`.  Grok 4.3
+  accepts ``EFFORT_NONE``, ``EFFORT_LOW`` and ``EFFORT_HIGH`` and
+  400s on ``EFFORT_MEDIUM`` (https://docs.x.ai/docs/models/grok-4-3).
+  Picking ``"minimal"`` is the no-thinking path (issue #373).
 * ``search_parameters`` — xAI's Live Search was removed in May 2026;
   we no longer send this field.  Pawrrtal's canonical web tool is
   ``exa_search`` (gated by ``EXA_API_KEY``).  If xAI ships a
@@ -119,18 +121,28 @@ def _map_reasoning_effort(
 ) -> chat_pb2.ReasoningEffort | None:
     """Map Pawrrtal's five-level UI knob onto xAI's proto enum.
 
-    Grok 4.3 accepts ``EFFORT_LOW`` or ``EFFORT_HIGH``
-    (https://docs.x.ai/docs/models/grok-4-3) and 400s on anything
-    else, including ``EFFORT_MEDIUM`` and ``EFFORT_NONE``.  The
-    Pawrrtal UI surfaces ``minimal | low | medium | high | extra-high``
-    — we collapse the lower three to ``EFFORT_LOW`` and the upper two
-    to ``EFFORT_HIGH`` so the user gets a meaningful difference
-    without overshooting xAI's schema.  ``None`` means "let xAI pick
-    the model default" and the field is omitted from the request.
+    Grok 4.3 accepts ``EFFORT_NONE``, ``EFFORT_LOW``, and ``EFFORT_HIGH``
+    (https://docs.x.ai/docs/models/grok-4-3) — xAI shipped a "no
+    thinking" tier (``EFFORT_NONE``) after the original two-tier
+    mapping landed, and Pawrrtal needs to expose it (issue #373).
+    ``EFFORT_MEDIUM`` is still rejected, so the four-level catalog
+    knob collapses as follows:
+
+    * ``"minimal"`` → ``EFFORT_NONE`` (the new no-thinking tier).
+    * ``"low" | "medium"`` → ``EFFORT_LOW``.
+    * ``"high" | "extra-high"`` → ``EFFORT_HIGH``.
+
+    ``None`` means "no override stored on the conversation" and the
+    field is omitted from the request entirely — xAI then picks the
+    model's server-side default, which is typically a low/medium
+    reasoning level rather than "off". Pick ``"minimal"`` explicitly
+    to opt into no-thinking.
     """
     if effort is None:
         return None
-    if effort in ("minimal", "low", "medium"):
+    if effort == "minimal":
+        return chat_pb2.ReasoningEffort.EFFORT_NONE
+    if effort in ("low", "medium"):
         return chat_pb2.ReasoningEffort.EFFORT_LOW
     return chat_pb2.ReasoningEffort.EFFORT_HIGH
 

--- a/backend/tests/test_telegram_thinking_picker.py
+++ b/backend/tests/test_telegram_thinking_picker.py
@@ -99,9 +99,15 @@ def test_claude_haiku_no_adaptive_thinking() -> None:
     assert _entry(Host.agent_sdk, "claude-haiku-4-5").supports_reasoning == ()
 
 
-def test_grok_collapses_to_two_levels() -> None:
-    """xai_provider._map_reasoning_effort folds four levels into two."""
-    assert _entry(Host.xai, "grok-4.3").supports_reasoning == ("low", "high")
+def test_grok_exposes_minimal_low_high() -> None:
+    """xai_provider._map_reasoning_effort spans three Grok 4.3 tiers.
+
+    xAI added a no-thinking tier (``EFFORT_NONE``) to Grok 4.3 (issue
+    #373). ``"minimal"`` maps to it; ``"low"`` and ``"medium"`` collapse
+    to ``EFFORT_LOW``; ``"high"`` and ``"extra-high"`` collapse to
+    ``EFFORT_HIGH``. The picker surfaces the three distinct tiers.
+    """
+    assert _entry(Host.xai, "grok-4.3").supports_reasoning == ("minimal", "low", "high")
 
 
 def test_gemini_3_flash_models_expose_all_four_levels() -> None:
@@ -257,10 +263,30 @@ def test_gemini_picker_state_reports_supported() -> None:
     assert model_supports_reasoning(_gemini_state()) is True
 
 
-def test_grok_picker_shows_two_buttons() -> None:
+def test_grok_picker_shows_three_buttons() -> None:
+    """Grok 4.3's picker now surfaces ``minimal | low | high`` after
+    xAI shipped the no-thinking tier (issue #373).
+    """
     state = _grok_state()
     rows = build_thinking_keyboard(state)
-    assert [row[0].text for row in rows] == ["low", "high"]
+    assert [row[0].text for row in rows] == ["minimal", "low", "high"]
+
+
+def test_grok_picker_minimal_button_maps_to_no_thinking_for_xai() -> None:
+    """A ``minimal`` callback for Grok 4.3 resolves through
+    ``_map_reasoning_effort`` to ``EFFORT_NONE`` — the new
+    no-thinking tier (issue #373). Crossing the integration
+    boundary here keeps the picker UI and the provider mapping
+    locked in step.
+    """
+    from app.core.providers.xai_provider import _map_reasoning_effort
+
+    try:
+        from xai_sdk.proto.v6 import chat_pb2
+    except ImportError:  # pragma: no cover — xai-sdk pin variance
+        from xai_sdk.proto.v5 import chat_pb2
+
+    assert _map_reasoning_effort("minimal") == chat_pb2.ReasoningEffort.EFFORT_NONE
 
 
 def test_unsupported_text_mentions_the_model() -> None:

--- a/backend/tests/test_telegram_thinking_picker.py
+++ b/backend/tests/test_telegram_thinking_picker.py
@@ -340,7 +340,7 @@ def test_resolve_select_rejects_stale_catalog_token() -> None:
 
 
 def test_resolve_select_rejects_effort_not_supported_by_model() -> None:
-    entry = _entry(Host.xai, "grok-4.3")  # only low + high
+    entry = _entry(Host.xai, "grok-4.3")  # minimal + low + high
     callback = ThinkingCallback(action="select", catalog_token=catalog_token(), effort="medium")
     assert resolve_select(callback, entry=entry) is None
 

--- a/backend/tests/test_xai_provider_translation.py
+++ b/backend/tests/test_xai_provider_translation.py
@@ -332,9 +332,18 @@ def test_resolve_api_key_workspace_override(
 # ---------------------------------------------------------------------------
 
 
-def test_map_reasoning_effort_collapses_four_levels_to_two() -> None:
-    """Pawrrtal's four-level UI knob → grok-4.3's two-level proto enum."""
+def test_map_reasoning_effort_collapses_five_levels_to_three() -> None:
+    """Pawrrtal's five-level UI knob → grok-4.3's three-tier proto enum.
+
+    xAI's Grok 4.3 reasoning enum is ``EFFORT_NONE``, ``EFFORT_LOW``,
+    ``EFFORT_HIGH``. ``"minimal"`` opts into the no-thinking tier
+    (issue #373); ``"low"`` and ``"medium"`` collapse to
+    ``EFFORT_LOW``; ``"high"`` and ``"extra-high"`` collapse to
+    ``EFFORT_HIGH``; ``None`` omits the field so xAI's server-side
+    default fires.
+    """
     assert _map_reasoning_effort(None) is None
+    assert _map_reasoning_effort("minimal") == chat_pb2.ReasoningEffort.EFFORT_NONE
     assert _map_reasoning_effort("low") == chat_pb2.ReasoningEffort.EFFORT_LOW
     assert _map_reasoning_effort("medium") == chat_pb2.ReasoningEffort.EFFORT_LOW
     assert _map_reasoning_effort("high") == chat_pb2.ReasoningEffort.EFFORT_HIGH


### PR DESCRIPTION
## Summary
Fix #373 — xAI shipped an `EFFORT_NONE` (no-thinking) tier for Grok 4.3 after the original two-tier mapping landed. Wire `"minimal"` through to `EFFORT_NONE` so users can actually opt into the no-thinking path from the Telegram `/thinking` picker.

- `_catalog_entries.py`: `grok-4.3.supports_reasoning` grows from `("low", "high")` to `("minimal", "low", "high")`. The picker now shows three buttons.
- `xai_provider._map_reasoning_effort`: `"minimal"` → `chat_pb2.ReasoningEffort.EFFORT_NONE`. `"low"`/`"medium"` still collapse to `EFFORT_LOW`; `"high"`/`"extra-high"` to `EFFORT_HIGH`. Docstring refreshed to describe the new three-tier shape and clarify that `None` still omits the field.

## Why
Per the issue: "Ensure Grok 4.3 supports no thinking option, which was added recently." xAI's docs at `https://docs.x.ai/docs/models/grok-4-3` now list `EFFORT_NONE` as a valid value for Grok 4.3. The xai-sdk's `chat_pb2.ReasoningEffort` enum already exposes `EFFORT_NONE = 4`, so this is a Pawrrtal-side mapping update only — no SDK bump needed.

Picking `"minimal"` explicitly in the picker is now the no-thinking path; leaving the override at `None` continues to let xAI's server pick the model default (typically some thinking, not "off"), so the two semantics stay distinct.

## Test plan
- [x] `pytest tests/test_xai_provider_translation.py tests/test_telegram_thinking_picker.py tests/test_reasoning_resolver.py tests/test_models_api.py tests/test_telegram_channel.py` — 136 passed (the existing two-tier tests are updated to the new three-tier shape; one new cross-cutting test locks the picker UI's `"minimal"` button to the provider's `EFFORT_NONE` mapping so the two surfaces can't drift).
- [x] `ruff check` + `ruff format --check` green on all four changed files.
- [x] `node scripts/check-file-lines.mjs` — no overflow.
- [x] `python3 scripts/check-nesting.py` — no functions over depth 3.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_