### PR TITLE
feat(telegram): match Claude Cage stream styling

### DIFF
--- a/backend/app/channels/telegram/delivery.py
+++ b/backend/app/channels/telegram/delivery.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import html as html_lib
 import logging
+import re
 from typing import TYPE_CHECKING, Any
-
-from app.tools.display import fallback_tool_display
 
 from .html import md_to_telegram_html
 
@@ -23,9 +22,33 @@ logger = logging.getLogger(__name__)
 # remains an optional dependency for non-telegram pytest runs.
 
 MAX_MESSAGE_LEN = 4096
+TOOL_DETAIL_MAX_CHARS = 160
+TOOL_DETAIL_TRUNCATE_CHARS = TOOL_DETAIL_MAX_CHARS - 3
 
 
 _BALANCED_TAGS: tuple[str, ...] = ("pre", "code")
+_GENERIC_TOOL_DETAIL_KEYS = (
+    "command",
+    "file_path",
+    "path",
+    "pattern",
+    "glob",
+    "url",
+    "query",
+    "description",
+)
+_TOOL_DETAIL_KEYS_BY_NAME = {
+    "Bash": ("command",),
+    "Read": ("file_path", "path"),
+    "Edit": ("file_path", "path"),
+    "Write": ("file_path", "path"),
+    "NotebookEdit": ("file_path", "path"),
+    "Grep": ("pattern", "glob"),
+    "Glob": ("pattern", "glob"),
+    "WebFetch": ("url", "query"),
+    "WebSearch": ("url", "query"),
+    "Task": ("description", "subagent_type"),
+}
 
 # Minimum chunks where boundary rebalancing applies. A single chunk has
 # no boundary so the helper short-circuits.
@@ -169,24 +192,30 @@ def _aiogram_errors() -> tuple[type[BaseException], ...]:
 
 
 def format_tool_use(event: StreamEvent, *, state: str = "present") -> str:
-    """Render a tool call with shared display metadata or a safe fallback."""
+    """Render a tool call in Claude Code's TUI style."""
     tool_name = str(event.get("name") or "tool")
-    raw_display = event.get("display")
-    if isinstance(raw_display, dict):
-        icon = str(raw_display.get("icon") or "").strip()
-        val = str(raw_display.get(state) or "").strip()
-        if val:
-            if icon and not val.startswith(icon):
-                val = f"{icon} {val}"
-            return val
     raw_input = event.get("input") or {}
     arguments = raw_input if isinstance(raw_input, dict) else {"input": raw_input}
-    fallback = fallback_tool_display(tool_name, arguments)
-    val = str(fallback.get(state) or tool_name)
-    fallback_icon = str(fallback.get("icon") or "").strip()
-    if fallback_icon and not val.startswith(fallback_icon):
-        val = f"{fallback_icon} {val}"
-    return val
+    detail = _tool_detail(tool_name, arguments)
+    return f"⏺ {tool_name}({detail})" if detail else f"⏺ {tool_name}"
+
+
+def _tool_detail(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Return the single useful argument Claude Code's TUI would surface."""
+    keys = _TOOL_DETAIL_KEYS_BY_NAME.get(tool_name, _GENERIC_TOOL_DETAIL_KEYS)
+    detail = _first_tool_argument(arguments, keys)
+    detail = re.sub(r"\s+", " ", detail).strip()
+    if len(detail) > TOOL_DETAIL_MAX_CHARS:
+        return f"{detail[:TOOL_DETAIL_TRUNCATE_CHARS]}…"
+    return detail
+
+
+def _first_tool_argument(arguments: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty argument value among ``keys``."""
+    for key in keys:
+        if arguments.get(key):
+            return str(arguments[key])
+    return ""
 
 
 def final_reply_text(
@@ -211,18 +240,13 @@ def plain_html(text: str) -> str:
 
 
 def thinking_html(text: str) -> str:
-    """Render thinking text as italic Telegram HTML with markdown applied.
+    """Render thinking text in the same plain TUI style as Claude Cage.
 
     The Paw's thinking stream may emit Markdown emphasis (``**bold**``,
-    ``_em_``, fenced code, etc.). Previously this helper only HTML-escaped
-    the text and wrapped it in ``<i>...</i>``, so users saw literal
-    ``**`` / ``_`` markers inside the thinking block. We now route the
-    text through :func:`md_to_telegram_html` first — same pipeline the
-    answer stream uses — then wrap the result in ``<i>`` so the whole
-    block still reads as a thinking aside. Telegram allows ``<b>`` /
-    ``<a>`` / etc. nested inside ``<i>``, so the combination renders
-    correctly even when the model emits formatting mid-trace.
-
+    ``_em_``, fenced code, etc.), so we still route through the same
+    Markdown renderer as answer text. The visible wrapper intentionally
+    stays minimal: Claude Cage surfaces TUI status as ``✻ ...`` rather
+    than a Telegram card.
     """
     rendered = md_to_telegram_html(text)
     # ``md_to_telegram_html`` falls back to the raw text when conversion
@@ -230,7 +254,7 @@ def thinking_html(text: str) -> str:
     # ``<``/``&`` from the model into Telegram's HTML parser.
     if rendered is text:
         rendered = html_lib.escape(text)
-    return f"💭 <b>Thinking...</b>\n\n<i>{rendered}</i>"
+    return f"✻ {rendered}"
 
 
 def optional_int(value: object) -> int | None:

--- a/backend/app/channels/telegram/dispatch.py
+++ b/backend/app/channels/telegram/dispatch.py
@@ -61,33 +61,19 @@ __all__ = [
 _EDIT_DEBOUNCE_CHARS = 40
 _MAX_EDIT_INTERVAL_S = 3.0
 _EMPTY_RESPONSE_FALLBACK = "⚠️ The agent finished without producing a reply. Please try again."
-_MAX_IN_FLIGHT_TOOLS = 10
 
 
 def _render_tools_block(
     tool_states: dict[str, ToolLineState],
     in_flight_names: list[str],
 ) -> str:
-    """Render the full tools trace from per-tool state.
-
-    In-flight tools appear in the summary header (HTML-escaped).
-    Completed tools appear as their success/error line below.  We
-    deliberately do NOT also list in-flight tools as raw display lines
-    in the body — that would (a) duplicate the header, and (b) leak
-    unescaped ``display`` text into Telegram's HTML parser.
-    """
+    """Render the full tools trace from per-tool state."""
+    del in_flight_names
     lines: list[str] = []
     for state in tool_states.values():
-        line = state.result_line or state.progress_line
-        if line is not None:
-            lines.append(line)
-    shown_in_flight = in_flight_names[:_MAX_IN_FLIGHT_TOOLS]
-    if len(in_flight_names) > _MAX_IN_FLIGHT_TOOLS:
-        shown_in_flight.append(f"+{len(in_flight_names) - _MAX_IN_FLIGHT_TOOLS} more")
-    header = render_tools_in_flight(shown_in_flight)
-    if lines:
-        return render_bounded_tools_block(header, lines)
-    return header
+        line = state.result_line or state.progress_line or html_lib.escape(state.display)
+        lines.append(line)
+    return render_bounded_tools_block("", lines)
 
 
 async def prepare_tools_block(

--- a/backend/app/channels/telegram/progress.py
+++ b/backend/app/channels/telegram/progress.py
@@ -9,8 +9,8 @@ State machine (used by the content-preview placeholder logic):
   INITIAL  → ``render_initial()``
   STARTING → ``render_starting(model, tool_count)``    (first event, model known)
   WORKING  → ``render_working(preview)``               (first text delta)
-  Tool path uses ``render_tools_in_flight`` + ``render_tool_success``
-  / ``render_tool_error`` rather than the WORKING state.
+  Tool path uses Claude Code TUI-style ``⏺ Tool(detail)`` lines with
+  optional ``⎿`` result previews rather than the WORKING state.
 """
 
 from __future__ import annotations
@@ -90,7 +90,7 @@ def render_working(preview: str) -> str:
 
 
 def render_tools_in_flight(tool_names: list[str]) -> str:
-    """Return HTML for the 'tools running' state — list of tool names.
+    """Return HTML for in-flight tool calls in Claude Code TUI style.
 
     Args:
         tool_names: Display names (already formatted) for in-flight tools.
@@ -99,9 +99,8 @@ def render_tools_in_flight(tool_names: list[str]) -> str:
         Telegram HTML string.
     """
     if not tool_names:
-        return "🔧 <b>Using tools...</b>"
-    esc_names = "\n".join(f"  {html.escape(n)}" for n in tool_names)
-    return f"🔧 <b>Using tools:</b>\n{esc_names}"
+        return "⏺ Tool"
+    return "\n".join(html.escape(n) for n in tool_names)
 
 
 MAX_TOOL_TRACE_CHARS = 3600
@@ -111,7 +110,7 @@ def render_bounded_tools_block(header: str, lines: list[str]) -> str:
     """Join complete Telegram HTML fragments without cutting tags."""
     output = header
     for line in lines:
-        candidate = f"{output}\n\n{line}"
+        candidate = f"{output}\n{line}" if output else line
         if len(candidate) > MAX_TOOL_TRACE_CHARS:
             continue
         output = candidate
@@ -134,21 +133,20 @@ def render_tool_success(
             ``format_tool_use`` in ``telegram_delivery.py`` already produces
             display-safe text).
         elapsed_ms: Wall-clock duration of the tool call in milliseconds.
+            Kept for the call contract; Claude Cage-style rendering does
+            not show timings in chat.
         result_preview: Optional compact stdout/result preview to show under
             the completed tool row.
 
     Returns:
         Telegram HTML string for one tool line.
     """
-    esc = html.escape(tool_display)
-    line = f"✅ <b>{esc}</b> ({elapsed_ms}ms)"
-    preview = (result_preview or "").strip()
+    del elapsed_ms
+    line = html.escape(tool_display)
+    preview = _format_tool_result_preview(result_preview or "")
     if not preview:
         return line
-    if len(preview) > TOOL_RESULT_PREVIEW_MAX_CHARS:
-        preview = preview[:TOOL_RESULT_PREVIEW_MAX_CHARS].rstrip()
-    esc_preview = html.escape(preview)
-    return f"{line}\n\n<code>{esc_preview}</code>"
+    return f"{line}\n{html.escape(preview)}"
 
 
 TOOL_PROGRESS_PREVIEW_MAX_CHARS = 500
@@ -156,14 +154,11 @@ TOOL_PROGRESS_PREVIEW_MAX_CHARS = 500
 
 def render_tool_progress(tool_display: str, result_preview: str) -> str:
     """Return HTML for a still-running tool with a compact progress preview."""
-    esc = html.escape(tool_display)
-    preview = result_preview.strip()
-    if len(preview) > TOOL_PROGRESS_PREVIEW_MAX_CHARS:
-        preview = preview[:TOOL_PROGRESS_PREVIEW_MAX_CHARS].rstrip()
-    esc_preview = html.escape(preview)
-    if not esc_preview:
-        return f"⏳ <b>{esc}</b>"
-    return f"⏳ <b>{esc}</b>\n\n<code>{esc_preview}</code>"
+    line = html.escape(tool_display)
+    preview = _format_tool_result_preview(result_preview, max_chars=TOOL_PROGRESS_PREVIEW_MAX_CHARS)
+    if not preview:
+        return line
+    return f"{line}\n{html.escape(preview)}"
 
 
 # Maximum characters of error text shown in a tool error card.
@@ -180,14 +175,27 @@ def render_tool_error(tool_display: str, error_message: str) -> str:
     Returns:
         Telegram HTML string for one tool line.
     """
-    esc_tool = html.escape(tool_display)
     msg = error_message.strip()
     if len(msg) > TOOL_ERROR_MAX_CHARS:
         msg = msg[:TOOL_ERROR_MAX_CHARS] + "…"
-    esc_msg = html.escape(msg)
-    return f"❌ <b>{esc_tool}</b>\n\n<i>{esc_msg}</i>"
+    return f"{html.escape(tool_display)}\n  ⎿ ✗ {html.escape(msg)}"
 
 
 def render_thinking_in_progress() -> str:
     """Return HTML for the 'thinking' state placeholder."""
-    return "💭 <b>Thinking...</b>"
+    return "✻ thinking"
+
+
+def _format_tool_result_preview(
+    text: str, *, max_chars: int = TOOL_RESULT_PREVIEW_MAX_CHARS
+) -> str:
+    """Return Claude Code TUI-style one-line result preview."""
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    first = stripped.splitlines()[0].strip()
+    if len(first) > max_chars:
+        first = f"{first[: max_chars - 1].rstrip()}…"
+    extra_lines = stripped.count("\n")
+    suffix = f"  (+{extra_lines} lines)" if extra_lines else ""
+    return f"  ⎿ {first}{suffix}"

--- a/backend/tests/test_telegram_channel.py
+++ b/backend/tests/test_telegram_channel.py
@@ -375,7 +375,7 @@ class TestTelegramChannelDeliver:
         )
 
     async def test_tool_use_edits_detailed_trace_message(self) -> None:
-        """``tool_use`` edits the trace with friendly display metadata."""
+        """``tool_use`` edits the trace with Claude Code TUI-style text."""
         bot = _make_bot()
         msg = _make_channel_message(bot)
         channel = TelegramChannel()
@@ -397,12 +397,12 @@ class TestTelegramChannelDeliver:
 
         last_call = bot.edit_message_text.call_args_list[-1]
         trace_text = last_call.kwargs["text"]
-        assert "🔎 Searching files for &quot;TelegramChannel&quot;" in trace_text
-        assert "/data/workspace" not in trace_text
+        assert trace_text == "⏺ search_files(/data/workspace)"
+        assert "🔎 Searching files" not in trace_text
         bot.send_message.assert_awaited_once_with(chat_id=123, text="answer")
 
-    async def test_thinking_event_renders_as_separate_italic_message(self) -> None:
-        """Detailed Telegram verbosity surfaces thinking separately in italics."""
+    async def test_thinking_event_renders_as_separate_tui_message(self) -> None:
+        """Detailed Telegram verbosity surfaces thinking in Claude Code TUI style."""
         bot = _make_bot()
         msg = _make_channel_message(bot)
         channel = TelegramChannel()
@@ -418,7 +418,7 @@ class TestTelegramChannelDeliver:
         bot.edit_message_text.assert_any_call(
             chat_id=123,
             message_id=456,
-            text="💭 <b>Thinking...</b>\n\n<i>checking the workspace</i>",
+            text="✻ checking the workspace",
             reply_markup=None,
         )
         # The final answer is sent as a new message
@@ -456,7 +456,7 @@ class TestTelegramChannelDeliver:
         bot.edit_message_text.assert_any_call(
             chat_id=88,
             message_id=11,
-            text="💭 <b>Thinking...</b>\n\n<i>let me check the workspace</i>",
+            text="✻ let me check the workspace",
             reply_markup=None,
         )
 
@@ -468,7 +468,7 @@ class TestTelegramChannelDeliver:
         sent_texts = [call.kwargs.get("text", "") for call in bot.send_message.await_args_list]
 
         # The second thinking message should be sent as a separate message
-        thinking_sends = [text for text in sent_texts if text.startswith("💭 <b>Thinking...</b>")]
+        thinking_sends = [text for text in sent_texts if text.startswith("✻ ")]
         assert len(thinking_sends) == 1
         assert "now I understand" in thinking_sends[0]
         assert "let me check the workspace" not in thinking_sends[0]
@@ -516,7 +516,7 @@ class TestTelegramChannelDeliver:
         assert any("Partial answer." in text for text in edit_texts)
         assert any("max_iterations" in text for text in edit_texts)
 
-    async def test_thinking_event_renders_markdown_bold_inside_italic(self) -> None:
+    async def test_thinking_event_renders_markdown_bold_inside_tui_line(self) -> None:
         """Thinking deltas with Markdown emphasis render formatted, not literal (#287)."""
         bot = _make_bot()
         msg = _make_channel_message(bot)
@@ -539,8 +539,9 @@ class TestTelegramChannelDeliver:
         first_edit = thinking_edits[0]
         # The literal ``**`` markers must not leak into the rendered
         # thinking message — they should be converted to Telegram's
-        # ``<b>`` tag while the surrounding italic envelope is preserved.
+        # ``<b>`` tag while keeping the Claude Code TUI marker.
         assert "**bold**" not in first_edit
+        assert first_edit.startswith("✻ ")
         assert "<i>" in first_edit and "</i>" in first_edit
         assert "<b>bold</b>" in first_edit
         # The final answer is sent as a new message
@@ -724,7 +725,7 @@ class TestTelegramChannelDeliver:
         bot.edit_message_text.assert_any_call(
             chat_id=42,
             message_id=99,
-            text="💭 <b>Thinking...</b>\n\n<i>thinking content</i>",
+            text="✻ thinking content",
             reply_markup=None,
         )
         # And the placeholder MUST NOT be deleted:
@@ -759,7 +760,7 @@ class TestTelegramChannelDeliver:
         bot.edit_message_text.assert_any_call(
             chat_id=42,
             message_id=99,
-            text="💭 <b>Thinking...</b>\n\n<i>The user said\nhello.</i>",
+            text="✻ The user said\nhello.",
             reply_markup=None,
         )
 

--- a/backend/tests/test_telegram_progress.py
+++ b/backend/tests/test_telegram_progress.py
@@ -1,5 +1,5 @@
-"""Tests for telegram_progress.py — multi-state progress emoji renderers
-and per-tool success/failure with timing.
+"""Tests for telegram_progress.py — multi-state progress renderers
+and Claude Code TUI-style tool success/failure text.
 
 Covers (Workstreams 3 and 4):
 - render_initial, render_starting, render_working, render_tools_in_flight
@@ -8,7 +8,7 @@ Covers (Workstreams 3 and 4):
 - HTML special chars escaped in model name and preview
 - Tool error message truncated to TOOL_ERROR_MAX_CHARS + ellipsis
 - handle_tool_use populates tool_states dict
-- handle_tool_result updates line to success with timing
+- handle_tool_result updates line to success with a compact result preview
 - handle_tool_result updates line to error with truncated escaped message
 - Multiple tools render in order
 """
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from app.channels.telegram.delivery import format_tool_use, thinking_html
 from app.channels.telegram.dispatch import (
     ToolLineState,
     handle_tool_progress,
@@ -120,7 +121,7 @@ class TestRenderToolsInFlight:
     def test_single_tool(self) -> None:
         result = render_tools_in_flight(["read_file"])
         assert "read_file" in result
-        assert "🔧" in result
+        assert "🔧" not in result
 
     def test_multiple_tools(self) -> None:
         result = render_tools_in_flight(["tool_a", "tool_b"])
@@ -129,7 +130,7 @@ class TestRenderToolsInFlight:
 
     def test_empty_list_generic_message(self) -> None:
         result = render_tools_in_flight([])
-        assert "🔧" in result
+        assert result == "⏺ Tool"
 
 
 class TestRenderToolSuccess:
@@ -137,17 +138,21 @@ class TestRenderToolSuccess:
         result = render_tool_success("read_file", 123)
         assert "read_file" in result
 
-    def test_contains_elapsed(self) -> None:
+    def test_omits_elapsed(self) -> None:
         result = render_tool_success("search", 456)
-        assert "456ms" in result
+        assert "456ms" not in result
 
-    def test_check_emoji(self) -> None:
-        assert "✅" in render_tool_success("anything", 1)
+    def test_no_check_emoji(self) -> None:
+        assert "✅" not in render_tool_success("anything", 1)
 
     def test_html_escaped(self) -> None:
         result = render_tool_success("<b>bold</b>", 10)
         # The display value is escaped in the card
         assert "<b>bold</b>" not in result or "&lt;b&gt;" in result
+
+    def test_result_preview_matches_claude_cage_style(self) -> None:
+        result = render_tool_success("⏺ Bash(ls -la /tmp)", 10, "line1\nline2\nline3")
+        assert result == "⏺ Bash(ls -la /tmp)\n  ⎿ line1  (+2 lines)"
 
 
 class TestRenderToolError:
@@ -159,8 +164,8 @@ class TestRenderToolError:
         result = render_tool_error("exa_search", "API key invalid")
         assert "API key invalid" in result
 
-    def test_x_emoji(self) -> None:
-        assert "❌" in render_tool_error("tool", "err")
+    def test_x_marker(self) -> None:
+        assert "  ⎿ ✗ err" in render_tool_error("tool", "err")
 
     def test_error_truncated(self) -> None:
         long_error = "x" * (TOOL_ERROR_MAX_CHARS + 50)
@@ -171,6 +176,43 @@ class TestRenderToolError:
     def test_html_escaped(self) -> None:
         result = render_tool_error("tool", "<script>bad</script>")
         assert "<script>" not in result
+
+
+class TestClaudeCageStyleRenderers:
+    def test_bash_tool_line(self) -> None:
+        result = format_tool_use(
+            {
+                "type": "tool_use",
+                "name": "Bash",
+                "input": {"command": "ls -la /tmp", "description": "list"},
+            }
+        )
+        assert result == "⏺ Bash(ls -la /tmp)"
+
+    def test_read_tool_line(self) -> None:
+        result = format_tool_use(
+            {"type": "tool_use", "name": "Read", "input": {"file_path": "/a/b/c.py"}}
+        )
+        assert result == "⏺ Read(/a/b/c.py)"
+
+    def test_grep_tool_line(self) -> None:
+        result = format_tool_use(
+            {"type": "tool_use", "name": "Grep", "input": {"pattern": "def foo"}}
+        )
+        assert result == "⏺ Grep(def foo)"
+
+    def test_long_tool_line_truncates(self) -> None:
+        result = format_tool_use(
+            {"type": "tool_use", "name": "Bash", "input": {"command": "x" * 200}}
+        )
+        assert "…" in result
+        assert len(result) < 180
+
+    def test_thinking_uses_tui_marker_without_card_heading(self) -> None:
+        result = thinking_html("thinking...")
+        assert result == "✻ thinking..."
+        assert "Thinking" not in result
+        assert "💭" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -292,8 +334,9 @@ class TestHandleToolResult:
         )
         state = tool_states["call_1"]
         assert state.result_line is not None
-        assert "✅" in state.result_line
-        assert "ms" in state.result_line
+        assert state.result_line.startswith("read_file")
+        assert "file contents here" in state.result_line
+        assert "ms" not in state.result_line
 
     async def test_error_result_updates_line(self) -> None:
         bot = _make_bot()
@@ -316,7 +359,7 @@ class TestHandleToolResult:
         )
         state = tool_states["call_2"]
         assert state.result_line is not None
-        assert "❌" in state.result_line
+        assert "  ⎿ ✗ API key expired" in state.result_line
         assert "API key expired" in state.result_line
 
     async def test_error_message_truncated(self) -> None:
@@ -426,7 +469,7 @@ class TestHandleToolProgress:
         bot = _make_bot()
         tool_states = {f"call_{i}": self._make_state(f"call_{i}", f"tool_{i}") for i in range(12)}
         for state in tool_states.values():
-            state.progress_line = f"⏳ <b>{state.display}</b>\n\n<code>{'x' * 600}</code>"
+            state.progress_line = f"{state.display}\n  ⎿ {'x' * 600}"
 
         trace, _, _ = await handle_tool_progress(
             event={
@@ -444,7 +487,7 @@ class TestHandleToolProgress:
         )
 
         assert len(trace) <= 3600
-        assert trace.count("<code>") == trace.count("</code>")
+        assert "<code>" not in trace
         assert "omitted" not in trace
 
     def test_large_tool_result_preview_does_not_render_omitted_marker(self) -> None:


### PR DESCRIPTION
## Summary
- Render Telegram thinking text with Claude Cage's plain `✻ ...` TUI marker instead of the old `💭 Thinking...` card.
- Render Telegram tool calls as `⏺ Tool(detail)` and results/errors as compact `⎿` preview lines.
- Keep the change scoped to the Telegram channel rendering layer and update channel/progress tests around the new visible text.

## User impact
Telegram turns now look closer to Claude Cage while preserving the existing stream/block behavior: thinking, tool calls, tool results, and final text still arrive in chronological message blocks.

## Testing
- `cd backend && env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest tests/test_telegram_channel.py tests/test_telegram_progress.py tests/test_telegram_dispatch.py`
- `cd backend && env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff check app/channels/telegram/delivery.py app/channels/telegram/progress.py app/channels/telegram/dispatch.py tests/test_telegram_progress.py tests/test_telegram_dispatch.py tests/test_telegram_channel.py`
- `cd backend && env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff format --check app/channels/telegram/delivery.py app/channels/telegram/progress.py app/channels/telegram/dispatch.py tests/test_telegram_progress.py tests/test_telegram_dispatch.py tests/test_telegram_channel.py`
- `cd backend && env UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run mypy app/channels/telegram`
- `python3 scripts/check-nesting.py`
- `node scripts/check-file-lines.mjs backend/app/channels/telegram/delivery.py backend/app/channels/telegram/progress.py backend/app/channels/telegram/dispatch.py backend/tests/test_telegram_progress.py backend/tests/test_telegram_dispatch.py backend/tests/test_telegram_channel.py`

## Notes
Commit hooks also passed hardcoded-secret detection, backend Ruff, backend mypy, backend Bandit, and the conventional commit check.