### PR TITLE
[7/12] Enforce database runtime safety

### DIFF
--- a/backend/app/cli/paw/commands/project/preflight.py
+++ b/backend/app/cli/paw/commands/project/preflight.py
@@ -15,6 +15,7 @@ from app.cli.paw.commands.project.state import DEFAULT_BACKEND_URL, DEFAULT_FRON
 from app.cli.paw.config import profile_dir
 from app.cli.paw.errors import LocalError
 from app.cli.paw.output import emit_human, emit_json, emit_plain_rows
+from app.infrastructure.database.safety import classify_database_target
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +26,7 @@ class PreflightCheck:
     passed: bool
     message: str
     hint: str | None = None
+    details: dict[str, str] | None = None
 
 
 def run_preflight_checks(*, profile: str) -> list[PreflightCheck]:
@@ -39,6 +41,7 @@ def run_preflight_checks(*, profile: str) -> list[PreflightCheck]:
             _env_path("XDG_CACHE_HOME", cache_root / "xdg"),
         ),
         _writable_dir_check("paw_config_dir_writable", profile_dir(profile)),
+        _database_target_check(),
         _port_available_check("frontend_port_available", DEFAULT_FRONTEND_URL),
         _port_available_check("backend_port_available", DEFAULT_BACKEND_URL),
     ]
@@ -137,6 +140,37 @@ def _writable_dir_check(name: str, path: Path) -> PreflightCheck:
             hint="Set the related environment variable to a writable directory.",
         )
     return PreflightCheck(name=name, passed=True, message=f"{path} is writable.")
+
+
+def _database_target_check() -> PreflightCheck:
+    """Check and describe the DB target the project/runtime will use."""
+    report = classify_database_target(
+        database_url=_effective_database_url(),
+        sqlite_db_filename=os.environ.get("SQLITE_DB_FILENAME", "pawrrtal.db"),
+        env=os.environ.get("ENV", "dev"),
+        repo_root=repo_root(),
+    )
+    message = f"{report.redacted_target} ({report.classification}, ENV={report.env or 'dev'})"
+    return PreflightCheck(
+        name="database_target_safe",
+        passed=report.safe,
+        message=message,
+        hint=report.hint,
+        details={
+            "target": report.redacted_target,
+            "classification": report.classification,
+            "env": report.env or "dev",
+            "deployed": str(report.deployed).lower(),
+        },
+    )
+
+
+def _effective_database_url() -> str:
+    """Return the database URL this preflight should evaluate."""
+    env = os.environ.get("ENV", "dev").strip().lower()
+    if env in {"prod", "production", "staging"}:
+        return os.environ.get("DATABASE_URL", "")
+    return os.environ.get("PAWRRTAL_DEV_DATABASE_URL", "")
 
 
 def _port_available_check(name: str, url: str) -> PreflightCheck:

--- a/backend/app/infrastructure/database/safety.py
+++ b/backend/app/infrastructure/database/safety.py
@@ -1,0 +1,153 @@
+"""Database target safety checks for runtime and Paw preflight."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse, urlsplit, urlunsplit
+
+from app.infrastructure.config_urls import normalize_database_url
+
+DEPLOYED_ENVS = frozenset({"prod", "production", "staging"})
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseSafetyReport:
+    """Classified database target with deployment safety metadata."""
+
+    env: str
+    normalized_url: str
+    redacted_target: str
+    classification: str
+    deployed: bool
+    safe: bool
+    reason: str
+    hint: str | None
+
+
+def classify_database_target(
+    *,
+    database_url: str,
+    sqlite_db_filename: str,
+    env: str,
+    repo_root: Path,
+    cwd: Path | None = None,
+) -> DatabaseSafetyReport:
+    """Classify the effective database target for runtime safety."""
+    normalized_url = normalize_database_url(database_url, sqlite_db_filename)
+    deployed = env.strip().lower() in DEPLOYED_ENVS
+    classification = _classify_url(normalized_url, repo_root=repo_root, cwd=cwd or Path.cwd())
+    redacted_target = redact_database_url(normalized_url)
+    unsafe_reason = _unsafe_reason(classification=classification, deployed=deployed)
+    if unsafe_reason is None:
+        return DatabaseSafetyReport(
+            env=env or "dev",
+            normalized_url=normalized_url,
+            redacted_target=redacted_target,
+            classification=classification,
+            deployed=deployed,
+            safe=True,
+            reason="database target is allowed for this environment",
+            hint=None,
+        )
+    return DatabaseSafetyReport(
+        env=env or "dev",
+        normalized_url=normalized_url,
+        redacted_target=redacted_target,
+        classification=classification,
+        deployed=deployed,
+        safe=False,
+        reason=unsafe_reason,
+        hint="Set DATABASE_URL to a Postgres service URL before starting this environment.",
+    )
+
+
+def assert_database_target_safe(
+    *,
+    database_url: str,
+    sqlite_db_filename: str,
+    env: str,
+    repo_root: Path,
+    cwd: Path | None = None,
+) -> None:
+    """Raise when the configured DB target is unsafe for this runtime."""
+    report = classify_database_target(
+        database_url=database_url,
+        sqlite_db_filename=sqlite_db_filename,
+        env=env,
+        repo_root=repo_root,
+        cwd=cwd,
+    )
+    if report.safe:
+        return
+    raise RuntimeError(
+        "Unsafe database target for "
+        f"ENV={report.env}: {report.redacted_target} "
+        f"({report.classification}). {report.reason} {report.hint}"
+    )
+
+
+def redact_database_url(url: str) -> str:
+    """Return ``url`` with any password removed from the authority."""
+    parts = urlsplit(url)
+    if parts.password is None:
+        return url
+    username = parts.username or ""
+    hostname = parts.hostname or ""
+    port = f":{parts.port}" if parts.port is not None else ""
+    netloc = f"{username}:***@{hostname}{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def _classify_url(normalized_url: str, *, repo_root: Path, cwd: Path) -> str:
+    """Return a stable label for the DB target."""
+    scheme = urlparse(normalized_url).scheme
+    if scheme.startswith("postgresql"):
+        return "postgres"
+    if scheme.startswith("sqlite"):
+        return _sqlite_classification(normalized_url, repo_root=repo_root, cwd=cwd)
+    return "unknown"
+
+
+def _sqlite_classification(normalized_url: str, *, repo_root: Path, cwd: Path) -> str:
+    """Classify SQLite as memory, repo-local, or external local file."""
+    sqlite_path = _sqlite_path(normalized_url, cwd=cwd)
+    if sqlite_path is None:
+        return "sqlite-memory"
+    if _is_relative_to(sqlite_path.resolve(), repo_root.resolve()):
+        return "sqlite-repo-local"
+    return "sqlite-local"
+
+
+def _sqlite_path(normalized_url: str, *, cwd: Path) -> Path | None:
+    """Return the SQLite filesystem path, or ``None`` for in-memory DBs."""
+    marker = ":///"
+    if marker not in normalized_url:
+        return None
+    raw_path = normalized_url.split(marker, 1)[1]
+    if raw_path in {":memory:", ""}:
+        return None
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return cwd / path
+
+
+def _unsafe_reason(*, classification: str, deployed: bool) -> str | None:
+    """Return why the classification is unsafe, if it is."""
+    if not deployed:
+        return None
+    if classification.startswith("sqlite"):
+        return "SQLite is only allowed for local development."
+    if classification == "unknown":
+        return "Only Postgres database URLs are allowed for deployed environments."
+    return None
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    """Compatibility wrapper for ``Path.is_relative_to``."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True

--- a/backend/app/infrastructure/startup/database.py
+++ b/backend/app/infrastructure/startup/database.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from app.infrastructure.config import settings
 from app.infrastructure.database.legacy import create_db_and_tables
+from app.infrastructure.database.safety import assert_database_target_safe
 from app.infrastructure.lifecycle import startup_hook
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 @startup_hook(order=20)
 async def start_database(app: FastAPI) -> None:
     """Create database tables for local/dev deployments."""
     del app
+    assert_database_target_safe(
+        database_url=settings.database_url,
+        sqlite_db_filename=settings.sqlite_db_filename,
+        env=settings.env,
+        repo_root=_REPO_ROOT,
+    )
     await create_db_and_tables()

--- a/backend/tests/infrastructure/test_database_runtime_safety.py
+++ b/backend/tests/infrastructure/test_database_runtime_safety.py
@@ -1,0 +1,82 @@
+"""Database runtime safety tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from app.infrastructure.database.safety import classify_database_target
+from app.infrastructure.startup import database as startup_database
+
+
+def test_classify_database_target_marks_dev_sqlite_repo_local_safe(tmp_path: Path) -> None:
+    """Local dev may use the implicit repo-local SQLite fallback."""
+    report = classify_database_target(
+        database_url="",
+        sqlite_db_filename="pawrrtal.db",
+        env="dev",
+        repo_root=tmp_path,
+        cwd=tmp_path,
+    )
+
+    assert report.safe is True
+    assert report.classification == "sqlite-repo-local"
+
+
+def test_classify_database_target_rejects_staging_sqlite(tmp_path: Path) -> None:
+    """Staging/prod must not boot against SQLite."""
+    report = classify_database_target(
+        database_url="sqlite:///./pawrrtal.db",
+        sqlite_db_filename="pawrrtal.db",
+        env="staging",
+        repo_root=tmp_path,
+        cwd=tmp_path,
+    )
+
+    assert report.safe is False
+    assert report.classification == "sqlite-repo-local"
+    assert (
+        report.hint
+        == "Set DATABASE_URL to a Postgres service URL before starting this environment."
+    )
+
+
+def test_classify_database_target_redacts_postgres_password(tmp_path: Path) -> None:
+    """Preflight output must not leak DB credentials."""
+    report = classify_database_target(
+        database_url="postgres://user:pw@db.example.com:5432/app",
+        sqlite_db_filename="pawrrtal.db",
+        env="prod",
+        repo_root=tmp_path,
+        cwd=tmp_path,
+    )
+
+    assert report.safe is True
+    assert report.classification == "postgres"
+    assert report.redacted_target == "postgresql://user:***@db.example.com:5432/app"
+
+
+@pytest.mark.anyio
+async def test_start_database_rejects_prod_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FastAPI startup fails before table creation when prod points at SQLite."""
+    from app.infrastructure.config import settings
+
+    monkeypatch.setattr(settings, "env", "prod")
+    monkeypatch.setattr(settings, "database_url", "sqlite:///./pawrrtal.db")
+    monkeypatch.setattr(settings, "sqlite_db_filename", "pawrrtal.db")
+
+    async def fail_create_db_and_tables() -> None:
+        raise AssertionError("startup should fail before touching the DB")
+
+    monkeypatch.setattr(
+        startup_database,
+        "create_db_and_tables",
+        fail_create_db_and_tables,
+    )
+
+    with pytest.raises(RuntimeError, match="Unsafe database target"):
+        await startup_database.start_database(FastAPI())

--- a/backend/tests/paw/test_command_project.py
+++ b/backend/tests/paw/test_command_project.py
@@ -14,6 +14,7 @@ import pytest
 from typer.testing import CliRunner
 
 import app.cli.paw.commands.project.cloudflared as cloudflared_module
+import app.cli.paw.commands.project.preflight as preflight_module
 import app.cli.paw.commands.project.service as service_module
 from app.cli.paw import config as paw_config
 from app.cli.paw.commands.project import cli as project_module
@@ -338,6 +339,38 @@ def test_env_check_json_uses_project_preflight(runner, monkeypatch):
     payload = json.loads(result.stdout.strip().splitlines()[-1])
     assert payload["ok"] is True
     assert payload["checks"][0]["name"] == "bun_available"
+
+
+def test_env_check_json_fails_prod_sqlite_database(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``paw env check --json`` exposes DB target details and rejects prod SQLite."""
+    monkeypatch.setenv("ENV", "prod")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./pawrrtal.db")
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "uv"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(
+        "app.cli.paw.commands.project.preflight.shutil.which",
+        lambda binary: f"/bin/{binary}",
+    )
+    monkeypatch.setattr(preflight_module, "_bind_error", lambda url: None)
+
+    result = runner.invoke(app, ["env", "check", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    db_check = next(check for check in payload["checks"] if check["name"] == "database_target_safe")
+    assert payload["ok"] is False
+    assert db_check["passed"] is False
+    assert db_check["details"] == {
+        "target": "sqlite:///./pawrrtal.db",
+        "classification": "sqlite-repo-local",
+        "env": "prod",
+        "deployed": "true",
+    }
+    assert "Postgres service URL" in db_check["hint"]
 
 
 def test_project_env_defaults_to_sqlite(monkeypatch):


### PR DESCRIPTION
## Summary

- add a shared database target safety classifier with redacted target output
- fail FastAPI startup before table creation when `ENV=prod|production|staging` points at SQLite or another non-Postgres target
- add `database_target_safe` to `paw project preflight` / `paw env check` JSON and human output, including target classification details
- keep local dev SQLite allowed and explicitly covered by tests

## Verification

- `cd backend && uv run pytest tests/infrastructure/test_database_runtime_safety.py tests/paw/test_command_project.py tests/test_config_sqlite_filename.py` -> `41 passed`
- `cd backend && uv run pytest tests/infrastructure/test_database_runtime_safety.py` -> `4 passed`
- `cd backend && uv run mypy .` -> `Success: no issues found in 717 source files`
- `just check` -> passed
- `just arch` -> passed
- `cd backend && uv run pytest` -> `2273 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `git diff --check` -> passed
- changed-file key/private-key/token scan -> no matches
- pre-commit hooks on commit -> passed, including hardcoded secret detection

## Paw CLI Proof

- `scripts/paw env check --json` emits `database_target_safe` with `sqlite-repo-local` / `ENV=dev`; command exits 1 here because local ports `3000` and `8000` are already bound
- `PAWRRTAL_ENV_FILE=/tmp/pr7-prod-sqlite.env scripts/paw env check --json` emits `database_target_safe` failed with `sqlite-repo-local` / `ENV=prod`; command also reports the already-bound local ports
- Installed `paw env check --json` appears to point at the deploy checkout and does not include this branch's new row yet; repo-local `scripts/paw` verifies the pushed branch code

## Stack

Base: `pr6-conversation-settings-title`

## Summary by Sourcery

Enforce database runtime safety by classifying database targets and preventing unsafe configurations in deployed environments.

New Features:
- Add a database target safety classifier that normalizes and redacts database URLs and reports safety metadata.
- Integrate a database safety preflight check into the Paw CLI `project preflight` / `env check` commands with structured details output.
- Add a runtime safety guard to FastAPI startup that validates the configured database target before creating tables.

Enhancements:
- Differentiate SQLite targets (in-memory, repo-local, external) and restrict SQLite use to local development environments.
- Extend preflight check results to include optional structured `details` fields for richer diagnostics.

Tests:
- Add unit and integration tests covering database target classification, redaction, preflight JSON output, and FastAPI startup failure on unsafe targets.