### PR TITLE
Fix AGY API unauthenticated fallback

### DIFF
--- a/backend/app/providers/selection.py
+++ b/backend/app/providers/selection.py
@@ -6,8 +6,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from app.providers.base import AILLM
-from app.providers.catalog import ModelEntry, find, first_catalog_model, require_known
-from app.providers.factory import resolve_llm
+from app.providers.catalog import (
+    ModelEntry,
+    find,
+    first_authenticated_catalog_model,
+    first_catalog_model,
+    require_known,
+)
+from app.providers.factory import host_authenticated, resolve_llm
 from app.providers.model_id import InvalidModelId, UnknownModelId, parse_model_id
 
 
@@ -24,6 +30,11 @@ class ProviderSelection:
 def default_model_id() -> str:
     """Return the catalog default model ID."""
     return first_catalog_model().id
+
+
+def _authenticated_default_model_id(workspace_root: Path | None = None) -> str:
+    """Return the first model whose host is authenticated for the workspace."""
+    return first_authenticated_catalog_model(workspace_root).id
 
 
 def effective_model_id(*, conversation_model_id: str | None) -> str:
@@ -66,14 +77,38 @@ def provider_or_default(
     *,
     workspace_root: Path | None = None,
 ) -> ProviderSelection:
-    """Resolve ``model_id``, falling back to the catalog default on bad IDs."""
+    """Resolve ``model_id`` or fall back to an authenticated catalog default."""
     try:
-        return require_provider(model_id, workspace_root=workspace_root)
+        entry = require_known(model_id)
     except (InvalidModelId, UnknownModelId) as exc:
-        fallback_id = default_model_id()
-        return ProviderSelection(
-            provider=resolve_llm(fallback_id, workspace_root=workspace_root),
-            effective_model_id=fallback_id,
+        return _fallback_selection(
+            model_id,
             warning=str(exc),
-            bad_model_id=model_id,
+            workspace_root=workspace_root,
         )
+    if host_authenticated(entry.host, workspace_root=workspace_root):
+        return ProviderSelection(
+            provider=resolve_llm(model_id, workspace_root=workspace_root),
+            effective_model_id=model_id,
+        )
+    return _fallback_selection(
+        model_id,
+        warning=f"host not authenticated: {entry.host.value}",
+        workspace_root=workspace_root,
+    )
+
+
+def _fallback_selection(
+    model_id: str,
+    *,
+    warning: str,
+    workspace_root: Path | None,
+) -> ProviderSelection:
+    """Build a provider selection for the authenticated fallback model."""
+    fallback_id = _authenticated_default_model_id(workspace_root)
+    return ProviderSelection(
+        provider=resolve_llm(fallback_id, workspace_root=workspace_root),
+        effective_model_id=fallback_id,
+        warning=warning,
+        bad_model_id=model_id,
+    )

--- a/backend/tests/test_provider_selection.py
+++ b/backend/tests/test_provider_selection.py
@@ -1,0 +1,107 @@
+"""Tests for provider selection fallbacks."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+import pytest
+
+from app.providers.base import AILLM, StreamEvent
+from app.providers.catalog import ModelEntry
+from app.providers.model_id import Host, Vendor
+from app.providers.selection import provider_or_default
+
+
+class DummyLLM:
+    """Tiny provider used to verify which model ID selection resolved."""
+
+    async def stream(
+        self,
+        question: str,
+        conversation_id: UUID,
+        user_id: UUID,
+        history: list[dict[str, str]] | None = None,
+        tools: object | None = None,
+        system_prompt: str | None = None,
+        reasoning_effort: str | None = None,
+        images: list[dict[str, str]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        if False:
+            yield {"type": "delta", "content": question}
+
+
+def _entry(model_id: str, host: Host) -> ModelEntry:
+    """Build the minimal catalog row selection needs for these tests."""
+    _, raw_model = model_id.split(":", maxsplit=1)
+    vendor, model = raw_model.split("/", maxsplit=1)
+    return ModelEntry(
+        host=host,
+        vendor=Vendor(vendor),
+        model=model,
+        display_name=model,
+        short_name=model,
+        description=model,
+    )
+
+
+def test_provider_or_default_falls_back_when_host_is_unauthenticated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A saved AGY API model should not construct AGY when auth is missing."""
+    requested_id = "agy-api:google/gemini-3.5-flash-low"
+    fallback_id = "claude-code-pty:anthropic/claude-opus-4-7"
+    resolved_ids: list[str] = []
+
+    def fake_host_authenticated(host: Host, *, workspace_root: Path | None = None) -> bool:
+        return host is not Host.agy_api
+
+    def fake_resolve_llm(model_id: str, *, workspace_root: Path | None = None) -> AILLM:
+        resolved_ids.append(model_id)
+        return cast(AILLM, DummyLLM())
+
+    monkeypatch.setattr(
+        "app.providers.selection.host_authenticated",
+        fake_host_authenticated,
+    )
+    monkeypatch.setattr(
+        "app.providers.selection.first_authenticated_catalog_model",
+        lambda workspace_root=None: _entry(fallback_id, Host.claude_code_pty),
+    )
+    monkeypatch.setattr("app.providers.selection.resolve_llm", fake_resolve_llm)
+
+    selection = provider_or_default(requested_id, workspace_root=tmp_path)
+
+    assert selection.effective_model_id == fallback_id
+    assert selection.bad_model_id == requested_id
+    assert selection.warning == "host not authenticated: agy-api"
+    assert resolved_ids == [fallback_id]
+
+
+def test_provider_or_default_bad_model_uses_authenticated_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid IDs should use the same authenticated default path."""
+    fallback_id = "claude-code-pty:anthropic/claude-opus-4-7"
+    resolved_ids: list[str] = []
+
+    def fake_resolve_llm(model_id: str, *, workspace_root: Path | None = None) -> AILLM:
+        resolved_ids.append(model_id)
+        return cast(AILLM, DummyLLM())
+
+    monkeypatch.setattr(
+        "app.providers.selection.first_authenticated_catalog_model",
+        lambda workspace_root=None: _entry(fallback_id, Host.claude_code_pty),
+    )
+    monkeypatch.setattr("app.providers.selection.resolve_llm", fake_resolve_llm)
+
+    selection = provider_or_default("not-a-model", workspace_root=tmp_path)
+
+    assert selection.effective_model_id == fallback_id
+    assert selection.bad_model_id == "not-a-model"
+    assert "not a valid model ID" in str(selection.warning)
+    assert resolved_ids == [fallback_id]


### PR DESCRIPTION
## Summary
- fall back to the first authenticated catalog model when a saved/requested host is unauthenticated
- keep invalid model fallback on the same authenticated-default path
- add provider selection tests that ensure AGY API is not constructed when its auth gate fails

## Verification
- cd backend && uv run pytest tests/test_provider_selection.py tests/test_agy_api_provider.py tests/test_agy_api_auth.py tests/test_models_api.py -q
- just check