### PR TITLE
fix(alembic): renumber user_preferences migrations to chain after 021

### DIFF
--- a/backend/alembic/versions/022_add_user_preferences_default_model_id.py
+++ b/backend/alembic/versions/022_add_user_preferences_default_model_id.py
@@ -6,8 +6,8 @@ explicit ``model_id``.  Used primarily by the Telegram ``/model``
 command so a user can pin a preferred model once and have every
 new Telegram conversation default to it.
 
-Revision ID: 021_add_user_preferences_default_model_id
-Revises: 020_add_conversation_reasoning_effort
+Revision ID: 022_add_user_preferences_default_model_id
+Revises: 021_conversation_reasoning_effort_check
 """
 
 from __future__ import annotations
@@ -15,8 +15,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "021_add_user_preferences_default_model_id"
-down_revision = "020_add_conversation_reasoning_effort"
+revision = "022_add_user_preferences_default_model_id"
+down_revision = "021_conversation_reasoning_effort_check"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/023_user_preferences_font_size_nullable.py
+++ b/backend/alembic/versions/023_user_preferences_font_size_nullable.py
@@ -5,8 +5,8 @@ own the canonical default value. Previously the column was NOT NULL
 with no schema default, which forced anyone seeding the row on
 demand to duplicate the frontend's default literal in Python.
 
-Revision ID: 022_user_preferences_font_size_nullable
-Revises: 021_add_user_preferences_default_model_id
+Revision ID: 023_user_preferences_font_size_nullable
+Revises: 022_add_user_preferences_default_model_id
 """
 
 from __future__ import annotations
@@ -14,8 +14,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "022_user_preferences_font_size_nullable"
-down_revision = "021_add_user_preferences_default_model_id"
+revision = "023_user_preferences_font_size_nullable"
+down_revision = "022_add_user_preferences_default_model_id"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary\n\nPR #376's migrations (021_add_user_preferences, 022_font_size_nullable) collided with the existing 021_conversation_reasoning_effort_check — both claimed `down_revision = "020_..."`, creating a multi-head Alembic state.\n\nRenumbered to 022 and 023 to restore a single-head linear chain:\n`019 → 020 → 021 → 022 → 023`\n\nhttps://claude.ai/code/session_014AAqsxUYhGQD8Vzz4Crxxz

---
_Generated by [Claude Code](https://claude.ai/code/session_014AAqsxUYhGQD8Vzz4Crxxz)_