### PR TITLE
[9/12] refactor(tools): add agent capability facade

### DIFF
--- a/backend/app/agents/tool_capabilities/__init__.py
+++ b/backend/app/agents/tool_capabilities/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-owned facade for model-visible tool capability factories."""

--- a/backend/app/agents/tool_capabilities/core.py
+++ b/backend/app/agents/tool_capabilities/core.py
@@ -1,0 +1,78 @@
+"""Agent-facing imports for core tool capability factories.
+
+The concrete implementations still live in ``app.tools`` during this
+architecture slice. Callers above the tool layer import through this facade so
+plugins and turn composition do not depend on tool implementation modules.
+"""
+
+from __future__ import annotations
+
+from app.tools.artifact_agent import make_artifact_tool
+from app.tools.cron_tools import (
+    make_reminder_cancel_tool,
+    make_reminder_list_tool,
+    make_reminder_schedule_tool,
+)
+from app.tools.exa_search_agent import make_exa_search_tool
+from app.tools.image_gen_agent import make_image_gen_tool
+from app.tools.lcm_agents import (
+    make_lcm_describe_tool,
+    make_lcm_expand_query_tool,
+    make_lcm_grep_tool,
+    make_lcm_list_summaries_tool,
+    make_lcm_search_tool,
+)
+from app.tools.markitdown_convert import make_markitdown_tool
+from app.tools.now import build_external_mcp_tools, make_now_tool
+from app.tools.plugin_catalog import make_search_plugin_capabilities_tool
+from app.tools.python_exec import make_virtual_python_tool
+from app.tools.report_issue import make_report_issue_tool
+from app.tools.send_message import SendFn, make_send_message_tool
+from app.tools.skill_invocation import (
+    make_invoke_skill_tool,
+    make_list_skills_tool,
+    make_read_skill_tool,
+)
+from app.tools.tasks_md import (
+    make_add_task_tool,
+    make_complete_task_tool,
+    make_list_tasks_tool,
+)
+from app.tools.telegram_tools import make_telegram_capability_tools
+from app.tools.workspace_files import (
+    make_list_dir_tool,
+    make_read_file_tool,
+    make_workspace_tools,
+)
+
+__all__ = [
+    "SendFn",
+    "build_external_mcp_tools",
+    "make_add_task_tool",
+    "make_artifact_tool",
+    "make_complete_task_tool",
+    "make_exa_search_tool",
+    "make_image_gen_tool",
+    "make_invoke_skill_tool",
+    "make_lcm_describe_tool",
+    "make_lcm_expand_query_tool",
+    "make_lcm_grep_tool",
+    "make_lcm_list_summaries_tool",
+    "make_lcm_search_tool",
+    "make_list_dir_tool",
+    "make_list_skills_tool",
+    "make_list_tasks_tool",
+    "make_markitdown_tool",
+    "make_now_tool",
+    "make_read_file_tool",
+    "make_read_skill_tool",
+    "make_reminder_cancel_tool",
+    "make_reminder_list_tool",
+    "make_reminder_schedule_tool",
+    "make_report_issue_tool",
+    "make_search_plugin_capabilities_tool",
+    "make_send_message_tool",
+    "make_telegram_capability_tools",
+    "make_virtual_python_tool",
+    "make_workspace_tools",
+]

--- a/backend/app/agents/tool_capabilities/display.py
+++ b/backend/app/agents/tool_capabilities/display.py
@@ -1,0 +1,7 @@
+"""Agent-facing display helpers for model-visible tools."""
+
+from __future__ import annotations
+
+from app.tools.display import make_tool_display, summarize_title
+
+__all__ = ["make_tool_display", "summarize_title"]

--- a/backend/app/agents/tool_capabilities/errors.py
+++ b/backend/app/agents/tool_capabilities/errors.py
@@ -1,0 +1,7 @@
+"""Agent-facing tool error types."""
+
+from __future__ import annotations
+
+from app.tools.errors import ToolError, ToolErrorCode
+
+__all__ = ["ToolError", "ToolErrorCode"]

--- a/backend/app/agents/tool_capabilities/messaging.py
+++ b/backend/app/agents/tool_capabilities/messaging.py
@@ -1,0 +1,7 @@
+"""Agent-facing channel delivery callback types."""
+
+from __future__ import annotations
+
+from app.tools.send_message import SendFn
+
+__all__ = ["SendFn"]

--- a/backend/app/agents/tool_surface.py
+++ b/backend/app/agents/tool_surface.py
@@ -31,23 +31,25 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from app.agents.tool_capabilities.core import (
+    SendFn,
+    build_external_mcp_tools,
+    make_lcm_describe_tool,
+    make_lcm_expand_query_tool,
+    make_lcm_grep_tool,
+    make_lcm_list_summaries_tool,
+    make_lcm_search_tool,
+    make_search_plugin_capabilities_tool,
+    make_send_message_tool,
+    make_telegram_capability_tools,
+    make_workspace_tools,
+)
 from app.agents.types import AgentTool
 from app.infrastructure.config import settings
 from app.plugins.adapters.tools import build_snapshot_agent_tools
 from app.plugins.errors import PluginError
 from app.plugins.host import get_plugin_host
 from app.plugins.tool_context import ToolContext
-from app.tools.lcm_agents import (
-    make_lcm_describe_tool,
-    make_lcm_expand_query_tool,
-    make_lcm_grep_tool,
-    make_lcm_list_summaries_tool,
-    make_lcm_search_tool,
-)
-from app.tools.now import build_external_mcp_tools
-from app.tools.plugin_catalog import make_search_plugin_capabilities_tool
-from app.tools.send_message import SendFn, make_send_message_tool
-from app.tools.workspace_files import make_workspace_tools
 
 log = logging.getLogger(__name__)
 
@@ -138,10 +140,6 @@ def build_agent_tools(
         # ``SendFn``; the model gets a richer tool catalogue without
         # the rest of the chat router learning about Telegram.
         if surface == "telegram":
-            from app.tools.telegram_tools import (  # noqa: PLC0415 — local import keeps the cross-channel tool surface lazy
-                make_telegram_capability_tools,
-            )
-
             tools.extend(make_telegram_capability_tools(send_fn))
 
     # LCM history tools — give the agent on-demand access to compacted

--- a/backend/app/plugins/active_recall/recall_agent.py
+++ b/backend/app/plugins/active_recall/recall_agent.py
@@ -9,6 +9,13 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from app.agents.tool_capabilities.core import (
+    make_lcm_grep_tool,
+    make_lcm_search_tool,
+    make_list_dir_tool,
+    make_read_file_tool,
+)
+from app.agents.tool_capabilities.errors import ToolError
 from app.agents.types import AgentTool
 from app.infrastructure.config import settings
 from app.plugins.adapters.turn_context import TurnContextProviderContext
@@ -17,10 +24,6 @@ from app.plugins.discovery import bundled_plugins_root
 from app.plugins.env import resolve_plugin_env
 from app.plugins.manifest import validate_plugin_manifest
 from app.providers._errors import ProviderError
-from app.tools.errors import ToolError
-from app.tools.lcm_grep_agent import make_lcm_grep_tool
-from app.tools.lcm_search_agent import make_lcm_search_tool
-from app.tools.workspace_files import make_list_dir_tool, make_read_file_tool
 from app.turns.pipeline.subcalls import LlmSubcall, stream_llm_subcall
 
 logger = logging.getLogger(__name__)

--- a/backend/app/plugins/artifacts/tools.py
+++ b/backend/app/plugins/artifacts/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_artifact_tool as build_artifact_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.artifact_agent import make_artifact_tool as build_artifact_tool
 
 
 def make_artifact_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/beans_tasks/tools.py
+++ b/backend/app/plugins/beans_tasks/tools.py
@@ -13,10 +13,10 @@ from typing import Any
 
 import yaml
 
+from app.agents.tool_capabilities.display import make_tool_display, summarize_title
+from app.agents.tool_capabilities.errors import ToolError, ToolErrorCode
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.display import make_tool_display, summarize_title
-from app.tools.errors import ToolError, ToolErrorCode
 
 _BEANS_DIR = ".beans"
 _BEANS_BINARY = "beans"

--- a/backend/app/plugins/document_conversion/tools.py
+++ b/backend/app/plugins/document_conversion/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_markitdown_tool as build_markitdown_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.markitdown_convert import make_markitdown_tool as build_markitdown_tool
 
 
 def make_markitdown_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/exa_search/tools.py
+++ b/backend/app/plugins/exa_search/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_exa_search_tool as build_exa_search_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.exa_search_agent import make_exa_search_tool as build_exa_search_tool
 
 
 def make_exa_search_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/github_issues/tools.py
+++ b/backend/app/plugins/github_issues/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_report_issue_tool as build_report_issue_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.report_issue import make_report_issue_tool as build_report_issue_tool
 
 
 def make_report_issue_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/image_generation/tools.py
+++ b/backend/app/plugins/image_generation/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_image_gen_tool as build_image_gen_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.image_gen_agent import make_image_gen_tool as build_image_gen_tool
 
 
 def make_image_gen_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/openai_codex_image_gen/codex_image_agent.py
+++ b/backend/app/plugins/openai_codex_image_gen/codex_image_agent.py
@@ -11,9 +11,10 @@ so we get proper streaming, reasoning, cost tracking, and observability.
 from __future__ import annotations
 
 import logging
-import uuid
 from pathlib import Path
 from typing import Any
+
+from app.turns.pipeline.subcalls import CodexImageSubcall, stream_codex_image_subcall
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +33,7 @@ async def generate_image_with_codex_agent(
     of the "image generation via Codex agent" capability from the original
     Codex SDK integration plan.
     """
-    # Lazy import: the provider package's `__init__` runs the vendored SDK
-    # discovery dance, which we only want triggered when this plugin is
-    # actually invoked.
-    from app.providers.openai_codex import OpenAICodexProvider  # noqa: PLC0415
-
     try:
-        provider = OpenAICodexProvider(
-            model_id=model or "gpt-5.5",
-            workspace_root=workspace_root,
-        )
-
         system_prompt = (
             "You are Pawrrtal's expert image generation agent. "
             "You have direct access to Codex's powerful native image_generation capability. "
@@ -55,13 +46,14 @@ async def generate_image_with_codex_agent(
         if style:
             full_prompt += f"\n\nDesired style / aesthetic: {style}"
 
-        # Stream through the provider (gives us native thinking, deltas, artifacts, usage, etc.)
-        async for event in provider.stream(
-            full_prompt,
-            conversation_id=uuid.uuid4(),
-            user_id=uuid.uuid4(),
-            system_prompt=system_prompt,
-            reasoning_effort="medium",
+        async for event in stream_codex_image_subcall(
+            CodexImageSubcall(
+                prompt=full_prompt,
+                model_id=model or "gpt-5.5",
+                workspace_root=workspace_root,
+                reasoning_effort="medium",
+                system_prompt=system_prompt,
+            )
         ):
             if event.get("type") == "artifact" and event.get("kind") == "image":
                 return {

--- a/backend/app/plugins/python_shell/tools.py
+++ b/backend/app/plugins/python_shell/tools.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_virtual_python_tool
 from app.agents.types import AgentTool
 from app.infrastructure.config import settings
 from app.plugins.tool_context import ToolContext
-from app.tools.python_exec import make_virtual_python_tool
 
 
 def make_python_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/reminders/tools.py
+++ b/backend/app/plugins/reminders/tools.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from app.agents.types import AgentTool
-from app.plugins.tool_context import ToolContext
-from app.tools.cron_tools import (
+from app.agents.tool_capabilities.core import (
     make_reminder_cancel_tool as build_reminder_cancel_tool,
 )
-from app.tools.cron_tools import (
+from app.agents.tool_capabilities.core import (
     make_reminder_list_tool as build_reminder_list_tool,
 )
-from app.tools.cron_tools import (
+from app.agents.tool_capabilities.core import (
     make_reminder_schedule_tool as build_reminder_schedule_tool,
 )
+from app.agents.types import AgentTool
+from app.plugins.tool_context import ToolContext
 
 
 def make_reminder_schedule_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/skills/tools.py
+++ b/backend/app/plugins/skills/tools.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from app.agents.types import AgentTool
-from app.plugins.tool_context import ToolContext
-from app.tools.skill_invocation import (
+from app.agents.tool_capabilities.core import (
     make_invoke_skill_tool as build_invoke_skill_tool,
 )
-from app.tools.skill_invocation import (
+from app.agents.tool_capabilities.core import (
     make_list_skills_tool as build_list_skills_tool,
 )
-from app.tools.skill_invocation import (
+from app.agents.tool_capabilities.core import (
     make_read_skill_tool as build_read_skill_tool,
 )
+from app.agents.types import AgentTool
+from app.plugins.tool_context import ToolContext
 
 
 def make_list_skills_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/tasks/tools.py
+++ b/backend/app/plugins/tasks/tools.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from app.agents.types import AgentTool
-from app.plugins.tool_context import ToolContext
-from app.tools.tasks_md import (
+from app.agents.tool_capabilities.core import (
     make_add_task_tool as build_add_task_tool,
 )
-from app.tools.tasks_md import (
+from app.agents.tool_capabilities.core import (
     make_complete_task_tool as build_complete_task_tool,
 )
-from app.tools.tasks_md import (
+from app.agents.tool_capabilities.core import (
     make_list_tasks_tool as build_list_tasks_tool,
 )
+from app.agents.types import AgentTool
+from app.plugins.tool_context import ToolContext
 
 
 def make_add_task_tool(ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/time_tools/tools.py
+++ b/backend/app/plugins/time_tools/tools.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from app.agents.tool_capabilities.core import make_now_tool as build_now_tool
 from app.agents.types import AgentTool
 from app.plugins.tool_context import ToolContext
-from app.tools.now import make_now_tool as build_now_tool
 
 
 def make_now_tool(_ctx: ToolContext) -> AgentTool:

--- a/backend/app/plugins/tool_context.py
+++ b/backend/app/plugins/tool_context.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.tools.send_message import SendFn
+    from app.agents.tool_capabilities.messaging import SendFn
 
 
 @dataclass(frozen=True)

--- a/backend/app/tools/lcm_expand_query.py
+++ b/backend/app/tools/lcm_expand_query.py
@@ -36,7 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.infrastructure.config import settings as _settings
 from app.lcm.summarization import _collect_stream, _format_turns
 from app.models import ChatMessage, LCMContextItem, LCMSummary
-from app.providers import resolve_llm
+from app.turns.pipeline.subcalls import LlmSubcall, stream_llm_subcall
 
 # Hard cap so we never build a prompt larger than the model can handle.
 _MAX_EXPAND_ITEMS = 500
@@ -90,19 +90,18 @@ async def lcm_expand_query(
 
     expansion_prompt = f"CONVERSATION HISTORY:\n{_format_turns(turns)}\n\nQUESTION:\n{prompt}"
     expand_model = _settings.lcm_summary_model or model_id
-    # resolve_llm does not accept user_id; per-user key resolution flows
-    # through workspace_root upstream. Drop the kwarg to silence mypy.
-    _ = user_id
-    provider = resolve_llm(expand_model)
 
     try:
-        stream = provider.stream(
-            question=expansion_prompt,
-            conversation_id=uuid.uuid4(),  # isolated; not a real turn
-            user_id=user_id,
-            history=None,
-            tools=None,
-            system_prompt=_EXPAND_SYSTEM_PROMPT,
+        stream = stream_llm_subcall(
+            LlmSubcall(
+                model_id=expand_model,
+                question=expansion_prompt,
+                conversation_id=uuid.uuid4(),  # isolated; not a real turn
+                user_id=user_id,
+                history=None,
+                tools=[],
+                system_prompt=_EXPAND_SYSTEM_PROMPT,
+            )
         )
         answer = await _collect_stream(stream)
         if answer:

--- a/backend/app/turns/pipeline/subcalls.py
+++ b/backend/app/turns/pipeline/subcalls.py
@@ -20,15 +20,18 @@ class LlmSubcall:
     question: str
     conversation_id: uuid.UUID
     user_id: uuid.UUID
-    workspace_root: Path
     tools: list[AgentTool]
     system_prompt: str
+    workspace_root: Path | None = None
     history: list[dict[str, str]] | None = None
 
 
 async def stream_llm_subcall(subcall: LlmSubcall) -> AsyncIterator[StreamEvent]:
     """Stream one internal LLM subcall through provider selection."""
-    provider = resolve_llm(subcall.model_id, workspace_root=subcall.workspace_root)
+    if subcall.workspace_root is None:
+        provider = resolve_llm(subcall.model_id)
+    else:
+        provider = resolve_llm(subcall.model_id, workspace_root=subcall.workspace_root)
     async for event in provider.stream(
         question=subcall.question,
         conversation_id=subcall.conversation_id,
@@ -36,5 +39,34 @@ async def stream_llm_subcall(subcall: LlmSubcall) -> AsyncIterator[StreamEvent]:
         history=subcall.history,
         tools=subcall.tools,
         system_prompt=subcall.system_prompt,
+    ):
+        yield event
+
+
+@dataclass(frozen=True, slots=True)
+class CodexImageSubcall:
+    """Codex image-generation subcall request owned by the Turn Pipeline."""
+
+    prompt: str
+    model_id: str
+    workspace_root: Path | None
+    system_prompt: str
+    reasoning_effort: str
+
+
+async def stream_codex_image_subcall(subcall: CodexImageSubcall) -> AsyncIterator[StreamEvent]:
+    """Stream one Codex image-generation subcall through provider selection."""
+    from app.providers.openai_codex import OpenAICodexProvider  # noqa: PLC0415
+
+    provider = OpenAICodexProvider(
+        model_id=subcall.model_id,
+        workspace_root=subcall.workspace_root,
+    )
+    async for event in provider.stream(
+        subcall.prompt,
+        conversation_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        system_prompt=subcall.system_prompt,
+        reasoning_effort=subcall.reasoning_effort,
     ):
         yield event

--- a/backend/tests/test_lcm_expand_query.py
+++ b/backend/tests/test_lcm_expand_query.py
@@ -126,7 +126,7 @@ def _make_failing_provider() -> Any:
 
 
 def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: Any) -> None:
-    import app.tools.lcm_expand_query as _mod
+    import app.turns.pipeline.subcalls as _mod
 
     monkeypatch.setattr(_mod, "resolve_llm", lambda *a, **kw: provider)
 


### PR DESCRIPTION
## Summary

- add `app.agents.tool_capabilities` as the agent-owned facade for model-visible tool factories
- rewire `build_agent_tools` and bundled Python plugin wrappers to import tool factories through the agent facade instead of `app.tools`
- move LLM/provider streaming used by `lcm_expand_query` and Codex image generation behind `turns.pipeline.subcalls`
- update LCM expand-query tests to patch the new provider boundary

## Verification

- `rg -n "from app\\.tools" backend/app/plugins backend/app/agents/tool_surface.py` -> no matches
- `rg -n "resolve_llm|provider\\.stream" backend/app/tools backend/app/plugins` -> no matches
- `python3 scripts/check-no-tools-in-providers.py` -> `check-no-tools-in-providers: OK`
- `cd backend && uv run pytest tests/test_agent_tools.py tests/test_plugin_tools.py tests/test_plugin_catalog_tool.py tests/test_external_mcp_tools.py tests/test_lcm_expand_query.py tests/test_workspace_files.py tests/test_virtual_python.py` -> `111 passed`
- `cd backend && uv run mypy .` -> `Success: no issues found in 723 source files`
- `just check` -> passed
- `just arch` -> passed, quality `7224`, all contracts kept
- `cd backend && uv run pytest` -> `2274 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `git diff --check` -> passed
- diff-level key/private-key/token scan -> no matches
- pre-commit hooks on commit -> passed, including hardcoded secret detection

## Runtime Proof

- `paw verify chat-roundtrip --json` -> blocked by local auth: `{"scenario": "chat-roundtrip", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`
- `paw plugins list --json` -> passed; returned active bundled plugins including `active_recall`, `lcm_memory`, `tasks`, `reminders`, `skills`, and channel plugins
- `paw plugins capabilities search --slot tasks --json` -> passed; returned enabled `tasks/add_task`, `tasks/complete_task`, and `tasks/list_tasks`

## Stack

Base: `pr8-active-recall-context-provider`

## Summary by Sourcery

Introduce an agent-owned facade for model-visible tool capability factories and route agents and plugins through it, while moving LLM and Codex image provider usage behind turn pipeline subcall helpers.

Enhancements:
- Add app.agents.tool_capabilities facade modules to expose core tool factories, display helpers, error types, and messaging callbacks without depending directly on app.tools implementations.
- Refactor agent tool surface and bundled plugin tools to import capabilities via the new agent tool_capabilities facade instead of app.tools modules.
- Update LLM subcall handling to support optional workspace roots and to stream LCM expand-query requests via the shared LlmSubcall pipeline helper.
- Introduce CodexImageSubcall and a shared streaming helper in the turn pipeline so Codex image generation is invoked via the same subcall abstraction as other providers.
- Adjust LCM expand-query tests to patch the new turn pipeline subcall boundary instead of the provider resolver directly.

Tests:
- Keep existing LCM expand-query behavior covered by updating tests to account for the new subcall-based provider boundary.