### PR TITLE
fix(agy): retry after remote auth refresh

### DIFF
--- a/backend/app/providers/agy_api/auth.py
+++ b/backend/app/providers/agy_api/auth.py
@@ -53,8 +53,21 @@ def has_agy_api_auth(workspace_root: Path | None = None) -> bool:
 _refresh_lock = asyncio.Lock()
 
 
-async def ensure_agy_api_auth(workspace_root: Path | None = None) -> AgyApiAuth:
-    """Load AGY auth, refreshing once through the CLI when the token expired."""
+async def ensure_agy_api_auth(
+    workspace_root: Path | None = None,
+    *,
+    force_refresh: bool = False,
+) -> AgyApiAuth:
+    """Load AGY auth, refreshing through the CLI when needed.
+
+    ``force_refresh`` is used after the remote API rejects a token that
+    still looked valid in the local Antigravity token file.
+    """
+    if force_refresh:
+        async with _refresh_lock:
+            await _run_agy_refresh_probe(workspace_root)
+            return load_agy_api_auth(workspace_root)
+
     try:
         return load_agy_api_auth(workspace_root)
     except AgyApiTokenExpiredError:

--- a/backend/app/providers/agy_api/client.py
+++ b/backend/app/providers/agy_api/client.py
@@ -21,7 +21,7 @@ from app.agents.types import (
 )
 from app.providers.base import StreamEvent
 
-from .auth import AgyApiAuth
+from .auth import AgyApiAuth, AgyApiAuthError
 from .events import (
     AgyApiStreamState,
     AgyApiUsageAccumulator,
@@ -33,6 +33,8 @@ from .messages import build_agy_contents, build_agy_tool_declarations
 
 _DEFAULT_BASE_URL = "https://daily-cloudcode-pa.googleapis.com"
 _HTTP_TIMEOUT_SECONDS = 60.0
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
 _HTTP_BAD_REQUEST = 400
 _HTTP_MAX_CONNECTIONS = 20
 _HTTP_MAX_KEEPALIVE_CONNECTIONS = 10
@@ -41,6 +43,10 @@ _HTTP_MAX_KEEPALIVE_CONNECTIONS = 10
 @dataclass
 class _ClientCache:
     client: httpx.AsyncClient | None = None
+
+
+class AgyApiRemoteAuthError(AgyApiAuthError):
+    """Raised when Cloud Code Assist rejects the current local AGY token."""
 
 
 _CLIENT_CACHE = _ClientCache()
@@ -158,6 +164,7 @@ async def _stream_llm_events_from_body(
             headers=_headers(auth.access_token),
             json=body,
         ) as response:
+            await _raise_for_remote_auth_error(response)
             error_text = await _api_error_text(response)
             if error_text is not None:
                 yield _error_text_delta(error_text)
@@ -190,6 +197,17 @@ async def _api_error_text(response: httpx.Response) -> str | None:
         return None
     text = await response.aread()
     return f"Antigravity API returned {response.status_code}: {text.decode(errors='replace')[:300]}"
+
+
+async def _raise_for_remote_auth_error(response: httpx.Response) -> None:
+    """Raise before a normal auth-refresh case becomes assistant text."""
+    if response.status_code not in {_HTTP_UNAUTHORIZED, _HTTP_FORBIDDEN}:
+        return
+    text = await response.aread()
+    preview = text.decode(errors="replace")[:300]
+    raise AgyApiRemoteAuthError(
+        f"Antigravity API rejected the local token with {response.status_code}: {preview}"
+    )
 
 
 async def _stream_events_from_response(response: httpx.Response) -> AsyncIterator[StreamEvent]:

--- a/backend/app/providers/agy_api/provider.py
+++ b/backend/app/providers/agy_api/provider.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 from app.agents import (
     DEFAULT_AGENT_SYSTEM_PROMPT as _FALLBACK_SYSTEM_PROMPT,
@@ -28,8 +29,8 @@ from app.providers._stream_logging import log_provider_stream_event
 from app.providers.base import ReasoningEffort, StreamEvent
 from app.providers.events import agent_event_to_stream_event, identity_convert
 
-from .auth import AgyApiAuthError, ensure_agy_api_auth
-from .client import stream_llm_events
+from .auth import AgyApiAuth, AgyApiAuthError, ensure_agy_api_auth
+from .client import AgyApiRemoteAuthError, stream_llm_events
 from .events import AgyApiUsageAccumulator
 from .messages import build_agy_generation_config
 
@@ -60,14 +61,36 @@ async def make_agy_api_stream_fn(
         model_id=model_id,
         reasoning_effort=reasoning_effort,
     )
+    retried_remote_auth = False
 
     async def stream_fn(
         messages: list[AgentMessage],
         tools: list[AgentTool],
     ) -> AsyncIterator[LLMEvent]:
-        async for event in stream_llm_events(
-            auth=auth,
-            model_id=wire_model_id,
+        nonlocal auth, retried_remote_auth
+        try:
+            async for event in _stream_llm_events_with_auth(
+                auth,
+                wire_model_id=wire_model_id,
+                messages=messages,
+                system_prompt=system_prompt,
+                tools=tools,
+                generation_config=generation_config,
+                usage_sink=usage_sink,
+            ):
+                yield event
+            return
+        except AgyApiRemoteAuthError:
+            if retried_remote_auth:
+                raise
+            retried_remote_auth = True
+            logger.info("AGY_API_REMOTE_AUTH_REFRESH_START model=%s", model_id)
+            auth = await ensure_agy_api_auth(workspace_root, force_refresh=True)
+            logger.info("AGY_API_REMOTE_AUTH_REFRESH_DONE model=%s", model_id)
+
+        async for event in _stream_llm_events_with_auth(
+            auth,
+            wire_model_id=wire_model_id,
             messages=messages,
             system_prompt=system_prompt,
             tools=tools,
@@ -77,6 +100,29 @@ async def make_agy_api_stream_fn(
             yield event
 
     return stream_fn
+
+
+async def _stream_llm_events_with_auth(
+    auth: AgyApiAuth,
+    *,
+    wire_model_id: str,
+    messages: list[AgentMessage],
+    system_prompt: str,
+    tools: list[AgentTool],
+    generation_config: dict[str, Any],
+    usage_sink: AgyApiUsageAccumulator,
+) -> AsyncIterator[LLMEvent]:
+    """Stream one AGY API attempt using one auth snapshot."""
+    async for event in stream_llm_events(
+        auth=auth,
+        model_id=wire_model_id,
+        messages=messages,
+        system_prompt=system_prompt,
+        tools=tools,
+        generation_config=generation_config,
+        usage_sink=usage_sink,
+    ):
+        yield event
 
 
 class AgyApiLLM:

--- a/backend/tests/test_agy_api_provider.py
+++ b/backend/tests/test_agy_api_provider.py
@@ -17,6 +17,7 @@ from app.providers.agy_api.auth import (
     load_agy_api_auth,
 )
 from app.providers.agy_api.client import (
+    AgyApiRemoteAuthError,
     _client,
     _event_from_sse_line,
     build_generate_body,
@@ -163,6 +164,57 @@ async def test_ensure_agy_api_auth_refreshes_expired_token_once(
     monkeypatch.setattr("app.providers.agy_api.auth._run_agy_refresh_probe", refresh_probe)
 
     auth = await ensure_agy_api_auth(workspace)
+
+    assert auth == AgyApiAuth(access_token="fresh-access", project_id="project-1")
+    assert refresh_calls == [workspace]
+
+
+@pytest.mark.anyio
+async def test_ensure_agy_api_auth_force_refreshes_valid_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    token_path = tmp_path / "token.json"
+    projects_path = tmp_path / "projects.json"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    token_path.write_text(
+        json.dumps(
+            {
+                "auth_method": "consumer",
+                "token": {
+                    "access_token": "stale-access",
+                    "refresh_token": "refresh",
+                    "token_type": "Bearer",
+                    "expiry": "2999-01-01T00:00:00Z",
+                },
+            }
+        )
+    )
+    projects_path.write_text(json.dumps({str(workspace): "project-1"}))
+    refresh_calls: list[Path | None] = []
+
+    async def refresh_probe(workspace_root: Path | None) -> None:
+        refresh_calls.append(workspace_root)
+        token_path.write_text(
+            json.dumps(
+                {
+                    "auth_method": "consumer",
+                    "token": {
+                        "access_token": "fresh-access",
+                        "refresh_token": "refresh",
+                        "token_type": "Bearer",
+                        "expiry": "2999-01-01T00:00:00Z",
+                    },
+                }
+            )
+        )
+
+    monkeypatch.setattr("app.providers.agy_api.auth._TOKEN_PATH", token_path)
+    monkeypatch.setattr("app.providers.agy_api.auth._PROJECTS_PATH", projects_path)
+    monkeypatch.setattr("app.providers.agy_api.auth._run_agy_refresh_probe", refresh_probe)
+
+    auth = await ensure_agy_api_auth(workspace, force_refresh=True)
 
     assert auth == AgyApiAuth(access_token="fresh-access", project_id="project-1")
     assert refresh_calls == [workspace]
@@ -387,6 +439,56 @@ async def test_agy_api_provider_uses_refreshing_auth_on_send(
 
     assert ensure_calls == [workspace]
     assert any(e["type"] == "delta" and e.get("content") == "answer" for e in events)
+
+
+@pytest.mark.anyio
+async def test_agy_api_provider_retries_remote_auth_failure_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    provider = AgyApiLLM("gemini-test", workspace_root=workspace)
+    ensure_calls: list[tuple[Path | None, bool]] = []
+    stream_auth_tokens: list[str] = []
+
+    async def ensure_auth(
+        workspace_root: Path | None,
+        *,
+        force_refresh: bool = False,
+    ) -> AgyApiAuth:
+        ensure_calls.append((workspace_root, force_refresh))
+        token = "fresh-access" if force_refresh else "stale-access"
+        return AgyApiAuth(access_token=token, project_id="project-1")
+
+    async def fake_stream_llm_events(**kwargs: object) -> AsyncIterator[LLMEvent]:
+        auth = kwargs["auth"]
+        assert isinstance(auth, AgyApiAuth)
+        stream_auth_tokens.append(auth.access_token)
+        if len(stream_auth_tokens) == 1:
+            raise AgyApiRemoteAuthError("401")
+        yield {"type": "text_delta", "text": "answer"}
+        yield {
+            "type": "done",
+            "stop_reason": "stop",
+            "content": [{"type": "text", "text": "answer"}],
+        }
+
+    monkeypatch.setattr("app.providers.agy_api.provider.ensure_agy_api_auth", ensure_auth)
+    monkeypatch.setattr("app.providers.agy_api.provider.stream_llm_events", fake_stream_llm_events)
+
+    events: list[StreamEvent] = [
+        event
+        async for event in provider.stream(
+            "hello",
+            conversation_id=uuid4(),
+            user_id=uuid4(),
+        )
+    ]
+
+    assert ensure_calls == [(workspace, False), (workspace, True)]
+    assert stream_auth_tokens == ["stale-access", "fresh-access"]
+    assert events == [{"type": "delta", "content": "answer"}]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

This stacked PR fixes the AGY API provider path that could show a normal Antigravity token rejection to the user instead of repairing auth and retrying the turn.

## Technical Changes

- Adds a forced-refresh mode to `ensure_agy_api_auth()` for cases where the local token file looks valid but the remote Cloud Code Assist API rejects it.
- Converts AGY API 401/403 stream responses into `AgyApiRemoteAuthError` before they become assistant text.
- Retries the same AGY stream attempt once after a forced CLI refresh, reusing the same user message, system prompt, tool list, and generation config.
- Adds regression tests for forced refresh and the provider-level remote-auth retry path.

## User Impact

When AGY auth expires or is rejected between picker-time and send-time, Pawrrtal now silently refreshes once and retries the user message instead of displaying the auth failure as model output.

## Verification

- `env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest tests/test_agy_api_provider.py`
- `env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest tests/test_agy_api_provider.py tests/test_agy_cli_provider.py tests/test_provider_plugins.py`
- `env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff check app/providers/agy_api/auth.py app/providers/agy_api/client.py app/providers/agy_api/provider.py tests/test_agy_api_provider.py`
- `env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff format --check app/providers/agy_api/auth.py app/providers/agy_api/client.py app/providers/agy_api/provider.py tests/test_agy_api_provider.py`
- `env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run mypy app/providers/agy_api`
- `node scripts/check-file-lines.mjs backend/app/providers/agy_api/auth.py backend/app/providers/agy_api/client.py backend/app/providers/agy_api/provider.py backend/tests/test_agy_api_provider.py`
- `python3 scripts/check-nesting.py`
- Live smoke: direct `AgyApiLLM("gemini-3.5-flash-low")` prompt returned `PONG` plus usage.

## Notes

`tests/test_models_api.py` was attempted but did not complete in this sandbox after roughly 90 seconds and no pytest process was visible afterward, so it is not counted as passing evidence here.
