### PR TITLE
[3/12] refactor(turns): prepare web chat in pipeline

### DIFF
--- a/backend/app/chat/router.py
+++ b/backend/app/chat/router.py
@@ -15,17 +15,8 @@ from fastapi.routing import APIRouter
 from opentelemetry import trace as _otel_trace
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.tool_surface import build_agent_tools
-
-# ``ChannelMessage`` is re-exported by ``app.channels.__init__``; we
-# pull all three names from the same package to keep chat.py's
-# fan-out under sentrux's ``no_god_files`` budget.
-from app.channels import ChannelMessage, resolve_channel, surface_from_header
-from app.chat import (
-    enforce_cost_budget,
-    load_external_mcp_configs,
-    publish_turn_started,
-)
+from app.channels import surface_from_header
+from app.chat import publish_turn_started
 from app.conversations.crud import (
     apply_model_switch_and_normalize_reasoning,
     get_conversation,
@@ -33,9 +24,7 @@ from app.conversations.crud import (
 from app.infrastructure.auth.users import get_allowed_user
 from app.infrastructure.database.legacy import User, get_async_session
 from app.infrastructure.middleware.logging import get_request_id
-from app.plugins.adapters.turn_context import build_turn_context_providers
-from app.providers import StreamEvent, resolve_llm
-from app.providers.session_preparer import prepare_provider_session
+from app.providers import StreamEvent
 from app.schemas import ChatRequest
 from app.tools.artifact_agent import (
     ARTIFACT_TOOL_NAME,
@@ -43,9 +32,10 @@ from app.tools.artifact_agent import (
     build_artifact,
 )
 from app.turns.pipeline import (
-    ChatTurnInput,
     EventHook,
-    run_turn,
+    TurnCommand,
+    prepare_turn,
+    run_prepared_turn,
 )
 from app.workspace.crud import get_default_workspace
 
@@ -127,9 +117,9 @@ async def _require_workspace(
     """Return the user's default workspace ``(id, path)`` or reject the chat turn.
 
     Returns the workspace UUID alongside the directory path so callers
-    can pass both into :func:`app.agents.tool_surface.build_agent_tools` —
-    the UUID drives plugin activation (and, post-migration, env-key
-    resolution); the path drives the existing core workspace tools.
+    can pass both into the Turn Pipeline — the UUID drives plugin activation
+    (and, post-migration, env-key resolution); the path drives the existing
+    core workspace tools.
     """
     workspace = await get_default_workspace(user_id, session)
     if workspace is None:
@@ -230,7 +220,6 @@ def get_chat_router() -> APIRouter:
         # Entry log — pairs with REQ_IN/REQ_OUT from the request middleware via rid.
         # Question length, not contents, to avoid leaking PII into the log file.
         surface = surface_from_header(x_pawrrtal_surface)
-        channel = resolve_channel(surface)
 
         rid = get_request_id()
 
@@ -298,32 +287,12 @@ def get_chat_router() -> APIRouter:
         # Refuse with 412 (Precondition Failed) so the frontend can route to
         # onboarding instead of pretending we shipped a degraded reply.
         #
-        # Hoisted above ``resolve_llm`` so we can pass ``workspace_root``
-        # into the Claude SDK as its ``cwd``. Without it, the SDK falls
-        # back to the uvicorn process directory and writes its transcript
-        # files there.
+        # Hoisted above turn preparation so provider adapters receive
+        # ``workspace_root`` for workspace-scoped credentials and native
+        # transcript paths.
         workspace_id, root = await _require_workspace(
             user_id=user.id, session=session, request_id=rid
         )
-        # Refuse over-budget turns before tool composition or provider work.
-        await enforce_cost_budget(
-            user_id=user.id,
-            session=session,
-            rid=rid,
-        )
-
-        # Provider construction must happen *after* workspace resolution so
-        # workspace-scoped API-key overrides (Gemini/Claude) take effect.
-        # ``workspace_root`` is also forwarded so the Claude SDK subprocess
-        # writes its transcripts under the user's workspace rather than
-        # the uvicorn process directory.
-        provider = resolve_llm(model_id, workspace_root=root)
-        # Per-turn tool composition lives in `app.agents.tool_surface` —
-        # the chat router only decides *that* the agent gets tools,
-        # not *which* (that's the builder's job, and where future
-        # per-agent / per-user permission gating will land).  Provider
-        # files stay tool-agnostic; see
-        # `.claude/rules/architecture/no-tools-in-providers.md`.
         # Web send_fn — lets the agent call send_message() to push text or
         # files back to the user mid-turn.  Events are placed on a per-request
         # queue and drained into the SSE stream after each provider event,
@@ -341,18 +310,6 @@ def get_chat_router() -> APIRouter:
                 event["mime"] = mime
             await _web_send_queue.put(event)
 
-        external_mcp_configs = await load_external_mcp_configs(session=session, user_id=user.id)
-        agent_tools = build_agent_tools(
-            workspace_root=root,
-            user_id=user.id,
-            workspace_id=workspace_id,
-            send_fn=_web_send_fn,
-            surface=surface,
-            conversation_id=request.conversation_id,
-            model_id=model_id,
-            external_mcp_configs=external_mcp_configs,
-        )
-
         def _artifact_hook(event: StreamEvent) -> list[StreamEvent]:
             extra = _maybe_artifact_event(event)
             return [extra] if extra is not None else []
@@ -363,14 +320,6 @@ def get_chat_router() -> APIRouter:
                 out.append(_web_send_queue.get_nowait())
             return out
 
-        channel_message: ChannelMessage = {
-            "user_id": user.id,
-            "conversation_id": request.conversation_id,
-            "text": request.question,
-            "surface": surface,
-            "model_id": model_id,
-            "metadata": {},
-        }
         # Forward multimodal image inputs in the provider-neutral turn input.
         image_inputs = (
             [{"data": img.data, "media_type": img.media_type} for img in request.images]
@@ -378,19 +327,29 @@ def get_chat_router() -> APIRouter:
             else None
         )
 
-        provider_session = await prepare_provider_session(
-            provider,
-            conversation_id=request.conversation_id,
-            workspace_root=root,
-            model_id=model_id,
-            tools=agent_tools,
-            reasoning_effort=effective_reasoning_effort,
-            question=request.question,
+        prepared_turn = await prepare_turn(
+            TurnCommand(
+                conversation_id=request.conversation_id,
+                user_id=user.id,
+                question=request.question,
+                workspace_root=root,
+                workspace_id=workspace_id,
+                surface=surface,
+                model_id=model_id,
+                reasoning_effort=effective_reasoning_effort,
+                images=image_inputs,
+                request_id=rid,
+                history_window=_HISTORY_WINDOW,
+                log_tag="CHAT",
+                send_fn=_web_send_fn,
+                db_session=session,
+            )
         )
 
-        # ``db_session`` is intentionally left at its ``None`` default so the
-        # turn runner opens its own ``async_session_maker()`` session inside
-        # the streaming generator. Passing the request-scoped session from
+        # ``db_session`` is intentionally not forwarded through
+        # ``TurnCommand`` into the persisted runner. The streaming path
+        # opens its own ``async_session_maker()`` session inside the
+        # response generator. Passing the request-scoped session from
         # ``Depends(get_async_session)`` breaks under SQLite/aiosqlite because
         # ``StreamingResponse`` keeps the response body iterating long after
         # the route handler returns — by the time ``_finalize_turn`` runs,
@@ -398,30 +357,6 @@ def get_chat_router() -> APIRouter:
         # ``session.execute`` raises ``OperationalError: no active connection``.
         # Postgres masks this because pool checkout + ``pool_pre_ping`` can
         # transparently reconnect; aiosqlite does not. Issue: pawrrtal-0dgj.
-        turn_input = ChatTurnInput(
-            conversation_id=request.conversation_id,
-            user_id=user.id,
-            question=request.question,
-            provider=provider,
-            channel=channel,
-            channel_message=channel_message,
-            workspace_root=root,
-            tools=agent_tools,
-            # ``effective_reasoning_effort`` is the resolved value
-            # from the shared backstop: per-turn override wins,
-            # otherwise the conversation's normalized stored effort.
-            reasoning_effort=effective_reasoning_effort,
-            images=image_inputs,
-            history_window=_HISTORY_WINDOW,
-            log_tag="CHAT",
-            log_extras={
-                "rid": rid,
-                "model_id": model_id,
-                "surface": surface,
-            },
-            turn_context_providers=build_turn_context_providers(workspace_root=root),
-            provider_session=provider_session,
-        )
         hooks: list[EventHook] = [_artifact_hook, _drain_send_queue]
 
         # Announce the turn so subscribers can react without coupling to the router.
@@ -434,7 +369,7 @@ def get_chat_router() -> APIRouter:
 
         async def event_stream() -> AsyncGenerator[bytes]:
             """Yield channel-encoded bytes from the shared turn runner."""
-            async for chunk in run_turn(turn_input, event_hooks=hooks):
+            async for chunk in run_prepared_turn(prepared_turn, event_hooks=hooks):
                 yield chunk
 
         return StreamingResponse(

--- a/backend/app/turns/pipeline/__init__.py
+++ b/backend/app/turns/pipeline/__init__.py
@@ -4,13 +4,31 @@ from __future__ import annotations
 
 from .finalize import _finalize_turn
 from .history import _load_history_and_persist, _workspace_system_prompt
-from .runner import _finalizing_stream, _guarded_stream, _should_deliver_event, run_turn
+from .prepare import prepare_turn
+from .runner import (
+    _finalizing_stream,
+    _guarded_stream,
+    _should_deliver_event,
+    run_prepared_turn,
+    run_turn,
+)
 from .state import _register_turn_finalize_task
-from .types import ChatTurnInput, EventHook
+from .types import (
+    ChatTurnInput,
+    DeliveryAdapter,
+    EventHook,
+    PreparedTurn,
+    TurnCommand,
+    TurnResult,
+)
 
 __all__ = [
     "ChatTurnInput",
+    "DeliveryAdapter",
     "EventHook",
+    "PreparedTurn",
+    "TurnCommand",
+    "TurnResult",
     "_finalize_turn",
     "_finalizing_stream",
     "_guarded_stream",
@@ -18,5 +36,7 @@ __all__ = [
     "_register_turn_finalize_task",
     "_should_deliver_event",
     "_workspace_system_prompt",
+    "prepare_turn",
+    "run_prepared_turn",
     "run_turn",
 ]

--- a/backend/app/turns/pipeline/prepare.py
+++ b/backend/app/turns/pipeline/prepare.py
@@ -1,0 +1,79 @@
+"""Turn Pipeline preparation for web/SSE chat turns."""
+
+from __future__ import annotations
+
+from app.agents.tool_surface import build_agent_tools
+from app.channels import ChannelMessage, resolve_channel
+from app.chat.cost_budget import enforce_cost_budget
+from app.chat.external_mcp import load_external_mcp_configs
+from app.plugins.adapters.turn_context import build_turn_context_providers
+from app.providers.factory import resolve_llm
+from app.providers.session_preparer import prepare_provider_session
+
+from .types import ChatTurnInput, PreparedTurn, TurnCommand
+
+
+async def prepare_turn(command: TurnCommand) -> PreparedTurn:
+    """Resolve provider, tools, context providers, and session state for a turn."""
+    if command.db_session is not None:
+        await enforce_cost_budget(
+            user_id=command.user_id,
+            session=command.db_session,
+            rid=command.request_id or "",
+        )
+
+    provider = resolve_llm(command.model_id, workspace_root=command.workspace_root)
+    external_mcp_configs = (
+        await load_external_mcp_configs(session=command.db_session, user_id=command.user_id)
+        if command.db_session is not None
+        else []
+    )
+    agent_tools = build_agent_tools(
+        workspace_root=command.workspace_root,
+        user_id=command.user_id,
+        workspace_id=command.workspace_id,
+        send_fn=command.send_fn,
+        surface=command.surface,
+        conversation_id=command.conversation_id,
+        model_id=command.model_id,
+        external_mcp_configs=external_mcp_configs,
+    )
+    provider_session = await prepare_provider_session(
+        provider,
+        conversation_id=command.conversation_id,
+        workspace_root=command.workspace_root,
+        model_id=command.model_id,
+        tools=agent_tools,
+        reasoning_effort=command.reasoning_effort,
+        question=command.question,
+    )
+    channel_message: ChannelMessage = {
+        "user_id": command.user_id,
+        "conversation_id": command.conversation_id,
+        "text": command.question,
+        "surface": command.surface,
+        "model_id": command.model_id,
+        "metadata": command.metadata,
+    }
+    turn_input = ChatTurnInput(
+        conversation_id=command.conversation_id,
+        user_id=command.user_id,
+        question=command.question,
+        provider=provider,
+        channel=resolve_channel(command.surface),
+        channel_message=channel_message,
+        workspace_root=command.workspace_root,
+        tools=agent_tools,
+        reasoning_effort=command.reasoning_effort,
+        images=command.images,
+        history_window=command.history_window,
+        log_tag=command.log_tag,
+        log_extras={
+            "rid": command.request_id,
+            "model_id": command.model_id,
+            "surface": command.surface,
+        },
+        turn_context_providers=build_turn_context_providers(workspace_root=command.workspace_root),
+        provider_session=provider_session,
+    )
+    return PreparedTurn(turn_input=turn_input, effective_model_id=command.model_id)

--- a/backend/app/turns/pipeline/runner.py
+++ b/backend/app/turns/pipeline/runner.py
@@ -27,7 +27,7 @@ from .context_providers import _run_turn_context_providers
 from .finalize import _finalize_turn
 from .history import _load_history_and_persist
 from .state import _register_turn_finalize_task
-from .types import ChatTurnInput, EventHook, _EventCounter
+from .types import ChatTurnInput, EventHook, PreparedTurn, _EventCounter
 
 if TYPE_CHECKING:
     from app.channels.base import ChannelMessage
@@ -116,6 +116,17 @@ async def run_turn(
                 yield chunk
         finally:
             await finalize_once()
+
+
+async def run_prepared_turn(
+    prepared_turn: PreparedTurn,
+    *,
+    event_hooks: list[EventHook] | None = None,
+) -> AsyncIterator[bytes]:
+    """Stream a prepared turn through the existing persisted runner."""
+    hooks = [*prepared_turn.event_hooks, *(event_hooks or [])]
+    async for chunk in run_turn(prepared_turn.turn_input, event_hooks=hooks):
+        yield chunk
 
 
 async def _stream_with_llm_span(

--- a/backend/app/turns/pipeline/types.py
+++ b/backend/app/turns/pipeline/types.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections import Counter
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from app.plugins.adapters.turn_context import TurnContextProviderAdapter
 from app.provider_sessions import ProviderSessionTurnState
@@ -20,6 +20,62 @@ if TYPE_CHECKING:
     from app.providers.base import AILLM, ReasoningEffort, StreamEvent
 
 EventHook = Callable[["StreamEvent"], list["StreamEvent"]]
+SendMessageFn = Callable[[str | None, Path | None, str | None], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class TurnCommand:
+    """Unresolved command for one user-visible assistant turn."""
+
+    conversation_id: uuid.UUID
+    user_id: uuid.UUID
+    question: str
+    workspace_root: Path
+    workspace_id: uuid.UUID
+    surface: str
+    model_id: str
+    reasoning_effort: ReasoningEffort | None = None
+    images: list[dict[str, str]] | None = None
+    request_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    history_window: int = 20
+    log_tag: str = "TURN"
+    send_fn: SendMessageFn | None = None
+    db_session: AsyncSession | None = field(default=None, repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class PreparedTurn:
+    """Resolved turn inputs ready for streaming through the runner."""
+
+    turn_input: ChatTurnInput
+    effective_model_id: str
+    event_hooks: list[EventHook] = field(default_factory=list)
+
+
+class DeliveryAdapter(Protocol):
+    """Protocol for channel-native stream delivery."""
+
+    surface: str
+
+    def deliver(
+        self,
+        stream: AsyncIterator[StreamEvent],
+        message: ChannelMessage,
+    ) -> AsyncIterator[bytes]:
+        """Consume provider stream events and yield channel output bytes."""
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """Final turn summary shape for future non-streaming callers."""
+
+    assistant_message_id: uuid.UUID | None = None
+    final_text: str = ""
+    event_counts: dict[str, int] = field(default_factory=dict)
+    stop_reason: str | None = None
+    elapsed_ms: float | None = None
+    error: str | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -81,7 +81,7 @@ async def test_chat_streams_provider_events(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Chat"})
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "hello"}]),
     )
 
@@ -109,7 +109,7 @@ async def test_chat_persists_user_and_finalized_assistant_messages(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Chat"})
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "hello"}]),
     )
 
@@ -173,7 +173,7 @@ async def test_chat_forwards_reasoning_effort(
                 yield event
 
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **_kwargs: CapturingProvider([{"type": "delta", "content": "ok"}]),
     )
 
@@ -201,7 +201,7 @@ async def test_chat_persists_requested_model_id(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Model"})
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "ok"}]),
     )
 
@@ -277,7 +277,7 @@ async def test_chat_stream_converts_provider_exception_to_error_event(
             yield {"type": "delta", "content": "unreachable"}
 
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm", lambda _model_id, **kwargs: FailingProvider()
+        "app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **kwargs: FailingProvider()
     )
 
     response = await client.post(
@@ -329,8 +329,10 @@ async def test_chat_multi_turn_tool_call_flows_through_full_http_path(
     monkeypatch.setattr(provider, "_stream_fn", script)
 
     # Inject both the provider and the echo tool into the chat path.
-    monkeypatch.setattr("app.chat.router.resolve_llm", lambda _model_id, **_kw: provider)
-    monkeypatch.setattr("app.chat.router.build_agent_tools", lambda *_args, **_kw: [echo])
+    monkeypatch.setattr("app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **_kw: provider)
+    monkeypatch.setattr(
+        "app.turns.pipeline.prepare.build_agent_tools", lambda *_args, **_kw: [echo]
+    )
 
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Tool HTTP Test"})
@@ -401,9 +403,9 @@ async def test_chat_safety_layer_fires_and_surfaces_agent_terminated(
         ),
     )
 
-    monkeypatch.setattr("app.chat.router.resolve_llm", lambda _model_id, **_kw: provider)
+    monkeypatch.setattr("app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **_kw: provider)
     monkeypatch.setattr(
-        "app.chat.router.build_agent_tools", lambda *_args, **_kw: [echo_tool("ping")]
+        "app.turns.pipeline.prepare.build_agent_tools", lambda *_args, **_kw: [echo_tool("ping")]
     )
 
     conversation_id = uuid4()

--- a/backend/tests/test_chat_sqlite_session_lifecycle.py
+++ b/backend/tests/test_chat_sqlite_session_lifecycle.py
@@ -53,9 +53,9 @@ async def test_chat_router_does_not_pass_request_session_into_turn_input(
     monkeypatch: pytest.MonkeyPatch,
     seeded_default_workspace: Workspace,
 ) -> None:
-    """Chat router must leave ``ChatTurnInput.db_session`` at its ``None`` default.
+    """Web turn preparation must leave ``ChatTurnInput.db_session`` at its default.
 
-    Capturing the kwargs the router uses to build ``ChatTurnInput`` is the
+    Capturing the kwargs used to build ``ChatTurnInput`` is the
     cheapest way to lock in the SQLite-safe lifecycle: if a future refactor
     re-introduces ``db_session=session``, the streaming generator holds the
     request session past the route handler and aiosqlite fails. See the
@@ -67,14 +67,14 @@ async def test_chat_router_does_not_pass_request_session_into_turn_input(
         json={"title": "SQLite Lifecycle"},
     )
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: _FakeProvider(),
     )
 
     captured: dict[str, Any] = {}
 
-    # The chat router imports ``ChatTurnInput`` from ``app.turns.pipeline``.
-    # Patch the symbol the router actually resolves so we observe the real
+    # Web chat now builds ``ChatTurnInput`` inside Turn Pipeline preparation.
+    # Patch the symbol that module resolves so we observe the real
     # construction call, not a stand-in.
     from app.turns.pipeline import ChatTurnInput as _OriginalChatTurnInput
 
@@ -83,7 +83,10 @@ async def test_chat_router_does_not_pass_request_session_into_turn_input(
         captured.update(kwargs)
         return _OriginalChatTurnInput(**kwargs)
 
-    monkeypatch.setattr("app.chat.router.ChatTurnInput", _capturing_chat_turn_input)
+    monkeypatch.setattr(
+        "app.turns.pipeline.prepare.ChatTurnInput",
+        _capturing_chat_turn_input,
+    )
 
     response = await client.post(
         "/api/v1/chat/",
@@ -124,7 +127,7 @@ async def test_chat_finalizes_assistant_status_on_sqlite(
         json={"title": "Finalize"},
     )
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: _FakeProvider(),
     )
 
@@ -209,7 +212,7 @@ async def test_finalize_turn_leaves_message_complete_on_cost_write_failure(
         json={"title": "Cost Failure"},
     )
     monkeypatch.setattr(
-        "app.chat.router.resolve_llm",
+        "app.turns.pipeline.prepare.resolve_llm",
         lambda _model_id, **kwargs: _FakeProvider(),
     )
 


### PR DESCRIPTION
## Summary
- add TurnCommand, PreparedTurn, DeliveryAdapter, TurnResult, and prepare_turn under app.turns.pipeline
- move web chat provider resolution, cost-budget check, tool composition, provider-session preparation, channel resolution, and context-provider assembly into Turn Pipeline preparation
- keep chat/router.py responsible for auth, conversation ownership, request validation, web SSE hooks, turn-start publication, and StreamingResponse creation
- add run_prepared_turn so the web path streams a PreparedTurn while Telegram and Google Chat keep the existing ChatTurnInput path for later PRs
- update web chat tests to patch the new pipeline prepare seams

## Verification
- rg -n "resolve_llm|prepare_provider_session|build_agent_tools|build_turn_context_provider_adapters" backend/app/chat/router.py: no matches
- cd backend && uv run pytest tests/test_chat_api.py tests/test_chat_request_images.py tests/test_turn_runner_hook_ordering.py tests/test_provider_session_preparer.py tests/paw/test_verify_chat_roundtrip.py: 35 passed
- cd backend && uv run pytest tests/test_chat_sqlite_session_lifecycle.py tests/test_chat_api.py tests/test_chat_request_images.py tests/test_turn_runner_hook_ordering.py tests/test_provider_session_preparer.py tests/paw/test_verify_chat_roundtrip.py: 39 passed
- cd backend && uv run pytest: 2268 passed, 2 skipped, 5 xfailed, 5 xpassed
- just check: passed
- just arch: passed
- python3 scripts/check-no-tools-in-providers.py: passed
- python3 scripts/check-nesting.py: passed
- node scripts/check-file-lines.mjs: passed
- git commit hooks: hardcoded-secret detection, Ruff, mypy, Bandit, Conventional Commit: passed

## Runtime proof
- paw verify chat-roundtrip --json: blocked locally because the Paw CLI session is expired or missing; command returned exit code 3 with hint to run paw login.

## Summary by Sourcery

Extract turn preparation responsibilities from the web chat router into the shared Turn Pipeline and introduce a structured command/prepared-turn model for running turns.

Enhancements:
- Introduce TurnCommand, PreparedTurn, DeliveryAdapter, TurnResult, and SendMessageFn types under the turn pipeline to model turn preparation and delivery.
- Add a prepare_turn function that resolves providers, tools, context providers, channels, and provider sessions from a TurnCommand into a PreparedTurn.
- Add run_prepared_turn to stream already-prepared turns through the existing turn runner while composing pipeline-level event hooks.
- Refactor the web chat route to construct a TurnCommand, delegate preparation to the Turn Pipeline, and stream via run_prepared_turn instead of building ChatTurnInput directly.
- Ensure web turn preparation leaves ChatTurnInput.db_session at its safe default for streaming lifecycles, while allowing cost-budget enforcement when a DB session is provided.
- Re-export new pipeline primitives (TurnCommand, PreparedTurn, DeliveryAdapter, TurnResult, prepare_turn, run_prepared_turn) from the turn pipeline package for broader use.

Tests:
- Update web chat API and SQLite session lifecycle tests to patch and observe the new prepare_turn flow and resolve_llm/build_agent_tools locations.