### PR TITLE
[8/12] Keep Active Recall context provider transport-neutral

### DIFF
--- a/backend/app/channels/telegram/bot.py
+++ b/backend/app/channels/telegram/bot.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import html as html_lib
 import ipaddress
 import logging
 import time
@@ -59,6 +60,7 @@ from app.channels.telegram.handlers import (
     handle_verbose_command,
     handle_whoami_command,
 )
+from app.channels.telegram.html import md_to_telegram_html
 from app.channels.telegram.tools_command import handle_tools_command
 from app.infrastructure.config import settings
 from app.infrastructure.database.legacy import async_session_maker
@@ -413,11 +415,16 @@ async def _run_llm_turn(  # noqa: C901, PLR0915
 
     has_active_recall = False
 
-    async def _draft_updater(html: str) -> None:
+    async def _draft_updater(text: str) -> None:
         nonlocal has_active_recall
         has_active_recall = True
         if message.bot:
-            await safe_edit_html(message.bot, message.chat.id, thinking_msg.message_id, html)
+            await safe_edit_html(
+                message.bot,
+                message.chat.id,
+                thinking_msg.message_id,
+                _render_turn_context_draft_html(text),
+            )
 
     async def _on_turn_context_finished() -> None:
         if has_active_recall:
@@ -863,6 +870,17 @@ def _extract_start_payload(text: str) -> str | None:
     if len(parts) < _START_COMMAND_PARTS_WITH_PAYLOAD:
         return None
     return parts[1].strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Turn-context draft helpers (module-level, not inside build_telegram_service)
+# ---------------------------------------------------------------------------
+
+
+def _render_turn_context_draft_html(text: str) -> str:
+    """Render generic turn-context draft text for Telegram."""
+    rendered = md_to_telegram_html(text)
+    return rendered if rendered else html_lib.escape(text)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/plugins/active_recall/recall_agent.py
+++ b/backend/app/plugins/active_recall/recall_agent.py
@@ -1,5 +1,4 @@
 import asyncio
-import html as html_lib
 import logging
 import os
 import time
@@ -10,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 from app.agents.types import AgentTool
-from app.channels.telegram.html import md_to_telegram_html
 from app.infrastructure.config import settings
 from app.infrastructure.keys import resolve_api_key
 from app.plugins.adapters.turn_context import TurnContextProviderContext
@@ -134,7 +132,7 @@ def _apply_stream_event(tel: _StreamTelemetry, event: dict[str, Any]) -> None:
         tel.error_msg = f"agent_terminated: {event.get('content')}"
 
 
-async def _collect_stream_telemetry(  # noqa: C901 — narrow per-event dispatch; splitting hurts readability
+async def _collect_stream_telemetry(
     stream: AsyncIterator[Any],
     draft_updater: DraftUpdater | None = None,
 ) -> tuple[str, list[str], int, int, float, str | None]:
@@ -147,27 +145,18 @@ async def _collect_stream_telemetry(  # noqa: C901 — narrow per-event dispatch
             return
 
         trace_str = " | ".join(trace_parts)
-        # Truncate so it works in one line
         max_len = 60
         if len(trace_str) > max_len:
             trace_str = "..." + trace_str[-(max_len - 3) :]
 
-        safe_trace = html_lib.escape(trace_str)
-        html = (
-            f"💭 <b>Recalling memory...</b>\n\n<i>{safe_trace}</i>"
-            if safe_trace
-            else "💭 <b>Recalling memory...</b>"
-        )
+        draft = f"Recalling memory...\n\n{trace_str}" if trace_str else "Recalling memory..."
 
         reply = "".join(tel.parts).strip()
         if reply:
-            rendered_reply = md_to_telegram_html(reply)
-            if rendered_reply is reply:
-                rendered_reply = html_lib.escape(reply)
-            html += f"\n\n<i>{rendered_reply}</i>"
+            draft += f"\n\n{reply}"
 
         try:
-            await asyncio.wait_for(draft_updater(html), timeout=_DRAFT_UPDATE_TIMEOUT_S)
+            await asyncio.wait_for(draft_updater(draft), timeout=_DRAFT_UPDATE_TIMEOUT_S)
         except TimeoutError:
             logger.warning("ACTIVE_RECALL_DRAFT_TIMEOUT timeout_s=%.1f", _DRAFT_UPDATE_TIMEOUT_S)
         except Exception:

--- a/backend/app/plugins/active_recall/recall_agent.py
+++ b/backend/app/plugins/active_recall/recall_agent.py
@@ -1,23 +1,27 @@
 import asyncio
+import json
 import logging
-import os
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from app.agents.types import AgentTool
 from app.infrastructure.config import settings
-from app.infrastructure.keys import resolve_api_key
 from app.plugins.adapters.turn_context import TurnContextProviderContext
+from app.plugins.contributions import EnvVarSpec
+from app.plugins.discovery import bundled_plugins_root
+from app.plugins.env import resolve_plugin_env
+from app.plugins.manifest import validate_plugin_manifest
 from app.providers._errors import ProviderError
-from app.providers.factory import resolve_llm
 from app.tools.errors import ToolError
 from app.tools.lcm_grep_agent import make_lcm_grep_tool
 from app.tools.lcm_search_agent import make_lcm_search_tool
 from app.tools.workspace_files import make_list_dir_tool, make_read_file_tool
+from app.turns.pipeline.subcalls import LlmSubcall, stream_llm_subcall
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +40,11 @@ _DRAFT_UPDATE_TIMEOUT_S: float = 2.0
 _DEFAULT_RECALL_TIMEOUT_S: float = 2.5
 
 DraftUpdater = Callable[[str], Awaitable[None]]
-"""Typed alias for the draft-updater callback. Receives the rendered HTML
-chunk; returns ``None``. Implementations should be idempotent — the same
-chunk may be passed twice if a retry fires."""
+"""Typed alias for the draft-updater callback.
+
+Receives neutral draft text and returns ``None``. Implementations should be
+idempotent; the same text may be passed twice if a retry fires.
+"""
 
 
 def _parse_bool(val: Any, default: bool) -> bool:
@@ -62,13 +68,31 @@ def _parse_positive_float(val: Any, default: float) -> float:
 
 
 def _resolve_active_recall_timeout_s(workspace_root: Path) -> float:
-    val_timeout_s = resolve_api_key(workspace_root, "ACTIVE_RECALL_TIMEOUT_S")
-    if val_timeout_s is None:
-        val_timeout_s = os.environ.get("ACTIVE_RECALL_TIMEOUT_S")
+    val_timeout_s = _resolve_active_recall_env(workspace_root, "ACTIVE_RECALL_TIMEOUT_S")
     return _parse_positive_float(
         val_timeout_s,
         default=_DEFAULT_RECALL_TIMEOUT_S,
     )
+
+
+@lru_cache(maxsize=1)
+def _active_recall_env_specs() -> dict[str, EnvVarSpec]:
+    """Return Active Recall env specs from the bundled plugin manifest."""
+    manifest_path = bundled_plugins_root() / "active_recall" / "plugin.json"
+    manifest = validate_plugin_manifest(
+        json.loads(manifest_path.read_text(encoding="utf-8")),
+        source_type="bundled",
+    )
+    return {spec.name: spec for spec in manifest.all_env_specs()}
+
+
+def _resolve_active_recall_env(workspace_root: Path, key: str) -> str | None:
+    """Resolve one Active Recall env value through plugin metadata."""
+    spec = _active_recall_env_specs().get(key)
+    if spec is None:
+        return None
+    resolution = resolve_plugin_env(workspace_root=workspace_root, spec=spec)
+    return resolution.value
 
 
 SYSTEM_PROMPT = """
@@ -202,7 +226,6 @@ async def _run_recall_stream(
     system_prompt: str,
     search_workspace: bool,
 ) -> tuple[str, list[str], int, int, float, str | None]:
-    provider = resolve_llm(model_id, workspace_root=ctx.workspace_root)
     lcm_tools: list[AgentTool] = [
         make_lcm_grep_tool(conversation_id=ctx.conversation_id),
         make_lcm_search_tool(conversation_id=ctx.conversation_id),
@@ -215,13 +238,17 @@ async def _run_recall_stream(
             ]
         )
 
-    stream = provider.stream(
-        question=_build_recall_question(ctx.question),
-        conversation_id=uuid.uuid4(),
-        user_id=ctx.user_id,
-        history=None,
-        tools=lcm_tools,
-        system_prompt=system_prompt or SYSTEM_PROMPT,
+    stream = stream_llm_subcall(
+        LlmSubcall(
+            model_id=model_id,
+            question=_build_recall_question(ctx.question),
+            conversation_id=uuid.uuid4(),
+            user_id=ctx.user_id,
+            workspace_root=ctx.workspace_root,
+            history=None,
+            tools=lcm_tools,
+            system_prompt=system_prompt or SYSTEM_PROMPT,
+        )
     )
     return await _collect_stream_telemetry(stream, draft_updater=ctx.draft_updater)
 
@@ -229,9 +256,7 @@ async def _run_recall_stream(
 async def run_active_recall(ctx: TurnContextProviderContext) -> str | None:
     """Search LCM for context relevant to the user's question before the main agent turn."""
     # Resolve ACTIVE_RECALL_ENABLED
-    val_enabled = resolve_api_key(ctx.workspace_root, "ACTIVE_RECALL_ENABLED")
-    if val_enabled is None:
-        val_enabled = os.environ.get("ACTIVE_RECALL_ENABLED")
+    val_enabled = _resolve_active_recall_env(ctx.workspace_root, "ACTIVE_RECALL_ENABLED")
     active_recall_enabled = _parse_bool(val_enabled, default=True)
 
     if active_recall_enabled is False or settings.lcm_enabled is False:
@@ -244,24 +269,23 @@ async def run_active_recall(ctx: TurnContextProviderContext) -> str | None:
         return None
 
     # Resolve ACTIVE_RECALL_MODEL
-    active_recall_model = resolve_api_key(ctx.workspace_root, "ACTIVE_RECALL_MODEL")
+    active_recall_model = _resolve_active_recall_env(ctx.workspace_root, "ACTIVE_RECALL_MODEL")
     if not active_recall_model:
-        active_recall_model = (
-            os.environ.get("ACTIVE_RECALL_MODEL") or "google-ai:google/gemini-3.1-flash-lite"
-        )
+        active_recall_model = "google-ai:google/gemini-3.1-flash-lite"
 
     # Resolve ACTIVE_RECALL_SEARCH_WORKSPACE
-    val_search_ws = resolve_api_key(ctx.workspace_root, "ACTIVE_RECALL_SEARCH_WORKSPACE")
-    if val_search_ws is None:
-        val_search_ws = os.environ.get("ACTIVE_RECALL_SEARCH_WORKSPACE")
+    val_search_ws = _resolve_active_recall_env(
+        ctx.workspace_root,
+        "ACTIVE_RECALL_SEARCH_WORKSPACE",
+    )
     active_recall_search_workspace = _parse_bool(val_search_ws, default=False)
 
     active_recall_timeout_s = _resolve_active_recall_timeout_s(ctx.workspace_root)
 
     # Resolve ACTIVE_RECALL_SYSTEM_PROMPT
-    active_recall_system_prompt = resolve_api_key(ctx.workspace_root, "ACTIVE_RECALL_SYSTEM_PROMPT")
-    if not active_recall_system_prompt:
-        active_recall_system_prompt = os.environ.get("ACTIVE_RECALL_SYSTEM_PROMPT") or ""
+    active_recall_system_prompt = (
+        _resolve_active_recall_env(ctx.workspace_root, "ACTIVE_RECALL_SYSTEM_PROMPT") or ""
+    )
 
     start_time = time.perf_counter()
     tools_called: list[str] = []

--- a/backend/app/turns/pipeline/subcalls.py
+++ b/backend/app/turns/pipeline/subcalls.py
@@ -1,0 +1,40 @@
+"""Bounded LLM subcall helpers for internal turn-adjacent tasks."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.agents.types import AgentTool
+from app.providers.base import StreamEvent
+from app.providers.factory import resolve_llm
+
+
+@dataclass(frozen=True, slots=True)
+class LlmSubcall:
+    """Model subcall request owned by the Turn Pipeline."""
+
+    model_id: str
+    question: str
+    conversation_id: uuid.UUID
+    user_id: uuid.UUID
+    workspace_root: Path
+    tools: list[AgentTool]
+    system_prompt: str
+    history: list[dict[str, str]] | None = None
+
+
+async def stream_llm_subcall(subcall: LlmSubcall) -> AsyncIterator[StreamEvent]:
+    """Stream one internal LLM subcall through provider selection."""
+    provider = resolve_llm(subcall.model_id, workspace_root=subcall.workspace_root)
+    async for event in provider.stream(
+        question=subcall.question,
+        conversation_id=subcall.conversation_id,
+        user_id=subcall.user_id,
+        history=subcall.history,
+        tools=subcall.tools,
+        system_prompt=subcall.system_prompt,
+    ):
+        yield event

--- a/backend/tests/test_turn_context_plugins.py
+++ b/backend/tests/test_turn_context_plugins.py
@@ -83,6 +83,31 @@ def test_active_recall_resolves_provider_with_workspace_root(
     assert result[0] == "NONE"
 
 
+@pytest.mark.anyio
+async def test_active_recall_draft_updates_are_transport_neutral() -> None:
+    """Active Recall emits plain draft text; channels own presentation formatting."""
+    updates: list[str] = []
+
+    async def _events() -> AsyncIterator[dict[str, object]]:
+        yield {"type": "tool_use", "name": "lcm_search"}
+        yield {"type": "delta", "content": "**memory** <raw>"}
+
+    async def _draft_updater(text: str) -> None:
+        updates.append(text)
+
+    result = await recall_agent._collect_stream_telemetry(
+        _events(),
+        draft_updater=_draft_updater,
+    )
+
+    assert result[0] == "**memory** <raw>"
+    assert updates[0] == "Recalling memory..."
+    assert any("lcm_search()" in update for update in updates)
+    assert any("**memory** <raw>" in update for update in updates)
+    assert all("<b>" not in update for update in updates)
+    assert all("<i>" not in update for update in updates)
+
+
 def test_turn_context_provider_hot_reload_respects_workspace_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_turn_context_plugins.py
+++ b/backend/tests/test_turn_context_plugins.py
@@ -59,7 +59,7 @@ def test_active_recall_resolves_provider_with_workspace_root(
         seen["workspace_root"] = kwargs.get("workspace_root")
         return _FakeRecallProvider()
 
-    monkeypatch.setattr(recall_agent, "resolve_llm", _resolve_llm)
+    monkeypatch.setattr("app.turns.pipeline.subcalls.resolve_llm", _resolve_llm)
     ctx = TurnContextProviderContext(
         conversation_id=uuid4(),
         user_id=uuid4(),


### PR DESCRIPTION
## Summary

- remove Telegram/HTML dependencies from the Active Recall turn context provider
- resolve `ACTIVE_RECALL_*` through the bundled plugin manifest and plugin env resolver
- route Active Recall model streaming through the Turn Pipeline subcall seam
- make Active Recall draft updates plain transport-neutral text
- render generic turn-context draft text to Telegram HTML at the Telegram adapter boundary
- add regression coverage for transport-neutral drafts and provider resolution through the pipeline seam

## Verification

- `rg -n "os\\.environ|getenv|channels\\.telegram|resolve_llm" backend/app/plugins/active_recall` -> no matches
- `cd backend && uv run pytest tests/test_turn_context_plugins.py tests/test_turn_runner_hook_ordering.py tests/test_active_recall_security.py tests/test_lcm_memory_plugin.py tests/test_plugin_state.py tests/test_plugin_manifest.py tests/test_plugin_tools.py tests/test_workspace_plugins_api.py` -> `77 passed`
- `cd backend && uv run mypy .` -> `Success: no issues found in 718 source files`
- `just check` -> passed
- `just arch` -> passed
- `cd backend && uv run pytest` -> `2274 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `git diff --check` -> passed
- diff-level key/private-key/token scan -> no matches
- pre-commit hooks on commit -> passed, including hardcoded secret detection

## Runtime Proof

- `paw verify chat-roundtrip --json` -> blocked by local auth: `{"scenario": "chat-roundtrip", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`
- `paw verify lcm --json` -> blocked by local auth: `{"scenario": "lcm", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`

## Stack

Base: `pr7-db-runtime-safety`
