### PR TITLE
api(models): filter catalog to authenticated hosts (#370)

### DIFF
--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -8,13 +8,33 @@ from fastapi.routing import APIRouter
 from pydantic import BaseModel
 
 from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry
+from app.core.providers.factory import host_authenticated
+from app.core.providers.model_id import Host
 from app.db import User
 from app.users import get_allowed_user
+
+
+def _auth_fingerprint() -> str:
+    """Stable per-process fingerprint of which hosts are authenticated.
+
+    Folded into the ETag so a deployment that authenticates an extra
+    provider after boot (or unsets a key) produces a different ETag
+    and clients re-fetch instead of replaying a stale 304. Stable
+    ordering means the same auth state always produces the same
+    fingerprint string.
+    """
+    return "".join(
+        "1" if host_authenticated(h) else "0" for h in sorted(Host, key=lambda h: h.value)
+    )
+
 
 # RFC 7232 requires ``ETag`` values to be wrapped in double quotes.  The
 # ``CATALOG_ETAG`` constant is a bare 16-hex string; we quote it once here
 # so both the response header and the ``If-None-Match`` comparison agree.
-ETAG_HEADER = f'"{CATALOG_ETAG}"'
+# The auth fingerprint is appended so the ``304`` path doesn't replay a
+# stale list when the deployment's authenticated provider set changes
+# (issue #370).
+ETAG_HEADER = f'"{CATALOG_ETAG}-{_auth_fingerprint()}"'
 
 
 class ModelOption(BaseModel):
@@ -77,7 +97,11 @@ def get_models_router() -> APIRouter:
                 status_code=status.HTTP_304_NOT_MODIFIED,
                 headers={"ETag": ETAG_HEADER},
             )
-        body = ModelsResponse(models=[_to_option(e) for e in MODEL_CATALOG])
+        # Filter out catalog entries whose host doesn't have credentials
+        # (or, for ``gemini_cli``, doesn't have the binary on PATH). Users
+        # shouldn't see picker rows they can't actually click — issue #370.
+        authed_entries = [e for e in MODEL_CATALOG if host_authenticated(e.host)]
+        body = ModelsResponse(models=[_to_option(e) for e in authed_entries])
         return JSONResponse(
             content=body.model_dump(),
             headers={

--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -2,39 +2,52 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import Depends, Request, Response, status
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG, ModelEntry
 from app.core.providers.factory import host_authenticated
 from app.core.providers.model_id import Host
-from app.db import User
+from app.crud.workspace import get_default_workspace
+from app.db import User, get_async_session
 from app.users import get_allowed_user
 
 
-def _auth_fingerprint() -> str:
-    """Stable per-process fingerprint of which hosts are authenticated.
+def _auth_fingerprint(workspace_root: Path | None) -> str:
+    """Fingerprint of which hosts are authenticated for this request.
 
     Folded into the ETag so a deployment that authenticates an extra
-    provider after boot (or unsets a key) produces a different ETag
-    and clients re-fetch instead of replaying a stale 304. Stable
-    ordering means the same auth state always produces the same
-    fingerprint string.
+    provider after boot (or unsets a key, or installs the gemini
+    binary on PATH) produces a different ETag and clients re-fetch
+    instead of replaying a stale 304. Stable ordering means the same
+    auth state always produces the same fingerprint string.
+
+    Workspace-keyed deployments (the documented per-user .env path)
+    produce a workspace-specific fingerprint when ``workspace_root``
+    is set, so two users with different workspace credentials get
+    distinct ETags and won't share cached responses.
     """
     return "".join(
-        "1" if host_authenticated(h) else "0" for h in sorted(Host, key=lambda h: h.value)
+        "1" if host_authenticated(h, workspace_root=workspace_root) else "0"
+        for h in sorted(Host, key=lambda h: h.value)
     )
 
 
-# RFC 7232 requires ``ETag`` values to be wrapped in double quotes.  The
-# ``CATALOG_ETAG`` constant is a bare 16-hex string; we quote it once here
-# so both the response header and the ``If-None-Match`` comparison agree.
-# The auth fingerprint is appended so the ``304`` path doesn't replay a
-# stale list when the deployment's authenticated provider set changes
-# (issue #370).
-ETAG_HEADER = f'"{CATALOG_ETAG}-{_auth_fingerprint()}"'
+def _etag_for(workspace_root: Path | None) -> str:
+    """Build the per-request ETag header value.
+
+    Computed live (not cached at module scope) because the auth state
+    can change during process lifetime — a new key written to a
+    workspace ``.env``, the ``gemini`` binary appearing on PATH, etc.
+    A stale module-level ETag would cause ``If-None-Match`` to return
+    304 with the old filtered list (issue #370 review feedback).
+    """
+    return f'"{CATALOG_ETAG}-{_auth_fingerprint(workspace_root)}"'
 
 
 class ModelOption(BaseModel):
@@ -79,33 +92,45 @@ def get_models_router() -> APIRouter:
     router = APIRouter(prefix="/api/v1/models", tags=["models"])
 
     @router.get("")
-    def list_models(
+    async def list_models(
         request: Request,
-        _user: User = Depends(get_allowed_user),
+        user: User = Depends(get_allowed_user),
+        session: AsyncSession = Depends(get_async_session),
     ) -> Response:
-        """Return the catalog with ``ETag`` caching.
+        """Return the catalog with ``ETag`` caching, filtered by auth.
+
+        The user's default workspace (if any) is resolved so the
+        filter sees per-workspace credential overrides — the
+        documented path for production deployments where keys live
+        in the workspace ``.env`` rather than the gateway-global
+        environment. The ETag is computed per-request so live changes
+        to auth state (new workspace key, ``gemini`` binary appearing
+        on PATH) don't get masked by a stale 304.
 
         A ``304 Not Modified`` (empty body) is returned when the
-        client's ``If-None-Match`` matches the in-memory catalog
-        hash. Use ``Response(status_code=304)`` rather than
-        ``HTTPException(304)`` so the response has no body — FastAPI
-        serialises ``HTTPException`` with a ``detail`` payload,
-        which violates RFC 7232.
+        client's ``If-None-Match`` matches. ``Response(status_code=304)``
+        keeps the body empty per RFC 7232 (``HTTPException(304)`` would
+        serialise a ``detail`` payload, which the spec forbids).
         """
-        if request.headers.get("if-none-match") == ETAG_HEADER:
+        workspace = await get_default_workspace(user.id, session)
+        workspace_root = Path(workspace.path) if workspace is not None else None
+        etag = _etag_for(workspace_root)
+        if request.headers.get("if-none-match") == etag:
             return Response(
                 status_code=status.HTTP_304_NOT_MODIFIED,
-                headers={"ETag": ETAG_HEADER},
+                headers={"ETag": etag},
             )
         # Filter out catalog entries whose host doesn't have credentials
         # (or, for ``gemini_cli``, doesn't have the binary on PATH). Users
         # shouldn't see picker rows they can't actually click — issue #370.
-        authed_entries = [e for e in MODEL_CATALOG if host_authenticated(e.host)]
+        authed_entries = [
+            e for e in MODEL_CATALOG if host_authenticated(e.host, workspace_root=workspace_root)
+        ]
         body = ModelsResponse(models=[_to_option(e) for e in authed_entries])
         return JSONResponse(
             content=body.model_dump(),
             headers={
-                "ETag": ETAG_HEADER,
+                "ETag": etag,
                 "Cache-Control": "private, must-revalidate",
             },
         )

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -42,39 +42,56 @@ this table must always agree.
 """
 
 
-def host_authenticated(host: Host) -> bool:
-    """Return whether the deployment has credentials wired for ``host``.
+# Host → (workspace env-key, settings attribute) used by the picker
+# filter (issue #370). The env-key path is what every provider invokes
+# at request time via :func:`app.core.keys.resolve_api_key` — keeping
+# the same key here means the picker's "has credentials" answer can
+# never disagree with the provider's. The settings attribute is the
+# fallback when there is no workspace context (system callers).
+#
+# Add a new row when introducing a new :class:`Host` member.
+_HOST_AUTH_KEYS: dict[Host, tuple[str, str]] = {
+    Host.agent_sdk: ("CLAUDE_CODE_OAUTH_TOKEN", "claude_code_oauth_token"),
+    Host.google_ai: ("GEMINI_API_KEY", "google_api_key"),
+    Host.litellm: ("OPENAI_API_KEY", "openai_api_key"),
+    Host.opencode_go: ("OPENCODE_API_KEY", "opencode_api_key"),
+    Host.xai: ("XAI_API_KEY", "xai_api_key"),
+}
+
+
+def host_authenticated(host: Host, *, workspace_root: Path | None = None) -> bool:
+    """Return whether ``host`` has credentials reachable for this request.
 
     Drives the "only show authenticated providers" filter on the
-    ``/api/v1/models`` endpoint (issue #370) so users don't see
-    catalog entries they can't actually pick. The check is
-    intentionally cheap and stable per-process — :data:`settings`
-    is read once at boot, so this function can be called freely
-    inside hot paths without touching disk.
+    ``/api/v1/models`` endpoint (issue #370) so users don't see catalog
+    entries they can't actually pick.
 
-    Args:
-        host: The :class:`Host` enum value to gate.
-
-    Returns:
-        ``True`` when a credential / binary required to drive the
-        host is present, ``False`` otherwise.
+    When ``workspace_root`` is provided, the gate uses the same
+    workspace → settings resolver that every provider invokes at
+    request time (:func:`app.core.keys.resolve_api_key`). This is the
+    contract the picker must match: a user who configures
+    ``XAI_API_KEY`` in their workspace ``.env`` (the documented path)
+    still gets xAI in the picker even when the gateway-global
+    ``settings.xai_api_key`` is empty. Without ``workspace_root`` the
+    gate falls back to global ``settings`` only, which is the right
+    default for callers without a workspace (system bootstrap, audit
+    log emitters).
 
     Mapping:
 
-    * ``agent_sdk`` (Claude): non-empty ``claude_code_oauth_token``.
+    * ``agent_sdk`` (Claude): non-empty ``CLAUDE_CODE_OAUTH_TOKEN``.
     * ``gemini_cli``: the ``gemini`` binary is on ``PATH`` (probed
-      via :func:`is_gemini_cli_available`).
-    * ``google_ai`` (native Gemini): ``google_api_key`` non-empty.
-      ``Settings`` marks the field as required so the value is always
-      populated at runtime, but the gate stays uniform with the other
-      key-driven hosts rather than carrying a special case.
-    * ``litellm``: ``openai_api_key`` non-empty. LiteLLM in this
+      via :func:`is_gemini_cli_available`). Workspace overrides don't
+      apply — the binary is a process-level dependency.
+    * ``google_ai`` (native Gemini): non-empty ``GEMINI_API_KEY``.
+    * ``litellm``: non-empty ``OPENAI_API_KEY``. LiteLLM in this
       catalog only routes OpenAI models, so the OpenAI key is the
       single credential we need.
-    * ``opencode_go``: ``opencode_api_key`` non-empty.
-    * ``xai``: ``xai_api_key`` non-empty.
+    * ``opencode_go``: non-empty ``OPENCODE_API_KEY``.
+    * ``xai``: non-empty ``XAI_API_KEY``.
 
-    Add a new branch when introducing a new :class:`Host`.
+    Add a new entry to :data:`_HOST_ENV_KEY` when introducing a new
+    :class:`Host`.
     """
     if host is Host.gemini_cli:
         # Local import: ``gemini_cli`` imports the agent loop which
@@ -82,22 +99,19 @@ def host_authenticated(host: Host) -> bool:
         from .gemini_cli import is_gemini_cli_available  # noqa: PLC0415
 
         return is_gemini_cli_available()
-    # Other hosts gate purely on a ``settings.*`` credential. The
-    # ``host → attribute`` mapping is a flat dict so adding a host
-    # costs one line of data rather than one branch of control flow,
-    # and it keeps the function under ruff's ``PLR0911`` return-count
-    # budget.
-    credential_attr_by_host: dict[Host, str] = {
-        Host.agent_sdk: "claude_code_oauth_token",
-        Host.google_ai: "google_api_key",
-        Host.litellm: "openai_api_key",
-        Host.opencode_go: "opencode_api_key",
-        Host.xai: "xai_api_key",
-    }
-    attr = credential_attr_by_host.get(host)
-    if attr is None:
+    keys = _HOST_AUTH_KEYS.get(host)
+    if keys is None:
         return False
-    return bool(getattr(settings, attr))
+    env_key, settings_attr = keys
+    if workspace_root is not None:
+        # ``resolve_api_key`` already does workspace → settings fallback,
+        # so this single call covers both the per-workspace and the
+        # global-default paths in one pass.
+        from app.core.keys import resolve_api_key  # noqa: PLC0415
+
+        return bool(resolve_api_key(workspace_root, env_key))
+    # No workspace context — gate on the gateway-global setting only.
+    return bool(getattr(settings, settings_attr))
 
 
 # Module-import-time exhaustiveness check — converts the "every

--- a/backend/app/core/providers/factory.py
+++ b/backend/app/core/providers/factory.py
@@ -41,6 +41,65 @@ Add a new entry when adding a new :class:`Host` — the catalog and
 this table must always agree.
 """
 
+
+def host_authenticated(host: Host) -> bool:
+    """Return whether the deployment has credentials wired for ``host``.
+
+    Drives the "only show authenticated providers" filter on the
+    ``/api/v1/models`` endpoint (issue #370) so users don't see
+    catalog entries they can't actually pick. The check is
+    intentionally cheap and stable per-process — :data:`settings`
+    is read once at boot, so this function can be called freely
+    inside hot paths without touching disk.
+
+    Args:
+        host: The :class:`Host` enum value to gate.
+
+    Returns:
+        ``True`` when a credential / binary required to drive the
+        host is present, ``False`` otherwise.
+
+    Mapping:
+
+    * ``agent_sdk`` (Claude): non-empty ``claude_code_oauth_token``.
+    * ``gemini_cli``: the ``gemini`` binary is on ``PATH`` (probed
+      via :func:`is_gemini_cli_available`).
+    * ``google_ai`` (native Gemini): ``google_api_key`` non-empty.
+      ``Settings`` marks the field as required so the value is always
+      populated at runtime, but the gate stays uniform with the other
+      key-driven hosts rather than carrying a special case.
+    * ``litellm``: ``openai_api_key`` non-empty. LiteLLM in this
+      catalog only routes OpenAI models, so the OpenAI key is the
+      single credential we need.
+    * ``opencode_go``: ``opencode_api_key`` non-empty.
+    * ``xai``: ``xai_api_key`` non-empty.
+
+    Add a new branch when introducing a new :class:`Host`.
+    """
+    if host is Host.gemini_cli:
+        # Local import: ``gemini_cli`` imports the agent loop which
+        # would re-enter the factory module on a top-level import.
+        from .gemini_cli import is_gemini_cli_available  # noqa: PLC0415
+
+        return is_gemini_cli_available()
+    # Other hosts gate purely on a ``settings.*`` credential. The
+    # ``host → attribute`` mapping is a flat dict so adding a host
+    # costs one line of data rather than one branch of control flow,
+    # and it keeps the function under ruff's ``PLR0911`` return-count
+    # budget.
+    credential_attr_by_host: dict[Host, str] = {
+        Host.agent_sdk: "claude_code_oauth_token",
+        Host.google_ai: "google_api_key",
+        Host.litellm: "openai_api_key",
+        Host.opencode_go: "opencode_api_key",
+        Host.xai: "xai_api_key",
+    }
+    attr = credential_attr_by_host.get(host)
+    if attr is None:
+        return False
+    return bool(getattr(settings, attr))
+
+
 # Module-import-time exhaustiveness check — converts the "every
 # ``Host`` member must have a provider class" invariant from an
 # implicit runtime ``KeyError`` in :func:`resolve_llm` into a clear

--- a/backend/tests/test_models_api.py
+++ b/backend/tests/test_models_api.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from app.api.models import ETAG_HEADER
 from app.core.providers.catalog import MODEL_CATALOG
 from app.core.providers.factory import host_authenticated
+from app.core.providers.model_id import Host
 
 
 def _authed_catalog_count() -> int:
-    """How many catalog rows survive the ``host_authenticated`` filter."""
+    """How many catalog rows survive the ``host_authenticated`` filter.
+
+    No workspace context is passed: the test client doesn't go through
+    the workspace bootstrap, so the endpoint sees ``workspace_root=None``
+    and the filter falls back to global ``settings.*`` only. Mirror that
+    here so the expected count matches the response.
+    """
     return sum(1 for entry in MODEL_CATALOG if host_authenticated(entry.host))
 
 
@@ -47,8 +53,6 @@ async def test_models_endpoint_omits_unauthenticated_hosts(client: AsyncClient) 
     for host_value in returned_hosts:
         # ``host_value`` is the StrEnum value (e.g. ``"google-ai"``);
         # construct the enum member back to feed the gate.
-        from app.core.providers.model_id import Host
-
         assert host_authenticated(Host(host_value)), (
             f"unauthenticated host {host_value!r} leaked through the filter"
         )
@@ -57,7 +61,11 @@ async def test_models_endpoint_omits_unauthenticated_hosts(client: AsyncClient) 
 @pytest.mark.anyio
 async def test_models_endpoint_sets_etag(client: AsyncClient) -> None:
     response = await client.get("/api/v1/models")
-    assert response.headers["etag"] == ETAG_HEADER
+    etag = response.headers["etag"]
+    # Auth-fingerprinted shape: ``"<catalog-hash>-<bitstring>"``.
+    assert etag.startswith('"')
+    assert etag.endswith('"')
+    assert "-" in etag
     assert "private" in response.headers["cache-control"]
 
 
@@ -65,10 +73,16 @@ async def test_models_endpoint_sets_etag(client: AsyncClient) -> None:
 async def test_models_endpoint_returns_304_when_etag_matches(
     client: AsyncClient,
 ) -> None:
-    response = await client.get(
-        "/api/v1/models",
-        headers={"If-None-Match": ETAG_HEADER},
-    )
+    """An ``If-None-Match`` matching the live ETag round-trips to 304.
+
+    The ETag is computed per-request now (so a workspace key landing
+    after boot doesn't get masked by a stale 304 — review feedback on
+    #370). Re-issuing the same request with the returned ETag must
+    still produce a clean 304 with no body.
+    """
+    first = await client.get("/api/v1/models")
+    etag = first.headers["etag"]
+    response = await client.get("/api/v1/models", headers={"If-None-Match": etag})
     assert response.status_code == 304
     assert response.content == b""  # 304 must have empty body
 
@@ -105,3 +119,31 @@ async def test_default_entry_present_when_default_host_authenticated(
     response = await client.get("/api/v1/models")
     defaults = [m for m in response.json()["models"] if m["is_default"]]
     assert len(defaults) == 1
+
+
+def test_host_authenticated_with_workspace_uses_workspace_key(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``workspace_root`` opens the documented per-workspace key path.
+
+    Even when global ``settings.xai_api_key`` is empty, a workspace
+    that wrote ``XAI_API_KEY=...`` to its encrypted ``.env`` should
+    pass the gate — otherwise the picker hides providers that
+    actually work for that workspace (review feedback on #370).
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    workspace_root = Path(str(tmp_path))
+    # Force global setting empty so the gate can't accidentally pass
+    # via the fallback path; the test would be silently weak otherwise.
+    from app.core.providers.factory import settings as factory_settings
+
+    monkeypatch.setattr(factory_settings, "xai_api_key", "")
+    # Stub the shared key resolver to simulate a workspace-keyed
+    # deployment: workspace has the key, global doesn't.
+    with patch("app.core.keys.resolve_api_key", return_value="ws-only-token"):
+        assert host_authenticated(Host.xai, workspace_root=workspace_root) is True
+    # Sanity check: without the workspace path, the gate stays False
+    # because global settings is still empty.
+    assert host_authenticated(Host.xai) is False

--- a/backend/tests/test_models_api.py
+++ b/backend/tests/test_models_api.py
@@ -5,28 +5,59 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from app.core.providers.catalog import CATALOG_ETAG, MODEL_CATALOG
+from app.api.models import ETAG_HEADER
+from app.core.providers.catalog import MODEL_CATALOG
+from app.core.providers.factory import host_authenticated
 
-# RFC 7232 mandates that ETag values are quoted.
-QUOTED_ETAG = f'"{CATALOG_ETAG}"'
+
+def _authed_catalog_count() -> int:
+    """How many catalog rows survive the ``host_authenticated`` filter."""
+    return sum(1 for entry in MODEL_CATALOG if host_authenticated(entry.host))
 
 
 @pytest.mark.anyio
-async def test_models_endpoint_returns_catalog(client: AsyncClient) -> None:
+async def test_models_endpoint_returns_authenticated_catalog(client: AsyncClient) -> None:
+    """The endpoint returns only catalog entries whose host has credentials.
+
+    Issue #370 — unauthenticated providers (e.g. OpenCode without an
+    API key, xAI without ``XAI_API_KEY``) used to show up in the
+    picker but couldn't be selected. Now they're filtered out so the
+    list only shows usable rows.
+    """
     response = await client.get("/api/v1/models")
     assert response.status_code == 200
     body = response.json()
     assert "models" in body
-    assert len(body["models"]) == len(MODEL_CATALOG)
-    first = body["models"][0]
-    for key in ("id", "host", "vendor", "model", "display_name", "is_default"):
-        assert key in first
+    expected_count = _authed_catalog_count()
+    assert len(body["models"]) == expected_count
+    # The pytest fixtures set GOOGLE_API_KEY, so at least the google_ai
+    # rows are present. If nothing is authenticated the list is empty —
+    # also a valid state, so we only assert shape when there's content.
+    if body["models"]:
+        first = body["models"][0]
+        for key in ("id", "host", "vendor", "model", "display_name", "is_default"):
+            assert key in first
+
+
+@pytest.mark.anyio
+async def test_models_endpoint_omits_unauthenticated_hosts(client: AsyncClient) -> None:
+    """No host in the response should fail the ``host_authenticated`` gate."""
+    response = await client.get("/api/v1/models")
+    returned_hosts = {entry["host"] for entry in response.json()["models"]}
+    for host_value in returned_hosts:
+        # ``host_value`` is the StrEnum value (e.g. ``"google-ai"``);
+        # construct the enum member back to feed the gate.
+        from app.core.providers.model_id import Host
+
+        assert host_authenticated(Host(host_value)), (
+            f"unauthenticated host {host_value!r} leaked through the filter"
+        )
 
 
 @pytest.mark.anyio
 async def test_models_endpoint_sets_etag(client: AsyncClient) -> None:
     response = await client.get("/api/v1/models")
-    assert response.headers["etag"] == QUOTED_ETAG
+    assert response.headers["etag"] == ETAG_HEADER
     assert "private" in response.headers["cache-control"]
 
 
@@ -36,14 +67,41 @@ async def test_models_endpoint_returns_304_when_etag_matches(
 ) -> None:
     response = await client.get(
         "/api/v1/models",
-        headers={"If-None-Match": QUOTED_ETAG},
+        headers={"If-None-Match": ETAG_HEADER},
     )
     assert response.status_code == 304
     assert response.content == b""  # 304 must have empty body
 
 
 @pytest.mark.anyio
-async def test_default_entry_present(client: AsyncClient) -> None:
+async def test_models_endpoint_etag_includes_auth_fingerprint(client: AsyncClient) -> None:
+    """The ETag must vary with the authenticated-host set.
+
+    Pinned so a future change can't silently drop the auth fingerprint
+    and bring back the stale-304 bug — a deployment that authenticated
+    a new provider after boot would otherwise serve the old filtered
+    list to any client that cached the previous ETag.
+    """
+    response = await client.get("/api/v1/models")
+    # The full ETag is ``"<catalog-hash>-<fingerprint>"``. Asserting on
+    # the dash structure keeps the test resilient to catalog-hash
+    # changes while still pinning the auth fingerprint requirement.
+    assert response.headers["etag"].count("-") >= 1
+    assert response.headers["etag"].endswith('"')
+
+
+@pytest.mark.anyio
+async def test_default_entry_present_when_default_host_authenticated(
+    client: AsyncClient,
+) -> None:
+    """The catalog default survives the filter when its host is authenticated.
+
+    Pytest's environment sets ``GOOGLE_API_KEY`` (required to boot the
+    settings), and the canonical default in the catalog is a Gemini
+    model, so the default row should always be in the filtered list
+    under the test fixtures. If the default ever moves to an
+    unauthenticated host, this test will surface that drift.
+    """
     response = await client.get("/api/v1/models")
     defaults = [m for m in response.json()["models"] if m["is_default"]]
     assert len(defaults) == 1


### PR DESCRIPTION
## Summary
Fix #370 — unauthenticated providers (OpenCode without `OPENCODE_API_KEY`, xAI without `XAI_API_KEY`, etc.) were appearing in the `/api/v1/models` response and the picker UI even though the chat router would 5xx the moment the provider tried to resolve the missing credential.

Add `host_authenticated(host)` to `app.core.providers.factory` — a small, cheap predicate that maps each `Host` to its single `settings.*` credential (plus the `gemini` binary probe for `gemini_cli`). Filter `MODEL_CATALOG` through that gate before serialising the response.

The ETag is extended with a per-process auth fingerprint (`"<catalog-hash>-<fingerprint>"`) so a deployment that authenticates a new provider after boot returns a different ETag and clients re-fetch instead of replaying a stale filtered list via 304.

## Why
The picker should reflect what the deployment can actually serve. Showing rows the user can't pick is worse than showing fewer rows. Per-host credentials are evaluated once per process (settings are immutable at boot), so the filter is essentially free at request time.

The single-attribute mapping table in `host_authenticated` is intentional: adding a new `Host` means appending one line of data, not branching control flow — and it keeps the function under ruff's `PLR0911` budget.

## Test plan
- [x] `pytest tests/test_models_api.py` — 6 tests (3 updated, 3 new). Pins: response only contains authenticated hosts; no unauthenticated host slips through; ETag is set + `Cache-Control: private`; `If-None-Match` still round-trips to 304; ETag pins the auth-fingerprint shape; the catalog default survives the filter under the test fixture (Gemini default + `GOOGLE_API_KEY` always set).
- [x] `pytest tests/test_models_api.py tests/test_providers_and_schemas.py tests/test_gemini_cli_provider.py tests/test_telegram_thinking_picker.py tests/test_provider_labels.py` — 143 total passed (no regressions in adjacent provider/catalog surfaces).
- [x] `ruff check` + `ruff format --check` green on all three changed files.
- [x] `node scripts/check-file-lines.mjs` — no overflow.
- [x] `python3 scripts/check-nesting.py` — no functions over depth 3.

https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM4QSf7i1yqizMqBwJ8ZR9)_