### PR TITLE
Capture Pawrrtal retro operating lessons

### DIFF
--- a/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
+++ b/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pawrrtal-extension-boundaries
+description: Use when touching Pawrrtal channels, providers, tools, plugins, subagents, context providers, turn orchestration, or code that decides where an integration should live. Enforces the split between generic kernel code, manifest plugins, trusted runtime adapters, provider adapters, channel adapters, and agent runtime primitives.
+---
+
+# Pawrrtal Extension Boundaries
+
+Use this before changing backend extension code. The goal is a thin generic kernel with optional pieces installed as plugins.
+
+## Vocabulary
+
+- **Kernel**: generic runtime code that owns auth, workspaces, persistence, turn orchestration, plugin discovery, enabled state, env resolution, and stable interfaces.
+- **Plugin manifest**: `backend/plugins/<plugin_id>/plugin.json`. Declarative metadata: capabilities, env requirements, validation commands, permissions, slots, and entrypoints.
+- **Plugin runtime**: `backend/app/plugins/`. Trusted host code plus bundled Python implementations that a manifest may activate.
+- **Provider adapter**: code that talks to one model provider or provider CLI. It belongs under `backend/app/providers/` or behind a provider plugin capability.
+- **Channel adapter**: code that talks to one user surface such as Telegram or Google Chat. It belongs under `backend/app/channels/` or behind a channel plugin capability.
+- **Tool adapter**: code that exposes one agent tool. Tool selection happens in the tool-surface/plugin layer, not inside providers.
+- **Subagent**: an agent-runtime primitive. Plugins may invoke subagents or contribute agent profiles, but plugins do not implement the subagent kernel.
+- **Slot**: a named extension point where multiple plugins can fit, such as `tasks`, `web_search`, `channel:telegram`, `provider:models`, or `conversation_memory`.
+
+## Directory Rules
+
+- Put bundled plugin manifests in `backend/plugins/<plugin_id>/plugin.json`.
+- Put trusted plugin host code and bundled implementations in `backend/app/plugins/`.
+- Put provider-specific code in `backend/app/providers/<provider>/`.
+- Put channel-specific code in `backend/app/channels/<channel>/`.
+- Keep `backend/app/chat/` provider-agnostic and channel-agnostic.
+- Keep `backend/app/conversations/` free of provider-specific helpers.
+- Keep turn orchestration free of provider, channel, and tool special cases.
+- Providers translate generic `AgentTool` values into SDK-specific formats; they do not import tool factories.
+- Channels choose a model and call the generic turn runner; they do not import provider internals.
+- Plugins do not import each other directly. Share behavior through kernel interfaces, slots, or runtime adapters.
+
+## Before Adding Code
+
+1. Name the capability type: `provider`, `channel`, `cli_tool`, `python_tool`, `turn_context_provider`, `conversation_memory`, `agent_runtime`, `agent_profile`, `router`, `settings`, or `scheduler`.
+2. Name the slot if users may choose among multiple implementations.
+3. Decide whether the code is generic kernel code or a trusted bundled adapter.
+4. Add or update the manifest first when the behavior is optional.
+5. Declare env requirements in the manifest. Use `user_workspace` or `workspace` scope when values must be overridable per workspace/user.
+6. Keep enabled/disabled behavior explicit. Disabled plugins must not advertise tools, providers, channels, or context providers.
+7. Add tests at the interface: manifest validation, registry/slot resolution, enabled-state behavior, env gating, and the runtime adapter.
+8. Verify through Paw when the behavior affects a user-visible flow.
+
+## Smells To Fix
+
+| Smell | Fix |
+| --- | --- |
+| `chat/` imports a provider, MCP adapter, or channel module | Move behavior behind a generic interface or plugin capability. |
+| `conversations/` contains `gemini_*`, `codex_*`, or another provider name | Move it to the provider package and expose a generic history adapter. |
+| Turn orchestration checks for one provider, tool, or channel by name | Emit or handle a generic event, or add an adapter hook. |
+| A provider imports tool factories | Pass generic `AgentTool` values into the provider and translate there. |
+| A channel formats tools, keyboards, or command output ad hoc | Move reusable formatting to channel runtime helpers or a channel adapter. |
+| Plugin code reads `os.environ` directly for user/workspace settings | Declare env in the manifest and use the plugin env resolver. |
+| A plugin is always on because it exists on disk | Add enabled-state tests and make the manifest default intentional. |
+| A subagent is implemented as a plugin | Move orchestration to the agent runtime and let plugins contribute profiles or invoke it. |
+
+## Verification
+
+Use Paw as the operator surface:
+
+```bash
+paw plugins spec --json
+paw plugins list --json
+paw plugins capabilities search --slot tasks --json
+paw plugins slots list --json
+paw plugins validate backend/plugins/<plugin_id>/plugin.json --source bundled --json
+```
+
+For runtime changes, add focused tests and then run the relevant gates:
+
+```bash
+cd backend && uv run pytest tests/test_plugin_discovery.py tests/test_plugin_tools.py
+cd backend && uv run pytest tests/test_channel_plugins.py tests/test_provider_plugins.py
+paw verify chat-roundtrip --json
+```
+
+Run broader CI gates before claiming the PR is ready.

--- a/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
+++ b/.agents/skills/pawrrtal-extension-boundaries/SKILL.md
@@ -57,14 +57,14 @@ Use this before changing backend extension code. The goal is a thin generic kern
 
 ## Verification
 
-Use Paw as the operator surface:
+Use Paw as the operator surface. From the repo root, prefer `just paw`; from `backend/`, use `uv run paw`.
 
 ```bash
-paw plugins spec --json
-paw plugins list --json
-paw plugins capabilities search --slot tasks --json
-paw plugins slots list --json
-paw plugins validate backend/plugins/<plugin_id>/plugin.json --source bundled --json
+just paw plugins spec --json
+just paw plugins list --json
+just paw plugins capabilities search --slot tasks --json
+just paw plugins slots list --json
+just paw plugins validate backend/plugins/<plugin_id>/plugin.json --source bundled --json
 ```
 
 For runtime changes, add focused tests and then run the relevant gates:
@@ -72,7 +72,7 @@ For runtime changes, add focused tests and then run the relevant gates:
 ```bash
 cd backend && uv run pytest tests/test_plugin_discovery.py tests/test_plugin_tools.py
 cd backend && uv run pytest tests/test_channel_plugins.py tests/test_provider_plugins.py
-paw verify chat-roundtrip --json
+cd backend && uv run paw verify chat-roundtrip --json
 ```
 
 Run broader CI gates before claiming the PR is ready.

--- a/.agents/skills/pawrrtal-live-ops/SKILL.md
+++ b/.agents/skills/pawrrtal-live-ops/SKILL.md
@@ -29,7 +29,7 @@ Read the relevant cookbook before acting:
 
 1. Do not trust memory. Inspect the live service state every time.
 2. Do not print tokens, credential JSON, origin certs, database URLs, service tokens, or bot tokens.
-3. Prefer `paw` for user-visible verification, but if `paw` fails before HTTP due local env drift, switch to live process logs and raw HTTP checks.
+3. Prefer `paw` for user-visible verification, but if `paw` fails before HTTP due to local env drift, switch to live process logs and raw HTTP checks.
 4. Compare the live process checkout and commit against the commit you think is deployed.
 5. If the database schema is involved, run migrations against the live service database, not the shell default.
 6. Use real provider/channel/browser proof when the user-visible claim depends on real integrations. Simulated Telegram or mocked provider tests are not enough to claim live behavior.

--- a/.agents/skills/pawrrtal-live-ops/SKILL.md
+++ b/.agents/skills/pawrrtal-live-ops/SKILL.md
@@ -22,6 +22,7 @@ Read the relevant cookbook before acting:
 | Live audit | [cookbook/live-audit.md](cookbook/live-audit.md) | Prove what is running and whether local/public origins are healthy. |
 | Functional verification | [cookbook/verify.md](cookbook/verify.md) | Prove user-visible flows such as login, chat, providers, and frontend checks. |
 | Telegram diagnosis | [cookbook/telegram.md](cookbook/telegram.md) | Telegram receives no reply, commands fail, polling/webhook is suspect, or bindings look wrong. |
+| Runner operations | `pawrrtal-runner-ops` skill | Start, stop, lock, clean, or inspect self-hosted GitHub Actions runners. |
 | Shutdown | [cookbook/take-down.md](cookbook/take-down.md) | Stop Pawrrtal cleanly, disable it, or prove it is down. |
 
 ## Operating Rules
@@ -31,7 +32,8 @@ Read the relevant cookbook before acting:
 3. Prefer `paw` for user-visible verification, but if `paw` fails before HTTP due local env drift, switch to live process logs and raw HTTP checks.
 4. Compare the live process checkout and commit against the commit you think is deployed.
 5. If the database schema is involved, run migrations against the live service database, not the shell default.
-6. After starting self-hosted runners for CI or verification, clean them and prove no runner services or processes remain.
+6. Use real provider/channel/browser proof when the user-visible claim depends on real integrations. Simulated Telegram or mocked provider tests are not enough to claim live behavior.
+7. After touching self-hosted runners for CI or verification, use `pawrrtal-runner-ops` and prove runner location, labels, processes, services, and disk state.
 
 ## Fast Triage
 

--- a/.agents/skills/pawrrtal-live-ops/cookbook/verify.md
+++ b/.agents/skills/pawrrtal-live-ops/cookbook/verify.md
@@ -36,7 +36,7 @@ uv run paw verify all --json
 
 Use focused suites first when debugging. Use `verify all` as a release gate, not as the first diagnostic tool.
 
-When the claim involves subscription-auth providers or live model behavior, run at least one real model roundtrip through Paw with the same workspace/user the app uses:
+When the claim involves subscription-auth providers or live model behavior, run at least one real model roundtrip through Paw with the same workspace/user the app uses. The model must mirror the production/channel default being claimed. Discover that default from the live process environment, the channel diagnostics, or `paw models ls --json` plus the workspace's configured default before choosing the verifier model.
 
 ```bash
 cd backend

--- a/.agents/skills/pawrrtal-live-ops/cookbook/verify.md
+++ b/.agents/skills/pawrrtal-live-ops/cookbook/verify.md
@@ -36,6 +36,15 @@ uv run paw verify all --json
 
 Use focused suites first when debugging. Use `verify all` as a release gate, not as the first diagnostic tool.
 
+When the claim involves subscription-auth providers or live model behavior, run at least one real model roundtrip through Paw with the same workspace/user the app uses:
+
+```bash
+cd backend
+paw verify chat-roundtrip --model <provider:model> --json
+```
+
+Do not claim "real models work" from mocked tests, provider list output, a token-presence check, or a simulated channel path. The evidence must include a successful final response from a live model call and the corresponding Paw verifier result.
+
 ### 4. Verify frontend and browser behavior
 
 Run project gates from the checkout that will be deployed:
@@ -71,5 +80,6 @@ Summarize:
 - Local health result.
 - Public Access result.
 - Paw verifier results.
+- Real model and channel proof when relevant.
 - Browser smoke result.
 - Any skipped check and why it was not authoritative.

--- a/.agents/skills/pawrrtal-pr-scope-audit/SKILL.md
+++ b/.agents/skills/pawrrtal-pr-scope-audit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pawrrtal-pr-scope-audit
+description: Audit whether Pawrrtal work is actually in the intended PR and matches the user's full requested scope. Use when continuing long goals, answering "is everything in this PR?", before saying a PR is ready, after operational VPS work, or whenever implementation, CI, reviews, live deploy, and runtime checks are mixed together.
+---
+
+# Pawrrtal PR Scope Audit
+
+Use this before claiming that a long Pawrrtal task is complete or that a PR contains the work.
+
+## Rule
+
+Separate **repo changes**, **live operations**, **CI/review state**, and **unimplemented scope**. Do not compress them into "done."
+
+## Checklist
+
+1. **Identify the authoritative branch and PR.**
+
+   ```bash
+   git status --short --branch
+   git rev-parse --show-toplevel
+   git rev-parse --abbrev-ref HEAD
+   gh pr view <number> --json number,title,headRefName,baseRefName,url,reviewDecision,statusCheckRollup
+   ```
+
+2. **Measure the PR honestly.**
+
+   ```bash
+   git rev-list --count origin/main..HEAD
+   git log --oneline origin/main..HEAD
+   git diff --stat origin/main...HEAD
+   ```
+
+3. **Map work to the user's requirements.** Make a table with:
+
+   | Requirement | Evidence in PR | Runtime/ops evidence | Status |
+   | --- | --- | --- | --- |
+
+   Status must be one of: `proven`, `partial`, `ops-only`, `missing`, `blocked`.
+
+4. **Call out work that is not in the PR.** VPS configuration, service restarts, live smoke tests, runner setup, Cloudflare settings, and manual GitHub settings are not PR code unless committed as docs/scripts/workflows.
+5. **Do not let a small passing subset redefine the goal.** If the user asked for provider/channel/core plugin architecture, a live deploy PR is not that architecture work.
+6. **Check review threads and CI from GitHub, not memory.**
+
+   ```bash
+   gh pr checks <number>
+   gh api graphql -f query='...' # review thread query when resolving comments
+   ```
+
+7. **Before pushing, stage only your files.** The Pawrrtal worktree is shared; never use `git add -A` for a mixed tree.
+
+## Answer Shape
+
+Lead with the truth:
+
+- "Yes, the PR contains X, Y, Z."
+- "No, it does not contain A, B, C."
+- "These items were operational work outside the PR."
+- "These checks are still pending/failing."
+
+Do not soften missing scope with "pre-existing" or "mostly." If it is not proved, it is not done.

--- a/.agents/skills/pawrrtal-pr-scope-audit/SKILL.md
+++ b/.agents/skills/pawrrtal-pr-scope-audit/SKILL.md
@@ -25,9 +25,11 @@ Separate **repo changes**, **live operations**, **CI/review state**, and **unimp
 2. **Measure the PR honestly.**
 
    ```bash
-   git rev-list --count origin/main..HEAD
-   git log --oneline origin/main..HEAD
-   git diff --stat origin/main...HEAD
+   BASE_REF="$(gh pr view <number> --json baseRefName --jq .baseRefName)"
+   git fetch origin "$BASE_REF"
+   git rev-list --count "origin/${BASE_REF}..HEAD"
+   git log --oneline "origin/${BASE_REF}..HEAD"
+   git diff --stat "origin/${BASE_REF}...HEAD"
    ```
 
 3. **Map work to the user's requirements.** Make a table with:

--- a/.agents/skills/pawrrtal-runner-ops/SKILL.md
+++ b/.agents/skills/pawrrtal-runner-ops/SKILL.md
@@ -11,7 +11,7 @@ Use this before touching GitHub Actions runners for Pawrrtal.
 
 1. Runner work directories, `_work`, `_tool`, caches, and temp state belong under `/mnt/HC_Volume_105512717/github-runners/`. Never put them on `/`, `/root`, or the VPS main disk.
 2. Do not print runner registration tokens, removal tokens, repository tokens, secrets, service tokens, or environment files.
-3. Public-repo self-hosted jobs must be locked by workflow policy, not trust. Jobs must gate on `github.actor == 'OctavianTocan'` and self-hosted jobs should require the `octavian-only` label.
+3. Public-repo self-hosted jobs must be locked by workflow policy, not trust. Jobs must gate on `github.actor == 'OctavianTocan'`. If workflows require an `octavian-only` label, the runner launcher and CI handbook must register that label in the same PR.
 4. Use repo-scoped runners for `OctavianTocan/Pawrrtal-AI`. Do not create org/global runners for this repo without explicit user approval.
 5. Installing persistent runner services is a security model change. Get explicit approval after stating the blast radius.
 
@@ -28,14 +28,21 @@ If the repo has intentionally renamed labels, paths, or scripts, follow the chec
 
 ## Runner Labels
 
-Use these labels for Pawrrtal runners unless the workflow intentionally needs a narrower pool:
+Use the labels that the checked-in launcher and CI handbook agree on. Current `main` defaults to:
 
 ```text
 self-hosted
 openclaw-mini
 pawrrtal
-octavian-only
 ```
+
+When moving to an explicit `octavian-only` runner pool, update all of these together:
+
+- `.github/workflows/**` `runs-on` labels
+- `scripts/ephemeral-self-hosted-runners.sh` `LABELS`
+- `frontend/content/docs/handbook/ci/self-hosted-runner.md`
+- `AGENTS.md`
+- this skill
 
 ## Before Starting Runners
 
@@ -55,7 +62,7 @@ When explicitly approved, persistent runners should be:
 - under `/mnt/HC_Volume_105512717/github-runners/pawrrtal-persistent/`
 - one system user per runner
 - repo-scoped to `OctavianTocan/Pawrrtal-AI`
-- labeled with `pawrrtal`, `openclaw-mini`, and `octavian-only`
+- labeled to match the checked-in workflow requirements
 - resource-bounded with systemd CPU, memory, task, and IO limits
 - configured so `HOME`, `RUNNER_TOOL_CACHE`, `ACTIONS_RUNNER_TEMP`, `UV_CACHE_DIR`, `BUN_INSTALL_CACHE_DIR`, and `npm_config_cache` point inside the runner directory
 

--- a/.agents/skills/pawrrtal-runner-ops/SKILL.md
+++ b/.agents/skills/pawrrtal-runner-ops/SKILL.md
@@ -15,6 +15,17 @@ Use this before touching GitHub Actions runners for Pawrrtal.
 4. Use repo-scoped runners for `OctavianTocan/Pawrrtal-AI`. Do not create org/global runners for this repo without explicit user approval.
 5. Installing persistent runner services is a security model change. Get explicit approval after stating the blast radius.
 
+## Authoritative Discovery
+
+Treat this skill as the policy, but confirm the current repo constants before editing workflows or installing runners:
+
+```bash
+rg -n "github\\.actor|octavian-only|runs-on: \\[self-hosted|github-runners|ephemeral-self-hosted-runners" AGENTS.md .github/workflows frontend/content/docs scripts
+df -h / /mnt/HC_Volume_105512717
+```
+
+If the repo has intentionally renamed labels, paths, or scripts, follow the checked-in policy and update this skill in the same PR.
+
 ## Runner Labels
 
 Use these labels for Pawrrtal runners unless the workflow intentionally needs a narrower pool:

--- a/.agents/skills/pawrrtal-runner-ops/SKILL.md
+++ b/.agents/skills/pawrrtal-runner-ops/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pawrrtal-runner-ops
+description: Operate Pawrrtal self-hosted GitHub Actions runners safely. Use when starting, stopping, installing, debugging, replacing, scaling, cleaning, or checking CI runners for Pawrrtal, especially on the VPS mounted volume.
+---
+
+# Pawrrtal Runner Ops
+
+Use this before touching GitHub Actions runners for Pawrrtal.
+
+## Non-Negotiables
+
+1. Runner work directories, `_work`, `_tool`, caches, and temp state belong under `/mnt/HC_Volume_105512717/github-runners/`. Never put them on `/`, `/root`, or the VPS main disk.
+2. Do not print runner registration tokens, removal tokens, repository tokens, secrets, service tokens, or environment files.
+3. Public-repo self-hosted jobs must be locked by workflow policy, not trust. Jobs must gate on `github.actor == 'OctavianTocan'` and self-hosted jobs should require the `octavian-only` label.
+4. Use repo-scoped runners for `OctavianTocan/Pawrrtal-AI`. Do not create org/global runners for this repo without explicit user approval.
+5. Installing persistent runner services is a security model change. Get explicit approval after stating the blast radius.
+
+## Runner Labels
+
+Use these labels for Pawrrtal runners unless the workflow intentionally needs a narrower pool:
+
+```text
+self-hosted
+openclaw-mini
+pawrrtal
+octavian-only
+```
+
+## Before Starting Runners
+
+```bash
+df -h / /mnt/HC_Volume_105512717
+gh api repos/OctavianTocan/Pawrrtal-AI/actions/runners --jq '{total_count, runners: [.runners[] | {name, status, busy, labels: [.labels[].name]}]}'
+ps -eo pid,user,cmd | rg 'actions-runner|Runner.Listener|Runner.Worker|gh pr checks' || true
+rg -n "github\\.actor|runs-on: \\[self-hosted|octavian-only" .github/workflows
+```
+
+If disk is tight, clean stale runner workdirs before adding capacity.
+
+## Persistent Runner Shape
+
+When explicitly approved, persistent runners should be:
+
+- under `/mnt/HC_Volume_105512717/github-runners/pawrrtal-persistent/`
+- one system user per runner
+- repo-scoped to `OctavianTocan/Pawrrtal-AI`
+- labeled with `pawrrtal`, `openclaw-mini`, and `octavian-only`
+- resource-bounded with systemd CPU, memory, task, and IO limits
+- configured so `HOME`, `RUNNER_TOOL_CACHE`, `ACTIONS_RUNNER_TEMP`, `UV_CACHE_DIR`, `BUN_INSTALL_CACHE_DIR`, and `npm_config_cache` point inside the runner directory
+
+## Ephemeral Runner Shape
+
+Only use ephemeral runners when the user asks for ephemeral behavior or the security model requires it. Use bounded batches and tags, then clean them.
+
+```bash
+scripts/ephemeral-self-hosted-runners.sh start --count <N> --tag <tag>
+scripts/ephemeral-self-hosted-runners.sh cleanup --count <N> --tag <tag>
+```
+
+## After CI Work
+
+Always prove the runner state and disk state:
+
+```bash
+gh api repos/OctavianTocan/Pawrrtal-AI/actions/runners --jq '{total_count, runners: [.runners[] | {name, status, busy, labels: [.labels[].name]}]}'
+systemctl list-units --type=service --all 'pawrrtal-gha-*.service' --no-pager
+ps -eo pid,user,cmd | rg 'actions-runner|Runner.Listener|Runner.Worker|ephemeral-self-hosted-runners' || true
+df -h / /mnt/HC_Volume_105512717
+```
+
+Report where runners live, which labels they have, whether any are busy, and how much disk remains.

--- a/.agents/skills/retro/SKILL.md
+++ b/.agents/skills/retro/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: retro
+description: Turn a bad or long Pawrrtal work session into durable project learning. Use when the user says $retro, asks to learn from a session, says too much went wrong, or asks to create/update skills or rules from recent failures.
+---
+
+# Retro
+
+Use this when the user wants the project to learn from a messy session. The goal is not a report; the goal is to change the next agent's behavior.
+
+## Process
+
+1. **Extract incidents from evidence.** Use the current thread, git diff, PR state, logs, and commands. Do not rely on vibes or blame.
+2. **Name each failure mode.** Phrase it as an action that should happen next time, such as "prove live Telegram with real delivery before claiming it works."
+3. **Choose the durable artifact.**
+   - Repeated workflow mistake: create or update a skill.
+   - Repo-wide rule: update `AGENTS.md` or a `.claude/rules/**` file.
+   - Product/code task: create a bean with the `beans` CLI.
+   - One-off fact that should be remembered across sessions: write a Codex memory note only when the user explicitly asked to remember it.
+4. **Prefer small skills over one giant policy.** A skill should trigger for a specific situation and fit in one context read.
+5. **Add verification to every skill.** The skill must say what evidence proves the agent followed it.
+6. **Reference project skills from `AGENTS.md`.** Future agents should discover them without guessing names.
+7. **Validate metadata.** Every skill description must include clear "Use when..." triggers and stay under 1024 characters.
+
+## Incident Patterns To Capture
+
+| Pattern | Durable Fix |
+| --- | --- |
+| Long-running goal drifts into a tiny PR | Add a scope-audit skill that maps requirements to commits, runtime work, PR diff, and missing items. |
+| "Works" claimed from a simulation only | Add live-ops verification requiring real browser/channel/provider proof. |
+| CI runners consume the wrong disk or wrong trust model | Add runner-ops instructions covering placement, labels, actor gates, and cleanup. |
+| Generic core gets provider/channel/tool details | Add extension-boundary instructions and tests at the interface. |
+| Secrets or credentials could leak in logs | Add redaction and "do not print" rules to the relevant operational skill. |
+| The user asks "why" after a failure | Answer from current evidence first, then make the durable fix. |
+
+## Output
+
+When done, report:
+
+- Skills/rules added or changed.
+- Which incident each artifact prevents.
+- Validation run.
+- Anything intentionally left for a follow-up bean or PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,14 @@ The Notion database query revealed the complete project scope after user questio
 Access 85k tokens of past work via get_observations([IDs]) or mem-search skill.
 ## Agent skills
 
+Use project skills before improvising recurring Pawrrtal workflows:
+
+- `retro` — use after a messy or long session to turn failures into durable skills, rules, beans, or memory notes.
+- `pawrrtal-pr-scope-audit` — use before answering whether work is really in a PR, before claiming a long goal is complete, or when repo work and VPS operations were mixed together.
+- `pawrrtal-live-ops` — use for live deployment, Cloudflared, Telegram, database, browser, shutdown, and real integration verification.
+- `pawrrtal-runner-ops` — use before touching self-hosted GitHub Actions runners; runner state must stay on `/mnt/HC_Volume_105512717/github-runners/` and self-hosted jobs must be locked to Octavian-only workflow gates.
+- `pawrrtal-extension-boundaries` — use before changing providers, channels, tools, plugins, subagents, context providers, or turn orchestration.
+
 ### Issue tracker
 
 Local markdown via `beans` CLI — tasks live in `.beans/` as individual markdown files with frontmatter (`status`, `type`, `priority`, `tags`). See `frontend/content/docs/handbook/agents/issue-tracker.md`.

--- a/backend/plugins/google_chat_channel/plugin.json
+++ b/backend/plugins/google_chat_channel/plugin.json
@@ -1,75 +1,75 @@
 {
-  "schema_version": 1,
-  "id": "google_chat_channel",
-  "name": "Google Chat Channel",
-  "description": "Google Chat Pub/Sub ingress and message delivery for Pawrrtal.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["network", "external_read", "external_write"],
-  "env": [
-    {
-      "name": "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Service Account File",
-      "description": "Path to the Google Cloud service account JSON used for Chat and Pub/Sub."
-    },
-    {
-      "name": "GOOGLE_CHAT_PROJECT_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Project ID",
-      "description": "Google Cloud project that owns the Pub/Sub resources."
-    },
-    {
-      "name": "GOOGLE_CHAT_SUBSCRIPTION_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Subscription ID",
-      "description": "Pub/Sub pull subscription that receives inbound Google Chat events."
-    },
-    {
-      "name": "GOOGLE_CHAT_DEV_ADMIN_ID",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Google Chat Dev Admin ID",
-      "description": "Optional sender resource name that auto-links to the seeded dev admin."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "channel",
-      "id": "google_chat",
-      "title": "Google Chat",
-      "description": "Receives Google Chat events and sends formatted Pawrrtal responses.",
-      "tags": ["chat", "google-chat", "messaging"],
-      "intents": ["message", "notify", "workspace-chat"],
-      "slots": ["channel:google_chat", "channel:messaging"],
-      "priority": 90,
-      "exposure": "catalog",
-      "permissions": ["network", "external_read", "external_write"],
-      "risk": "external_write",
-      "surface": "google_chat",
-      "entrypoint": "app.channels.plugin_adapters:make_google_chat_channel",
-      "commands": {
-        "slash": ["status", "compact"],
-        "cards": ["placeholder", "final_answer"],
-        "formatting": ["google_chat_markdown"]
-      },
-      "lifespan": {
-        "entrypoint": "app.channels.google_chat:google_chat_lifespan",
-        "context_key": "google_chat_lifespan_context",
-        "service_key": "google_chat_service",
-        "order": 72
-      }
-    }
-  ]
+	"schema_version": 1,
+	"id": "google_chat_channel",
+	"name": "Google Chat Channel",
+	"description": "Google Chat Pub/Sub ingress and message delivery for Pawrrtal.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["network", "external_read", "external_write"],
+	"env": [
+		{
+			"name": "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Service Account File",
+			"description": "Path to the Google Cloud service account JSON used for Chat and Pub/Sub."
+		},
+		{
+			"name": "GOOGLE_CHAT_PROJECT_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Project ID",
+			"description": "Google Cloud project that owns the Pub/Sub resources."
+		},
+		{
+			"name": "GOOGLE_CHAT_SUBSCRIPTION_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Subscription ID",
+			"description": "Pub/Sub pull subscription that receives inbound Google Chat events."
+		},
+		{
+			"name": "GOOGLE_CHAT_DEV_ADMIN_ID",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Google Chat Dev Admin ID",
+			"description": "Optional sender resource name that auto-links to the seeded dev admin."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "channel",
+			"id": "google_chat",
+			"title": "Google Chat",
+			"description": "Receives Google Chat events and sends formatted Pawrrtal responses.",
+			"tags": ["chat", "google-chat", "messaging"],
+			"intents": ["message", "notify", "workspace-chat"],
+			"slots": ["channel:google_chat", "channel:messaging"],
+			"priority": 90,
+			"exposure": "catalog",
+			"permissions": ["network", "external_read", "external_write"],
+			"risk": "external_write",
+			"surface": "google_chat",
+			"entrypoint": "app.channels.plugin_adapters:make_google_chat_channel",
+			"commands": {
+				"slash": ["status", "compact"],
+				"cards": ["placeholder", "final_answer"],
+				"formatting": ["google_chat_markdown"]
+			},
+			"lifespan": {
+				"entrypoint": "app.channels.google_chat:google_chat_lifespan",
+				"context_key": "google_chat_lifespan_context",
+				"service_key": "google_chat_service",
+				"order": 72
+			}
+		}
+	]
 }

--- a/backend/plugins/lcm_memory/plugin.json
+++ b/backend/plugins/lcm_memory/plugin.json
@@ -1,48 +1,48 @@
 {
-  "schema_version": 1,
-  "id": "lcm_memory",
-  "name": "LCM Memory",
-  "description": "Conversation history assembly, ingest, and compaction backed by LCM.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["external_read", "costly"],
-  "env": [
-    {
-      "name": "LCM_ENABLED",
-      "required": false,
-      "scope": "workspace",
-      "overridable": true,
-      "gateway_fallback": true,
-      "secret": false,
-      "label": "LCM Enabled",
-      "description": "Enables LCM history assembly and post-turn compaction."
-    },
-    {
-      "name": "LCM_SUMMARY_MODEL",
-      "required": false,
-      "scope": "user_workspace",
-      "overridable": true,
-      "gateway_fallback": true,
-      "secret": false,
-      "label": "LCM Summary Model",
-      "description": "Optional model used for LCM summary generation."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "conversation_memory",
-      "id": "lcm",
-      "title": "LCM",
-      "description": "Uses LCM context items to assemble history and compact completed turns.",
-      "tags": ["memory", "conversation-history", "compaction"],
-      "intents": ["history", "compaction", "long-context"],
-      "slots": ["conversation_memory"],
-      "priority": 100,
-      "exposure": "catalog",
-      "permissions": ["external_read", "costly"],
-      "risk": "costly",
-      "entrypoint": "app.plugins.lcm_memory.backend:create_memory_backend",
-      "order": 100
-    }
-  ]
+	"schema_version": 1,
+	"id": "lcm_memory",
+	"name": "LCM Memory",
+	"description": "Conversation history assembly, ingest, and compaction backed by LCM.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["external_read", "costly"],
+	"env": [
+		{
+			"name": "LCM_ENABLED",
+			"required": false,
+			"scope": "workspace",
+			"overridable": true,
+			"gateway_fallback": true,
+			"secret": false,
+			"label": "LCM Enabled",
+			"description": "Enables LCM history assembly and post-turn compaction."
+		},
+		{
+			"name": "LCM_SUMMARY_MODEL",
+			"required": false,
+			"scope": "user_workspace",
+			"overridable": true,
+			"gateway_fallback": true,
+			"secret": false,
+			"label": "LCM Summary Model",
+			"description": "Optional model used for LCM summary generation."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "conversation_memory",
+			"id": "lcm",
+			"title": "LCM",
+			"description": "Uses LCM context items to assemble history and compact completed turns.",
+			"tags": ["memory", "conversation-history", "compaction"],
+			"intents": ["history", "compaction", "long-context"],
+			"slots": ["conversation_memory"],
+			"priority": 100,
+			"exposure": "catalog",
+			"permissions": ["external_read", "costly"],
+			"risk": "costly",
+			"entrypoint": "app.plugins.lcm_memory.backend:create_memory_backend",
+			"order": 100
+		}
+	]
 }

--- a/backend/plugins/telegram_channel/plugin.json
+++ b/backend/plugins/telegram_channel/plugin.json
@@ -1,97 +1,97 @@
 {
-  "schema_version": 1,
-  "id": "telegram_channel",
-  "name": "Telegram Channel",
-  "description": "Telegram bot ingress, commands, keyboards, formatting, and delivery for Pawrrtal.",
-  "version": "1.0.0",
-  "enabled_by_default": true,
-  "permissions": ["network", "external_read", "external_write"],
-  "env": [
-    {
-      "name": "TELEGRAM_BOT_TOKEN",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": true,
-      "label": "Telegram Bot Token",
-      "description": "Bot token used to receive updates and send Telegram messages."
-    },
-    {
-      "name": "TELEGRAM_BOT_USERNAME",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Bot Username",
-      "description": "Bot username shown to users during channel linking."
-    },
-    {
-      "name": "TELEGRAM_MODE",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Mode",
-      "description": "Telegram runtime mode, usually polling locally or webhook in production."
-    },
-    {
-      "name": "TELEGRAM_WEBHOOK_URL",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": false,
-      "label": "Telegram Webhook URL",
-      "description": "Public webhook URL used when TELEGRAM_MODE is webhook."
-    },
-    {
-      "name": "TELEGRAM_WEBHOOK_SECRET",
-      "required": false,
-      "scope": "gateway",
-      "overridable": false,
-      "secret": true,
-      "label": "Telegram Webhook Secret",
-      "description": "Secret header value required for Telegram webhook requests."
-    }
-  ],
-  "capabilities": [
-    {
-      "type": "channel",
-      "id": "telegram",
-      "title": "Telegram",
-      "description": "Receives Telegram updates and sends formatted Pawrrtal responses.",
-      "tags": ["chat", "telegram", "messaging"],
-      "intents": ["message", "notify", "bot"],
-      "slots": ["channel:telegram", "channel:messaging"],
-      "priority": 100,
-      "exposure": "catalog",
-      "permissions": ["network", "external_read", "external_write"],
-      "risk": "external_write",
-      "surface": "telegram",
-      "entrypoint": "app.channels.plugin_adapters:make_telegram_channel",
-      "commands": {
-        "slash": [
-          "start",
-          "new",
-          "model",
-          "thinking",
-          "config",
-          "verbose",
-          "stop",
-          "status",
-          "whoami",
-          "lcm",
-          "compact"
-        ],
-        "inline_keyboards": ["model", "thinking", "status", "regenerate"],
-        "formatting": ["telegram_html", "chunked_delivery"]
-      },
-      "lifespan": {
-        "entrypoint": "app.channels.telegram:telegram_lifespan",
-        "context_key": "telegram_lifespan_context",
-        "service_key": "telegram_service",
-        "order": 70,
-        "post_start": "app.channels.telegram.notifications:register_telegram_notifications"
-      }
-    }
-  ]
+	"schema_version": 1,
+	"id": "telegram_channel",
+	"name": "Telegram Channel",
+	"description": "Telegram bot ingress, commands, keyboards, formatting, and delivery for Pawrrtal.",
+	"version": "1.0.0",
+	"enabled_by_default": true,
+	"permissions": ["network", "external_read", "external_write"],
+	"env": [
+		{
+			"name": "TELEGRAM_BOT_TOKEN",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": true,
+			"label": "Telegram Bot Token",
+			"description": "Bot token used to receive updates and send Telegram messages."
+		},
+		{
+			"name": "TELEGRAM_BOT_USERNAME",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Bot Username",
+			"description": "Bot username shown to users during channel linking."
+		},
+		{
+			"name": "TELEGRAM_MODE",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Mode",
+			"description": "Telegram runtime mode, usually polling locally or webhook in production."
+		},
+		{
+			"name": "TELEGRAM_WEBHOOK_URL",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": false,
+			"label": "Telegram Webhook URL",
+			"description": "Public webhook URL used when TELEGRAM_MODE is webhook."
+		},
+		{
+			"name": "TELEGRAM_WEBHOOK_SECRET",
+			"required": false,
+			"scope": "gateway",
+			"overridable": false,
+			"secret": true,
+			"label": "Telegram Webhook Secret",
+			"description": "Secret header value required for Telegram webhook requests."
+		}
+	],
+	"capabilities": [
+		{
+			"type": "channel",
+			"id": "telegram",
+			"title": "Telegram",
+			"description": "Receives Telegram updates and sends formatted Pawrrtal responses.",
+			"tags": ["chat", "telegram", "messaging"],
+			"intents": ["message", "notify", "bot"],
+			"slots": ["channel:telegram", "channel:messaging"],
+			"priority": 100,
+			"exposure": "catalog",
+			"permissions": ["network", "external_read", "external_write"],
+			"risk": "external_write",
+			"surface": "telegram",
+			"entrypoint": "app.channels.plugin_adapters:make_telegram_channel",
+			"commands": {
+				"slash": [
+					"start",
+					"new",
+					"model",
+					"thinking",
+					"config",
+					"verbose",
+					"stop",
+					"status",
+					"whoami",
+					"lcm",
+					"compact"
+				],
+				"inline_keyboards": ["model", "thinking", "status", "regenerate"],
+				"formatting": ["telegram_html", "chunked_delivery"]
+			},
+			"lifespan": {
+				"entrypoint": "app.channels.telegram:telegram_lifespan",
+				"context_key": "telegram_lifespan_context",
+				"service_key": "telegram_service",
+				"order": 70,
+				"post_start": "app.channels.telegram.notifications:register_telegram_notifications"
+			}
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- add project skills for retro sessions, PR scope audits, runner operations, and extension boundaries
- update live-ops verification to require real provider/channel/browser proof for live claims
- reference the new skills from AGENTS.md so future agents discover them
- format existing bundled plugin manifests so the repo check gate stays green

## Verification
- git diff --check
- skill metadata trigger/length check
- just check

## Notes
- This PR does not claim the broader provider/channel/core plugin architecture goal is complete. It captures the process lessons from the session so future work is harder to mis-scope or overclaim.

## Summary by Sourcery

Capture Pawrrtal operating lessons as reusable agent skills and tighten verification standards for live integrations.

New Features:
- Introduce retro, pawrrtal-pr-scope-audit, pawrrtal-runner-ops, and pawrrtal-extension-boundaries agent skills to guide retrospectives, PR scope audits, runner operations, and backend extension boundaries.
- Expose the new Pawrrtal workflow skills via AGENTS.md so agents can discover and apply them in future sessions.

Enhancements:
- Strengthen Pawrrtal live-ops verification guidelines to require real provider/channel/browser roundtrips before claiming live behavior works and update operating rules to use the runner-ops skill for self-hosted runners.
- Document clear architectural boundaries between kernel, plugins, providers, channels, tools, and subagents to keep backend extension code modular and slot-based.

Chores:
- Reformat existing bundled plugin manifests to satisfy repository formatting checks.