### PR TITLE
feat(dreaming): dreaming_jobs schema + ORM (#341 impl 1/N)

### DIFF
--- a/backend/alembic/versions/022_add_dreaming_jobs_table.py
+++ b/backend/alembic/versions/022_add_dreaming_jobs_table.py
@@ -1,0 +1,102 @@
+"""Add the ``dreaming_jobs`` table for between-sessions reflection (#341).
+
+Per the ADR at
+``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``,
+the dreaming pass runs in two modes (session-end + daily cron),
+both writing to the same ``DreamingJob`` row. The row records what
+the pass was given as input, what the pass produced, and how long
+it took — enough to grep operator logs, replay a failed pass, and
+trace any memory row back to the pass that created it via
+``memories.provenance_job_id``.
+
+Revision ID: 022_add_dreaming_jobs_table
+Revises: 021_add_memories_table
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "022_add_dreaming_jobs_table"
+down_revision = "021_add_memories_table"
+branch_labels = None
+depends_on = None
+
+# Allowed values for the ``scope`` discriminator.
+# ``session_end`` runs on a single conversation after it goes idle;
+# ``daily_rollup`` runs on the user's prior 24h across conversations.
+_SCOPE_VALUES = ("session_end", "daily_rollup")
+
+# Allowed values for the ``status`` field.
+# ``pending`` — created but not yet started.
+# ``running`` — actively reflecting.
+# ``completed`` — wrote its outputs successfully.
+# ``failed`` — terminal failure (logged + surfaced in /status).
+_STATUS_VALUES = ("pending", "running", "completed", "failed")
+
+
+def upgrade() -> None:
+    """Create the dreaming_jobs table and supporting indexes."""
+    op.create_table(
+        "dreaming_jobs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("conversation_id", sa.Uuid(), nullable=True),
+        sa.Column("scope", sa.String(length=24), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+        # Model used for the reflection. Stored verbatim so a future
+        # change to ``settings.dreaming_model`` doesn't rewrite the
+        # historical record.
+        sa.Column("model_id", sa.String(length=128), nullable=True),
+        # Token-bound window the pass actually read. Useful when the
+        # 24h dump exceeded the cap and the truncated tail mattered.
+        sa.Column("input_token_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_token_count", sa.Integer(), nullable=False, server_default="0"),
+        # Counts per output category — match the four bucket names
+        # from the ADR (consolidated_memories / patterns / followups /
+        # session_summary). Stored individually so /status can
+        # surface "🌙 last night: 3 memories, 1 follow-up".
+        sa.Column("memories_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("patterns_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("followups_written", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("session_summary", sa.Text(), nullable=True),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            f"scope IN ({', '.join(repr(v) for v in _SCOPE_VALUES)})",
+            name="ck_dreaming_jobs_scope_valid",
+        ),
+        sa.CheckConstraint(
+            f"status IN ({', '.join(repr(v) for v in _STATUS_VALUES)})",
+            name="ck_dreaming_jobs_status_valid",
+        ),
+    )
+    # /status panel asks "what was the last dreaming pass for this
+    # user?" — index by (user, created_at desc) to make that cheap.
+    op.create_index(
+        "ix_dreaming_jobs_user_created_at",
+        "dreaming_jobs",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the dreaming_jobs table and its index."""
+    op.drop_index("ix_dreaming_jobs_user_created_at", table_name="dreaming_jobs")
+    op.drop_table("dreaming_jobs")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -421,6 +421,60 @@ class NotionOperationLog(Base):
     )
 
 
+class DreamingJob(Base):
+    """One run of the between-sessions reflection pass (#341).
+
+    Per the ADR at
+    ``frontend/content/docs/handbook/decisions/2026-05-20-dreaming-background-reflection.mdx``,
+    the pass runs in two modes:
+
+    * ``session_end`` — single conversation after idle window.
+    * ``daily_rollup`` — user-scoped reflection over prior 24h.
+
+    Each row records the inputs (model, token counts), the outputs
+    (counts per category + session_summary), and the lifecycle
+    (status + timestamps + error_text). The dreaming pass writes
+    memory rows with ``source="dreaming"`` and
+    ``provenance_job_id=<this row's id>`` so any consolidated
+    memory can be traced back to the pass that produced it.
+    """
+
+    __tablename__ = "dreaming_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), index=True
+    )
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=True
+    )
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
+    # ``session_end`` | ``daily_rollup``. Pinned by
+    # ``ck_dreaming_jobs_scope_valid`` in migration 022.
+    scope: Mapped[str] = mapped_column(String(24), nullable=False)
+    # ``pending`` | ``running`` | ``completed`` | ``failed``.
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    input_token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_token_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    patterns_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    followups_written: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    session_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 class Memory(Base):
     """A typed proactive memory written by the post-turn classifier or dreaming pass.
 
@@ -477,6 +531,7 @@ __all__ = [
     "ChatMessage",
     "Conversation",
     "CostLedger",
+    "DreamingJob",
     "LCMContextItem",
     "LCMEmbedding",
     "LCMSummary",


### PR DESCRIPTION
Re-created from closed PR 396. Stacked on #395 which has been merged.

## Summary by Sourcery

Introduce a dedicated DreamingJob persistence layer to track between-session reflection runs and their lifecycle.

New Features:
- Add a DreamingJob ORM model to represent individual between-session reflection jobs, including scope, status, IO token counts, and result metrics.
- Create the dreaming_jobs database table and supporting indexes, including constraints on valid scopes and statuses, to support querying and auditing dreaming runs.

Enhancements:
- Register DreamingJob in the SQLAlchemy models export list for use across the backend.