### PR TITLE
Add Beans task plugin and reliable mobile dev login

### DIFF
--- a/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
+++ b/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pawrrtal-extension-boundaries
+description: Use when touching Pawrrtal channels, providers, tools, plugins, subagents, context providers, turn orchestration, or code that decides where an integration should live. Enforces the split between generic kernel code, manifest plugins, trusted runtime adapters, provider adapters, channel adapters, and agent runtime primitives.
+---
+
+# Pawrrtal Extension Boundaries
+
+Use this before changing backend extension code. The goal is a thin generic
+kernel with optional pieces installed as plugins.
+
+## Vocabulary
+
+- **Kernel**: generic runtime code that owns auth, workspaces, persistence,
+  turn orchestration, plugin discovery, enabled state, env resolution, and
+  stable interfaces.
+- **Plugin manifest**: `backend/plugins/<plugin_id>/plugin.json`. This is
+  declarative metadata: capabilities, env requirements, validation commands,
+  permissions, slots, and entrypoints.
+- **Plugin runtime**: `backend/app/plugins/`. This is trusted host code plus
+  bundled Python implementations that a manifest may activate.
+- **Provider adapter**: code that talks to one model provider or provider CLI.
+  It belongs under `backend/app/providers/` or behind a provider plugin
+  capability.
+- **Channel adapter**: code that talks to one user surface such as Telegram or
+  Google Chat. It belongs under `backend/app/channels/` or behind a channel
+  plugin capability.
+- **Tool adapter**: code that exposes one agent tool. Tool selection happens in
+  the tool-surface/plugin layer, not inside providers.
+- **Subagent**: an agent-runtime primitive. Plugins may invoke subagents or
+  contribute agent profiles, but plugins do not implement the subagent kernel.
+- **Slot**: a named extension point where multiple plugins can fit, such as
+  `tasks`, `web_search`, `channel:telegram`, `provider:models`, or
+  `conversation_memory`.
+
+## Directory Rules
+
+- Put bundled plugin manifests in `backend/plugins/<plugin_id>/plugin.json`.
+- Put trusted plugin host code and bundled implementations in
+  `backend/app/plugins/`.
+- Put provider-specific code in `backend/app/providers/<provider>/`.
+- Put channel-specific code in `backend/app/channels/<channel>/`.
+- Keep `backend/app/chat/` provider-agnostic and channel-agnostic.
+- Keep `backend/app/conversations/` free of provider-specific helpers.
+- Keep `backend/app/channels/turn_orchestrator/` free of provider, channel, and
+  tool special cases.
+- Do not make providers import tool modules. Providers translate generic
+  `AgentTool` objects into SDK-specific formats.
+- Do not make channels import provider internals. Channels choose a model and
+  call the generic turn runner.
+- Do not make plugins import each other directly. Share behavior through
+  kernel interfaces, slots, or runtime adapters.
+
+## Before Adding Code
+
+1. Name the capability type: `provider`, `channel`, `cli_tool`,
+   `python_tool`, `turn_context_provider`, `conversation_memory`,
+   `agent_runtime`, `agent_profile`, `router`, `settings`, or `scheduler`.
+2. Name the slot if users may choose among multiple implementations.
+3. Decide whether the code is generic kernel code or a trusted bundled adapter.
+4. Add or update the manifest first when the behavior is optional.
+5. Declare env requirements in the manifest. Use `user_workspace` or
+   `workspace` scope when values must be overridable per workspace/user.
+6. Keep enabled/disabled behavior explicit. Disabled plugins must not advertise
+   tools, providers, channels, or context providers.
+7. Add tests at the interface: manifest validation, registry/slot resolution,
+   enabled-state behavior, env gating, and the runtime adapter.
+8. Verify through Paw when the behavior affects a user-visible flow.
+
+## Smells To Fix
+
+| Smell | Fix |
+| --- | --- |
+| `chat/` imports a provider, MCP adapter, or channel module | Move the behavior behind a generic interface or plugin capability. |
+| `conversations/` contains `gemini_*`, `codex_*`, or another provider name | Move it to the provider package and expose a generic history adapter. |
+| `turn_orchestrator/` checks for one provider, tool, or channel by name | Emit/handle a generic event or add an adapter hook. |
+| A provider imports tool factories | Pass generic `AgentTool` values into the provider and translate there. |
+| A channel formats tools, keyboards, or command output ad hoc | Move reusable formatting to channel runtime helpers or a channel adapter. |
+| Plugin code reads `os.environ` directly for user/workspace settings | Declare env in the manifest and use the plugin env resolver. |
+| A plugin is always on because it exists on disk | Add enabled-state tests and make the manifest default intentional. |
+| A subagent is implemented as a plugin | Move orchestration to the agent runtime and let plugins contribute profiles or invoke it. |
+
+## Verification
+
+Use the Paw CLI as the operator surface:
+
+```bash
+paw plugins spec --json
+paw plugins list --json
+paw plugins capabilities search --slot tasks --json
+paw plugins slots list --json
+paw plugins validate backend/plugins/<plugin_id>/plugin.json --source bundled --json
+```
+
+For runtime changes, add focused tests and then run the relevant gates:
+
+```bash
+cd backend && uv run pytest tests/test_plugin_discovery.py tests/test_plugin_tools.py
+cd backend && uv run pytest tests/test_channel_plugins.py tests/test_provider_plugins.py
+paw verify chat-roundtrip --json
+```
+
+Run broader CI gates before claiming the PR is ready.

--- a/.github/workflows/backend-check.yml
+++ b/.github/workflows/backend-check.yml
@@ -37,10 +37,10 @@ jobs:
     # octaviantocan-only-and-self-hosted-runner.md). Push events have no
     # pull_request payload, so the second clause is vacuously true.
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,10 +43,10 @@ jobs:
   check:
     name: bun run check
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: [self-hosted, openclaw-mini, pawrrtal]
+    runs-on: [self-hosted, openclaw-mini, pawrrtal, octavian-only]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/dev-console-smoke.yml
+++ b/.github/workflows/dev-console-smoke.yml
@@ -45,14 +45,14 @@ jobs:
   smoke:
     name: Dev console clean
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
     # Self-hosted: `agent-browser` and its Chrome-for-Testing payload
     # are cached on the `pawrrtal` runner pool across runs; rebuilding the
     # cache on every GitHub-hosted ubuntu-latest run would dominate
     # the smoke's wall time.
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
   integration:
     name: Integration suite
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
     # Self-hosted to keep token spend bounded: the runner already has
@@ -50,7 +50,7 @@ jobs:
     # is on Tavi's box, not GitHub's.  Reserving 「ubuntu-latest」 for
     # the GitHub-hosted-only workloads (「playwright install --with-deps」
     # in the dev-console smoke).
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/paw-verify.yml
+++ b/.github/workflows/paw-verify.yml
@@ -49,10 +49,10 @@ jobs:
     # octaviantocan-only-and-self-hosted-runner.md). Push events have no
     # pull_request payload, so the second clause is vacuously true.
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, openclaw-mini, pawrrtal]
+    runs-on: [self-hosted, openclaw-mini, pawrrtal, octavian-only]
     timeout-minutes: 45
     steps:
       - name: Checkout repository

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -40,7 +40,7 @@ jobs:
   e2e:
     name: Playwright suite
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
     # Documented exception to the self-hosted-runner default per

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -30,10 +30,10 @@ jobs:
   react-doctor:
     name: React Doctor
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, openclaw-mini, pawrrtal]
+    runs-on: [self-hosted, openclaw-mini, pawrrtal, octavian-only]
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -114,8 +114,8 @@ jobs:
 
             if [[ -n "$CLAUDE_TRIGGER_TOKEN" ]]; then
               # Comments authored with the repository GITHUB_TOKEN show up as github-actions[bot]
-              # and Claude ignores that automated mention. Use a separate user/app token
-              # (preferably octagent) so the handoff matches the working manual comment path.
+              # and Claude ignores that automated mention. Use a separate approved
+              # user/app token so the handoff matches the working manual comment path.
               GH_TOKEN="$CLAUDE_TRIGGER_TOKEN" gh pr comment "$PR_NUMBER" --body "$CLAUDE_REQUEST"
             else
               MANUAL_FOLLOWUP=$(printf '⚠️ **Automated Rebase Blocked by Conflicts:** `CLAUDE_TRIGGER_TOKEN` is not configured, so this workflow cannot summon Claude automatically. A maintainer needs to post this comment manually:\n\n%s' "$CLAUDE_REQUEST")

--- a/.github/workflows/sentrux.yml
+++ b/.github/workflows/sentrux.yml
@@ -39,7 +39,7 @@ jobs:
     # Push events have no pull_request payload, so the second clause is
     # vacuously true and the workflow still runs on direct pushes.
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
@@ -114,10 +114,10 @@ jobs:
   backend-layers:
     name: import-linter (backend layers)
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -182,10 +182,10 @@ jobs:
   frontend-layers:
     name: dependency-cruiser (frontend layers)
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/stagehand-e2e.yml
+++ b/.github/workflows/stagehand-e2e.yml
@@ -38,7 +38,7 @@ jobs:
   stagehand:
     name: Stagehand suite
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,10 @@ jobs:
   frontend:
     name: Frontend Vitest
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, pawrrtal]
+    runs-on: [self-hosted, pawrrtal, octavian-only]
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -131,10 +131,10 @@ jobs:
   backend:
     name: Backend pytest
     if: >-
-      (github.actor == 'OctavianTocan' || github.actor == 'octagent') &&
+      github.actor == 'OctavianTocan' &&
       (github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, openclaw-mini, pawrrtal]
+    runs-on: [self-hosted, openclaw-mini, pawrrtal, octavian-only]
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 We rely on `just` as our primary task runner for the repository.
 
 - **Start all dev servers**: `just dev` (starts both frontend and backend concurrently).
+- **Paw CLI from any directory**: `just install-paw` installs the repo launcher to `~/.local/bin/paw`; then use `paw ...` directly instead of repeating `cd backend && uv run paw ...`.
 - **Check (Lint/Format read-only)**: `just check` (runs Biome).
 - **Lint & Auto-fix**: `just lint-fix` (runs Biome check with writes).
 - **Format**: `just format` (runs Biome format).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - **Design system (`DESIGN.md`)**: Repo-root [DESIGN.md](https://github.com/google-labs-code/design.md)-format spec describing the Craft Agents-inspired visual identity — colors, typography, spacing, shapes, elevation, and component bindings. Canonical token values live in `frontend/app/globals.css`; `DESIGN.md` mirrors them as machine-readable YAML front matter so coding agents have a persistent, structured understanding of the system. Lint with `bun run design:lint`.
 - **Docs (`docs/`)**: Project documentation, migration plans, and design specs.
 - **Tasks (`.beans/`)**: Markdown-based task tracking. Update the status of `.beans` files as work is completed.
+- **Extension boundaries (`.agents/skills/pawrrtal-extension-boundaries/SKILL.md`)**: Read this skill before touching channels, providers, tools, plugins, subagents, context providers, or turn orchestration. It defines where optional integrations live and how the kernel stays generic.
 - **Rule**: Always use the `beans` CLI (e.g. `beans create`, `beans update`) to manage `.beans` files. Never create or edit them manually.
 - **Rule (bean writing style)**: Write bean bodies so a junior engineer (or a future agent with zero context) can act on them without re-reading the codebase. Plain words over jargon. Use:
     - `## Goal` heading at the top (one sentence on what this step achieves).

--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -49,6 +49,7 @@ from app.channels.telegram.bot_runtime import (
     safe_edit_html,
     should_refresh_commands,
 )
+from app.channels.telegram.delivery import safe_send_html
 from app.channels.telegram.handlers import (
     TelegramSender,
     TelegramTurnContext,
@@ -674,7 +675,15 @@ def _register_telegram_tools_command_handler(dispatcher: Dispatcher) -> None:
         sender = _sender_from_message(message)
         async with async_session_maker() as session:
             reply = await handle_tools_command(sender=sender, session=session)
-        await message.answer(reply)
+        if message.bot is None:
+            raise RuntimeError("Telegram /tools command received a message without a bot.")
+        await safe_send_html(
+            message.bot,
+            message.chat.id,
+            reply,
+            reply_to_message_id=message.message_id,
+            message_thread_id=message.message_thread_id,
+        )
 
 
 def _register_telegram_identity_command_handlers(dispatcher: Dispatcher) -> None:

--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -989,7 +989,11 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
             await service.bot.delete_webhook(drop_pending_updates=True)
             logger.info("TELEGRAM_BOOT mode=polling")
             service.polling_task = asyncio.create_task(
-                service.dispatcher.start_polling(service.bot, handle_signals=False),
+                service.dispatcher.start_polling(
+                    service.bot,
+                    handle_signals=False,
+                    close_bot_session=False,
+                ),
                 name="telegram-polling",
             )
         else:
@@ -1011,19 +1015,29 @@ async def telegram_lifespan() -> AsyncIterator[TelegramService | None]:
         yield service
     finally:
         await shutdown_chat_queue_dispatcher()
-        if service.polling_task is not None:
-            service.polling_task.cancel()
-            # The task either finishes cleanly (CancelledError) or surfaces
-            # an unrelated shutdown error.  We swallow both because the
-            # lifespan is already tearing down; there is nothing to recover.
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await service.polling_task
+        await _stop_polling_task(service)
         try:
             await service.bot.session.close()
         except Exception:
             logger.warning("TELEGRAM_SHUTDOWN session_close_failed", exc_info=True)
         if service.polling_lock is not None:
             service.polling_lock.release()
+
+
+async def _stop_polling_task(service: TelegramService) -> None:
+    """Stop aiogram polling through its dispatcher-owned shutdown signal."""
+    task = service.polling_task
+    if task is None:
+        return
+    if not task.done():
+        try:
+            await service.dispatcher.stop_polling()
+        except RuntimeError as exc:
+            if "Polling is not started" not in str(exc):
+                raise
+            task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
 
 
 def _validate_telegram_webhook_url(url: str) -> None:

--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -60,6 +60,7 @@ from app.channels.telegram.handlers import (
     handle_verbose_command,
     handle_whoami_command,
 )
+from app.channels.telegram.tools_command import handle_tools_command
 from app.channels.turn_orchestrator import ChatTurnInput, run_turn
 from app.infrastructure.config import settings
 from app.infrastructure.database.legacy import async_session_maker
@@ -86,6 +87,7 @@ _TELEGRAM_COMMANDS: tuple[tuple[str, str], ...] = (
     ("verbose", "Set detail level: 0 quiet, 1 tools, 2 thinking"),
     ("stop", "Stop the active run"),
     ("status", "Show gateway + conversation status"),
+    ("tools", "Show available tools and plugin capabilities"),
     ("whoami", "Show your Telegram ID and Pawrrtal binding"),
     ("lcm", "Show LCM (long-context memory) status for this conversation"),
     ("compact", "Force an LCM leaf-compaction pass now"),
@@ -648,6 +650,7 @@ def _register_telegram_command_handlers(dispatcher: Dispatcher) -> None:
         await message.answer(reply)
 
     _register_telegram_config_command_handler(dispatcher)
+    _register_telegram_tools_command_handler(dispatcher)
     _register_telegram_identity_command_handlers(dispatcher)
     _register_telegram_lcm_command_handlers(dispatcher)
 
@@ -660,6 +663,18 @@ def _register_telegram_config_command_handler(dispatcher: Dispatcher) -> None:
     async def _on_config(message: Message) -> None:
         config_picker_runtime = import_module("app.channels.telegram.config_picker_runtime")
         await config_picker_runtime.answer_config_command(message=message)
+
+
+def _register_telegram_tools_command_handler(dispatcher: Dispatcher) -> None:
+    """Register the tool-surface diagnostic command."""
+    from aiogram.filters import Command  # noqa: PLC0415
+
+    @dispatcher.message(Command("tools"))
+    async def _on_tools(message: Message) -> None:
+        sender = _sender_from_message(message)
+        async with async_session_maker() as session:
+            reply = await handle_tools_command(sender=sender, session=session)
+        await message.answer(reply)
 
 
 def _register_telegram_identity_command_handlers(dispatcher: Dispatcher) -> None:

--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -24,7 +24,7 @@ import ipaddress
 import logging
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from importlib import import_module
@@ -78,6 +78,8 @@ if TYPE_CHECKING:
     from app.channels.telegram._attachments import TelegramVoiceNote
 
 logger = logging.getLogger(__name__)
+_AIOGRAM_DISPATCHER_LOGGER = logging.getLogger("aiogram.dispatcher")
+_SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS = False
 
 _TELEGRAM_COMMANDS: tuple[tuple[str, str], ...] = (
     ("start", "Connect your Pawrrtal account"),
@@ -98,6 +100,49 @@ _TELEGRAM_COMMANDS: tuple[tuple[str, str], ...] = (
 # without reading the wall clock at boot. Process-local — multi-worker
 # deployments report only the worker that handled the command.
 _BOT_START_MONOTONIC: float = time.monotonic()
+
+
+class _AiogramPollingShutdownFilter(logging.Filter):
+    """Hide aiogram long-poll cancellation noise during planned shutdown only."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not _should_suppress_aiogram_polling_log(record)
+
+
+def _should_suppress_aiogram_polling_log(record: logging.LogRecord) -> bool:
+    """Return whether an aiogram dispatcher record is expected shutdown noise."""
+    if not _SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS:
+        return False
+    message = record.getMessage()
+    if "Failed to fetch updates" in message and "ServerDisconnectedError" in message:
+        return True
+    return message.startswith("Sleep for ") and "try again" in message
+
+
+def _install_aiogram_polling_shutdown_filter() -> None:
+    """Install the process-wide aiogram shutdown filter once."""
+    if any(
+        isinstance(item, _AiogramPollingShutdownFilter)
+        for item in _AIOGRAM_DISPATCHER_LOGGER.filters
+    ):
+        return
+    _AIOGRAM_DISPATCHER_LOGGER.addFilter(_AiogramPollingShutdownFilter())
+
+
+@contextlib.contextmanager
+def _suppress_aiogram_polling_shutdown_logs() -> Iterator[None]:
+    """Temporarily suppress aiogram polling cancellation logs during teardown."""
+    global _SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS  # noqa: PLW0603
+
+    previous = _SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS
+    _SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS = True
+    try:
+        yield
+    finally:
+        _SUPPRESS_AIOGRAM_POLLING_SHUTDOWN_LOGS = previous
+
+
+_install_aiogram_polling_shutdown_filter()
 
 
 def get_bot_uptime_seconds() -> float:
@@ -1029,15 +1074,16 @@ async def _stop_polling_task(service: TelegramService) -> None:
     task = service.polling_task
     if task is None:
         return
-    if not task.done():
-        try:
-            await service.dispatcher.stop_polling()
-        except RuntimeError as exc:
-            if "Polling is not started" not in str(exc):
-                raise
-            task.cancel()
-    with contextlib.suppress(asyncio.CancelledError, Exception):
-        await task
+    with _suppress_aiogram_polling_shutdown_logs():
+        if not task.done():
+            try:
+                await service.dispatcher.stop_polling()
+            except RuntimeError as exc:
+                if "Polling is not started" not in str(exc):
+                    raise
+                task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
 
 
 def _validate_telegram_webhook_url(url: str) -> None:

--- a/backend/app/channels/telegram/tools_command.py
+++ b/backend/app/channels/telegram/tools_command.py
@@ -26,7 +26,18 @@ _MAX_CAPABILITY_ROWS = 40
 
 
 async def handle_tools_command(*, sender: TelegramSender, session: AsyncSession) -> str:
-    """Return the concrete tools and plugin capabilities for this Telegram turn."""
+    """Return available tools and plugin capabilities for one Telegram sender.
+
+    Args:
+        sender: Telegram chat and user identity for the command request.
+        session: Database session used to resolve bindings, workspace, and conversation state.
+
+    Returns:
+        HTML-formatted text suitable for Telegram delivery. The text includes the effective
+        model, concrete agent tools, and enabled plugin capabilities for the resolved
+        workspace. Short plain-text messages are returned when the sender is not bound or
+        does not have an onboarded workspace.
+    """
     pawrrtal_user_id = await resolve_or_autolink_telegram_user(session=session, sender=sender)
     if pawrrtal_user_id is None:
         return _NOT_BOUND_MESSAGE

--- a/backend/app/channels/telegram/tools_command.py
+++ b/backend/app/channels/telegram/tools_command.py
@@ -1,0 +1,142 @@
+"""Telegram `/tools` command for the live agent tool surface."""
+
+from __future__ import annotations
+
+import html
+from collections import defaultdict
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.tool_surface import build_agent_tools
+from app.agents.types import AgentTool
+from app.channels.crud import get_or_create_telegram_conversation_full
+from app.channels.telegram.dev_admin import resolve_or_autolink_telegram_user
+from app.channels.telegram.model_defaults import resolve_effective_model_id
+from app.channels.telegram.sender import TelegramSender
+from app.plugins.capability_catalog import CapabilityRecord
+from app.plugins.errors import PluginError
+from app.plugins.host import get_plugin_host
+from app.workspace.crud import get_default_workspace
+
+_NOT_BOUND_MESSAGE = "Connect your account first before listing tools."
+_NO_WORKSPACE_MESSAGE = "Finish workspace onboarding before listing tools."
+_MAX_TOOL_ROWS = 40
+_MAX_CAPABILITY_ROWS = 40
+
+
+async def handle_tools_command(*, sender: TelegramSender, session: AsyncSession) -> str:
+    """Return the concrete tools and plugin capabilities for this Telegram turn."""
+    pawrrtal_user_id = await resolve_or_autolink_telegram_user(session=session, sender=sender)
+    if pawrrtal_user_id is None:
+        return _NOT_BOUND_MESSAGE
+
+    workspace = await get_default_workspace(pawrrtal_user_id, session)
+    if workspace is None:
+        return _NO_WORKSPACE_MESSAGE
+
+    conversation = await get_or_create_telegram_conversation_full(
+        user_id=pawrrtal_user_id,
+        session=session,
+        thread_id=sender.thread_id,
+    )
+    model_id = resolve_effective_model_id(conversation_model_id=conversation.model_id)
+    workspace_root = Path(workspace.path)
+    tools = build_agent_tools(
+        workspace_root=workspace_root,
+        user_id=pawrrtal_user_id,
+        workspace_id=workspace.id,
+        send_fn=_noop_send,
+        surface="telegram",
+        conversation_id=conversation.id,
+        model_id=model_id,
+    )
+    capabilities, plugin_error = _load_enabled_capabilities(workspace_root=workspace_root)
+    return _render_tools_message(
+        model_id=model_id,
+        tools=tools,
+        capabilities=capabilities,
+        plugin_error=plugin_error,
+    )
+
+
+async def _noop_send(
+    _text: str | None,
+    _file_path: Path | None,
+    _mime: str | None,
+) -> None:
+    """Let `/tools` include channel delivery tools without sending anything."""
+
+
+def _load_enabled_capabilities(
+    *,
+    workspace_root: Path,
+) -> tuple[tuple[CapabilityRecord, ...], str | None]:
+    try:
+        _previous, snapshot = get_plugin_host().reload(workspace_root=workspace_root)
+    except PluginError as exc:
+        return (), str(exc)
+    return tuple(row for row in snapshot.capabilities if row.state == "enabled"), None
+
+
+def _render_tools_message(
+    *,
+    model_id: str,
+    tools: list[AgentTool],
+    capabilities: tuple[CapabilityRecord, ...],
+    plugin_error: str | None,
+) -> str:
+    lines = [
+        "<b>Tools available</b>",
+        f"Model: <code>{html.escape(model_id)}</code>",
+        "",
+        f"<b>Agent tools ({len(tools)})</b>",
+        *_render_tool_rows(tools),
+        "",
+        f"<b>Enabled plugin capabilities ({len(capabilities)})</b>",
+        *_render_capability_rows(capabilities),
+    ]
+    if plugin_error is not None:
+        lines.extend(("", f"Plugin catalog error: <code>{html.escape(plugin_error)}</code>"))
+    return "\n".join(lines)
+
+
+def _render_tool_rows(tools: list[AgentTool]) -> list[str]:
+    if not tools:
+        return ["none"]
+    names = sorted({tool.name for tool in tools})
+    rows = [f"- <code>{html.escape(name)}</code>" for name in names[:_MAX_TOOL_ROWS]]
+    return _with_more_row(rows, total=len(names), shown=len(rows))
+
+
+def _render_capability_rows(capabilities: tuple[CapabilityRecord, ...]) -> list[str]:
+    if not capabilities:
+        return ["none"]
+
+    by_slot: dict[str, list[CapabilityRecord]] = defaultdict(list)
+    for capability in capabilities:
+        slots = capability.slots or ("unslotted",)
+        for slot in slots:
+            by_slot[slot].append(capability)
+
+    rows: list[str] = []
+    for slot in sorted(by_slot):
+        rows.append(f"- <b>{html.escape(slot)}</b>")
+        for capability in sorted(by_slot[slot], key=lambda row: row.key):
+            if len(rows) >= _MAX_CAPABILITY_ROWS:
+                return _with_more_row(rows, total=_capability_row_count(by_slot), shown=len(rows))
+            rows.append(
+                f"  - <code>{html.escape(capability.key)}</code> ({html.escape(capability.type)})"
+            )
+    return rows
+
+
+def _capability_row_count(by_slot: dict[str, list[CapabilityRecord]]) -> int:
+    return len(by_slot) + sum(len(rows) for rows in by_slot.values())
+
+
+def _with_more_row(rows: list[str], *, total: int, shown: int) -> list[str]:
+    hidden = total - shown
+    if hidden > 0:
+        rows.append(f"- ...and {hidden} more")
+    return rows

--- a/backend/app/cli/paw/commands/project/cli.py
+++ b/backend/app/cli/paw/commands/project/cli.py
@@ -1,9 +1,9 @@
 """Whole-project dev lifecycle commands for ``paw project``.
 
 ``paw dev`` intentionally manages only the FastAPI backend. This module
-wraps the root ``dev.ts`` orchestrator so an operator can start, stop,
-inspect, and find logs for the full local app from the CLI: Next.js on
-``localhost:3000`` and FastAPI on ``127.0.0.1:8000``.
+wraps the root ``dev.ts`` orchestrator for local development and exposes
+service helpers for the Cloudflared-facing production loopback server:
+Next.js on ``localhost:3000`` and FastAPI on ``127.0.0.1:8000``.
 """
 
 from __future__ import annotations
@@ -53,7 +53,7 @@ from app.cli.paw.output import emit_human, emit_json, emit_plain_rows, require_o
 app = typer.Typer(no_args_is_help=True)
 env_app = typer.Typer(no_args_is_help=True)
 app.add_typer(cloudflared_app, name="cloudflared", help="Install/manage Cloudflared.")
-app.add_typer(service_app, name="service", help="Install/manage the user systemd dev service.")
+app.add_typer(service_app, name="service", help="Install/manage the systemd app service.")
 
 
 def pid_alive(pid: int) -> bool:

--- a/backend/app/cli/paw/commands/project/service.py
+++ b/backend/app/cli/paw/commands/project/service.py
@@ -114,6 +114,7 @@ def _unit_text(*, enable_dev_login: bool, env_file: Path | None) -> str:
             "RestartSec=15",
             "KillMode=control-group",
             "TimeoutStopSec=25",
+            "SuccessExitStatus=143 130",
             *env_lines,
             "",
             "[Install]",

--- a/backend/app/cli/paw/commands/project/service.py
+++ b/backend/app/cli/paw/commands/project/service.py
@@ -83,6 +83,7 @@ def _unit_text(*, enable_dev_login: bool, env_file: Path | None) -> str:
         _systemd_env_line("PATH", path),
         _systemd_env_line("UV_CACHE_DIR", str(cache_root / "uv")),
         _systemd_env_line("XDG_CACHE_HOME", str(cache_root / "xdg")),
+        _systemd_env_line("UV_LINK_MODE", "copy"),
         _systemd_env_line("NODE_ENV", "production"),
         _systemd_env_line("NEXT_TELEMETRY_DISABLED", "1"),
         _systemd_env_line("ENV", "prod"),

--- a/backend/app/cli/paw/commands/project/service.py
+++ b/backend/app/cli/paw/commands/project/service.py
@@ -1,8 +1,7 @@
-"""User systemd service management for the local Pawrrtal dev project."""
+"""Systemd service management for the Cloudflared-facing Pawrrtal server."""
 
 from __future__ import annotations
 
-import getpass
 import os
 import shutil
 import subprocess
@@ -17,14 +16,22 @@ from app.cli.paw.output import emit_human
 
 app = typer.Typer(no_args_is_help=True)
 
-SERVICE_NAME = "pawrrtal-dev.service"
+SERVICE_NAME = "pawrrtal.service"
+DEFAULT_ENV_FILE_NAME = "backend/.env"
+STANDARD_SERVICE_PATHS = (
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+)
 
 
 def _unit_dir() -> Path:
-    """Return the user systemd unit directory."""
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
-    config_home = Path(xdg_config_home) if xdg_config_home else Path.home() / ".config"
-    return config_home / "systemd" / "user"
+    """Return the systemd unit directory."""
+    override = os.environ.get("PAWRRTAL_SYSTEMD_UNIT_DIR")
+    return Path(override) if override else Path("/etc/systemd/system")
 
 
 def _unit_path() -> Path:
@@ -40,69 +47,91 @@ def _require_binary(name: str) -> str:
     return path
 
 
-def _current_user() -> str:
-    """Return the current login name for linger management."""
-    return getpass.getuser()
-
-
 def _systemd_env_line(name: str, value: str) -> str:
     """Return one quoted systemd Environment= line."""
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     return f'Environment="{name}={escaped}"'
 
 
-def _next_allowed_dev_origins() -> str:
-    """Return explicit or Cloudflared-derived Next dev origins."""
-    explicit = os.environ.get("NEXT_ALLOWED_DEV_ORIGINS", "").strip()
-    if explicit:
-        return explicit
+def _service_path(binary_paths: list[str]) -> str:
+    """Return a stable PATH for the systemd service."""
+    entries = [str(Path(binary_path).parent) for binary_path in binary_paths]
+    entries.extend(STANDARD_SERVICE_PATHS)
+    deduped = list(dict.fromkeys(entries))
+    return ":".join(deduped)
+
+
+def _public_hostname() -> str:
+    """Return the saved public hostname, if Cloudflared has been installed."""
     cloudflared_state = load_cloudflared_state()
     if cloudflared_state is None:
         return ""
-    return cloudflared_state.public_url.rstrip("/")
+    return cloudflared_state.hostname.strip()
 
 
-def _unit_text() -> str:
-    """Render the user service unit for the current checkout."""
+def _unit_text(*, enable_dev_login: bool, env_file: Path | None) -> str:
+    """Render the system service unit for the current checkout."""
     bun = _require_binary("bun")
+    uv = _require_binary("uv")
+    node = _require_binary("node")
     root = repo_root()
     cache_root = root / ".cache"
-    path = os.environ.get("PATH", "")
-    dev_database_url = os.environ.get("PAWRRTAL_DEV_DATABASE_URL", "")
-    next_allowed_dev_origins = _next_allowed_dev_origins()
+    path = _service_path([bun, uv, node])
+    public_hostname = _public_hostname()
+    env_file_line = f"EnvironmentFile=-{env_file}" if env_file is not None else None
     env_lines = [
         _systemd_env_line("PATH", path),
         _systemd_env_line("UV_CACHE_DIR", str(cache_root / "uv")),
         _systemd_env_line("XDG_CACHE_HOME", str(cache_root / "xdg")),
-        _systemd_env_line("DATABASE_URL", ""),
-        _systemd_env_line("PAWRRTAL_DEV_DATABASE_URL", dev_database_url),
+        _systemd_env_line("NODE_ENV", "production"),
+        _systemd_env_line("NEXT_TELEMETRY_DISABLED", "1"),
+        _systemd_env_line("ENV", "prod"),
+        _systemd_env_line("HOSTNAME", "127.0.0.1"),
+        _systemd_env_line("PORT", "3000"),
+        _systemd_env_line("PAWRRTAL_BACKEND_HOST", "127.0.0.1"),
+        _systemd_env_line("PAWRRTAL_BACKEND_PORT", "8000"),
         _systemd_env_line("BACKEND_INTERNAL_URL", "http://127.0.0.1:8000"),
     ]
-    if next_allowed_dev_origins:
-        env_lines.append(_systemd_env_line("NEXT_ALLOWED_DEV_ORIGINS", next_allowed_dev_origins))
+    if public_hostname:
+        env_lines.append(_systemd_env_line("PAWRRTAL_PUBLIC_HOSTNAME", public_hostname))
+    if enable_dev_login:
+        env_lines.append(_systemd_env_line("PAWRRTAL_ENABLE_DEV_LOGIN", "true"))
     return "\n".join(
         [
             "[Unit]",
-            "Description=Pawrrtal local dev server",
-            "After=network.target",
+            "Description=Pawrrtal production app server",
+            "After=network-online.target",
+            "Wants=network-online.target",
             "StartLimitIntervalSec=120",
             "StartLimitBurst=3",
             "",
             "[Service]",
             "Type=simple",
             f"WorkingDirectory={root}",
-            f"ExecStart={bun} run dev.ts",
+            *(line for line in [env_file_line] if line is not None),
+            f"ExecStart={bun} run serve.ts",
             "Restart=on-failure",
             "RestartSec=15",
             "KillMode=control-group",
-            "TimeoutStopSec=20",
+            "TimeoutStopSec=25",
             *env_lines,
             "",
             "[Install]",
-            "WantedBy=default.target",
+            "WantedBy=multi-user.target",
             "",
         ]
     )
+
+
+def _resolve_env_file(value: str) -> Path | None:
+    """Resolve a service env-file path relative to the active checkout."""
+    stripped = value.strip()
+    if not stripped:
+        return None
+    path = Path(stripped).expanduser()
+    if not path.is_absolute():
+        path = repo_root() / path
+    return path
 
 
 def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -112,7 +141,7 @@ def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[
     except FileNotFoundError as exc:
         raise LocalError(
             f"`{args[0]}` not found on PATH.",
-            hint="This service helper requires a Linux host with systemd user services.",
+            hint="This service helper requires a Linux host with systemd.",
         ) from exc
     except subprocess.CalledProcessError as exc:
         output = (exc.stderr or exc.stdout or "").strip()
@@ -124,18 +153,18 @@ def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[
 
 
 def _systemctl(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-    """Run ``systemctl --user`` with ``args``."""
-    return _run(["systemctl", "--user", *args], check=check)
+    """Run ``systemctl`` with ``args``."""
+    return _run(["systemctl", *args], check=check)
 
 
 def _preflight_systemd() -> None:
-    """Fail before writing unit files when user systemd is unavailable."""
+    """Fail before writing unit files when systemd is unavailable."""
     result = _systemctl("is-system-running", check=False)
     output = (result.stdout or result.stderr or "").strip()
     if "Failed to connect to bus" in output or "Operation not permitted" in output:
         raise LocalError(
-            "User systemd is not available in this environment.",
-            hint=output or "Run from a login session with a user systemd bus.",
+            "Systemd is not available in this environment.",
+            hint=output or "Run on the deployment host with systemd available.",
         )
 
 
@@ -143,17 +172,26 @@ def _preflight_systemd() -> None:
 def install(
     enable: bool = typer.Option(True, "--enable/--no-enable", help="Enable the unit."),
     now: bool = typer.Option(True, "--now/--no-now", help="Start the unit after install."),
-    linger: bool = typer.Option(
+    enable_dev_login: bool = typer.Option(
         False,
-        "--linger",
-        help="Run `loginctl enable-linger` so the user service starts at machine boot.",
+        "--enable-dev-login",
+        help="Expose the Dev Admin shortcut in production. Use only behind Cloudflare Access.",
+    ),
+    env_file: str = typer.Option(
+        DEFAULT_ENV_FILE_NAME,
+        "--env-file",
+        help="Optional backend env file loaded by systemd. Use an empty value to disable.",
     ),
 ) -> None:
-    """Install the Pawrrtal dev server as a user systemd service."""
+    """Install the Pawrrtal production loopback server as a systemd service."""
     _preflight_systemd()
+    resolved_env_file = _resolve_env_file(env_file)
     unit_path = _unit_path()
     unit_path.parent.mkdir(parents=True, exist_ok=True)
-    unit_path.write_text(_unit_text(), encoding="utf-8")
+    unit_path.write_text(
+        _unit_text(enable_dev_login=enable_dev_login, env_file=resolved_env_file),
+        encoding="utf-8",
+    )
     _systemctl("daemon-reload")
     if enable:
         args = ["enable", SERVICE_NAME]
@@ -162,14 +200,12 @@ def install(
         _systemctl(*args)
     elif now:
         _systemctl("start", SERVICE_NAME)
-    if linger:
-        _run(["loginctl", "enable-linger", _current_user()])
     emit_human(f"installed {SERVICE_NAME} at {unit_path}")
 
 
 @app.command("uninstall")
 def uninstall() -> None:
-    """Disable and remove the Pawrrtal dev server user systemd service."""
+    """Disable and remove the Pawrrtal systemd service."""
     _systemctl("disable", "--now", SERVICE_NAME)
     unit_path = _unit_path()
     unit_path.unlink(missing_ok=True)
@@ -179,28 +215,28 @@ def uninstall() -> None:
 
 @app.command("start")
 def start() -> None:
-    """Start the user systemd service."""
+    """Start the systemd service."""
     _systemctl("start", SERVICE_NAME)
     emit_human(f"started {SERVICE_NAME}")
 
 
 @app.command("stop")
 def stop() -> None:
-    """Stop the user systemd service."""
+    """Stop the systemd service."""
     _systemctl("stop", SERVICE_NAME)
     emit_human(f"stopped {SERVICE_NAME}")
 
 
 @app.command("restart")
 def restart() -> None:
-    """Restart the user systemd service."""
+    """Restart the systemd service."""
     _systemctl("restart", SERVICE_NAME)
     emit_human(f"restarted {SERVICE_NAME}")
 
 
 @app.command("status")
 def status() -> None:
-    """Show user systemd service status."""
+    """Show systemd service status."""
     result = _systemctl("status", SERVICE_NAME, "--no-pager", check=False)
     body = (result.stdout or result.stderr).strip()
     emit_human(body)
@@ -212,10 +248,9 @@ def logs(
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow logs."),
     lines: int = typer.Option(100, "--lines", min=1, help="Number of log lines to show."),
 ) -> None:
-    """Show journal logs for the user systemd service."""
+    """Show journal logs for the systemd service."""
     args = [
         "journalctl",
-        "--user",
         "-u",
         SERVICE_NAME,
         "--no-pager",

--- a/backend/app/infrastructure/auth/dev_login.py
+++ b/backend/app/infrastructure/auth/dev_login.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import RedirectResponse, Response
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app.infrastructure.auth.users import (
@@ -11,12 +11,91 @@ from app.infrastructure.auth.users import (
 from app.infrastructure.config import settings
 
 
+def _safe_redirect_path(value: object) -> str:
+    if not isinstance(value, str):
+        return "/"
+    stripped = value.strip()
+    if not stripped.startswith("/") or stripped.startswith("//") or "\\" in stripped:
+        return "/"
+    return stripped
+
+
+async def _form_redirect_target(request: Request) -> str | None:
+    redirect_query = request.query_params.get("redirect_to")
+    if redirect_query is not None:
+        return _safe_redirect_path(redirect_query)
+
+    content_type = request.headers.get("content-type", "")
+    if "application/x-www-form-urlencoded" not in content_type:
+        return None
+
+    form = await request.form()
+    if "redirect_to" not in form:
+        return None
+    return _safe_redirect_path(form.get("redirect_to"))
+
+
+def _redirect_with_login_cookie(login_response: Response, redirect_to: str) -> RedirectResponse:
+    redirect = RedirectResponse(url=redirect_to, status_code=status.HTTP_303_SEE_OTHER)
+    for header_name, header_value in login_response.raw_headers:
+        if header_name.lower() == b"set-cookie":
+            redirect.raw_headers.append((header_name, header_value))
+    return redirect
+
+
+async def _dev_login_response(
+    request: Request,
+    user_manager: UserManager,
+    fallback_redirect: str | None,
+) -> Response:
+    if settings.is_production:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Dev login is not available in production.",
+        )
+
+    if (not settings.admin_email) or (not settings.admin_password):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dev login is not configured on this deployment.",
+        )
+
+    credentials = OAuth2PasswordRequestForm(
+        grant_type="password",
+        username=settings.admin_email,
+        password=settings.admin_password,
+        scope="",
+    )
+    user = await user_manager.authenticate(credentials)
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dev login credentials are misconfigured on this deployment.",
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The dev admin account is inactive.",
+        )
+
+    login_response = await auth_backend.login(get_jwt_strategy(), user)
+    redirect_to = await _form_redirect_target(request)
+    if redirect_to is None:
+        if fallback_redirect is None:
+            return login_response
+        redirect_to = fallback_redirect
+    return _redirect_with_login_cookie(login_response, redirect_to)
+
+
 def get_auth_router() -> APIRouter:
     """Build the auth ``APIRouter`` exposing the dev-login helper endpoint."""
     router = APIRouter(tags=["auth"])
 
     @router.post("/auth/dev-login")
     async def dev_login(
+        request: Request,
         user_manager: UserManager = Depends(get_user_manager),
     ) -> Response:
         """Log in with the seeded admin account without exposing its password to the client.
@@ -30,38 +109,14 @@ def get_auth_router() -> APIRouter:
         ``frontend/e2e/fixtures.ts`` for tests that need a fully-rendered
         home shell.
         """
-        if settings.is_production:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Dev login is not available in production.",
-            )
+        return await _dev_login_response(request, user_manager, fallback_redirect=None)
 
-        if (not settings.admin_email) or (not settings.admin_password):
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Dev login is not configured on this deployment.",
-            )
-
-        credentials = OAuth2PasswordRequestForm(
-            grant_type="password",
-            username=settings.admin_email,
-            password=settings.admin_password,
-            scope="",
-        )
-        user = await user_manager.authenticate(credentials)
-
-        if user is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Dev login credentials are misconfigured on this deployment.",
-            )
-
-        if not user.is_active:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="The dev admin account is inactive.",
-            )
-
-        return await auth_backend.login(get_jwt_strategy(), user)
+    @router.post("/auth/dev-login/browser")
+    async def dev_login_browser(
+        request: Request,
+        user_manager: UserManager = Depends(get_user_manager),
+    ) -> Response:
+        """Log in from server-rendered browser forms before React hydrates."""
+        return await _dev_login_response(request, user_manager, fallback_redirect="/")
 
     return router

--- a/backend/app/infrastructure/auth/dev_login.py
+++ b/backend/app/infrastructure/auth/dev_login.py
@@ -48,7 +48,7 @@ async def _dev_login_response(
     user_manager: UserManager,
     fallback_redirect: str | None,
 ) -> Response:
-    if settings.is_production:
+    if settings.is_production and not settings.pawrrtal_enable_dev_login:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Dev login is not available in production.",

--- a/backend/app/infrastructure/config.py
+++ b/backend/app/infrastructure/config.py
@@ -128,6 +128,10 @@ class Settings(BaseSettings):
     # Admin user credentials (for testing).
     admin_email: str | None = None
     admin_password: str | None = None
+    # Explicitly expose the seeded admin shortcut outside local development.
+    # Keep false by default; Cloudflare Access-protected operator deploys may
+    # set PAWRRTAL_ENABLE_DEV_LOGIN=true on both frontend and backend.
+    pawrrtal_enable_dev_login: bool = False
 
     # --- Access control ------------------------------------------------------
     # Optional bearer token all clients must supply in the X-Pawrrtal-Key

--- a/backend/app/plugins/README.md
+++ b/backend/app/plugins/README.md
@@ -1,0 +1,20 @@
+# Plugin Runtime
+
+This package is the plugin runtime host plus trusted bundled plugin
+implementations.
+
+Core runtime modules such as `manifest.py`, `discovery.py`, `registry.py`,
+`state.py`, and `adapters/` load manifest data, apply enabled/disabled state,
+resolve env requirements, and turn capabilities into runtime adapters.
+
+Bundled implementation packages such as `active_recall/`, `notion/`, `tasks/`,
+and tool packages are imported only after the manifest layer allows them.
+
+The matching bundled manifests live under `backend/plugins/`. Keep that
+directory declarative:
+
+- Add or edit plugin metadata in `backend/plugins/<plugin_id>/plugin.json`.
+- Add trusted Python implementation code here when a bundled manifest needs it.
+- Do not add workspace or third-party plugin code here.
+- Do not make providers, channels, or tools import each other directly; expose
+  them through manifest capabilities and runtime adapters.

--- a/backend/app/plugins/beans_tasks/__init__.py
+++ b/backend/app/plugins/beans_tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Beans-backed task plugin."""

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -1,0 +1,309 @@
+"""Agent tools for simple workspace-local Beans tasks."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import secrets
+import string
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.agents.types import AgentTool
+from app.plugins.tool_context import ToolContext
+from app.tools.display import make_tool_display, summarize_title
+from app.tools.errors import ToolError, ToolErrorCode
+
+_BEANS_DIR = ".beans"
+_ID_ALPHABET = string.ascii_lowercase + string.digits
+_VALID_STATUSES = frozenset({"todo", "in-progress", "completed", "scrapped"})
+
+
+@dataclass(frozen=True, slots=True)
+class Bean:
+    """One parsed `.beans/*.md` task file."""
+
+    bean_id: str
+    path: Path
+    meta: dict[str, str]
+    body: str
+
+
+def make_beans_create_tool(ctx: ToolContext) -> AgentTool:
+    """Return the workspace-bound ``beans_create`` tool."""
+
+    async def execute(_tool_call_id: str, **kwargs: Any) -> str:
+        try:
+            title = _required_text(kwargs, "title")
+            status = _status(kwargs.get("status") or "todo")
+        except ToolError as exc:
+            return exc.render()
+        priority = str(kwargs.get("priority") or "normal").strip() or "normal"
+        task_type = str(kwargs.get("type") or "task").strip() or "task"
+        body = str(kwargs.get("body") or "").strip()
+        bean_id = _new_bean_id()
+        path = _beans_root(ctx.workspace_root) / f"{bean_id}--{_slug(title)}.md"
+        now = _now()
+        meta = {
+            "title": title,
+            "status": status,
+            "type": task_type,
+            "priority": priority,
+            "created_at": now,
+            "updated_at": now,
+        }
+        _write_bean(path, bean_id=bean_id, meta=meta, body=body)
+        return f"Created bean {bean_id}: {title}"
+
+    return AgentTool(
+        name="beans_create",
+        description="Create a task bean under .beans in the user's workspace.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Short task title."},
+                "body": {"type": "string", "description": "Optional Markdown body."},
+                "status": {
+                    "type": "string",
+                    "description": "todo, in-progress, completed, or scrapped.",
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Priority label. Defaults to normal.",
+                },
+                "type": {"type": "string", "description": "Bean type. Defaults to task."},
+            },
+            "required": ["title"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="B",
+            label="Beans Create",
+            present=lambda args: f"Creating bean: {summarize_title(args.get('title'), 'untitled')}",
+            compact=lambda args: f"beans_create({str(args.get('title') or '')[:40]})",
+        ),
+    )
+
+
+def make_beans_list_tool(ctx: ToolContext) -> AgentTool:
+    """Return the workspace-bound ``beans_list`` tool."""
+
+    async def execute(_tool_call_id: str, **kwargs: Any) -> str:
+        include_completed = bool(kwargs.get("include_completed"))
+        status_filter = str(kwargs.get("status") or "").strip()
+        beans = _load_beans(ctx.workspace_root)
+        rows = []
+        for bean in beans:
+            status = bean.meta.get("status", "todo")
+            if status_filter and status != status_filter:
+                continue
+            if not include_completed and status in {"completed", "scrapped"}:
+                continue
+            rows.append(_format_row(bean))
+        return "\n".join(rows) if rows else "No beans found."
+
+    return AgentTool(
+        name="beans_list",
+        description="List task beans from .beans in the user's workspace.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "description": "Optional exact status filter."},
+                "include_completed": {
+                    "type": "boolean",
+                    "description": "Include completed and scrapped beans.",
+                },
+            },
+            "required": [],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="B",
+            label="Beans List",
+            present=lambda _args: "Listing beans",
+            compact=lambda _args: "beans_list()",
+        ),
+    )
+
+
+def make_beans_update_tool(ctx: ToolContext) -> AgentTool:
+    """Return the workspace-bound ``beans_update`` tool."""
+
+    async def execute(_tool_call_id: str, **kwargs: Any) -> str:
+        try:
+            bean = _find_bean(ctx.workspace_root, _required_text(kwargs, "bean"))
+        except ToolError as exc:
+            return exc.render()
+        meta = dict(bean.meta)
+        for key in ("title", "priority", "type"):
+            value = kwargs.get(key)
+            if isinstance(value, str) and value.strip():
+                meta[key] = value.strip()
+        if kwargs.get("status"):
+            try:
+                meta["status"] = _status(kwargs["status"])
+            except ToolError as exc:
+                return exc.render()
+        meta["updated_at"] = _now()
+        body = bean.body
+        if isinstance(kwargs.get("body"), str):
+            body = kwargs["body"].strip()
+        if isinstance(kwargs.get("body_append"), str) and kwargs["body_append"].strip():
+            body = f"{body.rstrip()}\n\n{kwargs['body_append'].strip()}".strip()
+        _write_bean(bean.path, bean_id=bean.bean_id, meta=meta, body=body)
+        return f"Updated bean {bean.bean_id}."
+
+    return AgentTool(
+        name="beans_update",
+        description="Update a task bean by id or title substring.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "bean": {"type": "string", "description": "Bean id or title substring."},
+                "title": {"type": "string"},
+                "status": {"type": "string"},
+                "priority": {"type": "string"},
+                "type": {"type": "string"},
+                "body": {"type": "string"},
+                "body_append": {"type": "string"},
+            },
+            "required": ["bean"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="B",
+            label="Beans Update",
+            present=lambda args: f"Updating bean: {summarize_title(args.get('bean'), 'unknown')}",
+            compact=lambda args: f"beans_update({str(args.get('bean') or '')[:40]})",
+        ),
+    )
+
+
+def make_beans_complete_tool(ctx: ToolContext) -> AgentTool:
+    """Return the workspace-bound ``beans_complete`` tool."""
+
+    async def execute(_tool_call_id: str, **kwargs: Any) -> str:
+        try:
+            bean = _find_bean(ctx.workspace_root, _required_text(kwargs, "bean"))
+        except ToolError as exc:
+            return exc.render()
+        meta = dict(bean.meta)
+        meta["status"] = "completed"
+        meta["updated_at"] = _now()
+        _write_bean(bean.path, bean_id=bean.bean_id, meta=meta, body=bean.body)
+        return f"Completed bean {bean.bean_id}."
+
+    return AgentTool(
+        name="beans_complete",
+        description="Mark a task bean completed by id or title substring.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "bean": {"type": "string", "description": "Bean id or title substring."}
+            },
+            "required": ["bean"],
+        },
+        execute=execute,
+        display=make_tool_display(
+            icon="B",
+            label="Beans Complete",
+            present=lambda args: f"Completing bean: {summarize_title(args.get('bean'), 'unknown')}",
+            compact=lambda args: f"beans_complete({str(args.get('bean') or '')[:40]})",
+        ),
+    )
+
+
+def _beans_root(workspace_root: Path) -> Path:
+    return workspace_root / _BEANS_DIR
+
+
+def _load_beans(workspace_root: Path) -> list[Bean]:
+    root = _beans_root(workspace_root)
+    if not root.exists():
+        return []
+    return sorted((_read_bean(path) for path in root.glob("*.md")), key=lambda bean: bean.bean_id)
+
+
+def _find_bean(workspace_root: Path, query: str) -> Bean:
+    needle = query.casefold()
+    matches = [
+        bean
+        for bean in _load_beans(workspace_root)
+        if needle in bean.bean_id.casefold() or needle in bean.meta.get("title", "").casefold()
+    ]
+    if not matches:
+        raise ToolError(ToolErrorCode.NOT_FOUND, f"No bean matched {query!r}.")
+    if len(matches) > 1:
+        ids = ", ".join(bean.bean_id for bean in matches[:5])
+        raise ToolError(ToolErrorCode.INVALID_PATH, f"Multiple beans matched {query!r}: {ids}.")
+    return matches[0]
+
+
+def _read_bean(path: Path) -> Bean:
+    raw = path.read_text(encoding="utf-8")
+    meta, body = _split_frontmatter(raw)
+    return Bean(bean_id=_bean_id_from_path(path), path=path, meta=meta, body=body.strip())
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, str], str]:
+    if not raw.startswith("---\n"):
+        return {}, raw
+    _, rest = raw.split("---\n", 1)
+    head, marker, body = rest.partition("\n---\n")
+    if not marker:
+        return {}, raw
+    meta: dict[str, str] = {}
+    for line in head.splitlines():
+        if line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        meta[key.strip()] = value.strip()
+    return meta, body
+
+
+def _write_bean(path: Path, *, bean_id: str, meta: dict[str, str], body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---", f"# {bean_id}"]
+    lines.extend(f"{key}: {value}" for key, value in meta.items())
+    lines.extend(["---", "", body.strip(), ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _required_text(kwargs: dict[str, Any], key: str) -> str:
+    value = str(kwargs.get(key) or "").strip()
+    if not value:
+        raise ToolError(ToolErrorCode.INVALID_PATH, f"The {key!r} argument is required.")
+    return value
+
+
+def _status(value: object) -> str:
+    status = str(value or "").strip()
+    if status not in _VALID_STATUSES:
+        raise ToolError(ToolErrorCode.INVALID_PATH, f"Unsupported bean status {status!r}.")
+    return status
+
+
+def _new_bean_id() -> str:
+    suffix = "".join(secrets.choice(_ID_ALPHABET) for _ in range(4))
+    return f"pawrrtal-{suffix}"
+
+
+def _slug(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.casefold()).strip("-")
+    return slug[:70] or "task"
+
+
+def _bean_id_from_path(path: Path) -> str:
+    return path.stem.split("--", 1)[0]
+
+
+def _now() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_row(bean: Bean) -> str:
+    title = bean.meta.get("title", "(untitled)")
+    status = bean.meta.get("status", "todo")
+    priority = bean.meta.get("priority", "normal")
+    return f"- {bean.bean_id} [{status}/{priority}] {title}"

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -22,7 +22,7 @@ _BEANS_DIR = ".beans"
 _BEANS_BINARY = "beans"
 _BEANS_TIMEOUT_SECONDS = 5
 _UPDATE_BASE_ARG_COUNT = 2
-_VALID_STATUSES = frozenset({"todo", "in-progress", "completed", "scrapped"})
+_VALID_STATUSES = frozenset({"draft", "todo", "in-progress", "in-review", "completed", "scrapped"})
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ def make_beans_create_tool(ctx: ToolContext) -> AgentTool:
                 "body": {"type": "string", "description": "Optional Markdown body."},
                 "status": {
                     "type": "string",
-                    "description": "todo, in-progress, completed, or scrapped.",
+                    "description": "draft, todo, in-progress, in-review, completed, or scrapped.",
                 },
                 "priority": {
                     "type": "string",

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import datetime as dt
-import re
-import secrets
-import string
+import shutil
+import subprocess  # nosec B404 - canonical beans CLI invocation uses argv lists, never shell.
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -18,7 +17,9 @@ from app.tools.display import make_tool_display, summarize_title
 from app.tools.errors import ToolError, ToolErrorCode
 
 _BEANS_DIR = ".beans"
-_ID_ALPHABET = string.ascii_lowercase + string.digits
+_BEANS_BINARY = "beans"
+_BEANS_TIMEOUT_SECONDS = 5
+_UPDATE_BASE_ARG_COUNT = 2
 _VALID_STATUSES = frozenset({"todo", "in-progress", "completed", "scrapped"})
 
 
@@ -44,19 +45,18 @@ def make_beans_create_tool(ctx: ToolContext) -> AgentTool:
         priority = str(kwargs.get("priority") or "normal").strip() or "normal"
         task_type = str(kwargs.get("type") or "task").strip() or "task"
         body = str(kwargs.get("body") or "").strip()
-        bean_id = _new_bean_id({bean.bean_id for bean in _load_beans(ctx.workspace_root)})
-        path = _beans_root(ctx.workspace_root) / f"{bean_id}--{_slug(title)}.md"
-        now = _now()
-        meta: dict[str, object] = {
-            "title": title,
-            "status": status,
-            "type": task_type,
-            "priority": priority,
-            "created_at": now,
-            "updated_at": now,
-        }
-        _write_bean(path, bean_id=bean_id, meta=meta, body=body)
-        return f"Created bean {bean_id}: {title}"
+        before = {bean.bean_id for bean in _load_beans(ctx.workspace_root)}
+        args = ["create", title, "-s", status, "-p", priority, "-t", task_type]
+        if body:
+            args.extend(["-d", body])
+        try:
+            stdout = await _run_beans(ctx.workspace_root, args)
+        except ToolError as exc:
+            return exc.render()
+        created = [bean for bean in _load_beans(ctx.workspace_root) if bean.bean_id not in before]
+        if len(created) == 1:
+            return f"Created bean {created[0].bean_id}: {_meta_text(created[0], 'title', title)}"
+        return stdout or "Created bean."
 
     return AgentTool(
         name="beans_create",
@@ -140,24 +140,28 @@ def make_beans_update_tool(ctx: ToolContext) -> AgentTool:
             bean = _find_bean(ctx.workspace_root, _required_text(kwargs, "bean"))
         except ToolError as exc:
             return exc.render()
-        meta = dict(bean.meta)
+        args = ["update", bean.bean_id]
         for key in ("title", "priority", "type"):
             value = kwargs.get(key)
             if isinstance(value, str) and value.strip():
-                meta[key] = value.strip()
+                args.extend(_field_args(key, value.strip()))
         if kwargs.get("status"):
             try:
-                meta["status"] = _status(kwargs["status"])
+                args.extend(["-s", _status(kwargs["status"])])
             except ToolError as exc:
                 return exc.render()
-        meta["updated_at"] = _now()
-        body = bean.body
+        body_file_text = None
         if isinstance(kwargs.get("body"), str):
-            body = kwargs["body"].strip()
+            body_file_text = kwargs["body"].strip()
         if isinstance(kwargs.get("body_append"), str) and kwargs["body_append"].strip():
-            body = f"{body.rstrip()}\n\n{kwargs['body_append'].strip()}".strip()
-        _write_bean(bean.path, bean_id=bean.bean_id, meta=meta, body=body)
-        return f"Updated bean {bean.bean_id}."
+            args.extend(["--body-append", kwargs["body_append"].strip()])
+        if len(args) == _UPDATE_BASE_ARG_COUNT and body_file_text is None:
+            return f"No bean changes requested for {bean.bean_id}."
+        try:
+            stdout = await _run_beans(ctx.workspace_root, args, body_file_text=body_file_text)
+        except ToolError as exc:
+            return exc.render()
+        return stdout or f"Updated bean {bean.bean_id}."
 
     return AgentTool(
         name="beans_update",
@@ -193,11 +197,13 @@ def make_beans_complete_tool(ctx: ToolContext) -> AgentTool:
             bean = _find_bean(ctx.workspace_root, _required_text(kwargs, "bean"))
         except ToolError as exc:
             return exc.render()
-        meta = dict(bean.meta)
-        meta["status"] = "completed"
-        meta["updated_at"] = _now()
-        _write_bean(bean.path, bean_id=bean.bean_id, meta=meta, body=bean.body)
-        return f"Completed bean {bean.bean_id}."
+        try:
+            stdout = await _run_beans(
+                ctx.workspace_root, ["update", bean.bean_id, "-s", "completed"]
+            )
+        except ToolError as exc:
+            return exc.render()
+        return stdout or f"Completed bean {bean.bean_id}."
 
     return AgentTool(
         name="beans_complete",
@@ -265,16 +271,6 @@ def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
     return meta, body
 
 
-def _write_bean(path: Path, *, bean_id: str, meta: dict[str, object], body: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines = ["---", f"# {bean_id}"]
-    dumped_meta = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False).strip()
-    if dumped_meta and dumped_meta != "{}":
-        lines.extend(dumped_meta.splitlines())
-    lines.extend(["---", "", body.strip(), ""])
-    path.write_text("\n".join(lines), encoding="utf-8")
-
-
 def _required_text(kwargs: dict[str, Any], key: str) -> str:
     value = str(kwargs.get(key) or "").strip()
     if not value:
@@ -294,25 +290,8 @@ def _optional_status(value: object) -> str:
     return _status(raw) if raw else ""
 
 
-def _new_bean_id(existing_ids: set[str]) -> str:
-    while True:
-        suffix = "".join(secrets.choice(_ID_ALPHABET) for _ in range(8))
-        bean_id = f"pawrrtal-{suffix}"
-        if bean_id not in existing_ids:
-            return bean_id
-
-
-def _slug(title: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", title.casefold()).strip("-")
-    return slug[:70] or "task"
-
-
 def _bean_id_from_path(path: Path) -> str:
     return path.stem.split("--", 1)[0]
-
-
-def _now() -> str:
-    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _format_row(bean: Bean) -> str:
@@ -327,3 +306,78 @@ def _meta_text(bean: Bean, key: str, fallback: str) -> str:
     if value is None:
         return fallback
     return str(value)
+
+
+def _field_args(key: str, value: str) -> list[str]:
+    if key == "title":
+        return ["--title", value]
+    if key == "priority":
+        return ["-p", value]
+    return ["-t", value]
+
+
+async def _run_beans(
+    workspace_root: Path,
+    args: list[str],
+    *,
+    body_file_text: str | None = None,
+) -> str:
+    return _run_beans_sync(workspace_root, args, body_file_text=body_file_text)
+
+
+def _run_beans_sync(
+    workspace_root: Path,
+    args: list[str],
+    *,
+    body_file_text: str | None,
+) -> str:
+    binary = shutil.which(_BEANS_BINARY)
+    if binary is None:
+        raise ToolError(ToolErrorCode.NOT_FOUND, "beans CLI is not installed or not on PATH.")
+
+    body_file_path = _write_body_file(body_file_text)
+    cli_args = [binary, *args]
+    if body_file_path is not None:
+        cli_args.extend(["--body-file", str(body_file_path)])
+
+    try:
+        result = subprocess.run(  # noqa: S603  # nosec B603 - resolved binary, no shell.
+            cli_args,
+            cwd=workspace_root,
+            capture_output=True,
+            text=True,
+            timeout=_BEANS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ToolError(ToolErrorCode.IO_ERROR, "beans CLI timed out.") from exc
+    except OSError as exc:
+        raise ToolError(ToolErrorCode.IO_ERROR, f"beans CLI failed to start: {exc}") from exc
+    finally:
+        if body_file_path is not None:
+            body_file_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit {result.returncode}"
+        raise ToolError(ToolErrorCode.IO_ERROR, f"{_beans_action(args)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def _write_body_file(body_file_text: str | None) -> Path | None:
+    if body_file_text is None:
+        return None
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        prefix="pawrrtal-bean-body-",
+        suffix=".md",
+        delete=False,
+    ) as body_file:
+        body_file.write(body_file_text)
+        return Path(body_file.name)
+
+
+def _beans_action(args: list[str]) -> str:
+    if args:
+        return f"beans {args[0]}"
+    return "beans"

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import shutil
 import subprocess  # nosec B404 - canonical beans CLI invocation uses argv lists, never shell.
 import tempfile
@@ -21,6 +23,8 @@ _BEANS_BINARY = "beans"
 _BEANS_TIMEOUT_SECONDS = 5
 _UPDATE_BASE_ARG_COUNT = 2
 _VALID_STATUSES = frozenset({"todo", "in-progress", "completed", "scrapped"})
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,7 +237,13 @@ def _load_beans(workspace_root: Path) -> list[Bean]:
     root = _beans_root(workspace_root)
     if not root.exists():
         return []
-    return sorted((_read_bean(path) for path in root.glob("*.md")), key=lambda bean: bean.bean_id)
+    beans: list[Bean] = []
+    for path in root.glob("*.md"):
+        try:
+            beans.append(_read_bean(path))
+        except (OSError, yaml.YAMLError) as exc:
+            logger.warning("BEANS_TASKS_SKIP_INVALID_FILE path=%s error=%s", path, exc)
+    return sorted(beans, key=lambda bean: bean.bean_id)
 
 
 def _find_bean(workspace_root: Path, query: str) -> Bean:
@@ -322,15 +332,6 @@ async def _run_beans(
     *,
     body_file_text: str | None = None,
 ) -> str:
-    return _run_beans_sync(workspace_root, args, body_file_text=body_file_text)
-
-
-def _run_beans_sync(
-    workspace_root: Path,
-    args: list[str],
-    *,
-    body_file_text: str | None,
-) -> str:
     binary = shutil.which(_BEANS_BINARY)
     if binary is None:
         raise ToolError(ToolErrorCode.NOT_FOUND, "beans CLI is not installed or not on PATH.")
@@ -340,27 +341,58 @@ def _run_beans_sync(
     if body_file_path is not None:
         cli_args.extend(["--body-file", str(body_file_path)])
 
+    stdout_path = _temp_output_path("stdout")
+    stderr_path = _temp_output_path("stderr")
+    stdout_file = stdout_path.open("wb")
+    stderr_file = stderr_path.open("wb")
+    process_finished = False
     try:
-        result = subprocess.run(  # noqa: S603  # nosec B603 - resolved binary, no shell.
+        # Only process creation is synchronous; waiting below is async polling.
+        process = subprocess.Popen(  # noqa: ASYNC220,S603  # nosec B603
             cli_args,
             cwd=workspace_root,
-            capture_output=True,
-            text=True,
-            timeout=_BEANS_TIMEOUT_SECONDS,
-            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
         )
-    except subprocess.TimeoutExpired as exc:
-        raise ToolError(ToolErrorCode.IO_ERROR, "beans CLI timed out.") from exc
+        stdout_file.close()
+        stderr_file.close()
+        if not await _wait_for_process(process, timeout_seconds=_BEANS_TIMEOUT_SECONDS):
+            process.kill()
+            await _wait_for_process(process, timeout_seconds=1)
+            raise ToolError(ToolErrorCode.IO_ERROR, "beans CLI timed out.")
+        process_finished = True
     except OSError as exc:
         raise ToolError(ToolErrorCode.IO_ERROR, f"beans CLI failed to start: {exc}") from exc
     finally:
+        if not stdout_file.closed:
+            stdout_file.close()
+        if not stderr_file.closed:
+            stderr_file.close()
         if body_file_path is not None:
             body_file_path.unlink(missing_ok=True)
+        if not process_finished:
+            stdout_path.unlink(missing_ok=True)
+            stderr_path.unlink(missing_ok=True)
 
-    if result.returncode != 0:
-        detail = (result.stderr or result.stdout).strip() or f"exit {result.returncode}"
+    stdout = stdout_path.read_text(encoding="utf-8", errors="replace").strip()
+    stderr = stderr_path.read_text(encoding="utf-8", errors="replace").strip()
+    stdout_path.unlink(missing_ok=True)
+    stderr_path.unlink(missing_ok=True)
+    if process.returncode != 0:
+        detail = stderr or stdout or f"exit {process.returncode}"
         raise ToolError(ToolErrorCode.IO_ERROR, f"{_beans_action(args)} failed: {detail}")
-    return result.stdout.strip()
+    return stdout
+
+
+async def _wait_for_process(process: subprocess.Popen[bytes], *, timeout_seconds: int) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    while process.poll() is None:
+        if loop.time() >= deadline:
+            return False
+        await asyncio.sleep(0.05)
+    return True
 
 
 def _write_body_file(body_file_text: str | None) -> Path | None:
@@ -375,6 +407,15 @@ def _write_body_file(body_file_text: str | None) -> Path | None:
     ) as body_file:
         body_file.write(body_file_text)
         return Path(body_file.name)
+
+
+def _temp_output_path(stream_name: str) -> Path:
+    with tempfile.NamedTemporaryFile(
+        "wb",
+        prefix=f"pawrrtal-beans-{stream_name}-",
+        delete=False,
+    ) as output_file:
+        return Path(output_file.name)
 
 
 def _beans_action(args: list[str]) -> str:

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
 from app.tools.display import make_tool_display, summarize_title
@@ -26,7 +28,7 @@ class Bean:
 
     bean_id: str
     path: Path
-    meta: dict[str, str]
+    meta: dict[str, object]
     body: str
 
 
@@ -42,10 +44,10 @@ def make_beans_create_tool(ctx: ToolContext) -> AgentTool:
         priority = str(kwargs.get("priority") or "normal").strip() or "normal"
         task_type = str(kwargs.get("type") or "task").strip() or "task"
         body = str(kwargs.get("body") or "").strip()
-        bean_id = _new_bean_id()
+        bean_id = _new_bean_id({bean.bean_id for bean in _load_beans(ctx.workspace_root)})
         path = _beans_root(ctx.workspace_root) / f"{bean_id}--{_slug(title)}.md"
         now = _now()
-        meta = {
+        meta: dict[str, object] = {
             "title": title,
             "status": status,
             "type": task_type,
@@ -91,11 +93,14 @@ def make_beans_list_tool(ctx: ToolContext) -> AgentTool:
 
     async def execute(_tool_call_id: str, **kwargs: Any) -> str:
         include_completed = bool(kwargs.get("include_completed"))
-        status_filter = str(kwargs.get("status") or "").strip()
+        try:
+            status_filter = _optional_status(kwargs.get("status"))
+        except ToolError as exc:
+            return exc.render()
         beans = _load_beans(ctx.workspace_root)
         rows = []
         for bean in beans:
-            status = bean.meta.get("status", "todo")
+            status = _meta_text(bean, "status", "todo")
             if status_filter and status != status_filter:
                 continue
             if not include_completed and status in {"completed", "scrapped"}:
@@ -230,7 +235,7 @@ def _find_bean(workspace_root: Path, query: str) -> Bean:
     matches = [
         bean
         for bean in _load_beans(workspace_root)
-        if needle in bean.bean_id.casefold() or needle in bean.meta.get("title", "").casefold()
+        if needle in bean.bean_id.casefold() or needle in _meta_text(bean, "title", "").casefold()
     ]
     if not matches:
         raise ToolError(ToolErrorCode.NOT_FOUND, f"No bean matched {query!r}.")
@@ -246,26 +251,26 @@ def _read_bean(path: Path) -> Bean:
     return Bean(bean_id=_bean_id_from_path(path), path=path, meta=meta, body=body.strip())
 
 
-def _split_frontmatter(raw: str) -> tuple[dict[str, str], str]:
+def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
     if not raw.startswith("---\n"):
         return {}, raw
     _, rest = raw.split("---\n", 1)
     head, marker, body = rest.partition("\n---\n")
     if not marker:
         return {}, raw
-    meta: dict[str, str] = {}
-    for line in head.splitlines():
-        if line.startswith("#") or ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        meta[key.strip()] = value.strip()
+    parsed = yaml.safe_load(head)
+    if not isinstance(parsed, dict):
+        return {}, body
+    meta = {str(key): value for key, value in parsed.items()}
     return meta, body
 
 
-def _write_bean(path: Path, *, bean_id: str, meta: dict[str, str], body: str) -> None:
+def _write_bean(path: Path, *, bean_id: str, meta: dict[str, object], body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = ["---", f"# {bean_id}"]
-    lines.extend(f"{key}: {value}" for key, value in meta.items())
+    dumped_meta = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False).strip()
+    if dumped_meta and dumped_meta != "{}":
+        lines.extend(dumped_meta.splitlines())
     lines.extend(["---", "", body.strip(), ""])
     path.write_text("\n".join(lines), encoding="utf-8")
 
@@ -284,9 +289,17 @@ def _status(value: object) -> str:
     return status
 
 
-def _new_bean_id() -> str:
-    suffix = "".join(secrets.choice(_ID_ALPHABET) for _ in range(4))
-    return f"pawrrtal-{suffix}"
+def _optional_status(value: object) -> str:
+    raw = str(value or "").strip()
+    return _status(raw) if raw else ""
+
+
+def _new_bean_id(existing_ids: set[str]) -> str:
+    while True:
+        suffix = "".join(secrets.choice(_ID_ALPHABET) for _ in range(8))
+        bean_id = f"pawrrtal-{suffix}"
+        if bean_id not in existing_ids:
+            return bean_id
 
 
 def _slug(title: str) -> str:
@@ -303,7 +316,14 @@ def _now() -> str:
 
 
 def _format_row(bean: Bean) -> str:
-    title = bean.meta.get("title", "(untitled)")
-    status = bean.meta.get("status", "todo")
-    priority = bean.meta.get("priority", "normal")
+    title = _meta_text(bean, "title", "(untitled)")
+    status = _meta_text(bean, "status", "todo")
+    priority = _meta_text(bean, "priority", "normal")
     return f"- {bean.bean_id} [{status}/{priority}] {title}"
+
+
+def _meta_text(bean: Bean, key: str, fallback: str) -> str:
+    value = bean.meta.get(key)
+    if value is None:
+        return fallback
+    return str(value)

--- a/backend/app/plugins/notion/tool.py
+++ b/backend/app/plugins/notion/tool.py
@@ -50,7 +50,8 @@ NTN_TOOL_DESCRIPTION = (
     "\n"
     "Common subcommands (each arg is a separate `args` element; do not "
     "wrap values in shell quotes — there is no shell):\n"
-    '  • `args = ["api", "<path>"]` — call the Notion HTTP API. Add '
+    '  • `args = ["api", "/v1/<path>"]` — call the Notion HTTP API '
+    "(for example, `/v1/search`, `/v1/users/me`, or `/v1/pages/<id>`). Add "
     '`"-X", "PATCH"` / `"-X", "DELETE"` / `"-X", "POST"` for '
     'non-GET methods, `"-d", "<raw json>"` for a body, and '
     '`"key==value"` for query-string params.\n'

--- a/backend/plugins/README.md
+++ b/backend/plugins/README.md
@@ -1,0 +1,19 @@
+# Plugin Manifests
+
+This directory is the bundled plugin manifest root. Each child directory is a
+plugin package with a `plugin.json` manifest.
+
+Manifests are declarative. They describe plugin metadata, capabilities, env
+requirements, validation commands, and runtime entrypoints. They do not contain
+Python implementation modules.
+
+Runtime implementations for bundled plugins live under `backend/app/plugins/`.
+That split is intentional:
+
+- `backend/plugins/` is the control plane: discoverable plugin packages.
+- `backend/app/plugins/` is the trusted runtime host and bundled implementation
+  code.
+
+External or workspace-installed plugins should follow the manifest contract
+here, but they should not import arbitrary Python into the backend process. Only
+trusted bundled manifests may point at `app.plugins.*` entrypoints.

--- a/backend/plugins/beans_tasks/plugin.json
+++ b/backend/plugins/beans_tasks/plugin.json
@@ -2,22 +2,22 @@
 	"schema_version": 1,
 	"id": "beans_tasks",
 	"name": "Beans Tasks",
-	"description": "Manage workspace .beans task files through agent tools.",
+	"description": "Manage workspace Beans tasks through the canonical beans CLI.",
 	"version": "1.0.0",
 	"enabled_by_default": true,
-	"permissions": ["filesystem_read", "filesystem_write"],
+	"permissions": ["filesystem_read", "filesystem_write", "subprocess"],
 	"capabilities": [
 		{
 			"type": "python_tool",
 			"id": "beans_create",
 			"tool_name": "beans_create",
 			"title": "Beans Create",
-			"description": "Create a task bean in the workspace .beans directory.",
+			"description": "Create a task bean through the workspace beans CLI.",
 			"tags": ["tasks", "beans", "workspace"],
 			"intents": ["tasks.add", "workspace.plan"],
 			"slots": ["tasks"],
 			"exposure": "direct_and_catalog",
-			"permissions": ["filesystem_write"],
+			"permissions": ["filesystem_write", "subprocess"],
 			"risk": "local_read",
 			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_create_tool"
 		},
@@ -45,7 +45,7 @@
 			"intents": ["tasks.update", "workspace.plan"],
 			"slots": ["tasks"],
 			"exposure": "direct_and_catalog",
-			"permissions": ["filesystem_read", "filesystem_write"],
+			"permissions": ["filesystem_read", "filesystem_write", "subprocess"],
 			"risk": "local_read",
 			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_update_tool"
 		},
@@ -59,7 +59,7 @@
 			"intents": ["tasks.complete", "workspace.plan"],
 			"slots": ["tasks"],
 			"exposure": "direct_and_catalog",
-			"permissions": ["filesystem_read", "filesystem_write"],
+			"permissions": ["filesystem_read", "filesystem_write", "subprocess"],
 			"risk": "local_read",
 			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_complete_tool"
 		}

--- a/backend/plugins/beans_tasks/plugin.json
+++ b/backend/plugins/beans_tasks/plugin.json
@@ -4,7 +4,7 @@
 	"name": "Beans Tasks",
 	"description": "Manage workspace Beans tasks through the canonical beans CLI.",
 	"version": "1.0.0",
-	"enabled_by_default": true,
+	"enabled_by_default": false,
 	"permissions": ["filesystem_read", "filesystem_write", "subprocess"],
 	"capabilities": [
 		{

--- a/backend/plugins/beans_tasks/plugin.json
+++ b/backend/plugins/beans_tasks/plugin.json
@@ -1,0 +1,67 @@
+{
+	"schema_version": 1,
+	"id": "beans_tasks",
+	"name": "Beans Tasks",
+	"description": "Manage workspace .beans task files through agent tools.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["filesystem_read", "filesystem_write"],
+	"capabilities": [
+		{
+			"type": "python_tool",
+			"id": "beans_create",
+			"tool_name": "beans_create",
+			"title": "Beans Create",
+			"description": "Create a task bean in the workspace .beans directory.",
+			"tags": ["tasks", "beans", "workspace"],
+			"intents": ["tasks.add", "workspace.plan"],
+			"slots": ["tasks"],
+			"exposure": "direct_and_catalog",
+			"permissions": ["filesystem_write"],
+			"risk": "local_read",
+			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_create_tool"
+		},
+		{
+			"type": "python_tool",
+			"id": "beans_list",
+			"tool_name": "beans_list",
+			"title": "Beans List",
+			"description": "List task beans from the workspace .beans directory.",
+			"tags": ["tasks", "beans", "workspace"],
+			"intents": ["tasks.list", "workspace.plan"],
+			"slots": ["tasks"],
+			"exposure": "direct_and_catalog",
+			"permissions": ["filesystem_read"],
+			"risk": "local_read",
+			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_list_tool"
+		},
+		{
+			"type": "python_tool",
+			"id": "beans_update",
+			"tool_name": "beans_update",
+			"title": "Beans Update",
+			"description": "Update status, title, priority, or body text for a task bean.",
+			"tags": ["tasks", "beans", "workspace"],
+			"intents": ["tasks.update", "workspace.plan"],
+			"slots": ["tasks"],
+			"exposure": "direct_and_catalog",
+			"permissions": ["filesystem_read", "filesystem_write"],
+			"risk": "local_read",
+			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_update_tool"
+		},
+		{
+			"type": "python_tool",
+			"id": "beans_complete",
+			"tool_name": "beans_complete",
+			"title": "Beans Complete",
+			"description": "Mark a matching task bean completed.",
+			"tags": ["tasks", "beans", "workspace"],
+			"intents": ["tasks.complete", "workspace.plan"],
+			"slots": ["tasks"],
+			"exposure": "direct_and_catalog",
+			"permissions": ["filesystem_read", "filesystem_write"],
+			"risk": "local_read",
+			"entrypoint": "app.plugins.beans_tasks.tools:make_beans_complete_tool"
+		}
+	]
+}

--- a/backend/plugins/google_chat_channel/plugin.json
+++ b/backend/plugins/google_chat_channel/plugin.json
@@ -1,75 +1,75 @@
 {
-  "schema_version": 1,
-  "id": "google_chat_channel",
-  "name": "Google Chat Channel",
-  "description": "Google Chat Pub/Sub ingress and message delivery for Pawrrtal.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["network", "external_read", "external_write"],
-  "env": [
-    {
-      "name": "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Service Account File",
-      "description": "Path to the Google Cloud service account JSON used for Chat and Pub/Sub."
-    },
-    {
-      "name": "GOOGLE_CHAT_PROJECT_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Project ID",
-      "description": "Google Cloud project that owns the Pub/Sub resources."
-    },
-    {
-      "name": "GOOGLE_CHAT_SUBSCRIPTION_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Subscription ID",
-      "description": "Pub/Sub pull subscription that receives inbound Google Chat events."
-    },
-    {
-      "name": "GOOGLE_CHAT_DEV_ADMIN_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Dev Admin ID",
-      "description": "Optional sender resource name that auto-links to the seeded dev admin."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "channel",
-      "id": "google_chat",
-      "title": "Google Chat",
-      "description": "Receives Google Chat events and sends formatted Pawrrtal responses.",
-      "tags": ["chat", "google-chat", "messaging"],
-      "intents": ["message", "notify", "workspace-chat"],
-      "slots": ["channel:google_chat", "channel:messaging"],
-      "priority": 90,
-      "exposure": "catalog",
-      "permissions": ["network", "external_read", "external_write"],
-      "risk": "external_write",
-      "surface": "google_chat",
-      "entrypoint": "app.channels.plugin_adapters:make_google_chat_channel",
-      "commands": {
-        "slash": ["status", "compact"],
-        "cards": ["placeholder", "final_answer"],
-        "formatting": ["google_chat_markdown"]
-      },
-      "lifespan": {
-        "entrypoint": "app.channels.google_chat:google_chat_lifespan",
-        "context_key": "google_chat_lifespan_context",
-        "service_key": "google_chat_service",
-        "order": 72
-      }
-    }
-  ]
+	"schema_version": 1,
+	"id": "google_chat_channel",
+	"name": "Google Chat Channel",
+	"description": "Google Chat Pub/Sub ingress and message delivery for Pawrrtal.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["network", "external_read", "external_write"],
+	"env": [
+		{
+			"name": "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Service Account File",
+			"description": "Path to the Google Cloud service account JSON used for Chat and Pub/Sub."
+		},
+		{
+			"name": "GOOGLE_CHAT_PROJECT_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Project ID",
+			"description": "Google Cloud project that owns the Pub/Sub resources."
+		},
+		{
+			"name": "GOOGLE_CHAT_SUBSCRIPTION_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Subscription ID",
+			"description": "Pub/Sub pull subscription that receives inbound Google Chat events."
+		},
+		{
+			"name": "GOOGLE_CHAT_DEV_ADMIN_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Dev Admin ID",
+			"description": "Optional sender resource name that auto-links to the seeded dev admin."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "channel",
+			"id": "google_chat",
+			"title": "Google Chat",
+			"description": "Receives Google Chat events and sends formatted Pawrrtal responses.",
+			"tags": ["chat", "google-chat", "messaging"],
+			"intents": ["message", "notify", "workspace-chat"],
+			"slots": ["channel:google_chat", "channel:messaging"],
+			"priority": 90,
+			"exposure": "catalog",
+			"permissions": ["network", "external_read", "external_write"],
+			"risk": "external_write",
+			"surface": "google_chat",
+			"entrypoint": "app.channels.plugin_adapters:make_google_chat_channel",
+			"commands": {
+				"slash": ["status", "compact"],
+				"cards": ["placeholder", "final_answer"],
+				"formatting": ["google_chat_markdown"]
+			},
+			"lifespan": {
+				"entrypoint": "app.channels.google_chat:google_chat_lifespan",
+				"context_key": "google_chat_lifespan_context",
+				"service_key": "google_chat_service",
+				"order": 72
+			}
+		}
+	]
 }

--- a/backend/plugins/lcm_memory/plugin.json
+++ b/backend/plugins/lcm_memory/plugin.json
@@ -1,48 +1,48 @@
 {
-  "schema_version": 1,
-  "id": "lcm_memory",
-  "name": "LCM Memory",
-  "description": "Conversation history assembly, ingest, and compaction backed by LCM.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["external_read", "costly"],
-  "env": [
-    {
-      "name": "LCM_ENABLED",
-      "required": false,
-      "scope": "workspace",
-      "overridable": true,
-      "gateway_fallback": true,
-      "secret": false,
-      "label": "LCM Enabled",
-      "description": "Enables LCM history assembly and post-turn compaction."
-    },
-    {
-      "name": "LCM_SUMMARY_MODEL",
-      "required": false,
-      "scope": "user_workspace",
-      "overridable": true,
-      "gateway_fallback": true,
-      "secret": false,
-      "label": "LCM Summary Model",
-      "description": "Optional model used for LCM summary generation."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "conversation_memory",
-      "id": "lcm",
-      "title": "LCM",
-      "description": "Uses LCM context items to assemble history and compact completed turns.",
-      "tags": ["memory", "conversation-history", "compaction"],
-      "intents": ["history", "compaction", "long-context"],
-      "slots": ["conversation_memory"],
-      "priority": 100,
-      "exposure": "catalog",
-      "permissions": ["external_read", "costly"],
-      "risk": "costly",
-      "entrypoint": "app.plugins.lcm_memory.backend:create_memory_backend",
-      "order": 100
-    }
-  ]
+	"schema_version": 1,
+	"id": "lcm_memory",
+	"name": "LCM Memory",
+	"description": "Conversation history assembly, ingest, and compaction backed by LCM.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["external_read", "costly"],
+	"env": [
+		{
+			"name": "LCM_ENABLED",
+			"required": false,
+			"scope": "workspace",
+			"overridable": true,
+			"gateway_fallback": true,
+			"secret": false,
+			"label": "LCM Enabled",
+			"description": "Enables LCM history assembly and post-turn compaction."
+		},
+		{
+			"name": "LCM_SUMMARY_MODEL",
+			"required": false,
+			"scope": "user_workspace",
+			"overridable": true,
+			"gateway_fallback": true,
+			"secret": false,
+			"label": "LCM Summary Model",
+			"description": "Optional model used for LCM summary generation."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "conversation_memory",
+			"id": "lcm",
+			"title": "LCM",
+			"description": "Uses LCM context items to assemble history and compact completed turns.",
+			"tags": ["memory", "conversation-history", "compaction"],
+			"intents": ["history", "compaction", "long-context"],
+			"slots": ["conversation_memory"],
+			"priority": 100,
+			"exposure": "catalog",
+			"permissions": ["external_read", "costly"],
+			"risk": "costly",
+			"entrypoint": "app.plugins.lcm_memory.backend:create_memory_backend",
+			"order": 100
+		}
+	]
 }

--- a/backend/plugins/telegram_channel/plugin.json
+++ b/backend/plugins/telegram_channel/plugin.json
@@ -78,6 +78,7 @@
           "verbose",
           "stop",
           "status",
+          "tools",
           "whoami",
           "lcm",
           "compact"

--- a/backend/plugins/telegram_channel/plugin.json
+++ b/backend/plugins/telegram_channel/plugin.json
@@ -1,98 +1,98 @@
 {
-  "schema_version": 1,
-  "id": "telegram_channel",
-  "name": "Telegram Channel",
-  "description": "Telegram bot ingress, commands, keyboards, formatting, and delivery for Pawrrtal.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["network", "external_read", "external_write"],
-  "env": [
-    {
-      "name": "TELEGRAM_BOT_TOKEN",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": true,
-      "label": "Telegram Bot Token",
-      "description": "Bot token used to receive updates and send Telegram messages."
-    },
-    {
-      "name": "TELEGRAM_BOT_USERNAME",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Bot Username",
-      "description": "Bot username shown to users during channel linking."
-    },
-    {
-      "name": "TELEGRAM_MODE",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Mode",
-      "description": "Telegram runtime mode, usually polling locally or webhook in production."
-    },
-    {
-      "name": "TELEGRAM_WEBHOOK_URL",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Webhook URL",
-      "description": "Public webhook URL used when TELEGRAM_MODE is webhook."
-    },
-    {
-      "name": "TELEGRAM_WEBHOOK_SECRET",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": true,
-      "label": "Telegram Webhook Secret",
-      "description": "Secret header value required for Telegram webhook requests."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "channel",
-      "id": "telegram",
-      "title": "Telegram",
-      "description": "Receives Telegram updates and sends formatted Pawrrtal responses.",
-      "tags": ["chat", "telegram", "messaging"],
-      "intents": ["message", "notify", "bot"],
-      "slots": ["channel:telegram", "channel:messaging"],
-      "priority": 100,
-      "exposure": "catalog",
-      "permissions": ["network", "external_read", "external_write"],
-      "risk": "external_write",
-      "surface": "telegram",
-      "entrypoint": "app.channels.plugin_adapters:make_telegram_channel",
-      "commands": {
-        "slash": [
-          "start",
-          "new",
-          "model",
-          "thinking",
-          "config",
-          "verbose",
-          "stop",
-          "status",
-          "tools",
-          "whoami",
-          "lcm",
-          "compact"
-        ],
-        "inline_keyboards": ["model", "thinking", "status", "regenerate"],
-        "formatting": ["telegram_html", "chunked_delivery"]
-      },
-      "lifespan": {
-        "entrypoint": "app.channels.telegram:telegram_lifespan",
-        "context_key": "telegram_lifespan_context",
-        "service_key": "telegram_service",
-        "order": 70,
-        "post_start": "app.channels.telegram.notifications:register_telegram_notifications"
-      }
-    }
-  ]
+	"schema_version": 1,
+	"id": "telegram_channel",
+	"name": "Telegram Channel",
+	"description": "Telegram bot ingress, commands, keyboards, formatting, and delivery for Pawrrtal.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["network", "external_read", "external_write"],
+	"env": [
+		{
+			"name": "TELEGRAM_BOT_TOKEN",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": true,
+			"label": "Telegram Bot Token",
+			"description": "Bot token used to receive updates and send Telegram messages."
+		},
+		{
+			"name": "TELEGRAM_BOT_USERNAME",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Bot Username",
+			"description": "Bot username shown to users during channel linking."
+		},
+		{
+			"name": "TELEGRAM_MODE",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Mode",
+			"description": "Telegram runtime mode, usually polling locally or webhook in production."
+		},
+		{
+			"name": "TELEGRAM_WEBHOOK_URL",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Webhook URL",
+			"description": "Public webhook URL used when TELEGRAM_MODE is webhook."
+		},
+		{
+			"name": "TELEGRAM_WEBHOOK_SECRET",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": true,
+			"label": "Telegram Webhook Secret",
+			"description": "Secret header value required for Telegram webhook requests."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "channel",
+			"id": "telegram",
+			"title": "Telegram",
+			"description": "Receives Telegram updates and sends formatted Pawrrtal responses.",
+			"tags": ["chat", "telegram", "messaging"],
+			"intents": ["message", "notify", "bot"],
+			"slots": ["channel:telegram", "channel:messaging"],
+			"priority": 100,
+			"exposure": "catalog",
+			"permissions": ["network", "external_read", "external_write"],
+			"risk": "external_write",
+			"surface": "telegram",
+			"entrypoint": "app.channels.plugin_adapters:make_telegram_channel",
+			"commands": {
+				"slash": [
+					"start",
+					"new",
+					"model",
+					"thinking",
+					"config",
+					"verbose",
+					"stop",
+					"status",
+					"tools",
+					"whoami",
+					"lcm",
+					"compact"
+				],
+				"inline_keyboards": ["model", "thinking", "status", "regenerate"],
+				"formatting": ["telegram_html", "chunked_delivery"]
+			},
+			"lifespan": {
+				"entrypoint": "app.channels.telegram:telegram_lifespan",
+				"context_key": "telegram_lifespan_context",
+				"service_key": "telegram_service",
+				"order": 70,
+				"post_start": "app.channels.telegram.notifications:register_telegram_notifications"
+			}
+		}
+	]
 }

--- a/backend/tests/paw/test_command_project.py
+++ b/backend/tests/paw/test_command_project.py
@@ -362,11 +362,10 @@ def test_project_env_can_opt_into_external_dev_database(monkeypatch):
 
 @pytest.fixture
 def fake_systemd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[str]]:
-    """Capture systemctl/loginctl calls and isolate the generated user unit."""
+    """Capture systemctl calls and isolate the generated system unit."""
     calls: list[list[str]] = []
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("PAWRRTAL_SYSTEMD_UNIT_DIR", str(tmp_path / "systemd"))
     monkeypatch.setattr(service_module, "_require_binary", lambda name: f"/fake/bin/{name}")
-    monkeypatch.setattr(service_module, "_current_user", lambda: "octavian")
 
     def fake_run(args: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
         calls.append(args)
@@ -376,47 +375,50 @@ def fake_systemd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[s
     return calls
 
 
-def test_project_service_install_writes_user_unit_and_enables_now(
+def test_project_service_install_writes_system_unit_and_enables_now(
     runner: CliRunner,
     fake_systemd: list[list[str]],
     tmp_path: Path,
 ) -> None:
-    """``paw project service install`` installs and starts a user systemd unit."""
+    """``paw project service install`` installs and starts a production systemd unit."""
     result = runner.invoke(app, ["project", "service", "install"])
     assert result.exit_code == 0, result.stdout
 
-    unit_path = tmp_path / "xdg" / "systemd" / "user" / "pawrrtal-dev.service"
+    unit_path = tmp_path / "systemd" / "pawrrtal.service"
     unit = unit_path.read_text()
     assert f"WorkingDirectory={repo_root()}" in unit
-    assert "ExecStart=/fake/bin/bun run dev.ts" in unit
+    assert f"EnvironmentFile=-{repo_root() / 'backend/.env'}" in unit
+    assert "ExecStart=/fake/bin/bun run serve.ts" in unit
     assert "RestartSec=15" in unit
     assert "KillMode=control-group" in unit
     assert "StartLimitBurst=3" in unit
-    assert 'Environment="DATABASE_URL="' in unit
+    assert (
+        'Environment="PATH=/fake/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
+    ) in unit
+    assert 'Environment="NODE_ENV=production"' in unit
+    assert 'Environment="ENV=prod"' in unit
+    assert 'Environment="PAWRRTAL_BACKEND_HOST=127.0.0.1"' in unit
+    assert 'Environment="PAWRRTAL_BACKEND_PORT=8000"' in unit
+    assert 'Environment="BACKEND_INTERNAL_URL=http://127.0.0.1:8000"' in unit
     assert fake_systemd == [
-        ["systemctl", "--user", "is-system-running"],
-        ["systemctl", "--user", "daemon-reload"],
-        ["systemctl", "--user", "enable", "--now", "pawrrtal-dev.service"],
+        ["systemctl", "is-system-running"],
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "enable", "--now", "pawrrtal.service"],
     ]
 
 
-def test_project_service_install_preserves_explicit_dev_database_url(
+def test_project_service_install_can_enable_dev_login(
     runner: CliRunner,
     fake_systemd: list[list[str]],
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The service passes the explicit non-SQLite dev DB override to ``dev.ts``."""
-    monkeypatch.setenv("PAWRRTAL_DEV_DATABASE_URL", "postgresql://u:p@localhost:5432/app")
-
-    result = runner.invoke(app, ["project", "service", "install"])
+    """``--enable-dev-login`` explicitly exposes the shortcut in production."""
+    result = runner.invoke(app, ["project", "service", "install", "--enable-dev-login"])
     assert result.exit_code == 0, result.stdout
 
-    unit_path = tmp_path / "xdg" / "systemd" / "user" / "pawrrtal-dev.service"
+    unit_path = tmp_path / "systemd" / "pawrrtal.service"
     unit = unit_path.read_text()
-    assert 'Environment="DATABASE_URL="' in unit
-    assert 'Environment="PAWRRTAL_DEV_DATABASE_URL=postgresql://u:p@localhost:5432/app"' in unit
-    assert 'Environment="BACKEND_INTERNAL_URL=http://127.0.0.1:8000"' in unit
+    assert 'Environment="PAWRRTAL_ENABLE_DEV_LOGIN=true"' in unit
 
 
 def test_project_service_install_allows_saved_cloudflared_origin(
@@ -424,7 +426,7 @@ def test_project_service_install_allows_saved_cloudflared_origin(
     fake_systemd: list[list[str]],
     tmp_path: Path,
 ) -> None:
-    """The managed dev service allows the saved Cloudflared public hostname."""
+    """The managed service records the saved Cloudflared public hostname."""
     save_state(
         CloudflaredState(
             schema_version=1,
@@ -444,19 +446,19 @@ def test_project_service_install_allows_saved_cloudflared_origin(
     result = runner.invoke(app, ["project", "service", "install"])
     assert result.exit_code == 0, result.stdout
 
-    unit_path = tmp_path / "xdg" / "systemd" / "user" / "pawrrtal-dev.service"
+    unit_path = tmp_path / "systemd" / "pawrrtal.service"
     unit = unit_path.read_text()
-    assert 'Environment="NEXT_ALLOWED_DEV_ORIGINS=https://pawrrtal.example.com"' in unit
+    assert 'Environment="PAWRRTAL_PUBLIC_HOSTNAME=pawrrtal.example.com"' in unit
 
 
-def test_project_service_install_can_enable_linger(
+def test_project_service_install_can_start_without_enable(
     runner: CliRunner,
     fake_systemd: list[list[str]],
 ) -> None:
-    """``--linger`` opts into machine-boot startup without an interactive login."""
-    result = runner.invoke(app, ["project", "service", "install", "--linger"])
+    """``--no-enable --now`` starts the unit without enabling boot startup."""
+    result = runner.invoke(app, ["project", "service", "install", "--no-enable", "--now"])
     assert result.exit_code == 0, result.stdout
-    assert ["loginctl", "enable-linger", "octavian"] in fake_systemd
+    assert ["systemctl", "start", "pawrrtal.service"] in fake_systemd
 
 
 @pytest.fixture
@@ -799,17 +801,17 @@ def test_project_service_uninstall_disables_and_removes_unit(
     tmp_path: Path,
 ) -> None:
     """``paw project service uninstall`` disables the unit and removes the file."""
-    unit_dir = tmp_path / "xdg" / "systemd" / "user"
+    unit_dir = tmp_path / "systemd"
     unit_dir.mkdir(parents=True)
-    unit_path = unit_dir / "pawrrtal-dev.service"
+    unit_path = unit_dir / "pawrrtal.service"
     unit_path.write_text("[Unit]\nDescription=old\n")
 
     result = runner.invoke(app, ["project", "service", "uninstall"])
     assert result.exit_code == 0, result.stdout
     assert not unit_path.exists()
     assert fake_systemd == [
-        ["systemctl", "--user", "disable", "--now", "pawrrtal-dev.service"],
-        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "disable", "--now", "pawrrtal.service"],
+        ["systemctl", "daemon-reload"],
     ]
 
 
@@ -817,9 +819,9 @@ def test_project_service_status_invokes_systemctl(
     runner: CliRunner,
     fake_systemd: list[list[str]],
 ) -> None:
-    """``paw project service status`` delegates to the user systemd service."""
+    """``paw project service status`` delegates to the systemd service."""
     result = runner.invoke(app, ["project", "service", "status"])
     assert result.exit_code == 0, result.stdout
     assert fake_systemd == [
-        ["systemctl", "--user", "status", "pawrrtal-dev.service", "--no-pager"],
+        ["systemctl", "status", "pawrrtal.service", "--no-pager"],
     ]

--- a/backend/tests/paw/test_command_project.py
+++ b/backend/tests/paw/test_command_project.py
@@ -391,6 +391,7 @@ def test_project_service_install_writes_system_unit_and_enables_now(
     assert "ExecStart=/fake/bin/bun run serve.ts" in unit
     assert "RestartSec=15" in unit
     assert "KillMode=control-group" in unit
+    assert "SuccessExitStatus=143 130" in unit
     assert "StartLimitBurst=3" in unit
     assert (
         'Environment="PATH=/fake/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'

--- a/backend/tests/paw/test_command_project.py
+++ b/backend/tests/paw/test_command_project.py
@@ -397,6 +397,7 @@ def test_project_service_install_writes_system_unit_and_enables_now(
         'Environment="PATH=/fake/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
     ) in unit
     assert 'Environment="NODE_ENV=production"' in unit
+    assert 'Environment="UV_LINK_MODE=copy"' in unit
     assert 'Environment="ENV=prod"' in unit
     assert 'Environment="PAWRRTAL_BACKEND_HOST=127.0.0.1"' in unit
     assert 'Environment="PAWRRTAL_BACKEND_PORT=8000"' in unit

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -16,11 +16,18 @@ stable.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 
-from app.infrastructure.auth.dev_login import _redirect_with_login_cookie, _safe_redirect_path
+from app.infrastructure.auth.dev_login import (
+    _dev_login_response,
+    _redirect_with_login_cookie,
+    _safe_redirect_path,
+)
+from app.infrastructure.config import settings
 from main import create_app
 
 
@@ -125,3 +132,39 @@ class TestDevLoginRoute:
         assert response.status_code == 303
         assert response.headers["location"] == "/settings"
         assert "session_token=test-session" in response.headers.get("set-cookie", "")
+
+    @pytest.mark.anyio
+    async def test_production_dev_login_requires_explicit_flag(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "env", "prod")
+        monkeypatch.setattr(settings, "pawrrtal_enable_dev_login", False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _dev_login_response(
+                cast(Any, object()),
+                cast(Any, object()),
+                fallback_redirect=None,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_production_dev_login_flag_opens_normal_config_gate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "env", "prod")
+        monkeypatch.setattr(settings, "pawrrtal_enable_dev_login", True)
+        monkeypatch.setattr(settings, "admin_email", None)
+        monkeypatch.setattr(settings, "admin_password", None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _dev_login_response(
+                cast(Any, object()),
+                cast(Any, object()),
+                fallback_redirect=None,
+            )
+
+        assert exc_info.value.status_code == 503

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -18,6 +18,10 @@ from __future__ import annotations
 
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import Response
+
+from app.infrastructure.auth.dev_login import _redirect_with_login_cookie, _safe_redirect_path
+from main import create_app
 
 
 def _route_methods(app: FastAPI, path: str) -> set[str]:
@@ -35,6 +39,12 @@ def _route_methods(app: FastAPI, path: str) -> set[str]:
     return methods
 
 
+@pytest.fixture
+def mounted_app() -> FastAPI:
+    """Build the app for route-table assertions without database fixtures."""
+    return create_app()
+
+
 class TestUsersMount:
     """The fastapi-users user router is mounted at two prefixes.
 
@@ -44,23 +54,21 @@ class TestUsersMount:
     """
 
     @pytest.mark.anyio
-    async def test_canonical_v1_users_me_is_mounted(self, app_with_overrides: FastAPI) -> None:
-        assert "GET" in _route_methods(app_with_overrides, "/api/v1/users/me")
-        assert "PATCH" in _route_methods(app_with_overrides, "/api/v1/users/me")
+    async def test_canonical_v1_users_me_is_mounted(self, mounted_app: FastAPI) -> None:
+        assert "GET" in _route_methods(mounted_app, "/api/v1/users/me")
+        assert "PATCH" in _route_methods(mounted_app, "/api/v1/users/me")
 
     @pytest.mark.anyio
-    async def test_legacy_users_me_alias_is_mounted(self, app_with_overrides: FastAPI) -> None:
-        assert "GET" in _route_methods(app_with_overrides, "/users/me")
-        assert "PATCH" in _route_methods(app_with_overrides, "/users/me")
+    async def test_legacy_users_me_alias_is_mounted(self, mounted_app: FastAPI) -> None:
+        assert "GET" in _route_methods(mounted_app, "/users/me")
+        assert "PATCH" in _route_methods(mounted_app, "/users/me")
 
     @pytest.mark.anyio
-    async def test_canonical_and_alias_expose_same_methods(
-        self, app_with_overrides: FastAPI
-    ) -> None:
+    async def test_canonical_and_alias_expose_same_methods(self, mounted_app: FastAPI) -> None:
         # If the two mounts ever drift, paw (canonical) and the frontend
         # (alias) would see divergent surfaces — guard against that.
-        canonical = _route_methods(app_with_overrides, "/api/v1/users/me")
-        alias = _route_methods(app_with_overrides, "/users/me")
+        canonical = _route_methods(mounted_app, "/api/v1/users/me")
+        alias = _route_methods(mounted_app, "/users/me")
         assert canonical == alias
 
 
@@ -73,10 +81,47 @@ class TestAuthLogoutRoute:
     """
 
     @pytest.mark.anyio
-    async def test_logout_route_is_mounted(self, app_with_overrides: FastAPI) -> None:
-        assert "POST" in _route_methods(app_with_overrides, "/auth/jwt/logout")
+    async def test_logout_route_is_mounted(self, mounted_app: FastAPI) -> None:
+        assert "POST" in _route_methods(mounted_app, "/auth/jwt/logout")
 
     @pytest.mark.anyio
-    async def test_login_route_is_mounted(self, app_with_overrides: FastAPI) -> None:
+    async def test_login_route_is_mounted(self, mounted_app: FastAPI) -> None:
         # Sanity check — the pair (login + logout) is what paw drives.
-        assert "POST" in _route_methods(app_with_overrides, "/auth/jwt/login")
+        assert "POST" in _route_methods(mounted_app, "/auth/jwt/login")
+
+    @pytest.mark.anyio
+    async def test_dev_login_route_is_mounted(self, mounted_app: FastAPI) -> None:
+        assert "POST" in _route_methods(mounted_app, "/auth/dev-login")
+        assert "POST" in _route_methods(mounted_app, "/auth/dev-login/browser")
+
+
+class TestDevLoginRoute:
+    """Dev-login supports API callers and pre-hydration browser form fallback."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("/", "/"),
+            ("/settings?tab=dev", "/settings?tab=dev"),
+            ("https://example.invalid/steal", "/"),
+            ("//example.invalid/steal", "/"),
+            ("\\settings", "/"),
+            (None, "/"),
+        ],
+    )
+    def test_safe_redirect_path_keeps_dev_login_local(
+        self,
+        value: object,
+        expected: str,
+    ) -> None:
+        assert _safe_redirect_path(value) == expected
+
+    def test_redirect_with_login_cookie_carries_session_cookie(self) -> None:
+        login_response = Response(status_code=204)
+        login_response.set_cookie("session_token", "test-session", httponly=True)
+
+        response = _redirect_with_login_cookie(login_response, "/settings")
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/settings"
+        assert "session_token=test-session" in response.headers.get("set-cookie", "")

--- a/backend/tests/test_beans_tasks_tool.py
+++ b/backend/tests/test_beans_tasks_tool.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import secrets
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
+
+import pytest
+import yaml
 
 from app.plugins.beans_tasks.tools import (
     make_beans_complete_tool,
@@ -21,6 +26,14 @@ def _ctx(workspace_root: Path) -> ToolContext:
         workspace_root=workspace_root,
         user_id=uuid.uuid4(),
     )
+
+
+def _frontmatter(path: Path) -> dict[str, object]:
+    raw = path.read_text(encoding="utf-8")
+    head = raw.split("---\n", 1)[1].partition("\n---\n")[0]
+    parsed = yaml.safe_load(head)
+    assert isinstance(parsed, dict)
+    return parsed
 
 
 def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
@@ -51,6 +64,92 @@ def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
     assert "Fix mobile login" not in open_listing
     assert f"{bean_id} [completed/normal] Fix mobile login" in all_listing
     assert (tmp_path / ".beans").is_dir()
+
+
+def test_beans_create_quotes_yaml_sensitive_title(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    create = make_beans_create_tool(ctx)
+    title = "Settings layout: align fields"
+
+    asyncio.run(create.execute("call-1", title=title))
+
+    path = next((tmp_path / ".beans").glob("*.md"))
+    assert _frontmatter(path)["title"] == title
+    assert "title: 'Settings layout: align fields'" in path.read_text(encoding="utf-8")
+
+
+def test_beans_update_and_complete_preserve_structured_frontmatter(tmp_path: Path) -> None:
+    root = tmp_path / ".beans"
+    root.mkdir()
+    path = root / "pawrrtal-abcd--existing.md"
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                "# pawrrtal-abcd",
+                "title: 'Existing: task'",
+                "status: todo",
+                "type: task",
+                "priority: high",
+                "tags:",
+                "  - backend",
+                "  - architecture",
+                "blocked_by:",
+                "  - pawrrtal-root",
+                "created_at: 2026-06-08T00:00:00Z",
+                "updated_at: 2026-06-08T00:00:00Z",
+                "---",
+                "",
+                "Body.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ctx = _ctx(tmp_path)
+    update = make_beans_update_tool(ctx)
+    complete = make_beans_complete_tool(ctx)
+
+    asyncio.run(update.execute("call-1", bean="existing", status="in-progress"))
+    asyncio.run(complete.execute("call-2", bean="existing"))
+
+    meta = _frontmatter(path)
+    assert meta["status"] == "completed"
+    assert meta["tags"] == ["backend", "architecture"]
+    assert meta["blocked_by"] == ["pawrrtal-root"]
+
+
+def test_beans_list_rejects_invalid_status_filter(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    list_tool = make_beans_list_tool(ctx)
+
+    result = asyncio.run(list_tool.execute("call-1", status="inprogress"))
+
+    assert result == "[invalid_path] Unsupported bean status 'inprogress'."
+
+
+def test_beans_create_regenerates_colliding_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / ".beans"
+    root.mkdir()
+    (root / "pawrrtal-aaaaaaaa--existing.md").write_text(
+        "---\n# pawrrtal-aaaaaaaa\ntitle: Existing\nstatus: todo\n---\n\n",
+        encoding="utf-8",
+    )
+    choices: Iterator[str] = iter("aaaaaaaabbbbbbbb")
+
+    def choose_id_character(_alphabet: str) -> str:
+        return next(choices)
+
+    monkeypatch.setattr(secrets, "choice", choose_id_character)
+    create = make_beans_create_tool(_ctx(tmp_path))
+
+    result = asyncio.run(create.execute("call-1", title="New task"))
+
+    assert result == "Created bean pawrrtal-bbbbbbbb: New task"
+    assert (root / "pawrrtal-bbbbbbbb--new-task.md").exists()
 
 
 def test_beans_update_reports_ambiguous_matches(tmp_path: Path) -> None:

--- a/backend/tests/test_beans_tasks_tool.py
+++ b/backend/tests/test_beans_tasks_tool.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import secrets
+import os
+import textwrap
 import uuid
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -18,6 +18,148 @@ from app.plugins.beans_tasks.tools import (
     make_beans_update_tool,
 )
 from app.plugins.tool_context import ToolContext
+
+
+@pytest.fixture
+def fake_beans_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    beans = bin_dir / "beans"
+    beans.write_text(
+        textwrap.dedent(
+            r"""
+            #!/usr/bin/env python3
+            import re
+            import sys
+            from pathlib import Path
+
+            import yaml
+
+            ROOT = Path.cwd() / ".beans"
+
+
+            def slug(title):
+                return re.sub(r"[^a-z0-9]+", "-", title.casefold()).strip("-")[:70] or "task"
+
+
+            def split_frontmatter(raw):
+                if not raw.startswith("---\n"):
+                    return {}, raw
+                _, rest = raw.split("---\n", 1)
+                head, marker, body = rest.partition("\n---\n")
+                if not marker:
+                    return {}, raw
+                parsed = yaml.safe_load(head)
+                return parsed or {}, body
+
+
+            def bean_id_from_path(path):
+                return path.stem.split("--", 1)[0]
+
+
+            def write_bean(path, bean_id, meta, body):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                lines = ["---", f"# {bean_id}"]
+                dumped = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False).strip()
+                if dumped and dumped != "{}":
+                    lines.extend(dumped.splitlines())
+                lines.extend(["---", "", body.strip(), ""])
+                path.write_text("\n".join(lines), encoding="utf-8")
+
+
+            def next_id():
+                index = 1
+                while True:
+                    bean_id = f"pawrrtal-{index:08d}"
+                    if not list(ROOT.glob(f"{bean_id}--*.md")):
+                        return bean_id
+                    index += 1
+
+
+            def find_path(bean_id):
+                matches = list(ROOT.glob(f"{bean_id}--*.md"))
+                if not matches:
+                    print(f"missing bean {bean_id}", file=sys.stderr)
+                    sys.exit(2)
+                return matches[0]
+
+
+            def create(args):
+                title = args[0]
+                meta = {
+                    "title": title,
+                    "status": "todo",
+                    "type": "task",
+                    "priority": "normal",
+                }
+                body = ""
+                index = 1
+                while index < len(args):
+                    flag = args[index]
+                    value = args[index + 1]
+                    if flag in ("-s", "--status"):
+                        meta["status"] = value
+                    elif flag in ("-p", "--priority"):
+                        meta["priority"] = value
+                    elif flag in ("-t", "--type"):
+                        meta["type"] = value
+                    elif flag in ("-d", "--description"):
+                        body = value
+                    else:
+                        print(f"unsupported create flag {flag}", file=sys.stderr)
+                        sys.exit(2)
+                    index += 2
+                bean_id = next_id()
+                write_bean(ROOT / f"{bean_id}--{slug(title)}.md", bean_id, meta, body)
+                print(f"Created bean {bean_id}: {title}")
+
+
+            def update(args):
+                bean_id = args[0]
+                path = find_path(bean_id)
+                meta, body = split_frontmatter(path.read_text(encoding="utf-8"))
+                index = 1
+                while index < len(args):
+                    flag = args[index]
+                    value = args[index + 1]
+                    if flag in ("-s", "--status"):
+                        meta["status"] = value
+                    elif flag in ("-p", "--priority"):
+                        meta["priority"] = value
+                    elif flag in ("-t", "--type"):
+                        meta["type"] = value
+                    elif flag == "--title":
+                        meta["title"] = value
+                    elif flag == "--body-append":
+                        body = f"{body.rstrip()}\n\n{value}".strip()
+                    elif flag == "--body-file":
+                        body = Path(value).read_text(encoding="utf-8")
+                    else:
+                        print(f"unsupported update flag {flag}", file=sys.stderr)
+                        sys.exit(2)
+                    index += 2
+                write_bean(path, bean_id_from_path(path), meta, body)
+                status = "Completed" if meta.get("status") == "completed" else "Updated"
+                print(f"{status} bean {bean_id}.")
+
+
+            if len(sys.argv) < 2:
+                print("missing command", file=sys.stderr)
+                sys.exit(2)
+            command = sys.argv[1]
+            if command == "create":
+                create(sys.argv[2:])
+            elif command == "update":
+                update(sys.argv[2:])
+            else:
+                print(f"unsupported command {command}", file=sys.stderr)
+                sys.exit(2)
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    beans.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
 
 
 def _ctx(workspace_root: Path) -> ToolContext:
@@ -36,7 +178,10 @@ def _frontmatter(path: Path) -> dict[str, object]:
     return parsed
 
 
-def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
+def test_beans_tools_create_list_update_and_complete(
+    tmp_path: Path,
+    fake_beans_cli: None,
+) -> None:
     ctx = _ctx(tmp_path)
     create = make_beans_create_tool(ctx)
     list_tool = make_beans_list_tool(ctx)
@@ -46,7 +191,7 @@ def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
     created = asyncio.run(
         create.execute("call-1", title="Fix mobile login", body="Tap should sign in.")
     )
-    assert created.startswith("Created bean pawrrtal-")
+    assert created == "Created bean pawrrtal-00000001: Fix mobile login"
 
     listing = asyncio.run(list_tool.execute("call-2"))
     assert "Fix mobile login" in listing
@@ -66,19 +211,24 @@ def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
     assert (tmp_path / ".beans").is_dir()
 
 
-def test_beans_create_quotes_yaml_sensitive_title(tmp_path: Path) -> None:
+def test_beans_create_passes_metadata_to_cli(tmp_path: Path, fake_beans_cli: None) -> None:
     ctx = _ctx(tmp_path)
     create = make_beans_create_tool(ctx)
     title = "Settings layout: align fields"
 
-    asyncio.run(create.execute("call-1", title=title))
+    asyncio.run(create.execute("call-1", title=title, status="in-progress", priority="high"))
 
     path = next((tmp_path / ".beans").glob("*.md"))
-    assert _frontmatter(path)["title"] == title
-    assert "title: 'Settings layout: align fields'" in path.read_text(encoding="utf-8")
+    meta = _frontmatter(path)
+    assert meta["title"] == title
+    assert meta["status"] == "in-progress"
+    assert meta["priority"] == "high"
 
 
-def test_beans_update_and_complete_preserve_structured_frontmatter(tmp_path: Path) -> None:
+def test_beans_update_and_complete_preserve_structured_frontmatter(
+    tmp_path: Path,
+    fake_beans_cli: None,
+) -> None:
     root = tmp_path / ".beans"
     root.mkdir()
     path = root / "pawrrtal-abcd--existing.md"
@@ -119,6 +269,21 @@ def test_beans_update_and_complete_preserve_structured_frontmatter(tmp_path: Pat
     assert meta["blocked_by"] == ["pawrrtal-root"]
 
 
+def test_beans_update_replaces_body_through_cli(
+    tmp_path: Path,
+    fake_beans_cli: None,
+) -> None:
+    ctx = _ctx(tmp_path)
+    create = make_beans_create_tool(ctx)
+    update = make_beans_update_tool(ctx)
+
+    asyncio.run(create.execute("call-1", title="Body task", body="Old body."))
+    result = asyncio.run(update.execute("call-2", bean="Body task", body="New body."))
+
+    assert result == "Updated bean pawrrtal-00000001."
+    assert "New body." in next((tmp_path / ".beans").glob("*.md")).read_text(encoding="utf-8")
+
+
 def test_beans_list_rejects_invalid_status_filter(tmp_path: Path) -> None:
     ctx = _ctx(tmp_path)
     list_tool = make_beans_list_tool(ctx)
@@ -128,31 +293,21 @@ def test_beans_list_rejects_invalid_status_filter(tmp_path: Path) -> None:
     assert result == "[invalid_path] Unsupported bean status 'inprogress'."
 
 
-def test_beans_create_regenerates_colliding_ids(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    root = tmp_path / ".beans"
-    root.mkdir()
-    (root / "pawrrtal-aaaaaaaa--existing.md").write_text(
-        "---\n# pawrrtal-aaaaaaaa\ntitle: Existing\nstatus: todo\n---\n\n",
-        encoding="utf-8",
-    )
-    choices: Iterator[str] = iter("aaaaaaaabbbbbbbb")
-
-    def choose_id_character(_alphabet: str) -> str:
-        return next(choices)
-
-    monkeypatch.setattr(secrets, "choice", choose_id_character)
+def test_beans_create_reports_missing_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    empty_path = tmp_path / "empty-path"
+    empty_path.mkdir()
+    monkeypatch.setenv("PATH", str(empty_path))
     create = make_beans_create_tool(_ctx(tmp_path))
 
     result = asyncio.run(create.execute("call-1", title="New task"))
 
-    assert result == "Created bean pawrrtal-bbbbbbbb: New task"
-    assert (root / "pawrrtal-bbbbbbbb--new-task.md").exists()
+    assert result == "[not_found] beans CLI is not installed or not on PATH."
 
 
-def test_beans_update_reports_ambiguous_matches(tmp_path: Path) -> None:
+def test_beans_update_reports_ambiguous_matches(
+    tmp_path: Path,
+    fake_beans_cli: None,
+) -> None:
     ctx = _ctx(tmp_path)
     create = make_beans_create_tool(ctx)
     update = make_beans_update_tool(ctx)

--- a/backend/tests/test_beans_tasks_tool.py
+++ b/backend/tests/test_beans_tasks_tool.py
@@ -149,8 +149,10 @@ def fake_beans_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
             command = sys.argv[1]
             if command == "create":
                 create(sys.argv[2:])
+                sys.exit(0)
             elif command == "update":
                 update(sys.argv[2:])
+                sys.exit(0)
             else:
                 print(f"unsupported command {command}", file=sys.stderr)
                 sys.exit(2)
@@ -188,30 +190,37 @@ def test_beans_tools_create_list_update_and_complete(
     update = make_beans_update_tool(ctx)
     complete = make_beans_complete_tool(ctx)
 
-    created = asyncio.run(
-        create.execute("call-1", title="Fix mobile login", body="Tap should sign in.")
-    )
-    assert created == "Created bean pawrrtal-00000001: Fix mobile login"
+    async def run_scenario() -> tuple[str, str, str, str, str, str]:
+        created = await create.execute(
+            "call-1",
+            title="Fix mobile login",
+            body="Tap should sign in.",
+        )
+        listing = await list_tool.execute("call-2")
+        bean_id = listing.split()[1]
+        updated = await update.execute("call-3", bean=bean_id, status="in-progress")
+        completed = await complete.execute("call-4", bean="mobile login")
+        open_listing = await list_tool.execute("call-5")
+        all_listing = await list_tool.execute("call-6", include_completed=True)
+        return created, listing, updated, completed, open_listing, all_listing
 
-    listing = asyncio.run(list_tool.execute("call-2"))
+    created, listing, updated, completed, open_listing, all_listing = asyncio.run(run_scenario())
+
+    assert created == "Created bean pawrrtal-00000001: Fix mobile login"
     assert "Fix mobile login" in listing
     bean_id = listing.split()[1]
-
-    updated = asyncio.run(update.execute("call-3", bean=bean_id, status="in-progress"))
     assert updated == f"Updated bean {bean_id}."
-
-    completed = asyncio.run(complete.execute("call-4", bean="mobile login"))
     assert completed == f"Completed bean {bean_id}."
-
-    open_listing = asyncio.run(list_tool.execute("call-5"))
-    all_listing = asyncio.run(list_tool.execute("call-6", include_completed=True))
 
     assert "Fix mobile login" not in open_listing
     assert f"{bean_id} [completed/normal] Fix mobile login" in all_listing
     assert (tmp_path / ".beans").is_dir()
 
 
-def test_beans_create_passes_metadata_to_cli(tmp_path: Path, fake_beans_cli: None) -> None:
+def test_beans_create_passes_metadata_to_cli(
+    tmp_path: Path,
+    fake_beans_cli: None,
+) -> None:
     ctx = _ctx(tmp_path)
     create = make_beans_create_tool(ctx)
     title = "Settings layout: align fields"
@@ -260,8 +269,11 @@ def test_beans_update_and_complete_preserve_structured_frontmatter(
     update = make_beans_update_tool(ctx)
     complete = make_beans_complete_tool(ctx)
 
-    asyncio.run(update.execute("call-1", bean="existing", status="in-progress"))
-    asyncio.run(complete.execute("call-2", bean="existing"))
+    async def run_scenario() -> None:
+        await update.execute("call-1", bean="existing", status="in-progress")
+        await complete.execute("call-2", bean="existing")
+
+    asyncio.run(run_scenario())
 
     meta = _frontmatter(path)
     assert meta["status"] == "completed"
@@ -277,8 +289,11 @@ def test_beans_update_replaces_body_through_cli(
     create = make_beans_create_tool(ctx)
     update = make_beans_update_tool(ctx)
 
-    asyncio.run(create.execute("call-1", title="Body task", body="Old body."))
-    result = asyncio.run(update.execute("call-2", bean="Body task", body="New body."))
+    async def run_scenario() -> str:
+        await create.execute("call-1", title="Body task", body="Old body.")
+        return await update.execute("call-2", bean="Body task", body="New body.")
+
+    result = asyncio.run(run_scenario())
 
     assert result == "Updated bean pawrrtal-00000001."
     assert "New body." in next((tmp_path / ".beans").glob("*.md")).read_text(encoding="utf-8")
@@ -293,7 +308,41 @@ def test_beans_list_rejects_invalid_status_filter(tmp_path: Path) -> None:
     assert result == "[invalid_path] Unsupported bean status 'inprogress'."
 
 
-def test_beans_create_reports_missing_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_beans_list_skips_malformed_frontmatter(tmp_path: Path) -> None:
+    root = tmp_path / ".beans"
+    root.mkdir()
+    (root / "pawrrtal-bad--broken.md").write_text(
+        "---\ntitle: [broken\n---\n\nBroken body.\n",
+        encoding="utf-8",
+    )
+    (root / "pawrrtal-good--valid.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "# pawrrtal-good",
+                "title: Valid task",
+                "status: todo",
+                "priority: high",
+                "---",
+                "",
+                "Valid body.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    list_tool = make_beans_list_tool(_ctx(tmp_path))
+
+    result = asyncio.run(list_tool.execute("call-1"))
+
+    assert "pawrrtal-good [todo/high] Valid task" in result
+    assert "pawrrtal-bad" not in result
+
+
+def test_beans_create_reports_missing_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     empty_path = tmp_path / "empty-path"
     empty_path.mkdir()
     monkeypatch.setenv("PATH", str(empty_path))
@@ -312,9 +361,11 @@ def test_beans_update_reports_ambiguous_matches(
     create = make_beans_create_tool(ctx)
     update = make_beans_update_tool(ctx)
 
-    asyncio.run(create.execute("call-1", title="Follow up"))
-    asyncio.run(create.execute("call-2", title="Follow through"))
+    async def run_scenario() -> str:
+        await create.execute("call-1", title="Follow up")
+        await create.execute("call-2", title="Follow through")
+        return await update.execute("call-3", bean="Follow")
 
-    result = asyncio.run(update.execute("call-3", bean="Follow"))
+    result = asyncio.run(run_scenario())
 
     assert result.startswith("[invalid_path] Multiple beans matched")

--- a/backend/tests/test_beans_tasks_tool.py
+++ b/backend/tests/test_beans_tasks_tool.py
@@ -1,0 +1,66 @@
+"""Tests for the Beans-backed task plugin tools."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+from app.plugins.beans_tasks.tools import (
+    make_beans_complete_tool,
+    make_beans_create_tool,
+    make_beans_list_tool,
+    make_beans_update_tool,
+)
+from app.plugins.tool_context import ToolContext
+
+
+def _ctx(workspace_root: Path) -> ToolContext:
+    return ToolContext(
+        workspace_id=uuid.uuid4(),
+        workspace_root=workspace_root,
+        user_id=uuid.uuid4(),
+    )
+
+
+def test_beans_tools_create_list_update_and_complete(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    create = make_beans_create_tool(ctx)
+    list_tool = make_beans_list_tool(ctx)
+    update = make_beans_update_tool(ctx)
+    complete = make_beans_complete_tool(ctx)
+
+    created = asyncio.run(
+        create.execute("call-1", title="Fix mobile login", body="Tap should sign in.")
+    )
+    assert created.startswith("Created bean pawrrtal-")
+
+    listing = asyncio.run(list_tool.execute("call-2"))
+    assert "Fix mobile login" in listing
+    bean_id = listing.split()[1]
+
+    updated = asyncio.run(update.execute("call-3", bean=bean_id, status="in-progress"))
+    assert updated == f"Updated bean {bean_id}."
+
+    completed = asyncio.run(complete.execute("call-4", bean="mobile login"))
+    assert completed == f"Completed bean {bean_id}."
+
+    open_listing = asyncio.run(list_tool.execute("call-5"))
+    all_listing = asyncio.run(list_tool.execute("call-6", include_completed=True))
+
+    assert "Fix mobile login" not in open_listing
+    assert f"{bean_id} [completed/normal] Fix mobile login" in all_listing
+    assert (tmp_path / ".beans").is_dir()
+
+
+def test_beans_update_reports_ambiguous_matches(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    create = make_beans_create_tool(ctx)
+    update = make_beans_update_tool(ctx)
+
+    asyncio.run(create.execute("call-1", title="Follow up"))
+    asyncio.run(create.execute("call-2", title="Follow through"))
+
+    result = asyncio.run(update.execute("call-3", bean="Follow"))
+
+    assert result.startswith("[invalid_path] Multiple beans matched")

--- a/backend/tests/test_beans_tasks_tool.py
+++ b/backend/tests/test_beans_tasks_tool.py
@@ -308,6 +308,38 @@ def test_beans_list_rejects_invalid_status_filter(tmp_path: Path) -> None:
     assert result == "[invalid_path] Unsupported bean status 'inprogress'."
 
 
+def test_beans_list_accepts_workspace_statuses(tmp_path: Path) -> None:
+    root = tmp_path / ".beans"
+    root.mkdir()
+    for bean_id, status in (
+        ("pawrrtal-draft", "draft"),
+        ("pawrrtal-review", "in-review"),
+    ):
+        (root / f"{bean_id}--task.md").write_text(
+            "\n".join(
+                [
+                    "---",
+                    f"# {bean_id}",
+                    f"title: {status} task",
+                    f"status: {status}",
+                    "priority: normal",
+                    "---",
+                    "",
+                    "Body.",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+    list_tool = make_beans_list_tool(_ctx(tmp_path))
+
+    draft = asyncio.run(list_tool.execute("call-1", status="draft"))
+    in_review = asyncio.run(list_tool.execute("call-2", status="in-review"))
+
+    assert "pawrrtal-draft [draft/normal] draft task" in draft
+    assert "pawrrtal-review [in-review/normal] in-review task" in in_review
+
+
 def test_beans_list_skips_malformed_frontmatter(tmp_path: Path) -> None:
     root = tmp_path / ".beans"
     root.mkdir()

--- a/backend/tests/test_plugin_tools.py
+++ b/backend/tests/test_plugin_tools.py
@@ -275,6 +275,26 @@ def test_bundled_tasks_manifest_exposes_task_tools(tmp_path: Path) -> None:
     assert {"add_task", "list_tasks", "complete_task"} <= names
 
 
+def test_bundled_beans_tasks_manifest_exposes_task_tools(tmp_path: Path) -> None:
+    names = _tool_names(tmp_path)
+
+    assert {"beans_create", "beans_list", "beans_update", "beans_complete"} <= names
+
+
+def test_bundled_beans_tasks_plugin_can_be_disabled(tmp_path: Path) -> None:
+    save_plugin_state(
+        plugin_state_path(plugin_id="beans_tasks", scope="workspace", workspace_root=tmp_path),
+        PluginState(enabled=False),
+    )
+
+    names = _tool_names(tmp_path)
+
+    assert "beans_create" not in names
+    assert "beans_list" not in names
+    assert "beans_update" not in names
+    assert "beans_complete" not in names
+
+
 def test_bundled_tasks_plugin_can_be_disabled(tmp_path: Path) -> None:
     save_plugin_state(
         plugin_state_path(plugin_id="tasks", scope="workspace", workspace_root=tmp_path),

--- a/backend/tests/test_plugin_tools.py
+++ b/backend/tests/test_plugin_tools.py
@@ -275,7 +275,21 @@ def test_bundled_tasks_manifest_exposes_task_tools(tmp_path: Path) -> None:
     assert {"add_task", "list_tasks", "complete_task"} <= names
 
 
-def test_bundled_beans_tasks_manifest_exposes_task_tools(tmp_path: Path) -> None:
+def test_bundled_beans_tasks_manifest_is_disabled_by_default(tmp_path: Path) -> None:
+    names = _tool_names(tmp_path)
+
+    assert "beans_create" not in names
+    assert "beans_list" not in names
+    assert "beans_update" not in names
+    assert "beans_complete" not in names
+
+
+def test_bundled_beans_tasks_manifest_exposes_task_tools_when_enabled(tmp_path: Path) -> None:
+    save_plugin_state(
+        plugin_state_path(plugin_id="beans_tasks", scope="workspace", workspace_root=tmp_path),
+        PluginState(enabled=True),
+    )
+
     names = _tool_names(tmp_path)
 
     assert {"beans_create", "beans_list", "beans_update", "beans_complete"} <= names

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -13,8 +13,10 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,6 +26,7 @@ from app.channels import registered_surfaces, resolve_channel
 from app.channels.base import ChannelMessage
 from app.channels.telegram import SURFACE_TELEGRAM, TelegramChannel
 from app.channels.telegram.bot import (
+    _TELEGRAM_COMMANDS,
     _refresh_telegram_commands_best_effort,
     refresh_telegram_commands,
 )
@@ -156,6 +159,16 @@ async def test_refresh_telegram_commands_sets_current_command_menu() -> None:
         "compact",
     ]
     assert all(command.description for command in commands)
+
+
+def test_telegram_channel_manifest_commands_match_runtime_menu() -> None:
+    manifest_path = Path(__file__).resolve().parents[1] / "plugins/telegram_channel/plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    capability = manifest["capabilities"][0]
+
+    assert capability["commands"]["slash"] == [
+        command for command, _description in _TELEGRAM_COMMANDS
+    ]
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -150,6 +150,7 @@ async def test_refresh_telegram_commands_sets_current_command_menu() -> None:
         "verbose",
         "stop",
         "status",
+        "tools",
         "whoami",
         "lcm",
         "compact",

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -13,11 +13,13 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,7 +29,9 @@ from app.channels.base import ChannelMessage
 from app.channels.telegram import SURFACE_TELEGRAM, TelegramChannel
 from app.channels.telegram.bot import (
     _TELEGRAM_COMMANDS,
+    TelegramService,
     _refresh_telegram_commands_best_effort,
+    _stop_polling_task,
     refresh_telegram_commands,
 )
 from app.channels.telegram.bot_provider_resolution import (
@@ -205,6 +209,32 @@ def test_telegram_command_refresh_cooldown() -> None:
 
     assert should_refresh_commands(token=token, now=159.0) is False
     assert should_refresh_commands(token=token, now=160.0) is True
+
+
+@pytest.mark.anyio
+async def test_stop_polling_task_uses_dispatcher_stop_signal() -> None:
+    """Polling teardown should ask aiogram to stop instead of cancelling directly."""
+    stopped = asyncio.Event()
+
+    async def wait_for_stop() -> None:
+        await stopped.wait()
+
+    async def stop_polling() -> None:
+        stopped.set()
+
+    polling_task = asyncio.create_task(wait_for_stop())
+    dispatcher = SimpleNamespace(stop_polling=AsyncMock(side_effect=stop_polling))
+    service = TelegramService(
+        bot=cast(Any, object()),
+        dispatcher=cast(Any, dispatcher),
+        polling_task=polling_task,
+    )
+
+    await _stop_polling_task(service)
+
+    dispatcher.stop_polling.assert_awaited_once()
+    assert polling_task.done()
+    assert not polling_task.cancelled()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -31,7 +32,9 @@ from app.channels.telegram.bot import (
     _TELEGRAM_COMMANDS,
     TelegramService,
     _refresh_telegram_commands_best_effort,
+    _should_suppress_aiogram_polling_log,
     _stop_polling_task,
+    _suppress_aiogram_polling_shutdown_logs,
     refresh_telegram_commands,
 )
 from app.channels.telegram.bot_provider_resolution import (
@@ -235,6 +238,34 @@ async def test_stop_polling_task_uses_dispatcher_stop_signal() -> None:
     dispatcher.stop_polling.assert_awaited_once()
     assert polling_task.done()
     assert not polling_task.cancelled()
+
+
+def test_aiogram_shutdown_log_filter_only_matches_during_teardown() -> None:
+    """Runtime polling errors must still log outside Pawrrtal's teardown window."""
+    record = logging.LogRecord(
+        "aiogram.dispatcher",
+        logging.ERROR,
+        "",
+        0,
+        "Failed to fetch updates - TelegramNetworkError: HTTP Client says - "
+        "ServerDisconnectedError: Server disconnected",
+        (),
+        None,
+    )
+    retry_record = logging.LogRecord(
+        "aiogram.dispatcher",
+        logging.WARNING,
+        "",
+        0,
+        "Sleep for 1.000000 seconds and try again... (tryings = 0, bot id = 1)",
+        (),
+        None,
+    )
+
+    assert _should_suppress_aiogram_polling_log(record) is False
+    with _suppress_aiogram_polling_shutdown_logs():
+        assert _should_suppress_aiogram_polling_log(record) is True
+        assert _should_suppress_aiogram_polling_log(retry_record) is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_tools_command.py
+++ b/backend/tests/test_telegram_tools_command.py
@@ -1,0 +1,107 @@
+"""Tests for the Telegram `/tools` command."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.types import AgentTool
+from app.channels.telegram.bot import _TELEGRAM_COMMANDS
+from app.channels.telegram.sender import TelegramSender
+from app.channels.telegram.tools_command import handle_tools_command
+from app.plugins.capability_catalog import CapabilityRecord
+
+
+def test_telegram_command_menu_includes_tools() -> None:
+    command_names = {command for command, _description in _TELEGRAM_COMMANDS}
+
+    assert "tools" in command_names
+
+
+@pytest.mark.anyio
+async def test_tools_command_requires_binding() -> None:
+    sender = TelegramSender(user_id=42, chat_id=42, username="tavi", full_name="Tavi")
+
+    with patch(
+        "app.channels.telegram.tools_command.resolve_or_autolink_telegram_user",
+        new=AsyncMock(return_value=None),
+    ):
+        reply = await handle_tools_command(sender=sender, session=AsyncMock())
+
+    assert "Connect your account first" in reply
+
+
+@pytest.mark.anyio
+async def test_tools_command_renders_actual_tools_and_plugin_capabilities(
+    tmp_path: Path,
+) -> None:
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    conversation_id = uuid.uuid4()
+    sender = TelegramSender(user_id=42, chat_id=42, username="tavi", full_name="Tavi")
+    workspace = SimpleNamespace(id=workspace_id, path=str(tmp_path))
+    conversation = SimpleNamespace(
+        id=conversation_id,
+        model_id="agy-api:google/gemini-3-flash-agent",
+    )
+    tool = AgentTool(
+        name="search_plugin_capabilities",
+        description="Search plugins.",
+        parameters={"type": "object", "properties": {}},
+        execute=AsyncMock(return_value="{}"),
+    )
+    capability = CapabilityRecord(
+        plugin_id="notion",
+        capability_id="notion_cli",
+        type="cli_tool",
+        title="Notion CLI",
+        description="Run ntn.",
+        tags=(),
+        intents=("notion.workspace",),
+        slots=("workspace_knowledge",),
+        state="enabled",
+        priority=0,
+        exposure="direct_and_catalog",
+        permissions=("secrets",),
+        requires_confirmation=False,
+        input_schema={},
+        examples=(),
+    )
+    snapshot = SimpleNamespace(capabilities=(capability,))
+    host = MagicMock()
+    host.reload.return_value = (None, snapshot)
+
+    with (
+        patch(
+            "app.channels.telegram.tools_command.resolve_or_autolink_telegram_user",
+            new=AsyncMock(return_value=user_id),
+        ),
+        patch(
+            "app.channels.telegram.tools_command.get_default_workspace",
+            new=AsyncMock(return_value=workspace),
+        ),
+        patch(
+            "app.channels.telegram.tools_command.get_or_create_telegram_conversation_full",
+            new=AsyncMock(return_value=conversation),
+        ),
+        patch(
+            "app.channels.telegram.tools_command.resolve_effective_model_id",
+            new=MagicMock(return_value=conversation.model_id),
+        ),
+        patch(
+            "app.channels.telegram.tools_command.build_agent_tools",
+            new=MagicMock(return_value=[tool]),
+        ),
+        patch("app.channels.telegram.tools_command.get_plugin_host", return_value=host),
+    ):
+        reply = await handle_tools_command(sender=sender, session=AsyncMock())
+
+    assert "Tools available" in reply
+    assert "agy-api:google/gemini-3-flash-agent" in reply
+    assert "search_plugin_capabilities" in reply
+    assert "workspace_knowledge" in reply
+    assert "notion/notion_cli" in reply

--- a/frontend/content/docs/handbook/deployment/vps-deploy.md
+++ b/frontend/content/docs/handbook/deployment/vps-deploy.md
@@ -124,19 +124,21 @@ just paw project up
 just paw project status
 ```
 
-For a persistent VPS process, install the user systemd service:
+For the persistent VPS process, install the systemd service:
 
 ```bash
-just paw project service install --linger
+just paw project service install --enable-dev-login
 just paw project service status
 ```
 
-The service runs `dev.ts`, which starts Next.js on `127.0.0.1:3000`
-and FastAPI on `127.0.0.1:8000`. It does not expose a public port.
-If this VPS should use Postgres instead of local SQLite, set
-`PAWRRTAL_DEV_DATABASE_URL` before installing the service; the service
-intentionally clears the generic `DATABASE_URL` so unrelated shell
-state cannot leak into local project launches.
+The service runs `serve.ts`: it builds the standalone Next.js bundle,
+starts the production Next server on `127.0.0.1:3000`, and starts
+FastAPI on `127.0.0.1:8000` without reload mode. It does not expose a
+public port. The service loads `backend/.env` through systemd's
+`EnvironmentFile`, and the generated unit only writes non-secret
+runtime settings such as ports, `ENV=prod`, and `BACKEND_INTERNAL_URL`.
+Use `--enable-dev-login` only for an operator deployment protected by
+Cloudflare Access.
 
 ## Cloudflared Install
 

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -8,6 +8,7 @@
  * aren't appropriate for the smoke suite.
  */
 
+import { devices } from '@playwright/test';
 import { expect, test } from './fixtures';
 
 test.describe('login page', () => {
@@ -35,6 +36,29 @@ test.describe('login page', () => {
 		await page.getByRole('button', { name: 'Dev Admin' }).click();
 
 		expect((await devLoginResponse).ok()).toBe(true);
+		await expect(page).toHaveURL(/\/$/);
+
+		const isAuthenticated = await page.evaluate(async () => {
+			const response = await fetch('/api/v1/users/me', { credentials: 'include' });
+			return response.ok;
+		});
+		expect(isAuthenticated).toBe(true);
+	});
+});
+
+test.describe('mobile login page', () => {
+	test.use({ ...devices['iPhone 13'] });
+
+	test('dev-admin shortcut signs in from a touch tap', async ({ page }) => {
+		await page.goto('/login');
+		const devLoginResponse = page.waitForResponse(
+			(response) =>
+				response.url().includes('/auth/dev-login') && response.request().method() === 'POST'
+		);
+
+		await page.getByRole('button', { name: 'Dev Admin' }).tap();
+
+		expect([204, 303]).toContain((await devLoginResponse).status());
 		await expect(page).toHaveURL(/\/$/);
 
 		const isAuthenticated = await page.evaluate(async () => {

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -11,6 +11,14 @@
 import { devices } from '@playwright/test';
 import { expect, test } from './fixtures';
 
+const mobileLoginDevice = {
+	deviceScaleFactor: devices['iPhone 13'].deviceScaleFactor,
+	hasTouch: devices['iPhone 13'].hasTouch,
+	isMobile: devices['iPhone 13'].isMobile,
+	userAgent: devices['iPhone 13'].userAgent,
+	viewport: devices['iPhone 13'].viewport,
+};
+
 test.describe('login page', () => {
 	test('renders email + password fields and the SSO buttons', async ({ page }) => {
 		await page.goto('/login');
@@ -47,7 +55,7 @@ test.describe('login page', () => {
 });
 
 test.describe('mobile login page', () => {
-	test.use({ ...devices['iPhone 13'] });
+	test.use(mobileLoginDevice);
 
 	test('dev-admin shortcut signs in from a touch tap', async ({ page }) => {
 		await page.goto('/login');

--- a/frontend/features/auth/LoginForm.tsx
+++ b/frontend/features/auth/LoginForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type React from 'react';
-import { useId, useState } from 'react';
+import { useCallback, useId, useRef, useState } from 'react';
 import { useDevAdminLoginMutation, useLoginMutation } from './hooks/use-login-mutations';
-import { LoginFormView } from './LoginFormView';
+import { type DevAdminLoginHandlers, LoginFormView } from './LoginFormView';
 
 interface LoginFormProps extends React.ComponentProps<'div'> {
 	canUseDevAdminLogin?: boolean;
@@ -19,6 +19,36 @@ interface LoginFormProps extends React.ComponentProps<'div'> {
 	 * out for the entire ``/login`` page.
 	 */
 	postLoginTarget?: string;
+}
+
+function useTouchTapCommit(commit: () => void | Promise<void>): DevAdminLoginHandlers {
+	const touchCommittedRef = useRef(false);
+
+	const handleTouchEnd = useCallback(
+		(event: React.TouchEvent<HTMLButtonElement>): void => {
+			event.preventDefault();
+			touchCommittedRef.current = true;
+			void commit();
+		},
+		[commit]
+	);
+
+	const handleClick = useCallback(
+		(event: React.MouseEvent<HTMLButtonElement>): void => {
+			event.preventDefault();
+			if (touchCommittedRef.current) {
+				touchCommittedRef.current = false;
+				return;
+			}
+			void commit();
+		},
+		[commit]
+	);
+
+	return {
+		onClick: handleClick,
+		onTouchEnd: handleTouchEnd,
+	};
 }
 
 /**
@@ -40,6 +70,7 @@ export function LoginForm({
 	const formId = useId();
 	const emailId = `${formId}-email`;
 	const passwordId = `${formId}-password`;
+	const devAdminFormId = `${formId}-dev-admin`;
 
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
@@ -95,6 +126,7 @@ export function LoginForm({
 			setFriendlyNetworkError(error);
 		}
 	};
+	const devAdminLoginHandlers = useTouchTapCommit(handleDevAdminLogin);
 
 	return (
 		<LoginFormView
@@ -108,8 +140,10 @@ export function LoginForm({
 			errorMessage={currentError}
 			isLoading={isLoading}
 			canUseDevAdminLogin={canUseDevAdminLogin}
+			devAdminFormId={devAdminFormId}
+			devAdminLoginHandlers={devAdminLoginHandlers}
+			postLoginTarget={postLoginTarget}
 			onSubmit={handleSubmit}
-			onDevAdminLogin={handleDevAdminLogin}
 			{...divProps}
 		/>
 	);

--- a/frontend/features/auth/LoginFormView.test.tsx
+++ b/frontend/features/auth/LoginFormView.test.tsx
@@ -1,7 +1,20 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { LoginFormView } from './LoginFormView';
+import { type DevAdminLoginHandlers, LoginFormView } from './LoginFormView';
+
+function makeDevAdminHandlers(onCommit = vi.fn()): DevAdminLoginHandlers {
+	return {
+		onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+			event.preventDefault();
+			onCommit();
+		},
+		onTouchEnd: (event: React.TouchEvent<HTMLButtonElement>) => {
+			event.preventDefault();
+			onCommit();
+		},
+	};
+}
 
 const baseProps = {
 	emailId: 'email',
@@ -11,10 +24,12 @@ const baseProps = {
 	errorMessage: '',
 	isLoading: false,
 	canUseDevAdminLogin: false,
+	devAdminFormId: 'dev-admin-form',
+	devAdminLoginHandlers: makeDevAdminHandlers(),
+	postLoginTarget: '/',
 	onEmailChange: () => undefined,
 	onPasswordChange: () => undefined,
 	onSubmit: (e: React.FormEvent<HTMLFormElement>) => e.preventDefault(),
-	onDevAdminLogin: () => undefined,
 };
 
 describe('LoginFormView', () => {
@@ -41,10 +56,44 @@ describe('LoginFormView', () => {
 		const onDevAdminLogin = vi.fn();
 		const user = userEvent.setup();
 		const { getByRole } = render(
-			<LoginFormView {...baseProps} canUseDevAdminLogin onDevAdminLogin={onDevAdminLogin} />
+			<LoginFormView
+				{...baseProps}
+				canUseDevAdminLogin
+				devAdminLoginHandlers={makeDevAdminHandlers(onDevAdminLogin)}
+			/>
 		);
 		await user.click(getByRole('button', { name: 'Dev Admin' }));
 		expect(onDevAdminLogin).toHaveBeenCalled();
+	});
+
+	it('wires the dev-admin touch handler for touch-style taps', () => {
+		const onDevAdminLogin = vi.fn();
+		const { getByRole } = render(
+			<LoginFormView
+				{...baseProps}
+				canUseDevAdminLogin
+				devAdminLoginHandlers={makeDevAdminHandlers(onDevAdminLogin)}
+			/>
+		);
+		fireEvent.touchEnd(getByRole('button', { name: 'Dev Admin' }));
+		expect(onDevAdminLogin).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders a form fallback for dev-admin login before hydration', () => {
+		const { container, getByRole } = render(
+			<LoginFormView {...baseProps} canUseDevAdminLogin postLoginTarget="/settings" />
+		);
+		const button = getByRole('button', { name: 'Dev Admin' });
+		const fallbackForm = container.querySelector(
+			'form[action="/auth/dev-login/browser?redirect_to=%2Fsettings"]'
+		);
+		expect(fallbackForm).toBeTruthy();
+		expect(fallbackForm?.getAttribute('method')).toBe('post');
+		expect(button.getAttribute('type')).toBe('submit');
+		expect(button.getAttribute('form')).toBe(fallbackForm?.id);
+		expect(
+			fallbackForm?.querySelector('input[name="redirect_to"]')?.getAttribute('value')
+		).toBe('/settings');
 	});
 
 	it('disables submit button when isLoading is true', () => {

--- a/frontend/features/auth/LoginFormView.tsx
+++ b/frontend/features/auth/LoginFormView.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { getBrowserApiUrl } from '@/lib/api';
+import { API_ENDPOINTS, getBrowserApiUrl } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
 /** Backend OAuth start URLs the SSO buttons navigate to. */
@@ -43,6 +43,16 @@ function SsoButton({ disabled, icon, label, provider }: SsoButtonProps): React.J
 	);
 }
 
+function buildDevLoginFormAction(postLoginTarget: string): string {
+	const base = getBrowserApiUrl(API_ENDPOINTS.auth.devLoginBrowser);
+	return `${base}?redirect_to=${encodeURIComponent(postLoginTarget)}`;
+}
+
+export interface DevAdminLoginHandlers {
+	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	onTouchEnd: (event: React.TouchEvent<HTMLButtonElement>) => void;
+}
+
 export interface LoginFormViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
 	/** Unique ID prefix for form field elements. */
 	emailId: string;
@@ -62,10 +72,14 @@ export interface LoginFormViewProps extends Omit<React.ComponentProps<'div'>, 'o
 	isLoading: boolean;
 	/** Whether the dev-only admin shortcut is available. */
 	canUseDevAdminLogin: boolean;
+	/** ID of the browser fallback form submitted before hydration. */
+	devAdminFormId: string;
+	/** Hydrated button handlers for the dev-admin shortcut. */
+	devAdminLoginHandlers: DevAdminLoginHandlers;
+	/** Safe relative path to load after a successful login. */
+	postLoginTarget: string;
 	/** Called when the form is submitted. */
 	onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-	/** Called when the "Dev Admin" button is clicked. */
-	onDevAdminLogin: () => void;
 }
 
 /**
@@ -86,8 +100,10 @@ export function LoginFormView({
 	errorMessage,
 	isLoading,
 	canUseDevAdminLogin,
+	devAdminFormId,
+	devAdminLoginHandlers,
+	postLoginTarget,
 	onSubmit,
-	onDevAdminLogin,
 	...props
 }: LoginFormViewProps): React.JSX.Element {
 	return (
@@ -159,8 +175,10 @@ export function LoginFormView({
 										<Button
 											className="cursor-pointer"
 											variant="outline"
-											type="button"
-											onClick={onDevAdminLogin}
+											type="submit"
+											form={devAdminFormId}
+											onClick={devAdminLoginHandlers.onClick}
+											onTouchEnd={devAdminLoginHandlers.onTouchEnd}
 											disabled={isLoading}
 										>
 											Dev Admin
@@ -188,6 +206,15 @@ export function LoginFormView({
 							</Field>
 						</FieldGroup>
 					</form>
+					{canUseDevAdminLogin && (
+						<form
+							action={buildDevLoginFormAction(postLoginTarget)}
+							id={devAdminFormId}
+							method="post"
+						>
+							<input type="hidden" name="redirect_to" value={postLoginTarget} />
+						</form>
+					)}
 				</CardContent>
 			</Card>
 		</div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -103,6 +103,11 @@ export const API_ENDPOINTS = {
 		 */
 		devLogin: '/auth/dev-login',
 		/**
+		 * Dev-only admin login browser form fallback.
+		 * @returns `/auth/dev-login/browser`
+		 */
+		devLoginBrowser: '/auth/dev-login/browser',
+		/**
 		 * Register endpoint.
 		 * @returns `/auth/register`
 		 */

--- a/justfile
+++ b/justfile
@@ -20,20 +20,26 @@ dev-telegram:
 #   just paw doctor --json
 #   just paw doctor --profile staging
 paw *ARGS:
-    @BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"; SAFE="$(printf "%s" "$BRANCH" | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/-+/-/g; s/^[-.]+//; s/[-.]+$//' | cut -c1-80)"; if [ -z "$SAFE" ] || [ "$SAFE" = "HEAD" ]; then SAFE=""; fi; DATABASE_URL="" SQLITE_DB_FILENAME="${SAFE:+pawrrtal-$SAFE.db}" uv run --project backend paw {{ARGS}}
+    @scripts/paw {{ARGS}}
+
+# Install the Paw launcher on PATH for invoking `paw` from any directory.
+install-paw:
+    mkdir -p "$HOME/.local/bin"
+    ln -sf "{{justfile_directory()}}/scripts/paw" "$HOME/.local/bin/paw"
+    @printf 'Installed paw launcher at %s\n' "$HOME/.local/bin/paw"
 
 # Fast local environment check for agents and CI smoke loops. This does not
 # start servers; it verifies writable cache/config paths, binaries, and ports.
 env-check:
-    cd backend && PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" uv run paw env check
+    PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" scripts/paw env check
 
 # Start, probe, and stop the full local app. Use this before claiming that
 # the developer startup path works end-to-end.
 smoke-dev:
-    cd backend && PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" uv run paw project preflight
-    cd backend && PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" uv run paw project up --boot-timeout 45
-    cd backend && PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" uv run paw project status
-    cd backend && PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" uv run paw project down
+    PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" scripts/paw project preflight
+    PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" scripts/paw project up --boot-timeout 45
+    PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" scripts/paw project status
+    PAW_CONFIG_DIR="{{justfile_directory()}}/.cache/paw" UV_CACHE_DIR="{{justfile_directory()}}/.cache/uv" XDG_CACHE_HOME="{{justfile_directory()}}/.cache/xdg" scripts/paw project down
 
 # Auto-generate conventional commit via Gemini
 commit *ARGS:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "bun run dev.ts",
+		"serve": "bun run serve.ts",
 		"commit": "bun run commit.ts",
 		"lint:file-lines": "node scripts/check-file-lines.mjs",
 		"lint:view-container": "node scripts/check-view-container.mjs",

--- a/scripts/paw
+++ b/scripts/paw
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+backend_dir="${PAWRRTAL_BACKEND_DIR:-${repo_root}/backend}"
+
+export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+
+cd "${backend_dir}"
+exec uv run paw "$@"

--- a/scripts/paw
+++ b/scripts/paw
@@ -26,6 +26,14 @@ if [[ ! -d "${backend_dir}" ]]; then
 	exit 1
 fi
 
+safe_branch="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+safe_branch="$(printf '%s' "${safe_branch}" | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/-+/-/g; s/^[-.]+//; s/[-.]+$//' | cut -c1-80)"
+if [[ -z "${safe_branch}" || "${safe_branch}" == "HEAD" ]]; then
+	safe_branch=""
+fi
+export DATABASE_URL="${DATABASE_URL-}"
+export SQLITE_DB_FILENAME="${SQLITE_DB_FILENAME:-${safe_branch:+pawrrtal-${safe_branch}.db}}"
+
 env_file="${PAWRRTAL_ENV_FILE:-}"
 if [[ -z "${env_file}" && -f "${backend_dir}/.env" ]]; then
 	env_file="${backend_dir}/.env"

--- a/scripts/paw
+++ b/scripts/paw
@@ -3,9 +3,27 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
-backend_dir="${PAWRRTAL_BACKEND_DIR:-${repo_root}/backend}"
+if [[ -d "${repo_root}/backend" ]]; then
+	default_backend_dir="${repo_root}/backend"
+else
+	default_backend_dir="/mnt/HC_Volume_105512717/dev/pawrrtal/backend"
+fi
+backend_dir="${PAWRRTAL_BACKEND_DIR:-${default_backend_dir}}"
+env_file="${PAWRRTAL_ENV_FILE:-}"
+if [[ -z "${env_file}" && -f "${backend_dir}/.env" ]]; then
+	env_file="${backend_dir}/.env"
+fi
+if [[ -z "${env_file}" && -f "/mnt/HC_Volume_105512717/dev/pawrrtal/backend/.env" ]]; then
+	env_file="/mnt/HC_Volume_105512717/dev/pawrrtal/backend/.env"
+fi
 
 export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/pawrrtal-uv-cache}"
+mkdir -p "${UV_CACHE_DIR}"
 
 cd "${backend_dir}"
+if [[ -n "${env_file}" ]]; then
+	exec uv run python -m dotenv --file "${env_file}" run -- uv run paw "$@"
+fi
+
 exec uv run paw "$@"

--- a/scripts/paw
+++ b/scripts/paw
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+launcher_path="${BASH_SOURCE[0]}"
+while [[ -L "${launcher_path}" ]]; do
+	launcher_dir="$(cd -P -- "$(dirname -- "${launcher_path}")" && pwd)"
+	launcher_path="$(readlink -- "${launcher_path}")"
+	if [[ "${launcher_path}" != /* ]]; then
+		launcher_path="${launcher_dir}/${launcher_path}"
+	fi
+done
+script_dir="$(cd -P -- "$(dirname -- "${launcher_path}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
-if [[ -d "${repo_root}/backend" ]]; then
-	default_backend_dir="${repo_root}/backend"
+
+if [[ -n "${PAWRRTAL_BACKEND_DIR:-}" ]]; then
+	backend_dir="${PAWRRTAL_BACKEND_DIR}"
+elif [[ -d "${repo_root}/backend" ]]; then
+	backend_dir="${repo_root}/backend"
 else
-	default_backend_dir="/mnt/HC_Volume_105512717/dev/pawrrtal/backend"
+	printf 'Error: could not locate Pawrrtal backend. Set PAWRRTAL_BACKEND_DIR or run this launcher from the repository scripts directory.\n' >&2
+	exit 1
 fi
-backend_dir="${PAWRRTAL_BACKEND_DIR:-${default_backend_dir}}"
+
+if [[ ! -d "${backend_dir}" ]]; then
+	printf 'Error: Pawrrtal backend directory does not exist: %s\n' "${backend_dir}" >&2
+	exit 1
+fi
+
 env_file="${PAWRRTAL_ENV_FILE:-}"
 if [[ -z "${env_file}" && -f "${backend_dir}/.env" ]]; then
 	env_file="${backend_dir}/.env"
-fi
-if [[ -z "${env_file}" && -f "/mnt/HC_Volume_105512717/dev/pawrrtal/backend/.env" ]]; then
-	env_file="/mnt/HC_Volume_105512717/dev/pawrrtal/backend/.env"
 fi
 
 export UV_LINK_MODE="${UV_LINK_MODE:-copy}"

--- a/serve.ts
+++ b/serve.ts
@@ -28,6 +28,7 @@ setEnv('NODE_ENV', 'production');
 setEnvDefault('NEXT_TELEMETRY_DISABLED', '1');
 setEnvDefault('UV_CACHE_DIR', `${CACHE_DIR}/uv`);
 setEnvDefault('XDG_CACHE_HOME', `${CACHE_DIR}/xdg`);
+setEnvDefault('UV_LINK_MODE', 'copy');
 setEnvDefault('BACKEND_INTERNAL_URL', BACKEND_URL);
 setEnvDefault('HOSTNAME', FRONTEND_BIND_HOST);
 setEnvDefault('PORT', String(FRONTEND_PORT));
@@ -123,6 +124,8 @@ const managedProcesses: ManagedProcess[] = [
 		'run',
 		'--project',
 		'backend',
+		'python',
+		'-m',
 		'uvicorn',
 		'main:app',
 		'--app-dir',

--- a/serve.ts
+++ b/serve.ts
@@ -1,0 +1,152 @@
+/**
+ * Production loopback orchestrator for the Cloudflared deployment.
+ *
+ * Builds the standalone Next.js server, then runs it beside FastAPI on
+ * loopback ports. Cloudflared owns the public surface.
+ */
+import { type ChildProcess, spawn } from 'node:child_process';
+import { access, cp, mkdir, rm } from 'node:fs/promises';
+import { $ } from 'bun';
+import { DEV_BACKEND_PORT, DEV_FRONTEND_BIND_HOST, DEV_FRONTEND_PORT } from './scripts/dev-ports';
+
+const CACHE_DIR = '.cache';
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+const FRONTEND_DIR = 'frontend';
+const STANDALONE_APP_DIR = `${FRONTEND_DIR}/.next/standalone/frontend`;
+const STANDALONE_SERVER = `${STANDALONE_APP_DIR}/server.js`;
+const BACKEND_BIND_HOST = envValue('PAWRRTAL_BACKEND_HOST') ?? '127.0.0.1';
+const BACKEND_PORT = Number(envValue('PAWRRTAL_BACKEND_PORT') ?? DEV_BACKEND_PORT);
+const FRONTEND_BIND_HOST = envValue('HOSTNAME') ?? DEV_FRONTEND_BIND_HOST;
+const FRONTEND_PORT = Number(envValue('PORT') ?? DEV_FRONTEND_PORT);
+const BACKEND_URL = `http://${BACKEND_BIND_HOST}:${BACKEND_PORT}`;
+const FRONTEND_URL = `http://${FRONTEND_BIND_HOST}:${FRONTEND_PORT}`;
+
+await mkdir(`${CACHE_DIR}/uv`, { recursive: true });
+await mkdir(`${CACHE_DIR}/xdg`, { recursive: true });
+
+setEnv('NODE_ENV', 'production');
+setEnvDefault('NEXT_TELEMETRY_DISABLED', '1');
+setEnvDefault('UV_CACHE_DIR', `${CACHE_DIR}/uv`);
+setEnvDefault('XDG_CACHE_HOME', `${CACHE_DIR}/xdg`);
+setEnvDefault('BACKEND_INTERNAL_URL', BACKEND_URL);
+setEnvDefault('HOSTNAME', FRONTEND_BIND_HOST);
+setEnvDefault('PORT', String(FRONTEND_PORT));
+setEnv('ENV', 'prod');
+
+logInfo('Building frontend production bundle');
+await $`bun --filter pawrrtal build`;
+await access(STANDALONE_SERVER);
+await copyStandaloneAssets();
+
+logInfo(`Starting Pawrrtal production services: ${FRONTEND_URL} + ${BACKEND_URL}`);
+
+type ManagedProcess = {
+	name: string;
+	child: ChildProcess;
+};
+
+function envValue(name: string): string | undefined {
+	return process.env[name];
+}
+
+function setEnv(name: string, value: string): void {
+	process.env[name] = value;
+}
+
+function setEnvDefault(name: string, value: string): void {
+	process.env[name] ??= value;
+}
+
+function logInfo(message: string): void {
+	process.stderr.write(`${message}\n`);
+}
+
+async function copyStandaloneAssets(): Promise<void> {
+	const staticTarget = `${STANDALONE_APP_DIR}/.next/static`;
+	const publicTarget = `${STANDALONE_APP_DIR}/public`;
+	await rm(staticTarget, { recursive: true, force: true });
+	await rm(publicTarget, { recursive: true, force: true });
+	await cp(`${FRONTEND_DIR}/.next/static`, staticTarget, { recursive: true });
+	await cp(`${FRONTEND_DIR}/public`, publicTarget, { recursive: true });
+}
+
+function startManagedProcess(
+	name: string,
+	command: string,
+	args: readonly string[]
+): ManagedProcess {
+	const child = spawn(command, [...args], {
+		cwd: process.cwd(),
+		detached: true,
+		env: process.env,
+		stdio: 'inherit',
+	});
+	return { name, child };
+}
+
+function waitForExit(processInfo: ManagedProcess): Promise<number> {
+	return new Promise((resolve) => {
+		processInfo.child.once('exit', (code, signal) => {
+			if (signal) {
+				logInfo(`${processInfo.name} exited from signal ${signal}`);
+				resolve(1);
+				return;
+			}
+			resolve(code ?? 1);
+		});
+	});
+}
+
+async function stopProcess(processInfo: ManagedProcess): Promise<void> {
+	const pid = processInfo.child.pid;
+	if (!pid || processInfo.child.exitCode !== null) return;
+	try {
+		process.kill(-pid, 'SIGTERM');
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+	}
+	await Promise.race([
+		waitForExit(processInfo),
+		new Promise((resolve) => setTimeout(resolve, SHUTDOWN_TIMEOUT_MS)),
+	]);
+	if (processInfo.child.exitCode !== null) return;
+	try {
+		process.kill(-pid, 'SIGKILL');
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+	}
+}
+
+const managedProcesses: ManagedProcess[] = [
+	startManagedProcess('frontend', 'node', [STANDALONE_SERVER]),
+	startManagedProcess('backend', 'uv', [
+		'run',
+		'--project',
+		'backend',
+		'uvicorn',
+		'main:app',
+		'--app-dir',
+		'backend',
+		'--host',
+		BACKEND_BIND_HOST,
+		'--port',
+		String(BACKEND_PORT),
+	]),
+];
+
+let shuttingDown = false;
+
+async function shutdown(exitCode: number): Promise<never> {
+	if (shuttingDown) process.exit(exitCode);
+	shuttingDown = true;
+	await Promise.all(managedProcesses.map((processInfo) => stopProcess(processInfo)));
+	process.exit(exitCode);
+}
+
+process.once('SIGINT', () => void shutdown(130));
+process.once('SIGTERM', () => void shutdown(143));
+
+const exitCode = await Promise.race(
+	managedProcesses.map((processInfo) => waitForExit(processInfo))
+);
+await shutdown(exitCode);


### PR DESCRIPTION
## Summary
- Add a bundled Beans Tasks plugin that exposes workspace-local .beans task tools through the plugin capability system.
- Make the dev-admin shortcut reliable on mobile and before hydration by adding a browser fallback endpoint while preserving the existing API endpoint contract.
- Add a repo Paw launcher plus installable wrapper path so agents can call paw without spelling uv run.

## Verification
- bun run test -- features/auth/LoginFormView.test.tsx lib/api.url-resolution.test.ts
- bun run check
- cd backend && uv run ruff check app/infrastructure/auth/dev_login.py tests/test_auth_routes.py app/plugins/beans_tasks tests/test_beans_tasks_tool.py tests/test_plugin_tools.py
- cd backend && uv run pytest tests/test_auth_routes.py tests/test_beans_tasks_tool.py tests/test_plugin_tools.py
- cd backend && uv run paw plugins validate plugins/beans_tasks/plugin.json --source bundled --json
- just sentrux
- Manual Playwright mobile smokes against isolated worktree services:
  - no-JS fallback: /auth/dev-login/browser returned 303, landed on /, session cookie present, backend /api/v1/users/me returned 200
  - immediate JS tap: fallback path authenticated
  - hydrated JS tap: /auth/dev-login returned 204 and authenticated

## Notes
- This PR does not merge the broader plugin-core/channel/provider separation plan yet.
- This PR does not fix the Telegram reply runtime issue; recent live logs need a separate targeted pass.

## Summary by Sourcery

Add a Beans-backed tasks plugin and make the dev-admin login shortcut reliable across browsers and mobile, including a pre-hydration fallback, while extending tests and API endpoints accordingly.

New Features:
- Introduce Beans-backed workspace-local task tools (create, list, update, complete) exposed via the plugin system.
- Add a dev-admin browser fallback endpoint and form-based login path for pre-hydration and no-JS environments.
- Expose a new auth dev-login browser endpoint in the frontend API map.

Bug Fixes:
- Ensure dev-admin login works reliably on mobile by handling touch events without double-submission and supporting a redirect flow.
- Harden dev-login redirect handling to keep redirects local and safely propagate session cookies.

Enhancements:
- Refactor dev-login logic into shared helpers reused by API and browser fallback routes.
- Add tests for Beans tools, dev-login redirect safety, and mobile dev-admin behavior, including route mounting checks.
- Adjust auth tests to build a mounted app without database fixtures for route table assertions.
- Add support for disabling the Beans tasks plugin via plugin state configuration.

Build:
- Add a Paw script/launcher wiring for invoking backend tooling via an installable wrapper path.

Tests:
- Extend frontend login form and Playwright tests to cover dev-admin touch interactions and pre-hydration fallback behavior.
- Add backend tests for Beans task tools covering create/list/update/complete flows and ambiguous matches.
- Add backend tests for dev-login redirect safety, cookie propagation, and route mounting of new endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beans Tasks plugin: workspace .beans task management via agent tools (create/list/update/complete).
  * Browser-facing dev-admin login endpoint with safe redirect handling and session-preserving redirects.
  * Telegram: added a /tools command to list available agent tools and plugin capabilities.
  * Mobile-friendly dev-admin login handlers and a production "serve" command + systemd service support.

* **Tests**
  * Expanded coverage for dev-login flows, Beans tools end-to-end, plugin tooling, Telegram /tools, and mobile E2E login.

* **Documentation**
  * Plugin runtime/manifest docs and extension-boundary guidance added.

* **Chores**
  * Improved local launcher script and developer recipes for robust env and service handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->