### PR TITLE
[1/12] test(architecture): add baseline turn proof harness

### DIFF
--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -100,6 +100,43 @@ async def test_chat_streams_provider_events(
 
 
 @pytest.mark.anyio
+async def test_chat_persists_user_and_finalized_assistant_messages(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    seeded_default_workspace: Workspace,
+) -> None:
+    """Web chat persists both sides of a successful streaming turn."""
+    conversation_id = uuid4()
+    await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Chat"})
+    monkeypatch.setattr(
+        "app.chat.router.resolve_llm",
+        lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "hello"}]),
+    )
+
+    response = await client.post(
+        "/api/v1/chat/",
+        json={
+            "question": "hello",
+            "conversation_id": str(conversation_id),
+            "model_id": "agent-sdk:anthropic/claude-opus-4-7",
+        },
+    )
+    messages_response = await client.get(f"/api/v1/conversations/{conversation_id}/messages")
+
+    assert response.status_code == 200
+    assert "data: [DONE]" in response.text
+    assert messages_response.status_code == 200
+    messages = messages_response.json()
+    assert len(messages) == 2
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "hello"
+    assert messages[0]["assistant_status"] is None
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["content"] == "hello"
+    assert messages[1]["assistant_status"] == "complete"
+
+
+@pytest.mark.anyio
 async def test_chat_forwards_reasoning_effort(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_config_sqlite_filename.py
+++ b/backend/tests/test_config_sqlite_filename.py
@@ -55,6 +55,12 @@ def test_default_sqlite_filename_is_pawrrtal_db(isolated_env: None) -> None:
     assert settings._normalized_database_url == "sqlite:///./pawrrtal.db"
 
 
+def test_empty_database_url_falls_back_to_default_sqlite(isolated_env: None) -> None:
+    """Blank ``DATABASE_URL`` currently behaves like an omitted ``DATABASE_URL``."""
+    settings = Settings(_env_file=None, database_url="   ")
+    assert settings._normalized_database_url == "sqlite:///./pawrrtal.db"
+
+
 def test_sqlite_db_filename_overrides_default(isolated_env: None) -> None:
     """``SQLITE_DB_FILENAME`` rewrites the implicit fallback filename."""
     settings = Settings(_env_file=None, sqlite_db_filename="experiment.db")

--- a/backend/tests/test_google_chat_ingress.py
+++ b/backend/tests/test_google_chat_ingress.py
@@ -1,0 +1,118 @@
+"""Tests for Google Chat ingress normalization into the shared turn runner."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.channels.google_chat import ingress
+from app.channels.google_chat.attachments import GoogleChatAttachments
+from app.channels.google_chat.channel import SURFACE_GOOGLE_CHAT
+from app.channels.turn_orchestrator import ChatTurnInput
+
+
+class _Provider:
+    """Provider sentinel for ingress tests."""
+
+
+class _Channel:
+    """Channel sentinel for ingress tests."""
+
+    surface = SURFACE_GOOGLE_CHAT
+
+
+@pytest.mark.anyio
+async def test_google_chat_message_event_submits_normalized_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Google Chat submits a ``ChatTurnInput`` without asserting provider internals."""
+    user_id = uuid4()
+    conversation_id = uuid4()
+    workspace_id = uuid4()
+    provider: Any = _Provider()
+    channel: Any = _Channel()
+    captured: dict[str, ChatTurnInput] = {}
+
+    async def resolve_turn_target(_event: dict[str, Any]) -> ingress._TurnTarget:
+        return ingress._TurnTarget(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            workspace_root=tmp_path,
+            workspace_id=workspace_id,
+            model_id="agent-sdk:anthropic/claude-opus-4-7",
+            verbose_level=2,
+        )
+
+    async def create_placeholder(
+        *,
+        space_name: str,
+        text: str,
+        thread_name: str | None,
+    ) -> str:
+        assert space_name == "spaces/AAA"
+        assert thread_name == "spaces/AAA/threads/BBB"
+        assert text
+        return "spaces/AAA/messages/placeholder"
+
+    async def collect_attachments(_event: dict[str, Any]) -> GoogleChatAttachments:
+        return GoogleChatAttachments(
+            images=[{"data": "aW1hZ2U=", "media_type": "image/png"}],
+            annotations=["[User sent a document: brief.md.]"],
+        )
+
+    async def run_turn(turn_input: ChatTurnInput) -> AsyncIterator[bytes]:
+        captured["turn_input"] = turn_input
+        yield b""
+
+    monkeypatch.setattr(ingress, "_resolve_turn_target", resolve_turn_target)
+    monkeypatch.setattr(
+        ingress,
+        "_resolve_provider",
+        lambda model_id, workspace_root: (provider, "agent-sdk:anthropic/claude-opus-4-7"),
+    )
+    monkeypatch.setattr(ingress, "build_agent_tools", lambda **_kwargs: [])
+    monkeypatch.setattr(ingress, "create_message", create_placeholder)
+    monkeypatch.setattr(ingress, "collect_attachments", collect_attachments)
+    monkeypatch.setattr("app.channels.registry.resolve_channel", lambda _surface: channel)
+    monkeypatch.setattr(ingress, "run_turn", run_turn)
+
+    event = {
+        "type": "MESSAGE",
+        "space": {"name": "spaces/AAA"},
+        "message": {
+            "name": "spaces/AAA/messages/original",
+            "text": "hello",
+            "thread": {"name": "spaces/AAA/threads/BBB"},
+        },
+    }
+
+    await ingress._handle_message_event(event)
+
+    turn_input = captured["turn_input"]
+    assert turn_input.conversation_id == conversation_id
+    assert turn_input.user_id == user_id
+    assert turn_input.question == "hello\n\n[User sent a document: brief.md.]"
+    assert turn_input.provider is provider
+    assert turn_input.channel is channel
+    assert turn_input.workspace_root == tmp_path
+    assert turn_input.tools == []
+    assert turn_input.images == [{"data": "aW1hZ2U=", "media_type": "image/png"}]
+    assert turn_input.log_tag == "GOOGLE_CHAT"
+    assert turn_input.channel_message == {
+        "user_id": user_id,
+        "conversation_id": conversation_id,
+        "text": "hello",
+        "surface": SURFACE_GOOGLE_CHAT,
+        "model_id": "agent-sdk:anthropic/claude-opus-4-7",
+        "metadata": {
+            "space_name": "spaces/AAA",
+            "thread_name": "spaces/AAA/threads/BBB",
+            "message_name": "spaces/AAA/messages/placeholder",
+            "verbose_level": 2,
+        },
+    }

--- a/backend/tests/test_turn_runner_hook_ordering.py
+++ b/backend/tests/test_turn_runner_hook_ordering.py
@@ -416,3 +416,78 @@ async def test_lightweight_codex_turn_still_runs_turn_context_providers(
     assert "memory" in provider.stream_kwargs["system_prompt"]
     assert "## Tools available this turn" in provider.stream_kwargs["system_prompt"]
     assert provider.stream_kwargs["reasoning_effort"] == "low"
+
+
+@pytest.mark.anyio
+async def test_turn_context_provider_draft_updater_is_surface_agnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Context providers receive the generic draft callback from ``ChatTurnInput``."""
+    provider = _ScriptedProvider(
+        [
+            {"type": "delta", "content": "ok"},
+            {"type": "done"},
+        ]
+    )
+    draft_updates: list[str] = []
+    finished = False
+
+    async def draft_updater(text: str) -> None:
+        draft_updates.append(text)
+
+    async def recall_hook(ctx: Any) -> str:
+        assert ctx.draft_updater is draft_updater
+        assert ctx.workspace_root is not None
+        await ctx.draft_updater("checking memory")
+        return "memory"
+
+    async def on_finished() -> None:
+        nonlocal finished
+        finished = True
+
+    async def no_persist(_turn_input: ChatTurnInput) -> tuple[list[dict[str, str]], Any]:
+        return [], "assistant-id"
+
+    async def no_finalize(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "app.channels.turn_orchestrator.runner._load_history_and_persist", no_persist
+    )
+    monkeypatch.setattr("app.channels.turn_orchestrator.runner._finalize_turn", no_finalize)
+
+    turn_input = ChatTurnInput(
+        conversation_id=MagicMock(),
+        user_id=MagicMock(),
+        question="hi",
+        provider=provider,
+        channel=_PassthroughChannel(),
+        channel_message={
+            "conversation_id": MagicMock(),
+            "metadata": {},
+            "model_id": "agent-sdk:anthropic/claude-opus-4-7",
+            "surface": "web",
+            "text": "hi",
+            "user_id": MagicMock(),
+        },
+        workspace_root=None,
+        tools=[],
+        turn_context_providers=[
+            TurnContextProviderAdapter(
+                plugin_id="active_recall",
+                capability_id="active_recall",
+                title="Active Recall",
+                order=100,
+                timeout_seconds=10,
+                provider=recall_hook,
+            )
+        ],
+        draft_updater=draft_updater,
+        on_turn_context_finished=on_finished,
+    )
+
+    _ = [chunk async for chunk in run_turn(turn_input)]
+
+    assert draft_updates == ["checking memory"]
+    assert finished is True
+    assert "# TURN CONTEXT\n\nmemory" in provider.stream_kwargs["system_prompt"]


### PR DESCRIPTION
## Summary
- add web chat proof that a successful streaming turn persists the user row and finalized assistant row
- add turn-context proof that draft updates flow through the generic ChatTurnInput callback, not a channel-specific path
- add Google Chat ingress proof that a mocked event normalizes into ChatTurnInput without asserting provider internals
- document current blank DATABASE_URL fallback behavior before the database cleanup PR changes config semantics

## Verification
- cd backend && uv run pytest tests/test_chat_api.py tests/test_turn_runner_hook_ordering.py tests/test_google_chat_ingress.py tests/test_config_sqlite_filename.py: 27 passed
- cd backend && uv run pytest tests/test_turn_runner_hook_ordering.py tests/test_chat_api.py tests/test_telegram_channel.py tests/test_telegram_media_context.py tests/test_event_bus_handlers.py tests/test_plugin_state.py tests/test_config_sqlite_filename.py tests/test_alembic_postgres_upgrade.py: 100 passed
- just check: passed
- just arch: passed
- git commit hooks: hardcoded-secret detection, Ruff, mypy, Conventional Commit: passed

## Runtime proof
- paw verify chat-roundtrip --json: blocked locally because the Paw CLI session is expired or missing; command returned exit code 3 with hint to run paw login.