### PR TITLE
[11/12] refactor(channels): mount routes from plugin contributions

### DIFF
--- a/backend/app/infrastructure/router_registry.py
+++ b/backend/app/infrastructure/router_registry.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 
 from fastapi import APIRouter, FastAPI
 
+from app.plugins.adapters.routers import build_plugin_routers
+
 _ROUTER_FACTORIES: tuple[tuple[str, str], ...] = (
     ("app.infrastructure.auth.dev_login", "get_auth_router"),
     ("app.conversations.router", "get_conversations_router"),
@@ -17,7 +19,6 @@ _ROUTER_FACTORIES: tuple[tuple[str, str], ...] = (
     ("app.workspace.personalization.router", "get_personalization_router"),
     ("app.workspace.appearance.router", "get_appearance_router"),
     ("app.infrastructure.auth.oauth.router", "get_oauth_router"),
-    ("app.channels.router", "get_channels_router"),
     ("app.workspace.router", "get_workspace_router"),
     ("app.workspace.env.router", "get_workspace_env_router"),
     ("app.workspace.plugins.router", "get_workspace_plugins_router"),
@@ -83,3 +84,5 @@ def register_routers(app: FastAPI) -> None:
 
     for module_path, factory_name in _ROUTER_FACTORIES:
         app.include_router(_router_from_factory(module_path, factory_name))
+    for router in build_plugin_routers():
+        app.include_router(router)

--- a/backend/app/plugins/adapters/routers.py
+++ b/backend/app/plugins/adapters/routers.py
@@ -1,0 +1,71 @@
+"""Adapters for plugin-provided API router capabilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from fastapi import APIRouter
+
+from app.plugins.contributions import RouterCapability
+from app.plugins.entrypoints import load_entrypoint_callable
+from app.plugins.errors import PluginError, PluginRuntimeError
+from app.plugins.host import get_plugin_host
+
+logger = logging.getLogger(__name__)
+
+
+def build_plugin_routers() -> list[APIRouter]:
+    """Build active API routers from bundled plugin manifests."""
+    try:
+        _previous, snapshot = get_plugin_host().reload()
+    except PluginError as exc:
+        logger.warning("manifest plugin reload failed during router composition: %s", exc)
+        return []
+
+    routers: list[APIRouter] = []
+    for outcome in snapshot.outcomes:
+        manifest = outcome.manifest
+        if not outcome.active or manifest is None:
+            continue
+        for capability in manifest.capabilities:
+            if not isinstance(capability, RouterCapability):
+                continue
+            if not outcome.state.is_capability_enabled(capability.id):
+                continue
+            router = _build_router(plugin_id=outcome.plugin_id, capability=capability)
+            if router is not None:
+                routers.append(router)
+    return routers
+
+
+def _build_router(*, plugin_id: str, capability: RouterCapability) -> APIRouter | None:
+    """Build one plugin-declared API router."""
+    try:
+        factory = cast(
+            "object",
+            load_entrypoint_callable(capability.entrypoint, context="router factory"),
+        )
+        if not callable(factory):
+            raise PluginRuntimeError(f"router factory {capability.entrypoint!r} is not callable")
+        router = factory()
+        _validate_router(capability=capability, router=router)
+        return cast(APIRouter, router)
+    except PluginRuntimeError as exc:
+        logger.warning(
+            "router plugin load failed plugin_id=%s capability_id=%s error=%s",
+            plugin_id,
+            capability.id,
+            exc,
+        )
+        return None
+
+
+def _validate_router(*, capability: RouterCapability, router: object) -> None:
+    """Validate that a loaded object is an APIRouter with the declared prefix."""
+    if not isinstance(router, APIRouter):
+        raise PluginRuntimeError(f"router {capability.id!r} did not return an APIRouter")
+    if router.prefix != capability.prefix:
+        raise PluginRuntimeError(
+            f"router prefix mismatch for {capability.id!r}: expected {capability.prefix!r}"
+        )

--- a/backend/plugins/core_channels/plugin.json
+++ b/backend/plugins/core_channels/plugin.json
@@ -23,6 +23,16 @@
 			"slots": ["chat_surface"],
 			"surface": "electron",
 			"entrypoint": "app.channels.plugin_adapters:make_sse_channel"
+		},
+		{
+			"type": "router",
+			"id": "channel_routes",
+			"title": "Channel Routes",
+			"description": "HTTP routes for channel binding, diagnostics, webhook ingress, and local simulation.",
+			"slots": ["api_router", "channel:messaging"],
+			"entrypoint": "app.channels.router:get_channels_router",
+			"prefix": "/api/v1/channels",
+			"tags": ["channels"]
 		}
 	]
 }

--- a/backend/tests/infrastructure/test_app_factory.py
+++ b/backend/tests/infrastructure/test_app_factory.py
@@ -40,6 +40,15 @@ def test_register_routers_adds_health_endpoint() -> None:
     assert any(getattr(route, "path", None) == "/api/v1/health" for route in app.routes)
 
 
+def test_register_routers_adds_plugin_channel_routes() -> None:
+    """Channel HTTP routes are mounted through plugin router contributions."""
+    app = FastAPI()
+    register_routers(app)
+    assert any(
+        getattr(route, "path", None) == "/api/v1/channels/telegram/webhook" for route in app.routes
+    )
+
+
 @pytest.mark.anyio
 async def test_create_app_health_endpoint_responds() -> None:
     """Factory-created app can serve a health request without lifespan startup."""


### PR DESCRIPTION
## Summary

- add a plugin router adapter that loads active `router` capabilities from bundled plugin manifests
- move channel HTTP route mounting out of `infrastructure.router_registry`'s static router list
- declare the existing `/api/v1/channels` router through the bundled `core_channels` plugin manifest
- add router-registration coverage proving the Telegram webhook route is mounted through plugin router contributions

## Verification

- `rg -n "app\\.channels\\.router|get_channels_router" backend/app/infrastructure` -> no matches
- `rg -n '"type"\\s*:\\s*"router"|channel_routes|app\\.channels\\.router:get_channels_router' backend/plugins/core_channels/plugin.json` -> router capability present
- `cd backend && uv run pytest tests/infrastructure/test_app_factory.py tests/infrastructure/test_plugin_lifespans.py tests/test_channel_plugins.py tests/test_plugin_manifest.py tests/test_channels_api.py tests/paw/test_command_channels.py tests/paw/test_verify_telegram.py tests/paw/test_verify_google_chat.py` -> `79 passed`
- `cd backend && uv run mypy .` -> `Success: no issues found in 725 source files`
- `just check` -> passed
- `just arch` -> passed, quality `7217`, all contracts kept
- `cd backend && uv run pytest` -> `2275 passed, 2 skipped, 5 xfailed, 5 xpassed`
- `git diff --check` -> passed
- diff-level key/private-key/token scan -> no matches
- pre-commit hooks on commit -> passed, including hardcoded secret detection

## Runtime Proof

- `paw verify google-chat --json` -> passed; registered surfaces: `["web", "electron", "google_chat", "telegram"]`
- `paw verify chat-roundtrip --json` -> blocked by local auth: `{"scenario": "chat-roundtrip", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`
- `paw verify telegram --json` -> blocked by local auth: `{"scenario": "telegram", "passed": false, "error": "Session expired or missing.", "exit_code": 3, "hint": "Run `paw login`."}`

## Stack

Base: `pr10-provider-adapter-cleanup`

## Summary by Sourcery

Refactor application router registration to source channel-related HTTP routes from plugin-provided router capabilities instead of static infrastructure configuration.

Enhancements:
- Introduce a plugin router adapter that builds FastAPI routers from active router capabilities declared in bundled plugin manifests.
- Update global router registration to include routers constructed from plugin capabilities and stop registering the legacy channels router directly from infrastructure.

Tests:
- Add an app factory test asserting that plugin-contributed channel routes (e.g. the Telegram webhook endpoint) are mounted on the FastAPI application.