### PR TITLE
🧭 Atlas: Extract EventBus CRUD dependencies into integrations

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,0 +1,5 @@
+## 2024-05-27 - Backend Core Layering Exceptions
+
+**Learning:** `backend/app/core/event_bus/handlers.py` intentionally violates the `be-core -> be-crud` layer boundary (defined in `.sentrux/rules.toml` and `backend/.importlinter`) by lazy-importing `app.crud.workspace` and `app.crud.chat_message`. This was grandfathered into the CI gates because extracting the database persistence out of the event bus handler requires a proper orchestration boundary or dependency injection pattern, which wasn't built yet.
+
+**Action:** When extracting or refactoring core orchestration logic (like agent loops or event bus handlers), avoid pushing persistence logic into the lower-level core module. Instead, invert the dependency: pass a callable (Protocol/interface) from the higher-level API/orchestration layer down into the core handler, so the core handler can trigger persistence without importing the concrete CRUD module.

--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -66,13 +66,6 @@ ignore_imports =
     app.core.governance.audit -> app.models
     app.core.governance.cost_tracker -> app.models
     app.core.scheduler.scheduler -> app.models
-    app.core.event_bus.handlers -> app.crud.workspace
-    ; AgentHandler optionally persists scheduled-job responses into a
-    ; target conversation (e.g. the heartbeat sink). Lazy-imports the
-    ; chat_message CRUD inside the persistence helper so the bus
-    ; module stays decoupled at load time; flatten in a follow-up
-    ; alongside the workspace one above.
-    app.core.event_bus.handlers -> app.crud.chat_message
     ; LCM (Stack B / PRs #186–#196) owns three ORM tables
     ; (lcm_summaries, lcm_summary_sources, lcm_context_items) and must
     ; read/write them directly to assemble context, compact leaves, and

--- a/backend/app/core/event_bus/handlers.py
+++ b/backend/app/core/event_bus/handlers.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import Iterable
-from pathlib import Path
+from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
 from app.core.event_bus.bus import Event
@@ -32,10 +31,13 @@ from app.core.event_bus.types import (
     ScheduledEvent,
     WebhookEvent,
 )
-from app.core.providers import default_model, resolve_llm
-from app.db import async_session_maker
 
 logger = logging.getLogger(__name__)
+
+# Injected dependencies to avoid core -> crud layering violations
+RunAgentTurnFn = Callable[[str, uuid.UUID], Awaitable[str]]
+PersistAssistantResponseFn = Callable[[uuid.UUID, uuid.UUID, str, str], Awaitable[None]]
+
 
 # How many characters of the webhook payload to flatten into the prompt.
 # Past this we truncate so a noisy GitHub payload can't blow the model
@@ -68,8 +70,16 @@ class AgentHandler:
     handler that persists a conversation row per fire is a follow-on.
     """
 
-    def __init__(self, *, default_user_id: uuid.UUID | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        default_user_id: uuid.UUID | None = None,
+        run_turn_fn: RunAgentTurnFn | None = None,
+        persist_response_fn: PersistAssistantResponseFn | None = None,
+    ) -> None:
         self._default_user_id = default_user_id
+        self._run_turn_fn = run_turn_fn
+        self._persist_response_fn = persist_response_fn
 
     def register(self, bus: Any) -> None:
         """Attach the agent handler to the bus.
@@ -142,8 +152,12 @@ class AgentHandler:
                 originating_event_id,
             )
             return
+        if self._run_turn_fn is None:
+            logger.error("AGENT_HANDLER_NO_RUN_TURN_FN originating_event_id=%s", originating_event_id)
+            return
+
         try:
-            text = await _run_agent_turn(prompt=prompt, user_id=user_id)
+            text = await self._run_turn_fn(prompt, user_id)
         except Exception:
             logger.exception(
                 "AGENT_HANDLER_RUN_FAILED originating_event_id=%s user_id=%s",
@@ -159,12 +173,18 @@ class AgentHandler:
             )
             return
         if target_conversation_id is not None:
-            await _persist_assistant_response(
-                conversation_id=target_conversation_id,
-                user_id=user_id,
-                text=text,
-                originating_event_id=originating_event_id,
-            )
+            if self._persist_response_fn is not None:
+                await self._persist_response_fn(
+                    target_conversation_id,
+                    user_id,
+                    text,
+                    originating_event_id,
+                )
+            else:
+                logger.warning(
+                    "AGENT_HANDLER_NO_PERSIST_FN originating_event_id=%s",
+                    originating_event_id,
+                )
         # Lazy import — keeps the handler module decoupled from the
         # bus-publish helper to avoid a circular import surface.
         from app.core.event_bus.global_bus import (  # noqa: PLC0415
@@ -323,141 +343,3 @@ def _flatten_dict(
             lines.append(f"{full}: {_format_leaf(value)}")
 
 
-async def _run_agent_turn(*, prompt: str, user_id: uuid.UUID) -> str:
-    """Stream one provider turn and return the concatenated assistant text.
-
-    Resolves the catalog default model + the user's workspace + the
-    standard tool composition.  Skips workspace tools when the user
-    hasn't completed onboarding (no default workspace) — webhook /
-    scheduled traffic shouldn't be gated on the onboarding flow.
-    """
-    # All imports are lazy so the bus module can be loaded without
-    # pulling in the chat router's heavy dependency tree.
-    from app.core.agent_loop.tools import build_agent_tools  # noqa: PLC0415
-    from app.core.governance.permissions import (  # noqa: PLC0415
-        PermissionContext,
-        build_default_permission_check,
-    )
-    from app.core.governance.workspace_context import (  # noqa: PLC0415
-        load_workspace_context,
-    )
-    from app.crud.workspace import get_default_workspace  # noqa: PLC0415
-
-    async with async_session_maker() as session:
-        workspace = await get_default_workspace(user_id, session)
-
-    workspace_root: Path | None = Path(workspace.path) if workspace is not None else None
-    workspace_ctx = load_workspace_context(workspace_root) if workspace_root is not None else None
-    system_prompt = workspace_ctx.system_prompt if workspace_ctx is not None else None
-    enabled_tools = workspace_ctx.enabled_tools if workspace_ctx is not None else None
-
-    agent_tools = (
-        build_agent_tools(
-            workspace_root=workspace_root,
-            user_id=user_id,
-            send_fn=None,
-            surface="webhook",
-        )
-        if workspace_root is not None
-        else []
-    )
-
-    from app.core.agent_loop.types import (  # noqa: PLC0415
-        PermissionCheckFn,
-        PermissionCheckResult,
-    )
-
-    permission_check_fn: PermissionCheckFn | None = None
-    if workspace_root is not None:
-        permission_context = PermissionContext(
-            user_id=str(user_id),
-            workspace_root=workspace_root,
-            conversation_id=str(uuid.uuid4()),
-            surface="webhook",
-            enabled_tools=enabled_tools,
-        )
-        gate = build_default_permission_check()
-
-        async def permission_check_for_handler(
-            tool_name: str, arguments: dict[str, Any]
-        ) -> PermissionCheckResult:
-            decision = await gate(tool_name, arguments, permission_context)
-            return PermissionCheckResult(
-                allow=decision.allow,
-                reason=decision.reason,
-                violation_type=decision.violation_type,
-            )
-
-        permission_check_fn = permission_check_for_handler
-
-    # resolve_llm does not accept user_id; workspace_root carries the
-    # per-user key resolution upstream. Kept for call-site symmetry.
-    _ = user_id
-    provider = resolve_llm(
-        default_model().id,
-        workspace_root=workspace_root,
-    )
-
-    accumulated: list[str] = [
-        stream_event.get("content", "")
-        async for stream_event in provider.stream(
-            prompt,
-            uuid.uuid4(),
-            user_id,
-            history=[],
-            tools=agent_tools or None,
-            system_prompt=system_prompt,
-            permission_check=permission_check_fn,
-        )
-        if stream_event.get("type") == "delta"
-    ]
-    return "".join(accumulated).strip()
-
-
-async def _persist_assistant_response(
-    *,
-    conversation_id: uuid.UUID,
-    user_id: uuid.UUID,
-    text: str,
-    originating_event_id: str,
-) -> None:
-    """Write the agent's response into a chat conversation as a finalised turn.
-
-    Lazy imports keep ``event_bus.handlers`` from pulling the
-    chat-message CRUD into its module-load graph — the sentrux layer
-    rule wants core code to avoid hard imports of ``app.crud.*``.
-
-    Failures are logged and swallowed: a persistence error must not
-    break the Telegram fan-out that follows in the caller. The row is
-    written via the same helpers the web chat router uses, so the
-    UI's existing ``GET .../messages`` path picks it up immediately.
-    """
-    from app.crud.chat_message import (  # noqa: PLC0415
-        append_assistant_placeholder,
-        finalize_assistant_message,
-    )
-
-    try:
-        async with async_session_maker() as session:
-            placeholder = await append_assistant_placeholder(
-                session,
-                conversation_id=conversation_id,
-                user_id=user_id,
-            )
-            await finalize_assistant_message(
-                session,
-                message_id=placeholder.id,
-                content=text,
-                thinking=None,
-                tool_calls=None,
-                timeline=None,
-                thinking_duration_seconds=None,
-                assistant_status="complete",
-            )
-            await session.commit()
-    except Exception:
-        logger.exception(
-            "AGENT_HANDLER_PERSIST_FAILED conversation_id=%s originating_event_id=%s",
-            conversation_id,
-            originating_event_id,
-        )

--- a/backend/app/integrations/event_bus_deps.py
+++ b/backend/app/integrations/event_bus_deps.py
@@ -1,0 +1,145 @@
+"""Dependencies for the EventBus, injected from the API layer down into core.
+
+These functions encapsulate persistence side-effects that the EventBus
+handlers need, without creating core -> crud layer violations.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+from typing import Any
+
+from app.core.agent_loop.tools import build_agent_tools
+from app.core.agent_loop.types import (
+    PermissionCheckFn,
+    PermissionCheckResult,
+)
+from app.core.governance.permissions import (
+    PermissionContext,
+    build_default_permission_check,
+)
+from app.core.governance.workspace_context import load_workspace_context
+from app.core.providers import default_model, resolve_llm
+from app.crud.chat_message import (
+    append_assistant_placeholder,
+    finalize_assistant_message,
+)
+from app.crud.workspace import get_default_workspace
+from app.db import async_session_maker
+
+logger = logging.getLogger(__name__)
+
+
+async def run_agent_turn(prompt: str, user_id: uuid.UUID) -> str:
+    """Stream one provider turn and return the concatenated assistant text.
+
+    Resolves the catalog default model + the user's workspace + the
+    standard tool composition.  Skips workspace tools when the user
+    hasn't completed onboarding (no default workspace) — webhook /
+    scheduled traffic shouldn't be gated on the onboarding flow.
+    """
+    async with async_session_maker() as session:
+        workspace = await get_default_workspace(user_id, session)
+
+    workspace_root: Path | None = Path(workspace.path) if workspace is not None else None
+    workspace_ctx = load_workspace_context(workspace_root) if workspace_root is not None else None
+    system_prompt = workspace_ctx.system_prompt if workspace_ctx is not None else None
+    enabled_tools = workspace_ctx.enabled_tools if workspace_ctx is not None else None
+
+    agent_tools = (
+        build_agent_tools(
+            workspace_root=workspace_root,
+            user_id=user_id,
+            send_fn=None,
+            surface="webhook",
+        )
+        if workspace_root is not None
+        else []
+    )
+
+    permission_check_fn: PermissionCheckFn | None = None
+    if workspace_root is not None:
+        permission_context = PermissionContext(
+            user_id=str(user_id),
+            workspace_root=workspace_root,
+            conversation_id=str(uuid.uuid4()),
+            surface="webhook",
+            enabled_tools=enabled_tools,
+        )
+        gate = build_default_permission_check()
+
+        async def permission_check_for_handler(
+            tool_name: str, arguments: dict[str, Any]
+        ) -> PermissionCheckResult:
+            decision = await gate(tool_name, arguments, permission_context)
+            return PermissionCheckResult(
+                allow=decision.allow,
+                reason=decision.reason,
+                violation_type=decision.violation_type,
+            )
+
+        permission_check_fn = permission_check_for_handler
+
+    # resolve_llm does not accept user_id; workspace_root carries the
+    # per-user key resolution upstream. Kept for call-site symmetry.
+    _ = user_id
+    provider = resolve_llm(
+        default_model().id,
+        workspace_root=workspace_root,
+    )
+
+    accumulated: list[str] = [
+        stream_event.get("content", "")
+        async for stream_event in provider.stream(
+            prompt,
+            uuid.uuid4(),
+            user_id,
+            history=[],
+            tools=agent_tools or None,
+            system_prompt=system_prompt,
+            permission_check=permission_check_fn,
+        )
+        if stream_event.get("type") == "delta"
+    ]
+    return "".join(accumulated).strip()
+
+
+async def persist_assistant_response(
+    conversation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    text: str,
+    originating_event_id: str,
+) -> None:
+    """Write the agent's response into a chat conversation as a finalised turn.
+
+    Failures are logged and swallowed: a persistence error must not
+    break the Telegram fan-out that follows in the caller. The row is
+    written via the same helpers the web chat router uses, so the
+    UI's existing ``GET .../messages`` path picks it up immediately.
+    """
+    try:
+        async with async_session_maker() as session:
+            placeholder = await append_assistant_placeholder(
+                session,
+                conversation_id=conversation_id,
+                user_id=user_id,
+            )
+            await finalize_assistant_message(
+                session,
+                message_id=placeholder.id,
+                content=text,
+                thinking=None,
+                tool_calls=None,
+                timeline=None,
+                thinking_duration_seconds=None,
+                assistant_status="complete",
+            )
+            await session.commit()
+    except Exception:
+        logger.exception(
+            "AGENT_HANDLER_PERSIST_FAILED conversation_id=%s originating_event_id=%s",
+            conversation_id,
+            originating_event_id,
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -47,6 +47,7 @@ from app.core.request_logging import RequestLoggingMiddleware
 from app.core.scheduler import JobScheduler, set_active_scheduler
 from app.core.telemetry import setup_tracing, shutdown_tracing
 from app.db import create_db_and_tables
+from app.integrations.event_bus_deps import persist_assistant_response, run_agent_turn
 from app.integrations.telegram import telegram_lifespan
 from app.integrations.webhooks import get_webhooks_router
 from app.logger_setup import (
@@ -144,7 +145,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         # bot instance.  Both are no-ops when the relevant pieces are
         # disabled (no bot → notifications skip; no default user → agent
         # handler logs + skips).
-        agent_handler = AgentHandler()
+        agent_handler = AgentHandler(
+            run_turn_fn=run_agent_turn,
+            persist_response_fn=persist_assistant_response,
+        )
         agent_handler.register(event_bus)
         notification_service = NotificationService(
             telegram_bot=telegram_service.bot if telegram_service is not None else None

--- a/backend/tests/test_event_bus_handlers.py
+++ b/backend/tests/test_event_bus_handlers.py
@@ -117,7 +117,14 @@ class TestAgentHandlerRouting:
 
     async def test_subscribes_to_both_event_types(self) -> None:
         bus = EventBus()
-        AgentHandler().register(bus)
+
+        async def dummy_run(prompt: str, user_id: uuid.UUID) -> str:
+            return "dummy"
+
+        async def dummy_persist(conversation_id: uuid.UUID, user_id: uuid.UUID, text: str, event_id: str) -> None:
+            pass
+
+        AgentHandler(run_turn_fn=dummy_run, persist_response_fn=dummy_persist).register(bus)
         # Internal check — the handler registered subscribers for
         # both event types, not just one.
         subs = bus._handlers
@@ -129,7 +136,14 @@ class TestAgentHandlerRouting:
         bus = EventBus()
         await bus.start()
         bot = _RecordingBot()
-        AgentHandler().register(bus)
+
+        async def dummy_run(prompt: str, user_id: uuid.UUID) -> str:
+            return "dummy"
+
+        async def dummy_persist(conversation_id: uuid.UUID, user_id: uuid.UUID, text: str, event_id: str) -> None:
+            pass
+
+        AgentHandler(run_turn_fn=dummy_run, persist_response_fn=dummy_persist).register(bus)
         NotificationService(telegram_bot=bot).register(bus)
         await bus.publish(WebhookEvent(provider="github", event_type_name="push", payload={}))
         await _drain(bus)
@@ -144,7 +158,14 @@ class TestAgentHandlerRouting:
         # the handler dispatches without crashing on a no-user event.
         bus = EventBus()
         await bus.start()
-        AgentHandler().register(bus)
+
+        async def dummy_run(prompt: str, user_id: uuid.UUID) -> str:
+            return "dummy"
+
+        async def dummy_persist(conversation_id: uuid.UUID, user_id: uuid.UUID, text: str, event_id: str) -> None:
+            pass
+
+        AgentHandler(run_turn_fn=dummy_run, persist_response_fn=dummy_persist).register(bus)
         await bus.publish(
             ScheduledEvent(
                 job_id=uuid.uuid4(),


### PR DESCRIPTION
## What
Extracted `_run_agent_turn` and `_persist_assistant_response` from `backend/app/core/event_bus/handlers.py` into a new `backend/app/integrations/event_bus_deps.py` module, and injected them as dependencies into `AgentHandler`. Removed the grandfathered exception in `backend/.importlinter`.

## Smell
Layering Violation: Backend core importing CRUD concerns. `backend/app/core/event_bus/handlers.py` had lazy imports of `app.crud.chat_message` and `app.crud.workspace`, which violates the rule that `app.core` must not import `app.crud`.

## Evidence
- `backend/.importlinter` contained explicit exceptions: `app.core.event_bus.handlers -> app.crud.workspace` and `app.core.event_bus.handlers -> app.crud.chat_message` with a `TODO` to flatten.
- `backend/app/core/event_bus/handlers.py` contained local lazy imports for `app.crud.workspace` and `app.crud.chat_message`.

## Why
Inversion of control via dependency injection properly isolates the `app.core` layer from persistence (`app.crud`) details. The core bus orchestration now knows only about a functional `RunAgentTurnFn` and `PersistAssistantResponseFn` seam without caring where those side-effects land, enabling cleaner tests and strict layer adherence.

## Boundaries protected
- backend api/crud/models/core layering

## Verification
- Local checks passed: `cd backend && uv run lint-imports --config .importlinter`
- Backend tests passed: `cd backend && uv run pytest`

## Risk
Extremely low. Behaviour is preserved identically. The initialization of `AgentHandler` is just moved out to the caller (`main.py`) where it provides the exact same functions that were previously hardcoded. Tests have been updated to supply safe mock functions.

---
*PR created automatically by Jules for task [15220868226094434137](https://jules.google.com/task/15220868226094434137) started by @OctavianTocan*

## Summary by Sourcery

Inject EventBus agent execution and persistence logic via integration-layer dependencies to restore core/crud layering boundaries.

Enhancements:
- Refactor AgentHandler to accept injectable run and persistence callables instead of hardcoding core-to-crud logic.
- Extract agent turn execution and assistant response persistence into a new integrations module consumed from main.
- Improve AgentHandler robustness with logging when injected dependencies are missing.

Documentation:
- Document the historical core layering exception and the dependency inversion pattern in a new Atlas note.

Tests:
- Update EventBus handler tests to construct AgentHandler with dummy injected dependencies.