### PR TITLE
[5/12] Refactor scheduled turns through pipeline

### DIFF
--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -73,12 +73,6 @@ ignore_imports =
     app.governance.cost_tracker -> app.models
     app.agents.scheduling.scheduler -> app.models
     app.infrastructure.event_bus.handlers -> app.workspace.crud
-    ; AgentHandler optionally persists scheduled-job responses into a
-    ; target conversation (e.g. the heartbeat sink). Lazy-imports the
-    ; chat_message CRUD inside the persistence helper so the bus
-    ; module stays decoupled at load time; flatten in a follow-up
-    ; alongside the workspace one above.
-    app.infrastructure.event_bus.handlers -> app.conversations.messages_crud
     ; LCM (Stack B / PRs #186–#196) owns three ORM tables
     ; (lcm_summaries, lcm_summary_sources, lcm_context_items) and must
     ; read/write them directly to assemble context, compact leaves, and

--- a/backend/app/infrastructure/event_bus/handlers.py
+++ b/backend/app/infrastructure/event_bus/handlers.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from app.infrastructure.database.legacy import async_session_maker
 from app.infrastructure.event_bus.bus import Event
@@ -14,7 +13,6 @@ from app.infrastructure.event_bus.types import (
     ScheduledEvent,
     WebhookEvent,
 )
-from app.providers import first_catalog_model, resolve_llm
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +30,13 @@ _PAYLOAD_LEAF_PREVIEW_CHARS = 200
 class AgentHandler:
     """Bus subscriber that runs an agent turn for webhook + scheduled events.
 
-    Both event types collapse to the same shape: build a prompt,
-    resolve the default provider, stream a turn (collecting just the
-    text deltas), and publish an :class:`AgentResponseEvent` carrying
-    the rendered text.
+    Targeted events collapse to the same shape: build a prompt, run it
+    through the Turn Pipeline using a system delivery adapter, then
+    publish an :class:`AgentResponseEvent` carrying the rendered text.
 
-    This is intentionally a thin orchestration layer — it does NOT
-    do tool composition, channel delivery, or persistence.  Each of
-    those already lives in a single source of truth elsewhere in
-    the codebase (``agent_tools.build_agent_tools``,
-    ``app.channels``, ``crud.chat_message``).  A more sophisticated
-    handler that persists a conversation row per fire is a follow-on.
+    This stays a thin orchestration layer. Provider resolution, tool
+    composition, provider sessions, context providers, persistence,
+    finalization, and cost accounting belong to the Turn Pipeline.
     """
 
     def __init__(self, *, default_user_id: uuid.UUID | None = None) -> None:
@@ -104,14 +98,12 @@ class AgentHandler:
         target_conversation_id: uuid.UUID | None = None,
         originating_event_id: str,
     ) -> None:
-        """Stream a turn, persist it, publish an AgentResponseEvent.
+        """Run a targeted turn and publish its text as an AgentResponseEvent.
 
-        When ``target_conversation_id`` is provided, the rendered text is
-        written into ``chat_messages`` as a finalised assistant turn
-        *before* Telegram fan-out. The persist step is best-effort: if
-        the conversation has been deleted or the write fails, the
-        delivery to Telegram still happens so the user isn't silently
-        denied the heartbeat output.
+        ``target_conversation_id`` is required because the Turn Pipeline
+        persists the user turn and assistant placeholder against a real
+        conversation. Untargeted webhook traffic is skipped until the
+        product has a deliberate destination for system-originated turns.
         """
         if user_id is None:
             logger.warning(
@@ -119,8 +111,20 @@ class AgentHandler:
                 originating_event_id,
             )
             return
+        if target_conversation_id is None:
+            logger.warning(
+                "AGENT_HANDLER_NO_TARGET_CONVERSATION originating_event_id=%s user_id=%s; skipping",
+                originating_event_id,
+                user_id,
+            )
+            return
         try:
-            text = await _run_agent_turn(prompt=prompt, user_id=user_id)
+            text = await _run_agent_turn(
+                prompt=prompt,
+                user_id=user_id,
+                conversation_id=target_conversation_id,
+                originating_event_id=originating_event_id,
+            )
         except Exception:
             logger.exception(
                 "AGENT_HANDLER_RUN_FAILED originating_event_id=%s user_id=%s",
@@ -135,13 +139,6 @@ class AgentHandler:
                 user_id,
             )
             return
-        if target_conversation_id is not None:
-            await _persist_assistant_response(
-                conversation_id=target_conversation_id,
-                user_id=user_id,
-                text=text,
-                originating_event_id=originating_event_id,
-            )
         # Lazy import — keeps the handler module decoupled from the
         # bus-publish helper to avoid a circular import surface.
         from app.infrastructure.event_bus.global_bus import (  # noqa: PLC0415
@@ -237,110 +234,56 @@ def _flatten_dict(
             lines.append(f"{full}: {_format_leaf(value)}")
 
 
-async def _run_agent_turn(*, prompt: str, user_id: uuid.UUID) -> str:
-    """Stream one provider turn and return the concatenated assistant text.
+async def _run_agent_turn(
+    *,
+    prompt: str,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    originating_event_id: str,
+) -> str:
+    """Run one targeted event through the Turn Pipeline and return text."""
+    from pathlib import Path  # noqa: PLC0415
 
-    Resolves the catalog default model + the user's workspace + the
-    standard tool composition.  Skips workspace tools when the user
-    hasn't completed onboarding (no default workspace) — webhook /
-    scheduled traffic shouldn't be gated on the onboarding flow.
-    """
-    # All imports are lazy so the bus module can be loaded without
-    # pulling in the chat router's heavy dependency tree.
-    from app.agents.tool_surface import build_agent_tools  # noqa: PLC0415
-    from app.governance.workspace_context import (  # noqa: PLC0415
-        load_workspace_context,
-    )
+    from app.conversations.crud import get_conversation  # noqa: PLC0415
+    from app.providers.base import ReasoningEffort  # noqa: PLC0415
+    from app.providers.selection import default_model_id  # noqa: PLC0415
+    from app.turns.pipeline import TurnCommand, prepare_turn, run_prepared_turn  # noqa: PLC0415
+    from app.turns.pipeline.delivery import SystemDeliveryAdapter  # noqa: PLC0415
     from app.workspace.crud import get_default_workspace  # noqa: PLC0415
 
     async with async_session_maker() as session:
         workspace = await get_default_workspace(user_id, session)
+        conversation = await get_conversation(user_id, session, conversation_id)
 
-    workspace_root: Path | None = Path(workspace.path) if workspace is not None else None
-    workspace_ctx = load_workspace_context(workspace_root) if workspace_root is not None else None
-    system_prompt = workspace_ctx.system_prompt if workspace_ctx is not None else None
-    model_id = first_catalog_model().id
-
-    agent_tools = (
-        build_agent_tools(
-            workspace_root=workspace_root,
-            user_id=user_id,
-            workspace_id=workspace.id,
-            send_fn=None,
-            surface="webhook",
-            model_id=model_id,
-        )
-        if workspace is not None and workspace_root is not None
-        else []
-    )
-
-    # resolve_llm does not accept user_id; workspace_root carries the
-    # per-user key resolution upstream. Kept for call-site symmetry.
-    _ = user_id
-    provider = resolve_llm(
-        model_id,
-        workspace_root=workspace_root,
-    )
-
-    accumulated: list[str] = [
-        stream_event.get("content", "")
-        async for stream_event in provider.stream(
-            prompt,
-            uuid.uuid4(),
-            user_id,
-            history=[],
-            tools=agent_tools or None,
-            system_prompt=system_prompt,
-        )
-        if stream_event.get("type") == "delta"
-    ]
-    return "".join(accumulated).strip()
-
-
-async def _persist_assistant_response(
-    *,
-    conversation_id: uuid.UUID,
-    user_id: uuid.UUID,
-    text: str,
-    originating_event_id: str,
-) -> None:
-    """Write the agent's response into a chat conversation as a finalised turn.
-
-    Lazy imports keep ``event_bus.handlers`` from pulling the
-    chat-message CRUD into its module-load graph — the sentrux layer
-    rule wants core code to avoid hard imports of ``app.crud.*``.
-
-    Failures are logged and swallowed: a persistence error must not
-    break the Telegram fan-out that follows in the caller. The row is
-    written via the same helpers the web chat router uses, so the
-    UI's existing ``GET .../messages`` path picks it up immediately.
-    """
-    from app.conversations.messages_crud import (  # noqa: PLC0415
-        append_assistant_placeholder,
-        finalize_assistant_message,
-    )
-
-    try:
-        async with async_session_maker() as session:
-            placeholder = await append_assistant_placeholder(
-                session,
-                conversation_id=conversation_id,
-                user_id=user_id,
-            )
-            await finalize_assistant_message(
-                session,
-                message_id=placeholder.id,
-                content=text,
-                thinking=None,
-                tool_calls=None,
-                timeline=None,
-                thinking_duration_seconds=None,
-                assistant_status="complete",
-            )
-            await session.commit()
-    except Exception:
-        logger.exception(
-            "AGENT_HANDLER_PERSIST_FAILED conversation_id=%s originating_event_id=%s",
+    if conversation is None:
+        logger.warning(
+            "AGENT_HANDLER_TARGET_CONVERSATION_MISSING conversation_id=%s originating_event_id=%s",
             conversation_id,
             originating_event_id,
         )
+        return ""
+
+    workspace_root = Path(workspace.path) if workspace is not None else None
+    delivery = SystemDeliveryAdapter()
+    prepared_turn = await prepare_turn(
+        TurnCommand(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            question=prompt,
+            workspace_root=workspace_root,
+            workspace_id=workspace.id if workspace is not None else None,
+            surface=delivery.surface,
+            model_id=conversation.model_id or default_model_id(),
+            reasoning_effort=cast(ReasoningEffort | None, conversation.reasoning_effort),
+            request_id=originating_event_id,
+            channel_metadata={
+                "originating_event_id": originating_event_id,
+                "source": "event_bus",
+            },
+            delivery_adapter=delivery,
+            verbose_level=conversation.verbose_level,
+        )
+    )
+    async for _chunk in run_prepared_turn(prepared_turn):
+        pass
+    return delivery.final_text

--- a/backend/app/turns/pipeline/__init__.py
+++ b/backend/app/turns/pipeline/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .delivery import SystemDeliveryAdapter
 from .finalize import _finalize_turn
 from .history import _load_history_and_persist, _workspace_system_prompt
 from .prepare import prepare_turn
@@ -27,6 +28,7 @@ __all__ = [
     "DeliveryAdapter",
     "EventHook",
     "PreparedTurn",
+    "SystemDeliveryAdapter",
     "TurnCommand",
     "TurnResult",
     "_finalize_turn",

--- a/backend/app/turns/pipeline/delivery.py
+++ b/backend/app/turns/pipeline/delivery.py
@@ -1,0 +1,35 @@
+"""Turn Pipeline delivery adapters for non-user surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+from app.channels import ChannelMessage
+from app.providers.base import StreamEvent
+
+
+@dataclass
+class SystemDeliveryAdapter:
+    """Collect turn events without writing to a user-channel transport."""
+
+    surface: str = "system"
+    events: list[StreamEvent] = field(default_factory=list)
+
+    @property
+    def final_text(self) -> str:
+        """Return concatenated assistant delta text from collected events."""
+        return "".join(
+            event.get("content", "") for event in self.events if event.get("type") == "delta"
+        ).strip()
+
+    async def deliver(
+        self,
+        stream: AsyncIterator[StreamEvent],
+        _message: ChannelMessage,
+    ) -> AsyncIterator[bytes]:
+        """Drain the stream and keep events for the caller to inspect."""
+        async for event in stream:
+            self.events.append(event)
+        if False:
+            yield b""

--- a/backend/app/turns/pipeline/prepare.py
+++ b/backend/app/turns/pipeline/prepare.py
@@ -72,7 +72,7 @@ async def prepare_turn(command: TurnCommand) -> PreparedTurn:
         user_id=command.user_id,
         question=command.question,
         provider=selection.provider,
-        channel=resolve_channel(command.surface),
+        channel=command.delivery_adapter or resolve_channel(command.surface),
         channel_message=channel_message,
         workspace_root=command.workspace_root,
         tools=agent_tools,

--- a/backend/app/turns/pipeline/types.py
+++ b/backend/app/turns/pipeline/types.py
@@ -44,6 +44,7 @@ class TurnCommand:
     send_fn: SendMessageFn | None = None
     channel_text: str | None = None
     channel_metadata: dict[str, Any] = field(default_factory=dict)
+    delivery_adapter: DeliveryAdapter | None = None
     verbose_level: int | None = None
     provider_selection: ProviderSelection | None = None
     draft_updater: Callable[[str], Awaitable[None]] | None = None

--- a/backend/tests/test_event_bus_handlers.py
+++ b/backend/tests/test_event_bus_handlers.py
@@ -8,17 +8,29 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any, cast
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.channels.telegram.notifications import TelegramNotificationService
+from app.infrastructure.database.legacy import User
 from app.infrastructure.event_bus import (
     AgentHandler,
     AgentResponseEvent,
     EventBus,
     ScheduledEvent,
     WebhookEvent,
+    global_bus,
 )
+from app.infrastructure.event_bus import handlers as event_handlers
+from app.models import ChatMessage, Conversation, Workspace
+from app.providers.base import AILLM, StreamEvent
+from app.providers.selection import ProviderSelection
 
 pytestmark = pytest.mark.anyio
 
@@ -45,6 +57,38 @@ class _RecordingBot:
 
     async def send_message(self, *, chat_id: str, text: str, **_kw: object) -> None:
         self.calls.append((chat_id, text))
+
+
+class _FakeTurnProvider:
+    """Provider stub used to prove event turns enter the Turn Pipeline."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        history: list[dict[str, str]] | None = None,
+        tools: object = None,
+        system_prompt: str | None = None,
+        reasoning_effort: object = None,
+        images: object = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.calls.append(
+            {
+                "question": question,
+                "conversation_id": conversation_id,
+                "user_id": user_id,
+                "history": history,
+                "tools": tools,
+                "system_prompt": system_prompt,
+                "reasoning_effort": reasoning_effort,
+                "images": images,
+            }
+        )
+        yield {"type": "delta", "content": "scheduled output"}
 
 
 class TestTelegramNotificationDelivery:
@@ -137,21 +181,112 @@ class TestAgentHandlerRouting:
         # Without a user the agent never runs, so no notification.
         assert bot.calls == []
 
-    async def test_scheduled_event_with_skill_prefix(self) -> None:
-        """Scheduled event with skill_name prefixes the prompt with /skill."""
-        # We don't stand up a real LLM here — _run_agent_turn would
-        # require a workspace + provider.  Instead we just assert
-        # the handler dispatches without crashing on a no-user event.
+    async def test_scheduled_event_with_skill_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Scheduled event prompt shaping is passed to the targeted turn runner."""
+        captured: dict[str, object] = {}
+
+        async def fake_run_agent_turn(**kwargs: object) -> str:
+            captured.update(kwargs)
+            return "done"
+
+        monkeypatch.setattr(event_handlers, "_run_agent_turn", fake_run_agent_turn)
         bus = EventBus()
+        global_bus.set_event_bus(bus)
         await bus.start()
-        AgentHandler().register(bus)
-        await bus.publish(
-            ScheduledEvent(
-                job_id=uuid.uuid4(),
-                job_name="daily-summary",
-                prompt="Summarize my email.",
-                skill_name="triage",
+        try:
+            responses: list[AgentResponseEvent] = []
+
+            async def record_response(event: object) -> None:
+                if isinstance(event, AgentResponseEvent):
+                    responses.append(event)
+
+            conversation_id = uuid.uuid4()
+            user_id = uuid.uuid4()
+            AgentHandler(default_user_id=user_id).register(bus)
+            bus.subscribe(AgentResponseEvent, record_response)
+            await bus.publish(
+                ScheduledEvent(
+                    job_id=uuid.uuid4(),
+                    job_name="daily-summary",
+                    prompt="Summarize my email.",
+                    skill_name="triage",
+                    target_chat_ids=["42"],
+                    target_conversation_id=conversation_id,
+                )
             )
+            await _drain(bus)
+        finally:
+            global_bus.set_event_bus(None)
+            await bus.stop()
+
+        assert captured["user_id"] == user_id
+        assert captured["conversation_id"] == conversation_id
+        assert "Reminder Fired - daily-summary" in str(captured["prompt"])
+        assert "/triage" in str(captured["prompt"])
+        assert "Summarize my email." in str(captured["prompt"])
+        assert len(responses) == 1
+        assert responses[0].user_id == user_id
+        assert responses[0].chat_id == "42"
+        assert responses[0].text == "done"
+        assert responses[0].originating_event_id == cast(str, captured["originating_event_id"])
+
+    async def test_run_agent_turn_uses_turn_pipeline(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        seeded_default_workspace: Workspace,
+        test_user: User,
+    ) -> None:
+        """Targeted event turns persist through the same runner as user chat."""
+        now = datetime.now(UTC).replace(tzinfo=None)
+        conversation = Conversation(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            title="Heartbeat",
+            created_at=now,
+            updated_at=now,
+            model_id="agent-sdk:anthropic/claude-opus-4-7",
+            reasoning_effort="low",
+            verbose_level=2,
         )
-        await _drain(bus)
-        await bus.stop()
+        db_session.add(conversation)
+        await db_session.commit()
+
+        provider = _FakeTurnProvider()
+        monkeypatch.setattr(
+            "app.turns.pipeline.prepare.require_provider",
+            lambda model_id, **_kwargs: ProviderSelection(
+                provider=cast(AILLM, provider),
+                effective_model_id=model_id,
+            ),
+        )
+
+        @asynccontextmanager
+        async def test_session_maker() -> AsyncIterator[AsyncSession]:
+            yield db_session
+
+        monkeypatch.setattr(event_handlers, "async_session_maker", test_session_maker)
+
+        text = await event_handlers._run_agent_turn(
+            prompt="Run the heartbeat.",
+            user_id=test_user.id,
+            conversation_id=conversation.id,
+            originating_event_id="evt-123",
+        )
+
+        assert text == "scheduled output"
+        assert len(provider.calls) == 1
+        assert provider.calls[0]["question"] == "Run the heartbeat."
+        assert provider.calls[0]["reasoning_effort"] == "low"
+
+        result = await db_session.execute(
+            select(ChatMessage)
+            .where(ChatMessage.conversation_id == conversation.id)
+            .order_by(ChatMessage.ordinal)
+        )
+        messages = list(result.scalars())
+        assert [(message.role, message.content) for message in messages] == [
+            ("user", "Run the heartbeat."),
+            ("assistant", "scheduled output"),
+        ]
+        assert messages[-1].assistant_status == "complete"

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -26,7 +26,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.channels import registered_surfaces, resolve_channel
-from app.channels.base import ChannelMessage
 from app.channels.telegram import SURFACE_TELEGRAM, TelegramChannel
 from app.channels.telegram.bot import (
     _TELEGRAM_COMMANDS,
@@ -60,7 +59,6 @@ from app.channels.telegram.status import (
 )
 from app.conversations.crud import ConversationStatus
 from app.providers.base import StreamEvent
-from app.providers.catalog import first_catalog_model
 from app.providers.selection import ProviderSelection
 
 # ---------------------------------------------------------------------------
@@ -78,7 +76,7 @@ def _make_channel_message(
     chat_id: int = 123,
     message_id: int = 456,
     reply_to_message_id: int | None = None,
-) -> ChannelMessage:
+) -> Any:
     metadata = {
         "bot": bot,
         "chat_id": chat_id,
@@ -86,14 +84,14 @@ def _make_channel_message(
     }
     if reply_to_message_id is not None:
         metadata["reply_to_message_id"] = reply_to_message_id
-    return ChannelMessage(
-        user_id=uuid.uuid4(),
-        conversation_id=uuid.uuid4(),
-        text="hello",
-        surface="telegram",
-        model_id=None,
-        metadata=metadata,
-    )
+    return {
+        "user_id": uuid.uuid4(),
+        "conversation_id": uuid.uuid4(),
+        "text": "hello",
+        "surface": "telegram",
+        "model_id": None,
+        "metadata": metadata,
+    }
 
 
 def _make_bot() -> AsyncMock:
@@ -102,6 +100,12 @@ def _make_bot() -> AsyncMock:
     bot.delete_message = AsyncMock()
     bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=777))
     return bot
+
+
+def _first_catalog_model_id() -> str:
+    from app.providers.catalog import first_catalog_model
+
+    return first_catalog_model().id
 
 
 @pytest.fixture(autouse=True)
@@ -617,14 +621,14 @@ class TestTelegramChannelDeliver:
 
         bot = _make_bot()
         conversation_id = uuid.uuid4()
-        msg = ChannelMessage(
-            user_id=uuid.uuid4(),
-            conversation_id=conversation_id,
-            text="hi",
-            surface="telegram",
-            model_id=None,
-            metadata={"bot": bot, "chat_id": 1, "message_id": 2},
-        )
+        msg: Any = {
+            "user_id": uuid.uuid4(),
+            "conversation_id": conversation_id,
+            "text": "hi",
+            "surface": "telegram",
+            "model_id": None,
+            "metadata": {"bot": bot, "chat_id": 1, "message_id": 2},
+        }
         channel = TelegramChannel()
         with patch(
             "app.channels.telegram.channel.settings.telegram_regenerate_button_enabled", True
@@ -1161,7 +1165,7 @@ class TestResolveProviderWithAutoClear:
         selection_mock = MagicMock(
             return_value=ProviderSelection(
                 provider=fake_default_provider,
-                effective_model_id=first_catalog_model().id,
+                effective_model_id=_first_catalog_model_id(),
                 warning="model not in catalog",
                 bad_model_id=context.model_id,
             )
@@ -1192,7 +1196,7 @@ class TestResolveProviderWithAutoClear:
         # Warning was produced and mentions the bad ID + the fallback.
         assert warning is not None
         assert "agent-sdk:anthropic/claude-nonexistent" in warning
-        assert first_catalog_model().id in warning
+        assert _first_catalog_model_id() in warning
 
         # Stored model_id was cleared to NULL.
         update_mock.assert_awaited_once()
@@ -1202,24 +1206,24 @@ class TestResolveProviderWithAutoClear:
 
         selection_mock.assert_called_once_with(context.model_id, workspace_root=None)
         assert selection.provider is fake_default_provider
-        assert selection.effective_model_id == first_catalog_model().id
+        assert selection.effective_model_id == _first_catalog_model_id()
 
     async def test_following_turn_uses_catalog_default_after_clear(self) -> None:
         """After the auto-clear, a turn with ``model_id=None`` resolves cleanly.
 
         ``handle_plain_message`` reads ``conversation.model_id`` and falls
-        back to ``first_catalog_model().id`` when it is ``NULL``.  Here we
+        back to ``_first_catalog_model_id()`` when it is ``NULL``.  Here we
         simulate that follow-up turn: the resolved context carries the
         first catalog entry directly, and the helper neither warns nor clears.
         """
-        context = self._make_context(first_catalog_model().id)
+        context = self._make_context(_first_catalog_model_id())
 
         fake_default_provider = MagicMock(name="default_provider")
         update_mock = AsyncMock(return_value=True)
         selection_mock = MagicMock(
             return_value=ProviderSelection(
                 provider=fake_default_provider,
-                effective_model_id=first_catalog_model().id,
+                effective_model_id=_first_catalog_model_id(),
             )
         )
 
@@ -1272,7 +1276,7 @@ class TestRenderStatusMessage:
 
         return ConversationStatus(
             conversation_id=uuid.uuid4(),
-            model_id=first_catalog_model().id,
+            model_id=_first_catalog_model_id(),
             verbose_level=1,
             reasoning_effort=None,
             started_at=_dt(2026, 5, 17, 18, 0, tzinfo=UTC),
@@ -1314,7 +1318,7 @@ class TestRenderStatusMessage:
 
         status = ConversationStatus(
             conversation_id=uuid.uuid4(),
-            model_id=first_catalog_model().id,
+            model_id=_first_catalog_model_id(),
             verbose_level=1,
             reasoning_effort=None,
             started_at=_dt(2026, 5, 17, 18, 0, tzinfo=UTC),
@@ -1346,7 +1350,7 @@ class TestRenderStatusMessage:
 
         status = ConversationStatus(
             conversation_id=uuid.uuid4(),
-            model_id=first_catalog_model().id,
+            model_id=_first_catalog_model_id(),
             verbose_level=1,
             reasoning_effort=None,
             started_at=_dt(2026, 5, 17, 18, 0, tzinfo=UTC),
@@ -1408,7 +1412,7 @@ class TestRenderStatusMessage:
 
         status = ConversationStatus(
             conversation_id=uuid.uuid4(),
-            model_id=first_catalog_model().id,
+            model_id=_first_catalog_model_id(),
             verbose_level=1,
             reasoning_effort=None,
             started_at=_dt(2026, 5, 17, 18, 0),  # tz-naive, matches DB
@@ -1474,7 +1478,7 @@ class TestHandleStatusCommand:
 
         fake_status = ConversationStatus(
             conversation_id=conv_id,
-            model_id=first_catalog_model().id,
+            model_id=_first_catalog_model_id(),
             verbose_level=2,
             reasoning_effort=None,
             started_at=_dt(2026, 5, 17, 18, 0, tzinfo=UTC),


### PR DESCRIPTION
## Changed seam

Event-bus scheduled turns now use the Turn Pipeline instead of a second direct provider runner in `app.infrastructure.event_bus.handlers`.

## Behavior preserved

- scheduled-event prompt shaping keeps the reminder header and skill prefix
- `AgentResponseEvent` fan-out still publishes rendered text to target chat IDs
- heartbeat/scheduled target conversations now persist through the same user/assistant turn path as web, Telegram, and Google Chat

## Files intentionally touched

- `backend/app/infrastructure/event_bus/handlers.py`
- `backend/app/turns/pipeline/delivery.py`
- `backend/app/turns/pipeline/types.py`
- `backend/app/turns/pipeline/prepare.py`
- `backend/.importlinter`
- focused event-bus tests plus a small Telegram test import cleanup needed to keep architecture gates green

## Tests run

- `cd backend && uv run pytest`  
  `2269 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `cd backend && uv run pytest tests/test_event_bus.py tests/test_event_bus_handlers.py tests/test_heartbeat.py tests/test_lcm_background_compaction.py tests/test_turn_runner_hook_ordering.py tests/test_telegram_channel.py`  
  `97 passed`
- `cd backend && uv run mypy .`  
  `Success: no issues found in 714 source files`
- `just check`
- `just arch`
- `python3 scripts/check-no-tools-in-providers.py`
- `python3 scripts/check-nesting.py`
- `node scripts/check-file-lines.mjs`
- acceptance grep:
  `rg -n "resolve_llm|provider\\.stream|build_agent_tools" backend/app/infrastructure/event_bus backend/app/agents/scheduling`  
  no matches

## Runtime proof

- `paw verify chat-roundtrip --json`  
  blocked by local Paw auth: `Session expired or missing. Run paw login.`
- `paw jobs list --json`  
  exited `3` with no JSON output, consistent with the same expired local Paw session

## Architecture gate

`just arch` passed. This PR also removed the stale import-linter grandfather for `app.infrastructure.event_bus.handlers -> app.conversations.messages_crud` because the event bus no longer imports the chat-message CRUD persistence helper.

## Secret check

- pre-commit `detect private key` passed
- pre-commit `Detect hardcoded secrets` passed
- changed-file secret scan returned no matches

## Follow-up explicitly not included

Untargeted webhook events still do not create an implicit system conversation. They now log and skip until the product has a deliberate destination for system-originated turns.

## Summary by Sourcery

Route event-bus scheduled turns through the shared Turn Pipeline using a system delivery adapter instead of a bespoke provider runner, keeping behavior aligned with user-initiated conversations while tightening architecture boundaries.

Enhancements:
- Refactor AgentHandler to require targeted conversations and run webhook/scheduled turns via the Turn Pipeline, delegating provider selection, tooling, and persistence to the shared runner.
- Introduce a SystemDeliveryAdapter and delivery_adapter plumbing on TurnCommand/prepare_turn to support non-user/system-originated surfaces that only need collected LLM output.
- Remove the legacy direct persistence path from event-bus handlers and drop the stale import-linter grandfather dependency on chat-message CRUD.

Tests:
- Expand event-bus handler tests to cover prompt shaping, AgentResponseEvent fan-out, and Turn Pipeline integration for scheduled turns.
- Adjust Telegram channel tests to use lightweight message dicts and a helper for catalog default model IDs, keeping assertions and selection behavior intact.