### PR TITLE
[10/12] refactor(providers): share neutral event mapping

### DIFF
--- a/backend/app/providers/agy_api/provider.py
+++ b/backend/app/providers/agy_api/provider.py
@@ -26,7 +26,7 @@ from app.agents.types import LLMEvent, TextContent
 from app.infrastructure.config import settings
 from app.providers._stream_logging import log_provider_stream_event
 from app.providers.base import ReasoningEffort, StreamEvent
-from app.providers.gemini.events import agent_event_to_stream_event, identity_convert
+from app.providers.events import agent_event_to_stream_event, identity_convert
 
 from .auth import AgyApiAuthError, ensure_agy_api_auth
 from .client import stream_llm_events

--- a/backend/app/providers/events.py
+++ b/backend/app/providers/events.py
@@ -1,0 +1,51 @@
+"""Provider-neutral AgentEvent to StreamEvent translation helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.agents.types import AgentMessage
+from app.providers.base import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Pass through messages the LLM understands; filter UI-only types."""
+    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
+
+
+def agent_event_to_stream_event(event: Any) -> StreamEvent | None:
+    """Translate one generic ``AgentEvent`` into a provider stream event."""
+    event_type = event["type"]
+    if event_type == "text_delta":
+        return StreamEvent(type="delta", content=event["text"])
+    if event_type == "thinking_delta":
+        thinking_event = StreamEvent(type="thinking", content=event["text"])
+        block_index = event.get("block_index")
+        if block_index is not None:
+            thinking_event["block_index"] = block_index
+        return thinking_event
+    if event_type == "tool_call_end":
+        return StreamEvent(
+            type="tool_use",
+            name=event["name"],
+            input=event["arguments"],
+            tool_use_id=event["tool_call_id"],
+            display=event.get("display"),
+        )
+    if event_type == "tool_result":
+        return StreamEvent(
+            type="tool_result",
+            content=event["content"],
+            tool_use_id=event["tool_call_id"],
+        )
+    if event_type == "agent_terminated":
+        logger.warning(
+            "AGENT_TERMINATED reason=%s details=%s",
+            event["reason"],
+            event["details"],
+        )
+        return StreamEvent(type="agent_terminated", content=event["message"])
+    return None

--- a/backend/app/providers/gemini/events.py
+++ b/backend/app/providers/gemini/events.py
@@ -1,70 +1,7 @@
-"""Gemini AgentEvent → StreamEvent translation helper.
-
-Split out of ``gemini_provider`` to keep that module under the 500-line
-file budget.  Pure translation — no I/O, no Gemini SDK references.
-"""
+"""Compatibility exports for provider-neutral event translation."""
 
 from __future__ import annotations
 
-import logging
-from typing import Any
+from app.providers.events import agent_event_to_stream_event, identity_convert
 
-from app.agents.types import AgentMessage
-from app.providers.base import StreamEvent
-
-logger = logging.getLogger(__name__)
-
-
-def identity_convert(messages: list[AgentMessage]) -> list[AgentMessage]:
-    """Pass through messages the LLM understands; filter UI-only types."""
-    return [m for m in messages if m["role"] in {"user", "assistant", "toolResult"}]
-
-
-def agent_event_to_stream_event(event: Any) -> StreamEvent | None:
-    """Translate one ``AgentEvent`` from the loop into a frontend ``StreamEvent``.
-
-    Returns ``None`` for events that don't carry user-facing payload
-    (``agent_start`` / ``agent_end`` / ``message_*`` / ``turn_*`` /
-    ``tool_call_start``) — the chat router emits the ``[DONE]`` sentinel
-    itself when the loop completes.
-    """
-    event_type = event["type"]
-    if event_type == "text_delta":
-        return StreamEvent(type="delta", content=event["text"])
-    if event_type == "thinking_delta":
-        thinking_event = StreamEvent(type="thinking", content=event["text"])
-        # Carry ``block_index`` through to the channel renderer when
-        # the provider supplied one (#353). Telegram dispatch uses it
-        # to insert paragraph breaks between distinct thinking blocks;
-        # the chat aggregator uses it to coalesce a single timeline
-        # entry per block.
-        block_index = event.get("block_index")
-        if block_index is not None:
-            thinking_event["block_index"] = block_index
-        return thinking_event
-    if event_type == "tool_call_end":
-        return StreamEvent(
-            type="tool_use",
-            name=event["name"],
-            input=event["arguments"],
-            tool_use_id=event["tool_call_id"],
-            display=event.get("display"),
-        )
-    if event_type == "tool_result":
-        return StreamEvent(
-            type="tool_result",
-            content=event["content"],
-            tool_use_id=event["tool_call_id"],
-        )
-    if event_type == "agent_terminated":
-        # Safety layer tripped — forward the structured event so the
-        # frontend can render a distinct termination notice instead of a
-        # generic error banner. ``reason`` is the machine-readable label;
-        # ``message`` is the human copy.
-        logger.warning(
-            "AGENT_TERMINATED reason=%s details=%s",
-            event["reason"],
-            event["details"],
-        )
-        return StreamEvent(type="agent_terminated", content=event["message"])
-    return None
+__all__ = ["agent_event_to_stream_event", "identity_convert"]

--- a/backend/app/providers/opencode_go/provider.py
+++ b/backend/app/providers/opencode_go/provider.py
@@ -60,7 +60,7 @@ from app.agents.types import (
 from app.infrastructure.config import settings
 from app.providers._stream_logging import log_provider_stream_event
 from app.providers.base import ReasoningEffort, StreamEvent
-from app.providers.gemini.events import agent_event_to_stream_event, identity_convert
+from app.providers.events import agent_event_to_stream_event, identity_convert
 
 from .events import (
     _OPENCODE_MISSING_KEY_NOTICE,

--- a/backend/app/turns/pipeline/subcalls.py
+++ b/backend/app/turns/pipeline/subcalls.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from app.agents.types import AgentTool
-from app.providers.base import StreamEvent
+from app.providers.base import ReasoningEffort, StreamEvent
 from app.providers.factory import resolve_llm
 
 
@@ -51,22 +51,26 @@ class CodexImageSubcall:
     model_id: str
     workspace_root: Path | None
     system_prompt: str
-    reasoning_effort: str
+    reasoning_effort: ReasoningEffort
 
 
 async def stream_codex_image_subcall(subcall: CodexImageSubcall) -> AsyncIterator[StreamEvent]:
     """Stream one Codex image-generation subcall through provider selection."""
-    from app.providers.openai_codex import OpenAICodexProvider  # noqa: PLC0415
-
-    provider = OpenAICodexProvider(
-        model_id=subcall.model_id,
-        workspace_root=subcall.workspace_root,
-    )
+    model_id = _codex_model_id(subcall.model_id)
+    provider = resolve_llm(model_id, workspace_root=subcall.workspace_root)
     async for event in provider.stream(
-        subcall.prompt,
+        question=subcall.prompt,
         conversation_id=uuid.uuid4(),
         user_id=uuid.uuid4(),
+        tools=[],
         system_prompt=subcall.system_prompt,
         reasoning_effort=subcall.reasoning_effort,
     ):
         yield event
+
+
+def _codex_model_id(model_id: str) -> str:
+    """Return a canonical OpenAI Codex model id."""
+    if ":" in model_id:
+        return model_id
+    return f"openai-codex:openai/{model_id}"


### PR DESCRIPTION
## Summary

- add provider-neutral `app.providers.events` for generic AgentEvent to StreamEvent conversion
- rewire Agy API and OpenCode Go providers away from Gemini event internals
- leave `app.providers.gemini.events` as a compatibility export over the neutral helper
- make Codex image subcalls resolve through the provider factory instead of importing `OpenAICodexProvider` directly

## Verification

- `rg -n "app\\.providers\\.gemini\\.events" backend/app/providers --glob '!backend/app/providers/gemini/**'` -> no matches
- `rg -n "OpenAICodexProvider|GeminiLLM|ClaudeLLM|XaiLLM|HOST_TO_PROVIDER" backend/app --glob '!backend/app/providers/**' --glob '!backend/app/plugins/**'` -> no matches
- `cd backend && uv run pytest tests/test_provider_plugins.py tests/test_providers_and_schemas.py tests/test_agy_api_provider.py tests/test_agy_cli_provider.py tests/test_opencode_go_provider_translation_352.py tests/test_gemini_stream_fn.py tests/test_openai_codex_provider.py` -> `104 passed, 1 skipped, 5 xfailed, 2 xpassed`
- `cd backend && uv run mypy .` -> `Success: no issues found in 724 source files`
- `just check` -> passed
- `just arch` -> passed, quality `7218`, all contracts kept
- `cd backend && uv run pytest` -> `2274 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `git diff --check` -> passed
- diff-level key/private-key/token scan -> no matches
- pre-commit hooks on commit -> passed, including hardcoded secret detection

## Runtime Proof

- `paw verify chat-roundtrip --json` -> blocked by local auth: `{"scenario": "chat-roundtrip", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`
- `paw verify all-providers --json` -> blocked by local auth: `{"scenario": "all-providers", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`

## Stack

Base: `pr9-tool-capability-surface`

## Summary by Sourcery

Introduce a provider-neutral event translation helper and update providers and Codex image subcalls to use shared abstractions instead of Gemini- or OpenAI-specific implementations.

Enhancements:
- Add a shared provider-neutral AgentEvent-to-StreamEvent translation module and update Gemini to re-export it for compatibility.
- Refactor Agy API and OpenCode Go providers to depend on the neutral event mapping instead of Gemini-specific internals.
- Route Codex image subcalls through the generic LLM provider resolution with canonical Codex model IDs, removing the direct OpenAICodexProvider dependency.