### PR TITLE
[4/12] Refactor channels through turn pipeline

### DIFF
--- a/backend/app/channels/google_chat/commands.py
+++ b/backend/app/channels/google_chat/commands.py
@@ -27,7 +27,7 @@ from app.channels.crud import (
 from app.infrastructure.keys import load_workspace_env, save_workspace_env
 from app.models import Conversation
 from app.providers.base import ReasoningEffort
-from app.providers.catalog import first_catalog_model
+from app.providers.selection import effective_model_id, model_display
 from app.workspace.crud import get_default_workspace
 
 from .conversation import start_new_google_chat_conversation
@@ -116,7 +116,7 @@ async def _cmd_whoami(ctx: CommandContext) -> str:
 
 async def _cmd_status(ctx: CommandContext) -> str:
     conv = ctx.conversation
-    model = conv.model_id or f"{first_catalog_model().id} (default)"
+    model = model_display(conv.model_id, default_suffix=True)
     verbose = _verbose_of(conv)
     reasoning = conv.reasoning_effort or "provider default"
     return (
@@ -129,7 +129,7 @@ async def _cmd_status(ctx: CommandContext) -> str:
 
 async def _cmd_model(ctx: CommandContext) -> str:
     if not ctx.args:
-        current = ctx.conversation.model_id or f"{first_catalog_model().id} (default)"
+        current = model_display(ctx.conversation.model_id, default_suffix=True)
         return f"Current model: {current}\nSet one with `/model <id>`."
     model_id = ctx.args.strip()
     await update_conversation_model(
@@ -189,7 +189,7 @@ async def _cmd_lcm(ctx: CommandContext) -> str:
 
 
 async def _cmd_compact(ctx: CommandContext) -> str:
-    model_id = ctx.conversation.model_id or first_catalog_model().id
+    model_id = effective_model_id(conversation_model_id=ctx.conversation.model_id)
     return await run_compaction(
         conversation_id=ctx.conversation.id, user_id=ctx.user_id, model_id=model_id
     )

--- a/backend/app/channels/google_chat/ingress.py
+++ b/backend/app/channels/google_chat/ingress.py
@@ -26,16 +26,11 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.tool_surface import build_agent_tools
-from app.channels.base import ChannelMessage
 from app.infrastructure.config import settings
 from app.infrastructure.database.legacy import async_session_maker
 from app.models import Conversation
-from app.providers.base import AILLM
-from app.providers.catalog import first_catalog_model
-from app.providers.factory import resolve_llm
-from app.providers.model_id import InvalidModelId, UnknownModelId
-from app.turns.pipeline import ChatTurnInput, run_turn
+from app.providers.selection import default_model_id, provider_or_default
+from app.turns.pipeline import TurnCommand, prepare_turn, run_prepared_turn
 from app.workspace.crud import get_default_workspace
 
 from .attachments import collect_attachments
@@ -319,34 +314,13 @@ async def _resolve_turn_target(event: dict[str, Any]) -> _TurnTarget | None:
             conversation_id=conversation.id,
             workspace_root=Path(workspace.path),
             workspace_id=workspace.id,
-            model_id=conversation.model_id or first_catalog_model().id,
+            model_id=conversation.model_id or default_model_id(),
             verbose_level=(
                 conversation.verbose_level
                 if conversation.verbose_level is not None
                 else DEFAULT_VERBOSE_LEVEL
             ),
         )
-
-
-def _resolve_provider(model_id: str, workspace_root: Path) -> tuple[AILLM, str]:
-    """Resolve a provider, falling back to the first catalog entry on a bad id.
-
-    Returns ``(provider, effective_model_id)`` so the channel envelope and
-    cost ledger record the model actually used. The first catalog entry is a
-    tool-forwarding model, so this also keeps the channel off the
-    tool-dropping CLI hosts by default.
-    """
-    try:
-        return resolve_llm(model_id, workspace_root=workspace_root), model_id
-    except (InvalidModelId, UnknownModelId) as exc:
-        fallback = first_catalog_model().id
-        logger.warning(
-            "GOOGLE_CHAT_MODEL_FALLBACK model=%s fallback=%s reason=%s",
-            model_id,
-            fallback,
-            exc,
-        )
-        return resolve_llm(fallback, workspace_root=workspace_root), fallback
 
 
 async def _handle_message_event(event: dict[str, Any]) -> None:
@@ -361,15 +335,17 @@ async def _handle_message_event(event: dict[str, Any]) -> None:
     if target is None:
         return
 
-    provider, effective_model_id = _resolve_provider(target.model_id, target.workspace_root)
-    agent_tools = build_agent_tools(
+    provider_selection = provider_or_default(
+        target.model_id,
         workspace_root=target.workspace_root,
-        user_id=target.user_id,
-        workspace_id=target.workspace_id,
-        surface=SURFACE_GOOGLE_CHAT,
-        conversation_id=target.conversation_id,
-        model_id=effective_model_id,
     )
+    if provider_selection.warning is not None:
+        logger.warning(
+            "GOOGLE_CHAT_MODEL_FALLBACK model=%s fallback=%s reason=%s",
+            target.model_id,
+            provider_selection.effective_model_id,
+            provider_selection.warning,
+        )
 
     thread = thread_name(event)
     message_name = await create_message(
@@ -381,38 +357,31 @@ async def _handle_message_event(event: dict[str, Any]) -> None:
         logger.warning("GOOGLE_CHAT_PLACEHOLDER_FAILED space=%s", space)
         return
 
-    # Local import breaks the registry ↔ google_chat package import cycle.
-    from app.channels.registry import resolve_channel  # noqa: PLC0415
-
     attachments = await collect_attachments(event)
     question = _build_question(text, attachments.annotations)
 
-    channel_message: ChannelMessage = {
-        "user_id": target.user_id,
-        "conversation_id": target.conversation_id,
-        "text": text or "(attachment)",
-        "surface": SURFACE_GOOGLE_CHAT,
-        "model_id": effective_model_id,
-        "metadata": {
-            "space_name": space,
-            "thread_name": thread,
-            "message_name": message_name,
-            "verbose_level": target.verbose_level,
-        },
-    }
-    turn_input = ChatTurnInput(
-        conversation_id=target.conversation_id,
-        user_id=target.user_id,
-        question=question,
-        provider=provider,
-        channel=resolve_channel(SURFACE_GOOGLE_CHAT),
-        channel_message=channel_message,
-        workspace_root=target.workspace_root,
-        tools=agent_tools,
-        images=attachments.images or None,
-        log_tag="GOOGLE_CHAT",
+    prepared_turn = await prepare_turn(
+        TurnCommand(
+            conversation_id=target.conversation_id,
+            user_id=target.user_id,
+            question=question,
+            workspace_root=target.workspace_root,
+            workspace_id=target.workspace_id,
+            surface=SURFACE_GOOGLE_CHAT,
+            model_id=target.model_id,
+            provider_selection=provider_selection,
+            channel_text=text or "(attachment)",
+            channel_metadata={
+                "space_name": space,
+                "thread_name": thread,
+                "message_name": message_name,
+                "verbose_level": target.verbose_level,
+            },
+            images=attachments.images or None,
+            log_tag="GOOGLE_CHAT",
+        )
     )
-    async for _ in run_turn(turn_input):
+    async for _ in run_prepared_turn(prepared_turn):
         pass
 
 

--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -32,8 +32,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from app.agents.tool_surface import build_agent_tools
-from app.channels.base import ChannelMessage
 from app.channels.telegram.bot_runtime import (
     COMMAND_REFRESH_COOLDOWN_SECONDS,
     ChatMessageQueueDispatcher,
@@ -64,9 +62,7 @@ from app.channels.telegram.handlers import (
 from app.channels.telegram.tools_command import handle_tools_command
 from app.infrastructure.config import settings
 from app.infrastructure.database.legacy import async_session_maker
-from app.plugins.adapters.turn_context import build_turn_context_providers
-from app.providers.session_preparer import prepare_provider_session
-from app.turns.pipeline import ChatTurnInput, run_turn
+from app.turns.pipeline import PreparedTurn, TurnCommand, prepare_turn, run_prepared_turn
 
 from .channel import SURFACE_TELEGRAM, make_telegram_sender, render_initial
 from .error_handler import register_telegram_error_handler
@@ -213,7 +209,7 @@ async def _chat_queue_consumer(turn: QueuedTurn) -> None:
 async def _execute_turn_body(
     *,
     message: Message,
-    turn_input: ChatTurnInput,
+    prepared_turn: PreparedTurn,
     user_text: str,
     context: TelegramTurnContext,
 ) -> None:
@@ -233,7 +229,7 @@ async def _execute_turn_body(
             name=f"telegram-typing-{chat_id}",
         )
     try:
-        async for _ in run_turn(turn_input):
+        async for _ in run_prepared_turn(prepared_turn):
             pass
     except asyncio.CancelledError:
         logger.info("TELEGRAM_STREAM_CANCELLED chat_id=%s", chat_id)
@@ -393,45 +389,12 @@ async def _run_llm_turn(  # noqa: C901, PLR0915
         message_thread_id=context.thread_id,
         reply_to_message_id=None,
     )
-    agent_tools = (
-        build_agent_tools(
-            workspace_root=Path(workspace.path),
-            user_id=context.pawrrtal_user_id,
-            workspace_id=workspace.id,
-            send_fn=tg_sender,
-            surface="telegram",
-            conversation_id=context.conversation_id,
-            model_id=context.model_id,
-        )
-        if workspace is not None
-        else []
-    )
-    turn_context_providers = (
-        build_turn_context_providers(workspace_root=workspace_root)
-        if workspace_root is not None
-        else []
-    )
-
-    provider, warning = await resolve_provider_with_auto_clear(
+    provider_selection, warning = await resolve_provider_with_auto_clear(
         context,
         workspace_root=workspace_root,
     )
     if warning is not None:
         await message.answer(warning, reply_parameters=_reply_parameters(message.message_id))
-
-    channel_message: ChannelMessage = {
-        "user_id": context.pawrrtal_user_id,
-        "conversation_id": context.conversation_id,
-        "text": user_text,
-        "surface": SURFACE_TELEGRAM,
-        "model_id": context.model_id,
-        "metadata": {
-            "bot": message.bot,
-            "chat_id": message.chat.id,
-            "message_id": thinking_msg.message_id,
-            "message_thread_id": context.thread_id,
-        },
-    }
 
     # Backstop: re-validate the stored reasoning_effort against the
     # current model. Telegram's /thinking picker writes the column,
@@ -445,16 +408,7 @@ async def _run_llm_turn(  # noqa: C901, PLR0915
     effective_effort = await normalize_reasoning_and_notify(
         message=message,
         conversation_id=context.conversation_id,
-        model_id=context.model_id,
-    )
-    provider_session = await prepare_provider_session(
-        provider,
-        conversation_id=context.conversation_id,
-        workspace_root=workspace_root,
-        model_id=context.model_id,
-        tools=agent_tools,
-        reasoning_effort=effective_effort,
-        question=user_text,
+        model_id=provider_selection.effective_model_id,
     )
 
     has_active_recall = False
@@ -472,37 +426,41 @@ async def _run_llm_turn(  # noqa: C901, PLR0915
             thinking_msg = await message.answer(
                 render_initial(),
             )
-            channel_message["metadata"]["message_id"] = thinking_msg.message_id
+            channel_metadata["message_id"] = thinking_msg.message_id
 
-    from app.channels.registry import resolve_channel  # noqa: PLC0415
-
-    turn_input = ChatTurnInput(
-        conversation_id=context.conversation_id,
-        user_id=context.pawrrtal_user_id,
-        question=user_text,
-        provider=provider,
-        channel=resolve_channel(SURFACE_TELEGRAM),
-        channel_message=channel_message,
-        workspace_root=workspace_root,
-        tools=agent_tools,
-        images=None,
-        # Helper to let context providers stream progress into the placeholder message.
-        draft_updater=_draft_updater,
-        on_turn_context_finished=_on_turn_context_finished,
-        log_tag="TELEGRAM",
-        log_extras={"chat_id": message.chat.id},
-        verbose_level=(
-            context.verbose_level
-            if context.verbose_level is not None
-            else settings.telegram_verbose_default
-        ),
-        turn_context_providers=turn_context_providers,
-        reasoning_effort=effective_effort,
-        provider_session=provider_session,
+    channel_metadata = {
+        "bot": message.bot,
+        "chat_id": message.chat.id,
+        "message_id": thinking_msg.message_id,
+        "message_thread_id": context.thread_id,
+    }
+    prepared_turn = await prepare_turn(
+        TurnCommand(
+            conversation_id=context.conversation_id,
+            user_id=context.pawrrtal_user_id,
+            question=user_text,
+            workspace_root=workspace_root,
+            workspace_id=workspace.id if workspace is not None else None,
+            surface=SURFACE_TELEGRAM,
+            model_id=context.model_id,
+            provider_selection=provider_selection,
+            send_fn=tg_sender,
+            channel_text=user_text,
+            channel_metadata=channel_metadata,
+            reasoning_effort=effective_effort,
+            draft_updater=_draft_updater,
+            on_turn_context_finished=_on_turn_context_finished,
+            log_tag="TELEGRAM",
+            verbose_level=(
+                context.verbose_level
+                if context.verbose_level is not None
+                else settings.telegram_verbose_default
+            ),
+        )
     )
 
     async def _do_stream() -> None:
-        async for _ in run_turn(turn_input):
+        async for _ in run_prepared_turn(prepared_turn):
             pass
 
     chat_id = message.chat.id
@@ -513,7 +471,7 @@ async def _run_llm_turn(  # noqa: C901, PLR0915
         async def _enqueued_body() -> None:
             await _execute_turn_body(
                 message=message,
-                turn_input=turn_input,
+                prepared_turn=prepared_turn,
                 user_text=user_text,
                 context=context,
             )

--- a/backend/app/channels/telegram/bot_provider_resolution.py
+++ b/backend/app/channels/telegram/bot_provider_resolution.py
@@ -1,12 +1,11 @@
-"""Provider resolution helper with auto-clear safety net.
+"""Provider-selection helper with auto-clear safety net.
 
 Extracted from :mod:`app.channels.telegram.bot` to keep that module's
 fan-out under the sentrux god-file threshold (15). The catalog / model-id
 machinery used by this helper accounts for ~4 of bot.py's import edges;
 hoisting it out concentrates them in one place.
 
-See ``_resolve_provider_with_auto_clear`` for the auto-clear contract
-(originally documented inline in ``bot.py``).
+See ``resolve_provider_with_auto_clear`` for the auto-clear contract.
 """
 
 from __future__ import annotations
@@ -17,10 +16,7 @@ from pathlib import Path
 from app.channels.crud import update_conversation_model
 from app.channels.telegram.handlers import TelegramTurnContext
 from app.infrastructure.database.legacy import async_session_maker
-from app.providers import resolve_llm
-from app.providers.base import AILLM
-from app.providers.catalog import first_catalog_model, require_known
-from app.providers.model_id import InvalidModelId, UnknownModelId
+from app.providers.selection import ProviderSelection, provider_or_default
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +25,13 @@ async def resolve_provider_with_auto_clear(
     context: TelegramTurnContext,
     *,
     workspace_root: Path | None = None,
-) -> tuple[AILLM, str | None]:
-    """Resolve a provider for ``context.model_id`` with an auto-clear safety net.
+) -> tuple[ProviderSelection, str | None]:
+    """Select a provider for ``context.model_id`` with an auto-clear safety net.
 
-    On either :class:`InvalidModelId` (string doesn't parse) or
-    :class:`UnknownModelId` (parses but isn't in the catalog), the stored
+    When the stored model is not usable, the stored
     ``conversation.model_id`` is cleared to ``NULL`` so the *next* turn
-    reads :func:`catalog.first_catalog_model` cleanly — no per-turn-fails-forever
-    UX trap — and the current turn falls back to the first catalog entry.
+    reads the catalog default cleanly — no per-turn-fails-forever UX trap —
+    and the current turn falls back to the default entry.
 
     Telegram is catalog-ignorant on the write side (``/model`` only runs
     the structural parser, per ADR 2026-05-14 §7), so this is the single
@@ -46,29 +41,21 @@ async def resolve_provider_with_auto_clear(
     Args:
         context: Resolved turn context with the stored ``model_id``.
         workspace_root: User's default workspace directory. Forwarded to
-            ``resolve_llm`` so the Claude SDK subprocess writes its
-            transcripts under the user workspace rather than the bot
-            process directory. ``None`` for users without a workspace
-            (pre-onboarding); the provider still runs isolated via
-            ``setting_sources=[]`` regardless.
+            provider adapters so native subprocesses write transcripts
+            under the user workspace rather than the bot process directory.
+            ``None`` for users without a workspace.
 
     Returns:
-        A tuple of ``(provider, warning_text_or_None)``. When the auto-clear
+        A tuple of ``(selection, warning_text_or_None)``. When the auto-clear
         path fires, ``warning_text`` is a human-readable string the caller
         should send to the user before streaming. When the stored ID is
         valid, ``warning_text`` is ``None``.
     """
-    try:
-        require_known(context.model_id)
-        provider = resolve_llm(
-            context.model_id,
-            workspace_root=workspace_root,
-        )
-    except (InvalidModelId, UnknownModelId) as exc:
-        fallback_id = first_catalog_model().id
+    selection = provider_or_default(context.model_id, workspace_root=workspace_root)
+    if selection.warning is not None:
         warning = (
-            f"Model <code>{context.model_id}</code> isn't usable: {exc}. "
-            f"Switching you back to the default ({fallback_id})."
+            f"Model <code>{context.model_id}</code> isn't usable: {selection.warning}. "
+            f"Switching you back to the default ({selection.effective_model_id})."
         )
         async with async_session_maker() as session:
             await update_conversation_model(
@@ -81,9 +68,5 @@ async def resolve_provider_with_auto_clear(
             context.conversation_id,
             context.model_id,
         )
-        provider = resolve_llm(
-            fallback_id,
-            workspace_root=workspace_root,
-        )
-        return provider, warning
-    return provider, None
+        return selection, warning
+    return selection, None

--- a/backend/app/channels/telegram/media_context.py
+++ b/backend/app/channels/telegram/media_context.py
@@ -18,18 +18,12 @@ from pathlib import Path
 
 from app.channels.telegram._attachments import TelegramVoiceNote
 from app.infrastructure.config import settings
-from app.providers.factory import resolve_llm
 from app.providers.xai.stt import XaiSttError, transcribe_xai_stt
+from app.turns.media_interpreter import describe_images_for_turn
 
 logger = logging.getLogger(__name__)
 
-_IMAGE_SYSTEM_PROMPT = (
-    "You are a visual understanding sub-agent for Pawrrtal. Describe the attached "
-    "Telegram image(s) for another agent. Be factual, concise, and include any "
-    "visible text, UI state, objects, people, diagrams, errors, or counts that "
-    "could matter to the user's request. Do not answer the user's request; only "
-    "describe the image evidence."
-)
+_IMAGE_FALLBACK_PROMPT = "Describe the attached Telegram image(s) for the next Pawrrtal agent."
 
 
 async def prepare_telegram_media_context(
@@ -101,12 +95,13 @@ async def _image_annotation(
     """Describe images with the configured vision-capable sub-agent."""
     model_id = settings.telegram_image_interpreter_model_id
     try:
-        description = await _describe_images(
+        description = await describe_images_for_turn(
             images=images,
             model_id=model_id,
             workspace_root=workspace_root,
             user_id=user_id,
             user_prompt=user_prompt,
+            fallback_prompt=_IMAGE_FALLBACK_PROMPT,
         )
     except Exception as exc:
         logger.warning(
@@ -119,49 +114,4 @@ async def _image_annotation(
     return (
         f"[Image understanding sub-agent ({model_id}) described {len(images)} image(s):\n"
         f"{description}]"
-    )
-
-
-async def _describe_images(
-    *,
-    images: list[dict[str, str]],
-    model_id: str,
-    workspace_root: Path | None,
-    user_id: uuid.UUID,
-    user_prompt: str,
-) -> str:
-    """Stream a single image-description turn and return its text."""
-    provider = resolve_llm(model_id, workspace_root=workspace_root)
-    question = _image_question(user_prompt)
-    chunks: list[str] = []
-    async for event in provider.stream(
-        question,
-        uuid.uuid4(),
-        user_id,
-        history=[],
-        tools=None,
-        system_prompt=_IMAGE_SYSTEM_PROMPT,
-        reasoning_effort="minimal",
-        images=images,
-    ):
-        if event.get("type") == "error":
-            raise RuntimeError(str(event.get("content") or "image sub-agent failed"))
-        if event.get("type") in {"delta", "message"}:
-            content = str(event.get("content") or "")
-            if content:
-                chunks.append(content)
-    description = "".join(chunks).strip()
-    if not description:
-        raise RuntimeError("image sub-agent returned an empty description")
-    return description
-
-
-def _image_question(user_prompt: str) -> str:
-    """Build the image-analysis request for the sub-agent."""
-    trimmed = user_prompt.strip()
-    if not trimmed:
-        return "Describe the attached Telegram image(s) for the next Pawrrtal agent."
-    return (
-        "Describe the attached Telegram image(s) for the next Pawrrtal agent.\n\n"
-        f"User text or caption:\n{trimmed}"
     )

--- a/backend/app/channels/telegram/model_defaults.py
+++ b/backend/app/channels/telegram/model_defaults.py
@@ -5,8 +5,7 @@ conversation using right now" walks the same fallback chain:
 
 1. ``Conversation.model_id`` (per-conversation override set via the
    picker, ``/model``, or the chat router).
-2. :func:`catalog.first_catalog_model` (positional first catalog
-   entry used as the system-wide fallback).
+2. The provider-selection default model.
 
 Centralising the chain in one helper avoids the drift that surfaces
 when ``/thinking``, ``/compact``, ``/status``, and the chat path
@@ -16,14 +15,12 @@ this module existed.
 
 from __future__ import annotations
 
-from app.providers.catalog import first_catalog_model
+from app.providers.selection import effective_model_id
 
 
 def resolve_effective_model_id(*, conversation_model_id: str | None) -> str:
     """Resolve the effective canonical model_id for a Telegram conversation.
 
-    Order: conversation override → first catalog entry.
+    Order: conversation override → provider-selection default.
     """
-    if conversation_model_id:
-        return conversation_model_id
-    return first_catalog_model().id
+    return effective_model_id(conversation_model_id=conversation_model_id)

--- a/backend/app/channels/telegram/status.py
+++ b/backend/app/channels/telegram/status.py
@@ -36,8 +36,9 @@ from app.channels.telegram.lcm_status import (
 from app.channels.telegram.model_defaults import resolve_effective_model_id
 from app.conversations.crud import ConversationStatus, get_conversation_status
 from app.infrastructure.config import settings
-from app.providers.catalog import find, first_catalog_model
+from app.providers.catalog import find
 from app.providers.model_id import InvalidModelId, parse_model_id
+from app.providers.selection import model_display
 
 
 class _TelegramSenderLike(Protocol):
@@ -146,7 +147,7 @@ def _format_model_display(model_id: str | None) -> tuple[str, str, str]:
     with a warning suffix so the status reply still renders without
     crashing.
     """
-    canonical = model_id or first_catalog_model().id
+    canonical = model_display(model_id)
     try:
         parsed = parse_model_id(canonical)
         entry = find(parsed)
@@ -181,7 +182,7 @@ def _resolve_reasoning_label(
     """
     if reasoning_effort:
         return reasoning_effort
-    canonical = model_id or first_catalog_model().id
+    canonical = model_display(model_id)
     try:
         parsed = parse_model_id(canonical)
         entry = find(parsed)

--- a/backend/app/channels/telegram/thinking_picker.py
+++ b/backend/app/channels/telegram/thinking_picker.py
@@ -31,9 +31,9 @@ from app.providers.catalog import (
     MODEL_CATALOG,
     ModelEntry,
     find,
-    first_catalog_model,
 )
 from app.providers.model_id import InvalidModelId, parse_model_id
+from app.providers.selection import model_entry_or_default
 
 PROVIDER = "telegram"
 THINKING_CALLBACK_PREFIX = "thk:"
@@ -137,7 +137,7 @@ async def get_thinking_picker_state(
     )
 
     model_id = resolve_effective_model_id(conversation_model_id=conversation.model_id)
-    entry = _resolve_entry(model_id) or first_catalog_model()
+    entry = _resolve_entry(model_id) or model_entry_or_default(model_id)
     return ThinkingPickerState(
         model_entry=entry,
         current_effort=conversation.reasoning_effort,

--- a/backend/app/channels/telegram/tool_icons.py
+++ b/backend/app/channels/telegram/tool_icons.py
@@ -46,7 +46,7 @@ _TOOL_ICONS: dict[str, str] = {
     "TodoWrite": "☑️",
     # Pawrrtal-native cross-provider tool factories (
     # ``app/core/tools/...``).  Each lands here when the chat router
-    # composes them via ``build_agent_tools``.
+    # composes them through the Turn Pipeline.
     "workspace_read": "\U0001f4d6",
     "read_file": "\U0001f4d6",
     "workspace_write": "✏️",

--- a/backend/app/channels/telegram/tools_command.py
+++ b/backend/app/channels/telegram/tools_command.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.tool_surface import build_agent_tools
 from app.agents.types import AgentTool
 from app.channels.crud import get_or_create_telegram_conversation_full
 from app.channels.telegram.dev_admin import resolve_or_autolink_telegram_user
@@ -17,6 +16,7 @@ from app.channels.telegram.sender import TelegramSender
 from app.plugins.capability_catalog import CapabilityRecord
 from app.plugins.errors import PluginError
 from app.plugins.host import get_plugin_host
+from app.turns.pipeline.prepare import compose_turn_tools
 from app.workspace.crud import get_default_workspace
 
 _NOT_BOUND_MESSAGE = "Connect your account first before listing tools."
@@ -53,7 +53,7 @@ async def handle_tools_command(*, sender: TelegramSender, session: AsyncSession)
     )
     model_id = resolve_effective_model_id(conversation_model_id=conversation.model_id)
     workspace_root = Path(workspace.path)
-    tools = build_agent_tools(
+    tools = compose_turn_tools(
         workspace_root=workspace_root,
         user_id=pawrrtal_user_id,
         workspace_id=workspace.id,

--- a/backend/app/providers/selection.py
+++ b/backend/app/providers/selection.py
@@ -1,0 +1,79 @@
+"""Provider selection helpers shared by turn preparation surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.providers.base import AILLM
+from app.providers.catalog import ModelEntry, find, first_catalog_model, require_known
+from app.providers.factory import resolve_llm
+from app.providers.model_id import InvalidModelId, UnknownModelId, parse_model_id
+
+
+@dataclass(frozen=True)
+class ProviderSelection:
+    """Resolved provider plus the model ID the turn should record."""
+
+    provider: AILLM
+    effective_model_id: str
+    warning: str | None = None
+    bad_model_id: str | None = None
+
+
+def default_model_id() -> str:
+    """Return the catalog default model ID."""
+    return first_catalog_model().id
+
+
+def effective_model_id(*, conversation_model_id: str | None) -> str:
+    """Resolve conversation override to catalog default."""
+    return conversation_model_id or default_model_id()
+
+
+def model_entry_or_default(model_id: str) -> ModelEntry:
+    """Return the catalog entry for ``model_id`` or the default entry."""
+    try:
+        parsed = parse_model_id(model_id)
+    except InvalidModelId:
+        return first_catalog_model()
+    return find(parsed) or first_catalog_model()
+
+
+def model_display(model_id: str | None, *, default_suffix: bool = False) -> str:
+    """Render a model ID with an optional default marker."""
+    if model_id:
+        return model_id
+    suffix = " (default)" if default_suffix else ""
+    return f"{default_model_id()}{suffix}"
+
+
+def require_provider(
+    model_id: str,
+    *,
+    workspace_root: Path | None = None,
+) -> ProviderSelection:
+    """Resolve ``model_id`` and propagate catalog/parse failures."""
+    require_known(model_id)
+    return ProviderSelection(
+        provider=resolve_llm(model_id, workspace_root=workspace_root),
+        effective_model_id=model_id,
+    )
+
+
+def provider_or_default(
+    model_id: str,
+    *,
+    workspace_root: Path | None = None,
+) -> ProviderSelection:
+    """Resolve ``model_id``, falling back to the catalog default on bad IDs."""
+    try:
+        return require_provider(model_id, workspace_root=workspace_root)
+    except (InvalidModelId, UnknownModelId) as exc:
+        fallback_id = default_model_id()
+        return ProviderSelection(
+            provider=resolve_llm(fallback_id, workspace_root=workspace_root),
+            effective_model_id=fallback_id,
+            warning=str(exc),
+            bad_model_id=model_id,
+        )

--- a/backend/app/turns/media_interpreter.py
+++ b/backend/app/turns/media_interpreter.py
@@ -1,0 +1,59 @@
+"""Generic media interpretation helpers used before a main turn."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from app.providers.selection import require_provider
+
+_IMAGE_SYSTEM_PROMPT = (
+    "You are a visual understanding sub-agent for Pawrrtal. Describe the attached "
+    "image(s) for another agent. Be factual, concise, and include any visible "
+    "text, UI state, objects, people, diagrams, errors, or counts that could "
+    "matter to the user's request. Do not answer the user's request; only "
+    "describe the image evidence."
+)
+
+
+async def describe_images_for_turn(
+    *,
+    images: list[dict[str, str]],
+    model_id: str,
+    workspace_root: Path | None,
+    user_id: uuid.UUID,
+    user_prompt: str,
+    fallback_prompt: str,
+) -> str:
+    """Stream a single image-description turn and return its text."""
+    selection = require_provider(model_id, workspace_root=workspace_root)
+    question = _image_question(user_prompt, fallback_prompt=fallback_prompt)
+    chunks: list[str] = []
+    async for event in selection.provider.stream(
+        question,
+        uuid.uuid4(),
+        user_id,
+        history=[],
+        tools=None,
+        system_prompt=_IMAGE_SYSTEM_PROMPT,
+        reasoning_effort="minimal",
+        images=images,
+    ):
+        if event.get("type") == "error":
+            raise RuntimeError(str(event.get("content") or "image sub-agent failed"))
+        if event.get("type") in {"delta", "message"}:
+            content = str(event.get("content") or "")
+            if content:
+                chunks.append(content)
+    description = "".join(chunks).strip()
+    if not description:
+        raise RuntimeError("image sub-agent returned an empty description")
+    return description
+
+
+def _image_question(user_prompt: str, *, fallback_prompt: str) -> str:
+    """Build the image-analysis request for the sub-agent."""
+    trimmed = user_prompt.strip()
+    if not trimmed:
+        return fallback_prompt
+    return f"{fallback_prompt}\n\nUser text or caption:\n{trimmed}"

--- a/backend/app/turns/pipeline/prepare.py
+++ b/backend/app/turns/pipeline/prepare.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import uuid
+from pathlib import Path
+from typing import Any
+
 from app.agents.tool_surface import build_agent_tools
+from app.agents.types import AgentTool
 from app.channels import ChannelMessage, resolve_channel
 from app.chat.cost_budget import enforce_cost_budget
 from app.chat.external_mcp import load_external_mcp_configs
-from app.plugins.adapters.turn_context import build_turn_context_providers
-from app.providers.factory import resolve_llm
+from app.plugins.adapters.turn_context import (
+    TurnContextProviderAdapter,
+    build_turn_context_providers,
+)
+from app.providers.selection import require_provider
 from app.providers.session_preparer import prepare_provider_session
+from app.tools.send_message import SendFn
 
 from .types import ChatTurnInput, PreparedTurn, TurnCommand
 
@@ -22,27 +31,30 @@ async def prepare_turn(command: TurnCommand) -> PreparedTurn:
             rid=command.request_id or "",
         )
 
-    provider = resolve_llm(command.model_id, workspace_root=command.workspace_root)
+    selection = command.provider_selection or require_provider(
+        command.model_id,
+        workspace_root=command.workspace_root,
+    )
     external_mcp_configs = (
         await load_external_mcp_configs(session=command.db_session, user_id=command.user_id)
         if command.db_session is not None
         else []
     )
-    agent_tools = build_agent_tools(
+    agent_tools = compose_turn_tools(
         workspace_root=command.workspace_root,
         user_id=command.user_id,
         workspace_id=command.workspace_id,
         send_fn=command.send_fn,
         surface=command.surface,
         conversation_id=command.conversation_id,
-        model_id=command.model_id,
+        model_id=selection.effective_model_id,
         external_mcp_configs=external_mcp_configs,
     )
     provider_session = await prepare_provider_session(
-        provider,
+        selection.provider,
         conversation_id=command.conversation_id,
         workspace_root=command.workspace_root,
-        model_id=command.model_id,
+        model_id=selection.effective_model_id,
         tools=agent_tools,
         reasoning_effort=command.reasoning_effort,
         question=command.question,
@@ -50,16 +62,16 @@ async def prepare_turn(command: TurnCommand) -> PreparedTurn:
     channel_message: ChannelMessage = {
         "user_id": command.user_id,
         "conversation_id": command.conversation_id,
-        "text": command.question,
+        "text": command.channel_text or command.question,
         "surface": command.surface,
-        "model_id": command.model_id,
-        "metadata": command.metadata,
+        "model_id": selection.effective_model_id,
+        "metadata": command.channel_metadata,
     }
     turn_input = ChatTurnInput(
         conversation_id=command.conversation_id,
         user_id=command.user_id,
         question=command.question,
-        provider=provider,
+        provider=selection.provider,
         channel=resolve_channel(command.surface),
         channel_message=channel_message,
         workspace_root=command.workspace_root,
@@ -70,10 +82,46 @@ async def prepare_turn(command: TurnCommand) -> PreparedTurn:
         log_tag=command.log_tag,
         log_extras={
             "rid": command.request_id,
-            "model_id": command.model_id,
+            "model_id": selection.effective_model_id,
             "surface": command.surface,
         },
-        turn_context_providers=build_turn_context_providers(workspace_root=command.workspace_root),
+        verbose_level=command.verbose_level,
+        turn_context_providers=_turn_context_providers(command),
         provider_session=provider_session,
+        draft_updater=command.draft_updater,
+        on_turn_context_finished=command.on_turn_context_finished,
     )
-    return PreparedTurn(turn_input=turn_input, effective_model_id=command.model_id)
+    return PreparedTurn(turn_input=turn_input, effective_model_id=selection.effective_model_id)
+
+
+def compose_turn_tools(
+    *,
+    workspace_root: Path | None,
+    user_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
+    send_fn: SendFn | None = None,
+    surface: str | None = None,
+    conversation_id: uuid.UUID | None = None,
+    model_id: str | None = None,
+    external_mcp_configs: list[dict[str, Any]] | None = None,
+) -> list[AgentTool]:
+    """Compose the agent tool surface when a workspace is available."""
+    if workspace_root is None or workspace_id is None:
+        return []
+    return build_agent_tools(
+        workspace_root=workspace_root,
+        user_id=user_id,
+        workspace_id=workspace_id,
+        send_fn=send_fn,
+        surface=surface,
+        conversation_id=conversation_id,
+        model_id=model_id,
+        external_mcp_configs=external_mcp_configs,
+    )
+
+
+def _turn_context_providers(command: TurnCommand) -> list[TurnContextProviderAdapter]:
+    """Build turn context providers only when the turn has a workspace root."""
+    if command.workspace_root is None:
+        return []
+    return build_turn_context_providers(workspace_root=command.workspace_root)

--- a/backend/app/turns/pipeline/types.py
+++ b/backend/app/turns/pipeline/types.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from app.plugins.adapters.turn_context import TurnContextProviderAdapter
 from app.provider_sessions import ProviderSessionTurnState
+from app.providers.selection import ProviderSelection
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,8 +31,8 @@ class TurnCommand:
     conversation_id: uuid.UUID
     user_id: uuid.UUID
     question: str
-    workspace_root: Path
-    workspace_id: uuid.UUID
+    workspace_root: Path | None
+    workspace_id: uuid.UUID | None
     surface: str
     model_id: str
     reasoning_effort: ReasoningEffort | None = None
@@ -41,6 +42,12 @@ class TurnCommand:
     history_window: int = 20
     log_tag: str = "TURN"
     send_fn: SendMessageFn | None = None
+    channel_text: str | None = None
+    channel_metadata: dict[str, Any] = field(default_factory=dict)
+    verbose_level: int | None = None
+    provider_selection: ProviderSelection | None = None
+    draft_updater: Callable[[str], Awaitable[None]] | None = None
+    on_turn_context_finished: Callable[[], Awaitable[None]] | None = None
     db_session: AsyncSession | None = field(default=None, repr=False, compare=False)
 
 

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -1,6 +1,7 @@
 """API tests for chat streaming routes."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -8,7 +9,18 @@ from httpx import AsyncClient
 
 from app.agents.types import AgentSafetyConfig
 from app.models import Workspace  # used via fixture type hint
+from app.providers.base import AILLM
+from app.providers.selection import ProviderSelection
 from tests.agent_loop_harness import ScriptedStreamFn, echo_tool, text_turn, tool_call_turn
+
+
+def _select_provider(provider: object) -> Callable[..., ProviderSelection]:
+    """Return a turn-pipeline provider selector for ``provider``."""
+
+    def _require_provider(model_id: str, **_kwargs: object) -> ProviderSelection:
+        return ProviderSelection(provider=cast(AILLM, provider), effective_model_id=model_id)
+
+    return _require_provider
 
 
 class FakeProvider:
@@ -81,8 +93,8 @@ async def test_chat_streams_provider_events(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Chat"})
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "hello"}]),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(FakeProvider([{"type": "delta", "content": "hello"}])),
     )
 
     response = await client.post(
@@ -109,8 +121,8 @@ async def test_chat_persists_user_and_finalized_assistant_messages(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Chat"})
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "hello"}]),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(FakeProvider([{"type": "delta", "content": "hello"}])),
     )
 
     response = await client.post(
@@ -173,8 +185,8 @@ async def test_chat_forwards_reasoning_effort(
                 yield event
 
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **_kwargs: CapturingProvider([{"type": "delta", "content": "ok"}]),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(CapturingProvider([{"type": "delta", "content": "ok"}])),
     )
 
     response = await client.post(
@@ -201,8 +213,8 @@ async def test_chat_persists_requested_model_id(
     conversation_id = uuid4()
     await client.post(f"/api/v1/conversations/{conversation_id}", json={"title": "Model"})
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: FakeProvider([{"type": "delta", "content": "ok"}]),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(FakeProvider([{"type": "delta", "content": "ok"}])),
     )
 
     response = await client.post(
@@ -277,7 +289,7 @@ async def test_chat_stream_converts_provider_exception_to_error_event(
             yield {"type": "delta", "content": "unreachable"}
 
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **kwargs: FailingProvider()
+        "app.turns.pipeline.prepare.require_provider", _select_provider(FailingProvider())
     )
 
     response = await client.post(
@@ -329,7 +341,7 @@ async def test_chat_multi_turn_tool_call_flows_through_full_http_path(
     monkeypatch.setattr(provider, "_stream_fn", script)
 
     # Inject both the provider and the echo tool into the chat path.
-    monkeypatch.setattr("app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **_kw: provider)
+    monkeypatch.setattr("app.turns.pipeline.prepare.require_provider", _select_provider(provider))
     monkeypatch.setattr(
         "app.turns.pipeline.prepare.build_agent_tools", lambda *_args, **_kw: [echo]
     )
@@ -403,7 +415,7 @@ async def test_chat_safety_layer_fires_and_surfaces_agent_terminated(
         ),
     )
 
-    monkeypatch.setattr("app.turns.pipeline.prepare.resolve_llm", lambda _model_id, **_kw: provider)
+    monkeypatch.setattr("app.turns.pipeline.prepare.require_provider", _select_provider(provider))
     monkeypatch.setattr(
         "app.turns.pipeline.prepare.build_agent_tools", lambda *_args, **_kw: [echo_tool("ping")]
     )

--- a/backend/tests/test_chat_sqlite_session_lifecycle.py
+++ b/backend/tests/test_chat_sqlite_session_lifecycle.py
@@ -16,7 +16,7 @@ generator — same connection lifecycle the Telegram path already uses.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any, cast
 from uuid import uuid4
 
@@ -25,8 +25,18 @@ from httpx import AsyncClient
 
 from app.channels.sse import SSEChannel
 from app.models import Workspace
-from app.providers.base import StreamEvent
+from app.providers.base import AILLM, StreamEvent
 from app.providers.catalog import first_catalog_model
+from app.providers.selection import ProviderSelection
+
+
+def _select_provider(provider: object) -> Callable[..., ProviderSelection]:
+    """Return a turn-pipeline provider selector for ``provider``."""
+
+    def _require_provider(model_id: str, **_kwargs: object) -> ProviderSelection:
+        return ProviderSelection(provider=cast(AILLM, provider), effective_model_id=model_id)
+
+    return _require_provider
 
 
 class _FakeProvider:
@@ -67,8 +77,8 @@ async def test_chat_router_does_not_pass_request_session_into_turn_input(
         json={"title": "SQLite Lifecycle"},
     )
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: _FakeProvider(),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(_FakeProvider()),
     )
 
     captured: dict[str, Any] = {}
@@ -127,8 +137,8 @@ async def test_chat_finalizes_assistant_status_on_sqlite(
         json={"title": "Finalize"},
     )
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: _FakeProvider(),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(_FakeProvider()),
     )
 
     response = await client.post(
@@ -212,8 +222,8 @@ async def test_finalize_turn_leaves_message_complete_on_cost_write_failure(
         json={"title": "Cost Failure"},
     )
     monkeypatch.setattr(
-        "app.turns.pipeline.prepare.resolve_llm",
-        lambda _model_id, **kwargs: _FakeProvider(),
+        "app.turns.pipeline.prepare.require_provider",
+        _select_provider(_FakeProvider()),
     )
 
     async def _explode(**_kwargs: Any) -> None:

--- a/backend/tests/test_google_chat_ingress.py
+++ b/backend/tests/test_google_chat_ingress.py
@@ -12,7 +12,8 @@ import pytest
 from app.channels.google_chat import ingress
 from app.channels.google_chat.attachments import GoogleChatAttachments
 from app.channels.google_chat.channel import SURFACE_GOOGLE_CHAT
-from app.turns.pipeline import ChatTurnInput
+from app.providers.selection import ProviderSelection
+from app.turns.pipeline import PreparedTurn
 
 
 class _Provider:
@@ -36,7 +37,7 @@ async def test_google_chat_message_event_submits_normalized_turn(
     workspace_id = uuid4()
     provider: Any = _Provider()
     channel: Any = _Channel()
-    captured: dict[str, ChatTurnInput] = {}
+    captured: dict[str, PreparedTurn] = {}
 
     async def resolve_turn_target(_event: dict[str, Any]) -> ingress._TurnTarget:
         return ingress._TurnTarget(
@@ -65,21 +66,24 @@ async def test_google_chat_message_event_submits_normalized_turn(
             annotations=["[User sent a document: brief.md.]"],
         )
 
-    async def run_turn(turn_input: ChatTurnInput) -> AsyncIterator[bytes]:
-        captured["turn_input"] = turn_input
+    async def run_prepared_turn(prepared_turn: PreparedTurn) -> AsyncIterator[bytes]:
+        captured["prepared_turn"] = prepared_turn
         yield b""
 
     monkeypatch.setattr(ingress, "_resolve_turn_target", resolve_turn_target)
     monkeypatch.setattr(
         ingress,
-        "_resolve_provider",
-        lambda model_id, workspace_root: (provider, "agent-sdk:anthropic/claude-opus-4-7"),
+        "provider_or_default",
+        lambda model_id, workspace_root: ProviderSelection(
+            provider=provider,
+            effective_model_id="agent-sdk:anthropic/claude-opus-4-7",
+        ),
     )
-    monkeypatch.setattr(ingress, "build_agent_tools", lambda **_kwargs: [])
     monkeypatch.setattr(ingress, "create_message", create_placeholder)
     monkeypatch.setattr(ingress, "collect_attachments", collect_attachments)
-    monkeypatch.setattr("app.channels.registry.resolve_channel", lambda _surface: channel)
-    monkeypatch.setattr(ingress, "run_turn", run_turn)
+    monkeypatch.setattr("app.turns.pipeline.prepare.compose_turn_tools", lambda **_kwargs: [])
+    monkeypatch.setattr("app.turns.pipeline.prepare.resolve_channel", lambda _surface: channel)
+    monkeypatch.setattr(ingress, "run_prepared_turn", run_prepared_turn)
 
     event = {
         "type": "MESSAGE",
@@ -93,7 +97,7 @@ async def test_google_chat_message_event_submits_normalized_turn(
 
     await ingress._handle_message_event(event)
 
-    turn_input = captured["turn_input"]
+    turn_input = captured["prepared_turn"].turn_input
     assert turn_input.conversation_id == conversation_id
     assert turn_input.user_id == user_id
     assert turn_input.question == "hello\n\n[User sent a document: brief.md.]"

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -61,6 +61,7 @@ from app.channels.telegram.status import (
 from app.conversations.crud import ConversationStatus
 from app.providers.base import StreamEvent
 from app.providers.catalog import first_catalog_model
+from app.providers.selection import ProviderSelection
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1127,11 +1128,11 @@ class TestResolveProviderWithAutoClear:
     """Cover the chat-turn safety net that catches unknown/malformed stored IDs.
 
     The handler in :mod:`app.channels.telegram.bot` wraps the
-    ``resolve_llm`` call so that an unknown-but-well-formed stored model
+    provider selection so that an unknown-but-well-formed stored model
     surfaces an immediate user-facing warning, clears the stored value,
     and still completes the current turn using the catalog default.
 
-    These tests mock ``async_session_maker`` and ``resolve_llm`` so the
+    These tests mock ``async_session_maker`` and provider selection so the
     branching is exercised without spinning up the DB or the providers.
     """
 
@@ -1157,8 +1158,14 @@ class TestResolveProviderWithAutoClear:
 
         fake_default_provider = MagicMock(name="default_provider")
         update_mock = AsyncMock(return_value=True)
-        # ``resolve_llm`` is a sync function — use MagicMock, not AsyncMock.
-        resolve_mock = MagicMock(side_effect=[fake_default_provider])
+        selection_mock = MagicMock(
+            return_value=ProviderSelection(
+                provider=fake_default_provider,
+                effective_model_id=first_catalog_model().id,
+                warning="model not in catalog",
+                bad_model_id=context.model_id,
+            )
+        )
 
         # ``async_session_maker`` is used as an async context manager.
         fake_session = AsyncMock()
@@ -1168,8 +1175,8 @@ class TestResolveProviderWithAutoClear:
 
         with (
             patch(
-                "app.channels.telegram.bot_provider_resolution.resolve_llm",
-                new=resolve_mock,
+                "app.channels.telegram.bot_provider_resolution.provider_or_default",
+                new=selection_mock,
             ),
             patch(
                 "app.channels.telegram.bot_provider_resolution.update_conversation_model",
@@ -1180,7 +1187,7 @@ class TestResolveProviderWithAutoClear:
                 new=fake_session_maker,
             ),
         ):
-            provider, warning = await _resolve_provider_with_auto_clear(context)
+            selection, warning = await _resolve_provider_with_auto_clear(context)
 
         # Warning was produced and mentions the bad ID + the fallback.
         assert warning is not None
@@ -1193,13 +1200,9 @@ class TestResolveProviderWithAutoClear:
         assert update_mock.await_args.kwargs["model_id"] is None
         assert update_mock.await_args.kwargs["conversation_id"] == context.conversation_id
 
-        # resolve_llm was called *once* — only for the catalog fallback.
-        # (For the unknown path ``require_known()`` raises first, so
-        # ``resolve_llm`` is only invoked for the fallback.)
-        assert resolve_mock.call_count == 1
-        fallback_call = resolve_mock.call_args
-        assert fallback_call.args[0] == first_catalog_model().id
-        assert provider is fake_default_provider
+        selection_mock.assert_called_once_with(context.model_id, workspace_root=None)
+        assert selection.provider is fake_default_provider
+        assert selection.effective_model_id == first_catalog_model().id
 
     async def test_following_turn_uses_catalog_default_after_clear(self) -> None:
         """After the auto-clear, a turn with ``model_id=None`` resolves cleanly.
@@ -1213,28 +1216,31 @@ class TestResolveProviderWithAutoClear:
 
         fake_default_provider = MagicMock(name="default_provider")
         update_mock = AsyncMock(return_value=True)
-        resolve_mock = MagicMock(side_effect=[fake_default_provider])
+        selection_mock = MagicMock(
+            return_value=ProviderSelection(
+                provider=fake_default_provider,
+                effective_model_id=first_catalog_model().id,
+            )
+        )
 
         with (
             patch(
-                "app.channels.telegram.bot_provider_resolution.resolve_llm",
-                new=resolve_mock,
+                "app.channels.telegram.bot_provider_resolution.provider_or_default",
+                new=selection_mock,
             ),
             patch(
                 "app.channels.telegram.bot_provider_resolution.update_conversation_model",
                 new=update_mock,
             ),
         ):
-            provider, warning = await _resolve_provider_with_auto_clear(context)
+            selection, warning = await _resolve_provider_with_auto_clear(context)
 
         # Clean path: no warning, no clear.
         assert warning is None
         update_mock.assert_not_awaited()
 
-        # resolve_llm was called exactly once with the stored canonical ID.
-        assert resolve_mock.call_count == 1
-        assert resolve_mock.call_args.args[0] == first_catalog_model().id
-        assert provider is fake_default_provider
+        selection_mock.assert_called_once_with(context.model_id, workspace_root=None)
+        assert selection.provider is fake_default_provider
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_media_context.py
+++ b/backend/tests/test_telegram_media_context.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from app.channels.telegram._attachments import TelegramVoiceNote
 from app.channels.telegram.media_context import prepare_telegram_media_context
 from app.infrastructure.config import Settings
-from app.providers.base import StreamEvent
+from app.providers.base import AILLM, StreamEvent
 from app.providers.model_id import Host, parse_model_id
+from app.providers.selection import ProviderSelection
 
 pytestmark = pytest.mark.anyio
 
@@ -49,8 +50,11 @@ async def test_prepare_media_context_interprets_images_with_sub_agent(
     """Image bytes become a text annotation and are not sent to the main model."""
     provider = _FakeImageProvider()
     monkeypatch.setattr(
-        "app.channels.telegram.media_context.resolve_llm",
-        lambda model_id, *, workspace_root: provider,
+        "app.turns.media_interpreter.require_provider",
+        lambda model_id, *, workspace_root: ProviderSelection(
+            provider=cast(AILLM, provider),
+            effective_model_id=model_id,
+        ),
     )
     monkeypatch.setattr(
         "app.channels.telegram.media_context.settings.telegram_image_interpreter_model_id",

--- a/backend/tests/test_telegram_tools_command.py
+++ b/backend/tests/test_telegram_tools_command.py
@@ -93,7 +93,7 @@ async def test_tools_command_renders_actual_tools_and_plugin_capabilities(
             new=MagicMock(return_value=conversation.model_id),
         ),
         patch(
-            "app.channels.telegram.tools_command.build_agent_tools",
+            "app.channels.telegram.tools_command.compose_turn_tools",
             new=MagicMock(return_value=[tool]),
         ),
         patch("app.channels.telegram.tools_command.get_plugin_host", return_value=host),

--- a/backend/tests/test_telegram_turn_provider_session.py
+++ b/backend/tests/test_telegram_turn_provider_session.py
@@ -14,6 +14,7 @@ import pytest
 from app.channels.telegram.bot import _run_llm_turn
 from app.channels.telegram.handlers import TelegramTurnContext
 from app.provider_sessions import ProviderSessionTurnState
+from app.providers.selection import ProviderSelection
 
 
 @pytest.mark.anyio
@@ -36,8 +37,8 @@ async def test_run_llm_turn_passes_prepared_provider_session(tmp_path: Path) -> 
     )
     captured: dict[str, Any] = {}
 
-    async def fake_run_turn(turn_input: Any) -> AsyncIterator[bytes]:
-        captured["turn_input"] = turn_input
+    async def fake_run_prepared_turn(prepared_turn: Any) -> AsyncIterator[bytes]:
+        captured["turn_input"] = prepared_turn.turn_input
         if False:
             yield b""
 
@@ -48,18 +49,25 @@ async def test_run_llm_turn_passes_prepared_provider_session(tmp_path: Path) -> 
     with (
         patch("app.channels.telegram.bot.async_session_maker", new=fake_session_maker),
         patch("app.workspace.crud.get_default_workspace", AsyncMock(return_value=workspace)),
-        patch("app.channels.telegram.bot.build_agent_tools", MagicMock(return_value=[])),
         patch(
             "app.channels.telegram.bot.resolve_provider_with_auto_clear",
-            AsyncMock(return_value=(MagicMock(), None)),
+            AsyncMock(
+                return_value=(
+                    ProviderSelection(
+                        provider=MagicMock(),
+                        effective_model_id="openai-codex:openai/gpt-5.5",
+                    ),
+                    None,
+                )
+            ),
         ),
         patch(
             "app.channels.telegram.bot.normalize_reasoning_and_notify",
             AsyncMock(return_value=None),
         ),
         patch(
-            "app.channels.telegram.bot.prepare_provider_session",
-            AsyncMock(
+            "app.turns.pipeline.prepare.prepare_provider_session",
+            new=AsyncMock(
                 return_value=ProviderSessionTurnState(
                     kind="openai_codex",
                     session_id="thr_telegram",
@@ -71,7 +79,7 @@ async def test_run_llm_turn_passes_prepared_provider_session(tmp_path: Path) -> 
                 ),
             ),
         ),
-        patch("app.channels.telegram.bot.run_turn", new=fake_run_turn),
+        patch("app.channels.telegram.bot.run_prepared_turn", new=fake_run_prepared_turn),
     ):
         await _run_llm_turn(message=cast(Any, message), context=context)
 


### PR DESCRIPTION
## Summary

- routes Telegram and Google Chat message turns through `TurnCommand`, `prepare_turn`, and `run_prepared_turn`
- moves shared provider selection and default/fallback display helpers into `app.providers.selection`
- moves Telegram image interpretation into `app.turns.media_interpreter`, leaving Telegram with attachment collection and channel-specific formatting only
- keeps channel responsibilities scoped to ingress, commands, rendering, placeholders, delivery, and channel metadata

## Architecture Proof

- `backend/app/channels/telegram/**` and `backend/app/channels/google_chat/**` no longer reference `resolve_llm`, `prepare_provider_session`, `build_agent_tools`, or `first_catalog_model`
- provider/session/tool composition now happens in `backend/app/turns/pipeline/prepare.py`
- optional channel behavior is passed through `TurnCommand` fields instead of assembled inside channel runners

## Verification

- `cd backend && uv run pytest`  
  `2268 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `cd backend && uv run pytest tests/test_telegram_channel.py tests/test_telegram_dispatch.py tests/test_telegram_media_context.py tests/test_telegram_message_queue.py tests/test_telegram_model_picker.py tests/test_telegram_turn_provider_session.py tests/paw/test_verify_telegram.py tests/paw/test_verify_google_chat.py tests/test_google_chat_ingress.py tests/test_chat_api.py tests/test_chat_sqlite_session_lifecycle.py tests/test_telegram_tools_command.py`  
  `126 passed`
- `cd backend && uv run mypy .`  
  `Success: no issues found in 713 source files`
- `just check`
- `just arch`
- `python3 scripts/check-no-tools-in-providers.py`
- `python3 scripts/check-nesting.py`
- `node scripts/check-file-lines.mjs`
- `git diff --cached --check`
- `paw verify google-chat --json`  
  passed
- `paw verify chat-roundtrip --json`  
  blocked by local Paw auth: `Session expired or missing. Run paw login.`
- `paw verify telegram --json`  
  blocked by local Paw auth: `Session expired or missing. Run paw login.`

## Secret Check

- pre-commit `detect private key` passed
- pre-commit `Detect hardcoded secrets` passed
- changed-file secret scan found only false positives such as token counters/settings names and test capability metadata

## Summary by Sourcery

Route Telegram and Google Chat turns through the shared turn pipeline and centralize provider/model selection and media interpretation utilities.

Enhancements:
- Refactor Telegram and Google Chat channels to construct TurnCommand objects, use prepare_turn, and stream via run_prepared_turn instead of assembling provider sessions per channel.
- Introduce a shared provider selection module to handle default model IDs, catalog lookups, and user-facing model display across channels and status commands.
- Extract image interpretation logic into a generic media interpreter for use before main turns, simplifying Telegram media context handling.
- Adjust turn pipeline types and helpers to support optional workspace context, richer channel metadata, and centralized tool composition.

Tests:
- Update Telegram, Google Chat, and chat API tests to work with provider selection, prepared turns, and the new media interpreter abstractions.