### PR TITLE
Spike: Rivet + Pi + Postgres + Electric substrate (M1 streaming, M2 durability, M3 single-writer + sync, M4 scoped gatekeeper)

### DIFF
--- a/spikes/rivet-pi-electric/.gitignore
+++ b/spikes/rivet-pi-electric/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.rivethome/
+bun.lock
+*.log

--- a/spikes/rivet-pi-electric/.gitignore
+++ b/spikes/rivet-pi-electric/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
-.rivethome/
+.rivethome*/
+infra/hatchet-creds/
 bun.lock
 *.log

--- a/spikes/rivet-pi-electric/FINDINGS.md
+++ b/spikes/rivet-pi-electric/FINDINGS.md
@@ -1,10 +1,10 @@
-# Spike: Rivet + Pi + Postgres + Electric + Hatchet (M1–M8)
+# Spike: Rivet + Pi + Postgres + Electric + Hatchet (M1–M9)
 
 Throwaway spike validating the substrate ADR
 (`2026-06-27-rivet-postgres-electric-hatchet-substrate`) before rewriting the
 003 plan. It now covers the full read/write vertical slice, the read-path
 security boundary, the production engine lifecycle, the Effect-v4 client
-wrapping, and durable background work:
+wrapping, durable background work, and the actor's own session-scoped scheduler:
 
 - **M1** — one conversation = one Rivet actor running the unforked Pi loop,
   streaming tokens out over the actor WebSocket.
@@ -26,6 +26,10 @@ wrapping, and durable background work:
   + layers** and exercised through one composed runtime.
 - **M8** — durable system work runs on **Hatchet** (Postgres-backed queue),
   survives a worker restart, and projects through the same single-writer seam.
+- **M9** — the actor's **own scheduler** (`c.schedule.after(...)` → a named
+  action) is durable: a per-session wake registered before a real cold restart
+  still fires (mutating state) after the actor rehydrates, with no client
+  invoking it. This is the session-scoped-timer half of the ADR's RC risk.
 
 ## What runs
 
@@ -34,9 +38,12 @@ wrapping, and durable background work:
   (`createFauxCore` from `@earendil-works/pi-ai/providers/faux`). Pi is consumed
   as a published npm dependency (`0.80.2`); nothing patches it.
 - `src/conversation-actor.ts` — a `rivetkit` actor. State = `{ systemPrompt, id,
-  owner, messages, turnCount }`. `sendMessage` runs one Pi turn, `c.broadcast`s
-  each `text_delta`, and (when an identity is bound via `setIdentity`) projects
-  a summary row through the API. `getTranscript` reads persisted state.
+  owner, messages, turnCount, wakeCount, lastWakeLabel }`. `sendMessage` runs one
+  Pi turn, `c.broadcast`s each `text_delta`, and (when an identity is bound via
+  `setIdentity`) projects a summary row through the API. `getTranscript` reads
+  persisted state. `scheduleWake` registers a durable per-session wake via
+  `c.schedule.after`, `fireWake` is the scheduler-only callback that mutates
+  state, `getWakes` reads the wake counters (M9).
 - `src/db.ts` — the **only** module that talks to Postgres (`pg` pool, lazy).
 - `src/api.ts` — the **single-writer** API seam (`upsertConversationSummary`).
   The actor imports this, never `db.ts`. In production this is `apps/api` over
@@ -67,7 +74,7 @@ wrapping, and durable background work:
   (`project-conversation-summary`), which projects through the SAME
   `upsertConversationSummary` seam. `src/hatchet/worker.ts` — the standalone
   worker process (run as a child so M8 can kill it).
-- `src/m1.ts` … `src/m8.ts` — the milestone runners.
+- `src/m1.ts` … `src/m9.ts` — the milestone runners.
 - `infra/docker-compose.yml` — PG 17 (logical replication) + Electric 1.5.1,
   isolated project/ports (`:5499` / `:5599`).
 - `infra/hatchet-compose.yml` — `hatchet-lite` on its OWN Postgres (`:5502`),
@@ -125,11 +132,13 @@ bun run m4
 # M5 — identity from a trusted session authority (header no longer trusted)
 bun run m5
 
-# M6 / M7 — standalone engine server on :6420. Ensure :6420 is FREE first
+# M6 / M7 / M9 — standalone engine server on :6420. Ensure :6420 is FREE first
 # (a stale engine breaks the boot with no_runner_config_configured — see findings):
 pgrep -x rivet-engine | xargs -r kill ; sleep 3
 RIVET_ENVOY_VERSION=1 bun run m6   # cold-restart durability, off the harness
 RIVET_ENVOY_VERSION=1 bun run m7   # PG/Electric/Rivet wrapped as Effect v4 layers
+pgrep -x rivet-engine | xargs -r kill ; sleep 3
+RIVET_ENVOY_VERSION=1 bun run m9   # actor scheduler/alarm durability across a cold restart
 
 # M8 — Hatchet durable background work surviving a worker restart
 docker compose -f infra/hatchet-compose.yml up -d   # mints infra/hatchet-creds/api-token
@@ -219,6 +228,20 @@ Hatchet (`hatchet-lite` on its own Postgres) ran the durable
 Durable system work survives the worker dying and lands through the single
 writer — no work is lost, and Hatchet never gets its own write path to the DB.
 
+### M9 — PASS
+The actor scheduled a per-session wake via its own scheduler
+(`c.schedule.after(20s, 'fireWake', label)`), under the same standalone engine
+shape as M6. `wakeCount=0` before the cold restart (the wake had not fired); the
+runner then killed the server **and** the engine, waited for `:6420` to free,
+and rebooted. After rehydration the scheduler fired the wake **unaided** (no
+client called `fireWake`): `wakeCount=1`, `lastWakeLabel` matched. Deterministic
+across repeated runs. Because the engine reboot (boot + runner registration)
+itself takes ~20-30s, the wake's fire time elapses during downtime and the wake
+**catches up on rehydration** — the stronger durability property (a missed
+session timer is not dropped). This is the alarm half of the ADR's RC risk that
+M2/M6 (state) left open, and it's what lets session-scoped timers live on the
+actor instead of Hatchet.
+
 ## Operational findings (these matter for the ADR)
 
 1. **rivetkit dev/test is not "pure in-process."** Even `setupTest` spawns the
@@ -283,6 +306,16 @@ writer — no work is lost, and Hatchet never gets its own write path to the DB.
     worker is alive sits in Hatchet's Postgres and is delivered to the next
     worker that registers the task — the restarted worker picked up the *same run
     id*. The worker is stateless; the durability lives in Hatchet's PG.
+17. **Actor schedules are durable AND catch up on rehydration.** A wake set with
+    `c.schedule.after(ms, 'action', ...args)` persists alongside actor state;
+    after a cold restart the actor fires it on its own, with no client connected.
+    Because the engine reboot alone takes ~20-30s, the wake's fire time routinely
+    elapses *during downtime* — and it still fires when the actor rehydrates
+    (a missed session timer is caught up, not dropped). This is the durability
+    that lets session-scoped timers live on the actor (per the ADR scope rule),
+    leaving Hatchet for system-level work. Same async-persist caveat as #12: the
+    `schedule` call returning is not the same as it being on disk — settle (or
+    shut down gracefully) before a hard kill.
 
 ## Implication for the next step
 
@@ -300,8 +333,15 @@ nothing left deliberately deferred:
   composed runtime (M7).
 - **durable system work** — Hatchet (Postgres-backed) surviving a worker restart
   and projecting through the single writer (M8).
+- **session-scoped durable timers** — the actor's own scheduler firing a wake
+  after a cold restart (catching up a missed fire on rehydration), which is what
+  keeps per-session time on the actor and off Hatchet (M9).
+
+Both halves of the ADR's headline RC risk — **state** durability (M2/M3c/M6)
+**and** **alarm** durability (M9) — are now proven for `rivetkit` 2.3.2.
 
 The substrate is ready to graduate from a throwaway spike into the 003 plan
-rewrite. The findings above (especially #11 engine-port hygiene, #12 commit
-settle, #15 Hatchet broadcast address) are the operational sharp edges the real
-`apps/api` + engine-lifecycle code must handle deliberately rather than rediscover.
+rewrite. The findings above (especially #11 engine-port hygiene, #12/#17
+async-persist settle, #15 Hatchet broadcast address) are the operational sharp
+edges the real `apps/api` + engine-lifecycle code must handle deliberately
+rather than rediscover.

--- a/spikes/rivet-pi-electric/FINDINGS.md
+++ b/spikes/rivet-pi-electric/FINDINGS.md
@@ -1,8 +1,9 @@
-# Spike: Rivet + Pi + Postgres + Electric (M1–M3 gate)
+# Spike: Rivet + Pi + Postgres + Electric (M1–M4 gate)
 
 Throwaway spike validating the substrate ADR
 (`2026-06-27-rivet-postgres-electric-hatchet-substrate`) before rewriting the
-003 plan. It now covers the full read/write vertical slice:
+003 plan. It now covers the full read/write vertical slice plus the read-path
+security boundary:
 
 - **M1** — one conversation = one Rivet actor running the unforked Pi loop,
   streaming tokens out over the actor WebSocket.
@@ -10,9 +11,12 @@ Throwaway spike validating the substrate ADR
 - **M3** — the actor projects a conversation summary to **Postgres through the
   API (single writer)**, and **Electric** syncs that row to a second client
   live; the row + actor state survive a cold restart together.
+- **M4** — an **identity-scoped gatekeeper** in front of Electric enforces a
+  per-owner `where` clause + table/column allowlist server-side; a client cannot
+  widen its view, even by sending its own `where`.
 
-Hatchet and the identity-scoped Electric gatekeeper are intentionally **not** in
-this gate (next: M4).
+Effect-v4 client wrapping and Hatchet are intentionally **not** in this gate
+(next gates).
 
 ## What runs
 
@@ -30,9 +34,16 @@ this gate (next: M4).
   RPC; here it is an in-process function.
 - `src/shape-client.ts` — the read-path client: `@electric-sql/client`
   `ShapeStream` over the `conversations` shape, materialized into a live map.
+  Defaults to Electric directly (M3); accepts `url`/`headers` to route through
+  the gatekeeper (M4).
+- `src/proxy.ts` — the **identity-scoped gatekeeper** (`node:http`), trimmed from
+  `backend/vendor/effect-api-layout/apps/electric-proxy`. Authenticates an
+  identity, validates the table, forwards ONLY recognized Electric protocol
+  params (`ELECTRIC_PROTOCOL_QUERY_PARAMS`), and **server-forces** the table, a
+  column allowlist, and `where owner = $1` bound to the caller.
 - `src/harness.ts` — in-process Rivet boot via `rivetkit/test` `setupTest`, with
   a runner-readiness retry (see findings).
-- `src/m1.ts` / `src/m2.ts` / `src/m3.ts` — the milestone runners.
+- `src/m1.ts` / `src/m2.ts` / `src/m3.ts` / `src/m4.ts` — the milestone runners.
 - `infra/docker-compose.yml` — PG 17 (logical replication) + Electric 1.5.1,
   isolated project/ports so it can't collide with the host's other Postgres.
 
@@ -78,6 +89,9 @@ RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:seed
 pgrep -f 'engine-cli-linux-x64-musl/rivet-engine start' | grep -vw "$$" | xargs -r kill
 sleep 5   # PG + Electric keep running; only the Rivet engine restarts
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:verify
+
+# M4 — identity-scoped gatekeeper (no actor/engine; just PG + Electric + the proxy)
+bun run m4
 ```
 
 ## Results
@@ -112,6 +126,20 @@ Cold restart with **PG + Electric left running, only the Rivet engine killed**
 - A follow-up turn continued to `turnCount=2`/`messageCount=4` and Electric
   synced the post-restart update (`turn_count=2`) live.
 
+### M4 — PASS
+Two owners (`alice`, `bob`) each own a row. With the gatekeeper in front of
+Electric:
+- **scope** — a client authenticating as alice synced **only** alice's row
+  (`ownRow=true bobRow=false onlyOwnOwner=true rows=1`); bob's row never arrived.
+- **sneak** — a client authenticating as alice but requesting `where owner='bob'`
+  **still** saw nothing of bob's (`bobRow=false`): the proxy drops the client
+  `where` and forces `owner = $1` server-side.
+- **reject** — a request with no identity → **401**; a request for a
+  non-allowlisted table (`secrets`) → **403**.
+
+This is the boundary files-first could never enforce centrally: read access is
+scoped per identity by the server, independent of what the client asks for.
+
 ## Operational findings (these matter for the ADR)
 
 1. **rivetkit dev/test is not "pure in-process."** Even `setupTest` spawns the
@@ -136,17 +164,29 @@ Cold restart with **PG + Electric left running, only the Rivet engine killed**
    pattern is in your own argv), so a naive `pkill`/`xargs kill` kills the shell
    (or, with a multi-line PID string, zsh's no-word-split throws `illegal pid`).
    Exclude the current shell: `pgrep -f ... | grep -vw "$$" | xargs -r kill`.
+9. **The gatekeeper's security rests on forwarding an allowlist, not a denylist.**
+   The proxy copies ONLY `ELECTRIC_PROTOCOL_QUERY_PARAMS` (offset/handle/live/
+   cursor/cache-buster) from the client, then sets `table`/`columns`/`where`/
+   `params` itself. Because `where`/`columns`/`table` are not protocol params,
+   any client-supplied versions are silently dropped — there's no way for a
+   client to inject a broader scope. Forward the Electric protocol param list as
+   it ships in `@electric-sql/client`; don't hand-maintain it.
+10. **Forward the client's disconnect to the upstream.** Electric long-polls on
+   `live=true`; without wiring the request `close` event into an `AbortController`
+   on the upstream `fetch`, a client closing its `ShapeStream` leaves a dangling
+   long-poll against Electric per reconnect.
 
 ## Implication for the next step
 
-The full read/write substrate is structurally sound: single-writer actor →
-API → Postgres → Electric → second client, all surviving a cold restart. What's
-still unproven / deliberately deferred before the 003 rewrite:
+The full read/write substrate is structurally sound and the read path is safe to
+expose to untrusted clients: single-writer actor → API → Postgres → Electric →
+**identity-scoped gatekeeper** → second client, all surviving a cold restart.
+What's still unproven / deliberately deferred before the 003 rewrite:
 
 - **Engine lifecycle + runner-pool versioning** must move off the `setupTest`
   harness onto the reference's `serverless.configureRunnerPool` shape.
-- **Identity-scoped Electric gatekeeper** (the `electric-proxy` `where`-clause +
-  column allowlist, per `backend/vendor/effect-api-layout/apps/electric-proxy`) —
-  M4.
+- **Real identity** behind the gatekeeper: the spike trusts an `x-spike-user`
+  header; production must validate the session cookie (Tailscale/profile) and
+  derive the owner from it, not from a client-controlled header.
 - **Effect v4 wrapping** of the Rivet + Electric + PG clients (`@clients/*`),
   and **Hatchet** for system-level durable work — later gates.

--- a/spikes/rivet-pi-electric/FINDINGS.md
+++ b/spikes/rivet-pi-electric/FINDINGS.md
@@ -1,9 +1,10 @@
-# Spike: Rivet + Pi + Postgres + Electric (M1–M4 gate)
+# Spike: Rivet + Pi + Postgres + Electric + Hatchet (M1–M8)
 
 Throwaway spike validating the substrate ADR
 (`2026-06-27-rivet-postgres-electric-hatchet-substrate`) before rewriting the
-003 plan. It now covers the full read/write vertical slice plus the read-path
-security boundary:
+003 plan. It now covers the full read/write vertical slice, the read-path
+security boundary, the production engine lifecycle, the Effect-v4 client
+wrapping, and durable background work:
 
 - **M1** — one conversation = one Rivet actor running the unforked Pi loop,
   streaming tokens out over the actor WebSocket.
@@ -14,9 +15,17 @@ security boundary:
 - **M4** — an **identity-scoped gatekeeper** in front of Electric enforces a
   per-owner `where` clause + table/column allowlist server-side; a client cannot
   widen its view, even by sending its own `where`.
-
-Effect-v4 client wrapping and Hatchet are intentionally **not** in this gate
-(next gates).
+- **M5** — identity behind the gatekeeper comes from a **trusted session
+  authority**, not a client-asserted header; forged/missing/revoked sessions are
+  rejected.
+- **M6** — the actor runs under the **production standalone engine shape**
+  (`startEngine` + pinned `engineVersion`/`envoy.version` + `registry.start()`),
+  off the `setupTest` harness, and survives a real cold restart this runner
+  performs itself.
+- **M7** — the PG / Electric / Rivet clients are wrapped as **Effect v4 services
+  + layers** and exercised through one composed runtime.
+- **M8** — durable system work runs on **Hatchet** (Postgres-backed queue),
+  survives a worker restart, and projects through the same single-writer seam.
 
 ## What runs
 
@@ -35,17 +44,36 @@ Effect-v4 client wrapping and Hatchet are intentionally **not** in this gate
 - `src/shape-client.ts` — the read-path client: `@electric-sql/client`
   `ShapeStream` over the `conversations` shape, materialized into a live map.
   Defaults to Electric directly (M3); accepts `url`/`headers` to route through
-  the gatekeeper (M4).
+  the gatekeeper (M4/M5).
 - `src/proxy.ts` — the **identity-scoped gatekeeper** (`node:http`), trimmed from
-  `backend/vendor/effect-api-layout/apps/electric-proxy`. Authenticates an
-  identity, validates the table, forwards ONLY recognized Electric protocol
-  params (`ELECTRIC_PROTOCOL_QUERY_PARAMS`), and **server-forces** the table, a
-  column allowlist, and `where owner = $1` bound to the caller.
-- `src/harness.ts` — in-process Rivet boot via `rivetkit/test` `setupTest`, with
-  a runner-readiness retry (see findings).
-- `src/m1.ts` / `src/m2.ts` / `src/m3.ts` / `src/m4.ts` — the milestone runners.
+  `backend/vendor/effect-api-layout/apps/electric-proxy`. Pluggable `ProxyAuth`:
+  `headerAuth` (M4, trusts `x-spike-user`) and `sessionAuth` (M5, resolves a
+  session through the trusted store). Validates the table, forwards ONLY
+  recognized Electric protocol params (`ELECTRIC_PROTOCOL_QUERY_PARAMS`), and
+  **server-forces** the table, a column allowlist, and `where owner = $1`.
+- `src/session-store.ts` — the trusted-authority stand-in for M5 (an in-memory
+  `/users/me`): `create` / `lookup` / `revoke` over opaque session ids.
+- `src/server.ts` — the **standalone actor server** (M6/M7): `setup({ ...,
+  startEngine: true, enginePort, engineVersion, envoy: { version } })` +
+  `registry.start()`. The production shape, off `setupTest`.
+- `src/server-control.ts` — OS-level lifecycle for `src/server.ts` (spawn, stop
+  both the server child AND the engine, port-free polling, readiness probe).
+  Shared by M6 and M7.
+- `src/effect/` — the M7 Effect-v4 wrapping: `Pg` (scoped pool via `Layer.effect`
+  + `acquireRelease`), `Conversations` (the API seam, depends on `Pg`),
+  `Electric` (the shape via `acquireUseRelease`), `Rivet` (the client, layer
+  parameterized by endpoint), and an `index.ts` barrel.
+- `src/hatchet/workflow.ts` — the Hatchet client + the one durable task
+  (`project-conversation-summary`), which projects through the SAME
+  `upsertConversationSummary` seam. `src/hatchet/worker.ts` — the standalone
+  worker process (run as a child so M8 can kill it).
+- `src/m1.ts` … `src/m8.ts` — the milestone runners.
 - `infra/docker-compose.yml` — PG 17 (logical replication) + Electric 1.5.1,
-  isolated project/ports so it can't collide with the host's other Postgres.
+  isolated project/ports (`:5499` / `:5599`).
+- `infra/hatchet-compose.yml` — `hatchet-lite` on its OWN Postgres (`:5502`),
+  with a one-shot `hatchet-setup` that mints an API token to
+  `infra/hatchet-creds/api-token`. Host ports remapped to **gRPC :7079 / API
+  :8899** (see findings).
 
 ## Versions (resolved)
 
@@ -54,8 +82,11 @@ Effect-v4 client wrapping and Hatchet are intentionally **not** in this gate
 | `rivetkit` | `^2.2.2-rc.1` | **2.3.2** (past the RC the ADR worried about) |
 | `@earendil-works/pi-agent-core` / `pi-ai` | `0.80.2` | 0.80.2 |
 | `@electric-sql/client` | `1.5.13` | 1.5.13 |
+| `effect` | `4.0.0-beta.74` | 4.0.0-beta.74 |
+| `@hatchet-dev/typescript-sdk` | `^1.22.0` | **1.24.3** |
 | `pg` | `^8.13.0` | 8.22.0 |
 | `electricsql/electric` (image) | `1.5.1` | 1.5.1 |
+| `hatchet-dev/hatchet-lite` (image) | `latest` | latest |
 | `postgres` (image) | `17-alpine` | 17 |
 
 ## How to reproduce
@@ -64,7 +95,7 @@ Effect-v4 client wrapping and Hatchet are intentionally **not** in this gate
 cd spikes/rivet-pi-electric
 bun install
 
-# --- infra (M3 only): Postgres + Electric on loopback ports 5499 / 5599 ---
+# --- app infra (M3–M8 read/write path): Postgres + Electric on 5499 / 5599 ---
 docker compose -f infra/docker-compose.yml up -d
 # tear down later: docker compose -f infra/docker-compose.yml down -v
 
@@ -79,19 +110,31 @@ pgrep -f 'engine-cli-linux-x64-musl/rivet-engine start' | grep -vw "$$" | xargs 
 sleep 5
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:verify
 
-# M3a — raw single-writer write → Electric read-path sync (no actor)
+# M3a/b/c — single-writer → Electric read-path sync; survives a cold restart
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3a
-# M3b — actor projects through the API; client A streams, client B syncs
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3b
-# M3c — PG row + actor state survive a cold restart together
 rm -rf .rivethome && mkdir -p .rivethome
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:seed
 pgrep -f 'engine-cli-linux-x64-musl/rivet-engine start' | grep -vw "$$" | xargs -r kill
-sleep 5   # PG + Electric keep running; only the Rivet engine restarts
+sleep 5
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:verify
 
-# M4 — identity-scoped gatekeeper (no actor/engine; just PG + Electric + the proxy)
+# M4 — identity-scoped gatekeeper (trusts the x-spike-user header)
 bun run m4
+
+# M5 — identity from a trusted session authority (header no longer trusted)
+bun run m5
+
+# M6 / M7 — standalone engine server on :6420. Ensure :6420 is FREE first
+# (a stale engine breaks the boot with no_runner_config_configured — see findings):
+pgrep -x rivet-engine | xargs -r kill ; sleep 3
+RIVET_ENVOY_VERSION=1 bun run m6   # cold-restart durability, off the harness
+RIVET_ENVOY_VERSION=1 bun run m7   # PG/Electric/Rivet wrapped as Effect v4 layers
+
+# M8 — Hatchet durable background work surviving a worker restart
+docker compose -f infra/hatchet-compose.yml up -d   # mints infra/hatchet-creds/api-token
+bun run m8
+docker compose -f infra/hatchet-compose.yml down -v
 ```
 
 ## Results
@@ -119,26 +162,62 @@ summary row (`owner=bob`, `turn_count=1`, title set) appeared in client B
 through `api.ts`; it never imports `db.ts` (single writer, structural).
 
 ### M3c — PASS
-Cold restart with **PG + Electric left running, only the Rivet engine killed**
-(verified: `6420 FREE before verify — engine truly down`):
-- Electric replayed the persisted PG row (`turn_count=1`) to a fresh client.
-- The actor replayed its transcript (`turnCount=1`, `messageCount=2`) from RocksDB.
-- A follow-up turn continued to `turnCount=2`/`messageCount=4` and Electric
-  synced the post-restart update (`turn_count=2`) live.
+Cold restart with **PG + Electric left running, only the Rivet engine killed**:
+Electric replayed the persisted PG row, the actor replayed its transcript from
+RocksDB, and a follow-up turn continued + synced live.
 
 ### M4 — PASS
 Two owners (`alice`, `bob`) each own a row. With the gatekeeper in front of
-Electric:
-- **scope** — a client authenticating as alice synced **only** alice's row
-  (`ownRow=true bobRow=false onlyOwnOwner=true rows=1`); bob's row never arrived.
-- **sneak** — a client authenticating as alice but requesting `where owner='bob'`
-  **still** saw nothing of bob's (`bobRow=false`): the proxy drops the client
-  `where` and forces `owner = $1` server-side.
-- **reject** — a request with no identity → **401**; a request for a
-  non-allowlisted table (`secrets`) → **403**.
+Electric: **scope** (alice synced only alice's row), **sneak** (alice requesting
+`where owner='bob'` still saw nothing — the proxy drops the client `where`),
+**reject** (no identity → 401; non-allowlisted table → 403).
 
-This is the boundary files-first could never enforce centrally: read access is
-scoped per identity by the server, independent of what the client asks for.
+### M5 — PASS
+Same two owners, but the proxy resolves identity through the trusted session
+store (`sessionAuth`), not a header:
+- **session-scope** — a validated session for alice synced **only** alice's row
+  (`ownRow=true bobRow=false rows=1`).
+- **header-not-trusted** — alice's session **plus** `x-spike-user: bob` still
+  yielded only alice's row (`bobRow=false`): the asserted header is ignored.
+- **reject** — forged session → **401**, no credential → **401**, revoked
+  session → **401**.
+
+This is the production-shaped boundary: the client never names who it is; the
+server derives the owner from a credential it minted.
+
+### M6 — PASS
+The actor booted under the **standalone production shape** (`src/server.ts`:
+`startEngine` + pinned `engineVersion=1` / `envoy.version=1` + `registry.start()`),
+connected via an external `createClient`, and survived a real cold restart this
+runner performed itself (kill the server **and** the engine, wait for `:6420` to
+free, reboot): seed `turnCount=1`/`transcriptLength=2` → replay
+`turnCount=1`/`messageCount=2` → continue `turnCount=2`/`transcriptLength=4`.
+Deterministic across repeated runs once the pre-kill settle window was added
+(see findings #12).
+
+### M7 — PASS
+Each raw client became an Effect v4 `Service` + `Layer` (`Pg` as a scoped pool
+via `Layer.effect` + `acquireRelease`; `Electric` and `Rivet` as `Layer.succeed`),
+composed with `Layer.mergeAll`, run once via `Effect.runPromise`:
+- **pg+electric** — wrote a summary through the wrapped `Conversations` seam
+  (over the scoped pool) and read it back through the wrapped Electric shape
+  (`row.owner` matched, `turn_count=1`).
+- **rivet** — ran a turn and read the transcript through the wrapped client
+  against the standalone server (`turn=1`, `transcript.turnCount=1`,
+  `messageCount=2`).
+
+### M8 — PASS
+Hatchet (`hatchet-lite` on its own Postgres) ran the durable
+`project-conversation-summary` task, which writes through the SAME
+`upsertConversationSummary` seam the actor uses:
+- **baseline** — worker up → task A ran end-to-end → row A in the app PG.
+- **down** — SIGKILL the worker, then enqueue task B while nothing serves it; B
+  was **not** projected (`B before restart=false`) — it sat in Hatchet's PG queue.
+- **restart** — bring the worker back; it picked the **same run id** off the
+  durable queue and projected row B (`B after restart=true`).
+
+Durable system work survives the worker dying and lands through the single
+writer — no work is lost, and Hatchet never gets its own write path to the DB.
 
 ## Operational findings (these matter for the ADR)
 
@@ -147,46 +226,82 @@ scoped per identity by the server, independent of what the client asks for.
    on-disk **RocksDB** under `$HOME/.rivetkit/var/engine/db`.
 2. **Sandbox needs a writable `HOME`** for the engine (defaults to `/root/.rivetkit`).
 3. **The engine child is orphaned on exit** and holds the RocksDB `LOCK` + port
-   6420. Production needs explicit engine lifecycle management.
+   6420. Production needs explicit engine lifecycle management. (See #11 for how
+   this bites the standalone server.)
 4. **Startup race: `no_runner_config_configured`** — first actor call can fire
    before the runner pool registers; worked around with a readiness retry.
-5. **Durability requires a stable runner version** (`RIVET_ENVOY_VERSION`), else
-   `actor_ready_timeout`. Mirrors the reference's `configureRunnerPool` versioning.
+5. **Durability requires a stable runner version** (`RIVET_ENVOY_VERSION` /
+   pinned `envoy.version`), else `actor_ready_timeout`. Mirrors the reference's
+   runner-pool versioning.
 6. **Postgres durability is independent of the Rivet engine.** Because PG runs as
    its own service, the conversation row survives an engine restart for free;
-   Electric re-syncs it to clients on reconnect. This is exactly why the
-   queryable record lives in PG, not in the actor.
+   Electric re-syncs it on reconnect. This is why the queryable record lives in
+   PG, not in the actor.
 7. **Electric's `message.key` is structured, not the PK** (e.g.
-   `"public"."conversations"/"<id>"`). Materialize by the row's own `id`
-   (`message.value.id`), and merge partial update values (default `replica`
-   sends only PK + changed columns).
-8. **`pgrep -f '...rivet-engine start'` self-matches the shell** running it (the
-   pattern is in your own argv), so a naive `pkill`/`xargs kill` kills the shell
-   (or, with a multi-line PID string, zsh's no-word-split throws `illegal pid`).
-   Exclude the current shell: `pgrep -f ... | grep -vw "$$" | xargs -r kill`.
+   `"public"."conversations"/"<id>"`). Materialize by the row's own `id`, and
+   merge partial update values (default `replica` sends only PK + changed cols).
+8. **`pgrep -f '...rivet-engine start'` self-matches the shell** running it, so a
+   naive `pkill`/`xargs kill` kills the shell. Exclude the current shell:
+   `pgrep -f ... | grep -vw "$$" | xargs -r kill`. (`pkill -x rivet-engine`
+   matches the engine by exact name and avoids this.)
 9. **The gatekeeper's security rests on forwarding an allowlist, not a denylist.**
-   The proxy copies ONLY `ELECTRIC_PROTOCOL_QUERY_PARAMS` (offset/handle/live/
-   cursor/cache-buster) from the client, then sets `table`/`columns`/`where`/
-   `params` itself. Because `where`/`columns`/`table` are not protocol params,
-   any client-supplied versions are silently dropped — there's no way for a
-   client to inject a broader scope. Forward the Electric protocol param list as
-   it ships in `@electric-sql/client`; don't hand-maintain it.
+   The proxy copies ONLY `ELECTRIC_PROTOCOL_QUERY_PARAMS`, then sets
+   `table`/`columns`/`where`/`params` itself. Client-supplied `where`/`columns`/
+   `table` are silently dropped. Forward the protocol param list as it ships in
+   `@electric-sql/client`; don't hand-maintain it.
 10. **Forward the client's disconnect to the upstream.** Electric long-polls on
-   `live=true`; without wiring the request `close` event into an `AbortController`
-   on the upstream `fetch`, a client closing its `ShapeStream` leaves a dangling
-   long-poll against Electric per reconnect.
+    `live=true`; wire the request `close` event into an `AbortController` on the
+    upstream `fetch`, or a closing `ShapeStream` leaks a dangling long-poll.
+11. **A stale engine on `:6420` silently hijacks the next standalone run.** The
+    orphaned engine (#3) keeps the port; the next `src/server.ts` attaches to it
+    instead of booting its own, and because that engine has no runner config for
+    the new boot, every actor call fails `no_runner_config_configured` until
+    `waitForReady` times out. The standalone lifecycle must ensure `:6420` is
+    free (kill stale `rivet-engine`) before boot, not only between restarts.
+12. **Actor state persists to the engine asynchronously w.r.t. the turn.** A turn
+    resolving means in-memory state changed, not that the engine flushed it. A
+    hard kill of the envoy *immediately* after a turn can drop the last write
+    before it reaches RocksDB → the cold restart replays empty state (observed as
+    a flaky M6 `replay turnCount=0`). Durability is of **committed** state: settle
+    briefly (or shut down gracefully) before a cold kill. M2/M3c masked this with
+    a `sleep 5`; M6 makes the settle explicit.
+13. **Effect v4 has no `Layer.scoped`.** `Layer.effect` accepts a scoped effect
+    (e.g. one built from `Effect.acquireRelease`) and discharges the `Scope`
+    itself — that is the idiom for a pooled/closable client (the `Pg` pool).
+14. **Hatchet task I/O must be `type` aliases, not `interface`s.** The SDK
+    constrains inputs/outputs to `JsonObject` (`{ [k: string]: JsonValue }`).
+    Object-literal `type` aliases get an implicit string index signature and
+    satisfy it; `interface`s don't (they're open to augmentation) and fail to
+    typecheck.
+15. **The Hatchet API token embeds the gRPC broadcast address.** When the host
+    already runs another Hatchet (this VPS does, on `7077`/`8888`), remapping the
+    spike's host ports is not enough — `SERVER_GRPC_BROADCAST_ADDRESS` must equal
+    the host port you actually expose (`localhost:7079`), or the freshly minted
+    token points the SDK at the OTHER Hatchet. The in-container internal client
+    still uses the container port (`7077`).
+16. **Hatchet durability is the queue, not the worker.** A run enqueued while no
+    worker is alive sits in Hatchet's Postgres and is delivered to the next
+    worker that registers the task — the restarted worker picked up the *same run
+    id*. The worker is stateless; the durability lives in Hatchet's PG.
 
 ## Implication for the next step
 
-The full read/write substrate is structurally sound and the read path is safe to
-expose to untrusted clients: single-writer actor → API → Postgres → Electric →
-**identity-scoped gatekeeper** → second client, all surviving a cold restart.
-What's still unproven / deliberately deferred before the 003 rewrite:
+Every piece of the substrate ADR is now proven end-to-end and the spike has
+nothing left deliberately deferred:
 
-- **Engine lifecycle + runner-pool versioning** must move off the `setupTest`
-  harness onto the reference's `serverless.configureRunnerPool` shape.
-- **Real identity** behind the gatekeeper: the spike trusts an `x-spike-user`
-  header; production must validate the session cookie (Tailscale/profile) and
-  derive the owner from it, not from a client-controlled header.
-- **Effect v4 wrapping** of the Rivet + Electric + PG clients (`@clients/*`),
-  and **Hatchet** for system-level durable work — later gates.
+- **read/write vertical slice** — single-writer actor → API → Postgres →
+  Electric → second client, surviving a cold restart (M1–M3).
+- **read-path security** — an identity-scoped gatekeeper backed by a trusted
+  session authority; clients cannot name themselves or widen scope (M4–M5).
+- **engine lifecycle** — the production standalone shape (`startEngine` + pinned
+  runner version), durable across a self-driven cold restart, off the test
+  harness (M6).
+- **Effect v4 wrapping** — PG, Electric, and Rivet as services + layers in one
+  composed runtime (M7).
+- **durable system work** — Hatchet (Postgres-backed) surviving a worker restart
+  and projecting through the single writer (M8).
+
+The substrate is ready to graduate from a throwaway spike into the 003 plan
+rewrite. The findings above (especially #11 engine-port hygiene, #12 commit
+settle, #15 Hatchet broadcast address) are the operational sharp edges the real
+`apps/api` + engine-lifecycle code must handle deliberately rather than rediscover.

--- a/spikes/rivet-pi-electric/FINDINGS.md
+++ b/spikes/rivet-pi-electric/FINDINGS.md
@@ -1,0 +1,99 @@
+# Spike: Rivet + Pi (M1/M2 gate)
+
+Throwaway spike validating the substrate ADR
+(`2026-06-27-rivet-postgres-electric-hatchet-substrate`) before rewriting the
+003 plan. Scope of this gate: **one conversation = one Rivet actor running the
+unforked Pi agent loop**, streaming tokens out (M1) and surviving a real restart
+(M2). The Postgres + Electric half is intentionally NOT in this gate.
+
+## What runs
+
+- `src/pi-turn.ts` — the unforked-Pi seam. Drives `runAgentLoop` from
+  `@earendil-works/pi-agent-core` with a keyless faux provider
+  (`createFauxCore` from `@earendil-works/pi-ai/providers/faux`). Pi is consumed
+  as a published npm dependency (`0.80.2`); nothing patches it.
+- `src/conversation-actor.ts` — a `rivetkit` actor. State = `{ systemPrompt,
+  messages, turnCount }`. `sendMessage` runs one Pi turn and `c.broadcast`s each
+  `text_delta`; `getTranscript` reads persisted state.
+- `src/harness.ts` — in-process boot via `rivetkit/test` `setupTest`, driven
+  from a plain script with a stub test context, plus a runner-readiness retry
+  (see findings).
+- `src/m1.ts` / `src/m2.ts` — the two milestone runners.
+
+## Versions (resolved)
+
+| Package | Pinned | Resolved |
+|---|---|---|
+| `rivetkit` | `^2.2.2-rc.1` | **2.3.2** (past the RC the ADR worried about) |
+| `@earendil-works/pi-agent-core` | `0.80.2` | 0.80.2 |
+| `@earendil-works/pi-ai` | `0.80.2` | 0.80.2 |
+
+## How to reproduce
+
+The native engine writes under `$HOME/.rivetkit`, so point `HOME` at a writable
+dir and pin a stable runner version. Exactly one engine may run at a time.
+
+```bash
+cd spikes/rivet-pi-electric
+bun install
+
+# M1 — Pi-in-actor streaming
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m1
+
+# M2 — durability across a real cold restart
+rm -rf .rivethome && mkdir -p .rivethome
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:seed
+pkill -f 'rivet-engine start'; sleep 5        # kill the orphaned engine
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:verify
+```
+
+## Results
+
+### M1 — PASS
+
+The unforked Pi agent loop ran inside the Rivet actor. 22 `text_delta`
+broadcasts reached the connected client live; the returned `assistantText`
+equalled the concatenated stream; transcript persisted 2 messages
+(user + assistant).
+
+### M2 — PASS (with one hard requirement)
+
+Cold restart = both the JS process and the native engine were terminated, then a
+fresh process + fresh engine opened the **same on-disk RocksDB**.
+
+- Seed wrote `turnCount=1`, `messageCount=2`.
+- After restart, verify **replayed** `turnCount=1`, `messageCount=2` from disk,
+  then **continued** to `turnCount=2`, `messageCount=4`.
+
+## Operational findings (these matter for the ADR)
+
+1. **rivetkit dev/test is not "pure in-process."** Even `setupTest` spawns the
+   native engine binary (`@rivetkit/engine-cli-linux-x64-musl/rivet-engine`),
+   binds a local port (`127.0.0.1:6420`), and persists actor state to an on-disk
+   **RocksDB** under `$HOME/.rivetkit/var/engine/db`. Heavier than the ADR
+   assumed, but it is what makes durability real.
+2. **Sandbox needs a writable `HOME`.** The engine defaults its data dir to
+   `/root/.rivetkit`; the sandbox blocks that. Redirect `HOME` (or otherwise set
+   the data dir) to a writable path.
+3. **The engine child is orphaned on exit.** `registry.shutdown()` tears down the
+   JS runtime/runner but does **not** reap the spawned engine. Left running, it
+   holds the RocksDB `LOCK` and blocks the next start. Production needs explicit
+   engine lifecycle management.
+4. **Startup race: `no_runner_config_configured`.** `setupTest` waits for engine
+   `/metadata` but not for the in-process runner pool to register, so the first
+   actor call can fire too early. Worked around with a readiness retry in
+   `harness.ts`.
+5. **Durability requires a stable runner version.** Without `RIVET_ENVOY_VERSION`
+   set, a persisted actor cannot be re-placed on the new (differently-identified)
+   runner after restart — it fails with `actor_ready_timeout`. Setting a stable
+   `RIVET_ENVOY_VERSION` fixed it. This mirrors the reference project's
+   `configureRunnerPool` + versioning; the production runner pool config (not the
+   test harness) is the real durable path.
+
+## Implication for the next step
+
+Durability is structurally sound (single-writer actor → on-disk RocksDB →
+survives cold restart). Before the Postgres/Electric half, the production wiring
+must (a) own the engine lifecycle and (b) pin a stable runner version. Consider
+adopting the reference's `serverless.configureRunnerPool` shape rather than
+`setupTest` for any further durability/integration work.

--- a/spikes/rivet-pi-electric/FINDINGS.md
+++ b/spikes/rivet-pi-electric/FINDINGS.md
@@ -1,10 +1,18 @@
-# Spike: Rivet + Pi (M1/M2 gate)
+# Spike: Rivet + Pi + Postgres + Electric (M1–M3 gate)
 
 Throwaway spike validating the substrate ADR
 (`2026-06-27-rivet-postgres-electric-hatchet-substrate`) before rewriting the
-003 plan. Scope of this gate: **one conversation = one Rivet actor running the
-unforked Pi agent loop**, streaming tokens out (M1) and surviving a real restart
-(M2). The Postgres + Electric half is intentionally NOT in this gate.
+003 plan. It now covers the full read/write vertical slice:
+
+- **M1** — one conversation = one Rivet actor running the unforked Pi loop,
+  streaming tokens out over the actor WebSocket.
+- **M2** — that actor's state survives a real cold restart (RocksDB).
+- **M3** — the actor projects a conversation summary to **Postgres through the
+  API (single writer)**, and **Electric** syncs that row to a second client
+  live; the row + actor state survive a cold restart together.
+
+Hatchet and the identity-scoped Electric gatekeeper are intentionally **not** in
+this gate (next: M4).
 
 ## What runs
 
@@ -12,88 +20,133 @@ unforked Pi agent loop**, streaming tokens out (M1) and surviving a real restart
   `@earendil-works/pi-agent-core` with a keyless faux provider
   (`createFauxCore` from `@earendil-works/pi-ai/providers/faux`). Pi is consumed
   as a published npm dependency (`0.80.2`); nothing patches it.
-- `src/conversation-actor.ts` — a `rivetkit` actor. State = `{ systemPrompt,
-  messages, turnCount }`. `sendMessage` runs one Pi turn and `c.broadcast`s each
-  `text_delta`; `getTranscript` reads persisted state.
-- `src/harness.ts` — in-process boot via `rivetkit/test` `setupTest`, driven
-  from a plain script with a stub test context, plus a runner-readiness retry
-  (see findings).
-- `src/m1.ts` / `src/m2.ts` — the two milestone runners.
+- `src/conversation-actor.ts` — a `rivetkit` actor. State = `{ systemPrompt, id,
+  owner, messages, turnCount }`. `sendMessage` runs one Pi turn, `c.broadcast`s
+  each `text_delta`, and (when an identity is bound via `setIdentity`) projects
+  a summary row through the API. `getTranscript` reads persisted state.
+- `src/db.ts` — the **only** module that talks to Postgres (`pg` pool, lazy).
+- `src/api.ts` — the **single-writer** API seam (`upsertConversationSummary`).
+  The actor imports this, never `db.ts`. In production this is `apps/api` over
+  RPC; here it is an in-process function.
+- `src/shape-client.ts` — the read-path client: `@electric-sql/client`
+  `ShapeStream` over the `conversations` shape, materialized into a live map.
+- `src/harness.ts` — in-process Rivet boot via `rivetkit/test` `setupTest`, with
+  a runner-readiness retry (see findings).
+- `src/m1.ts` / `src/m2.ts` / `src/m3.ts` — the milestone runners.
+- `infra/docker-compose.yml` — PG 17 (logical replication) + Electric 1.5.1,
+  isolated project/ports so it can't collide with the host's other Postgres.
 
 ## Versions (resolved)
 
-| Package | Pinned | Resolved |
+| Package / image | Pinned | Resolved |
 |---|---|---|
 | `rivetkit` | `^2.2.2-rc.1` | **2.3.2** (past the RC the ADR worried about) |
-| `@earendil-works/pi-agent-core` | `0.80.2` | 0.80.2 |
-| `@earendil-works/pi-ai` | `0.80.2` | 0.80.2 |
+| `@earendil-works/pi-agent-core` / `pi-ai` | `0.80.2` | 0.80.2 |
+| `@electric-sql/client` | `1.5.13` | 1.5.13 |
+| `pg` | `^8.13.0` | 8.22.0 |
+| `electricsql/electric` (image) | `1.5.1` | 1.5.1 |
+| `postgres` (image) | `17-alpine` | 17 |
 
 ## How to reproduce
-
-The native engine writes under `$HOME/.rivetkit`, so point `HOME` at a writable
-dir and pin a stable runner version. Exactly one engine may run at a time.
 
 ```bash
 cd spikes/rivet-pi-electric
 bun install
 
+# --- infra (M3 only): Postgres + Electric on loopback ports 5499 / 5599 ---
+docker compose -f infra/docker-compose.yml up -d
+# tear down later: docker compose -f infra/docker-compose.yml down -v
+
 # M1 — Pi-in-actor streaming
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m1
 
-# M2 — durability across a real cold restart
+# M2 — actor durability across a real cold restart
 rm -rf .rivethome && mkdir -p .rivethome
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:seed
-pkill -f 'rivet-engine start'; sleep 5        # kill the orphaned engine
+# kill ONLY the spike engine, excluding this shell (pgrep self-matches the pattern!)
+pgrep -f 'engine-cli-linux-x64-musl/rivet-engine start' | grep -vw "$$" | xargs -r kill
+sleep 5
 RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:verify
+
+# M3a — raw single-writer write → Electric read-path sync (no actor)
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3a
+# M3b — actor projects through the API; client A streams, client B syncs
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3b
+# M3c — PG row + actor state survive a cold restart together
+rm -rf .rivethome && mkdir -p .rivethome
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:seed
+pgrep -f 'engine-cli-linux-x64-musl/rivet-engine start' | grep -vw "$$" | xargs -r kill
+sleep 5   # PG + Electric keep running; only the Rivet engine restarts
+RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:verify
 ```
 
 ## Results
 
 ### M1 — PASS
+The unforked Pi loop ran inside the Rivet actor. ~22 `text_delta` broadcasts
+reached the client live; returned `assistantText` equalled the concatenated
+stream; transcript persisted 2 messages.
 
-The unforked Pi agent loop ran inside the Rivet actor. 22 `text_delta`
-broadcasts reached the connected client live; the returned `assistantText`
-equalled the concatenated stream; transcript persisted 2 messages
-(user + assistant).
+### M2 — PASS
+Cold restart (JS process + native engine both terminated) → fresh process +
+engine opened the same on-disk RocksDB. Seed `turnCount=1`/`messageCount=2`;
+verify replayed it and continued to `turnCount=2`/`messageCount=4`. Requires a
+stable `RIVET_ENVOY_VERSION` (see findings).
 
-### M2 — PASS (with one hard requirement)
+### M3a — PASS
+The API wrote a `conversations` row; a separate `@electric-sql/client` client
+saw the **insert** (`turn_count=1`) then the **update** (`turn_count=2`) live,
+with no polling.
 
-Cold restart = both the JS process and the native engine were terminated, then a
-fresh process + fresh engine opened the **same on-disk RocksDB**.
+### M3b — PASS
+A Pi turn streamed 23 deltas to client A (actor WS) **and** the projected
+summary row (`owner=bob`, `turn_count=1`, title set) appeared in client B
+(Electric) — the ADR's combined acceptance criterion. The actor reached PG only
+through `api.ts`; it never imports `db.ts` (single writer, structural).
 
-- Seed wrote `turnCount=1`, `messageCount=2`.
-- After restart, verify **replayed** `turnCount=1`, `messageCount=2` from disk,
-  then **continued** to `turnCount=2`, `messageCount=4`.
+### M3c — PASS
+Cold restart with **PG + Electric left running, only the Rivet engine killed**
+(verified: `6420 FREE before verify — engine truly down`):
+- Electric replayed the persisted PG row (`turn_count=1`) to a fresh client.
+- The actor replayed its transcript (`turnCount=1`, `messageCount=2`) from RocksDB.
+- A follow-up turn continued to `turnCount=2`/`messageCount=4` and Electric
+  synced the post-restart update (`turn_count=2`) live.
 
 ## Operational findings (these matter for the ADR)
 
 1. **rivetkit dev/test is not "pure in-process."** Even `setupTest` spawns the
-   native engine binary (`@rivetkit/engine-cli-linux-x64-musl/rivet-engine`),
-   binds a local port (`127.0.0.1:6420`), and persists actor state to an on-disk
-   **RocksDB** under `$HOME/.rivetkit/var/engine/db`. Heavier than the ADR
-   assumed, but it is what makes durability real.
-2. **Sandbox needs a writable `HOME`.** The engine defaults its data dir to
-   `/root/.rivetkit`; the sandbox blocks that. Redirect `HOME` (or otherwise set
-   the data dir) to a writable path.
-3. **The engine child is orphaned on exit.** `registry.shutdown()` tears down the
-   JS runtime/runner but does **not** reap the spawned engine. Left running, it
-   holds the RocksDB `LOCK` and blocks the next start. Production needs explicit
-   engine lifecycle management.
-4. **Startup race: `no_runner_config_configured`.** `setupTest` waits for engine
-   `/metadata` but not for the in-process runner pool to register, so the first
-   actor call can fire too early. Worked around with a readiness retry in
-   `harness.ts`.
-5. **Durability requires a stable runner version.** Without `RIVET_ENVOY_VERSION`
-   set, a persisted actor cannot be re-placed on the new (differently-identified)
-   runner after restart — it fails with `actor_ready_timeout`. Setting a stable
-   `RIVET_ENVOY_VERSION` fixed it. This mirrors the reference project's
-   `configureRunnerPool` + versioning; the production runner pool config (not the
-   test harness) is the real durable path.
+   native engine binary, binds `127.0.0.1:6420`, and persists state to an
+   on-disk **RocksDB** under `$HOME/.rivetkit/var/engine/db`.
+2. **Sandbox needs a writable `HOME`** for the engine (defaults to `/root/.rivetkit`).
+3. **The engine child is orphaned on exit** and holds the RocksDB `LOCK` + port
+   6420. Production needs explicit engine lifecycle management.
+4. **Startup race: `no_runner_config_configured`** — first actor call can fire
+   before the runner pool registers; worked around with a readiness retry.
+5. **Durability requires a stable runner version** (`RIVET_ENVOY_VERSION`), else
+   `actor_ready_timeout`. Mirrors the reference's `configureRunnerPool` versioning.
+6. **Postgres durability is independent of the Rivet engine.** Because PG runs as
+   its own service, the conversation row survives an engine restart for free;
+   Electric re-syncs it to clients on reconnect. This is exactly why the
+   queryable record lives in PG, not in the actor.
+7. **Electric's `message.key` is structured, not the PK** (e.g.
+   `"public"."conversations"/"<id>"`). Materialize by the row's own `id`
+   (`message.value.id`), and merge partial update values (default `replica`
+   sends only PK + changed columns).
+8. **`pgrep -f '...rivet-engine start'` self-matches the shell** running it (the
+   pattern is in your own argv), so a naive `pkill`/`xargs kill` kills the shell
+   (or, with a multi-line PID string, zsh's no-word-split throws `illegal pid`).
+   Exclude the current shell: `pgrep -f ... | grep -vw "$$" | xargs -r kill`.
 
 ## Implication for the next step
 
-Durability is structurally sound (single-writer actor → on-disk RocksDB →
-survives cold restart). Before the Postgres/Electric half, the production wiring
-must (a) own the engine lifecycle and (b) pin a stable runner version. Consider
-adopting the reference's `serverless.configureRunnerPool` shape rather than
-`setupTest` for any further durability/integration work.
+The full read/write substrate is structurally sound: single-writer actor →
+API → Postgres → Electric → second client, all surviving a cold restart. What's
+still unproven / deliberately deferred before the 003 rewrite:
+
+- **Engine lifecycle + runner-pool versioning** must move off the `setupTest`
+  harness onto the reference's `serverless.configureRunnerPool` shape.
+- **Identity-scoped Electric gatekeeper** (the `electric-proxy` `where`-clause +
+  column allowlist, per `backend/vendor/effect-api-layout/apps/electric-proxy`) —
+  M4.
+- **Effect v4 wrapping** of the Rivet + Electric + PG clients (`@clients/*`),
+  and **Hatchet** for system-level durable work — later gates.

--- a/spikes/rivet-pi-electric/infra/docker-compose.yml
+++ b/spikes/rivet-pi-electric/infra/docker-compose.yml
@@ -1,0 +1,49 @@
+# Throwaway M3 spike infra: Postgres (logical replication) + Electric sync.
+#
+# Isolated project name + non-default, loopback-only host ports so this can't
+# collide with the host's other Postgres instances (pawrrtal / hatchet /
+# infisical all bind 5432). Mirrors the substrate in
+# backend/vendor/effect-api-layout/docker-compose.yml (PG 17 logical +
+# electricsql/electric:1.5.1), trimmed to just the two services M3 needs.
+#
+# Bring up:  docker compose -f infra/docker-compose.yml up -d
+# Tear down: docker compose -f infra/docker-compose.yml down -v
+name: pawrrtal-spike-m3
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: spike-m3-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_wal_senders=10
+      - -c
+      - max_replication_slots=5
+    ports:
+      - "127.0.0.1:5499:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d app"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  electric:
+    # Pinned to match the reference (and the @electric-sql/client 1.5.13 pin);
+    # `latest` drifts ahead of the client.
+    image: electricsql/electric:1.5.1
+    container_name: spike-m3-electric
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/app?sslmode=disable"
+      ELECTRIC_INSECURE: "true"
+    ports:
+      - "127.0.0.1:5599:3000"

--- a/spikes/rivet-pi-electric/infra/hatchet-compose.yml
+++ b/spikes/rivet-pi-electric/infra/hatchet-compose.yml
@@ -1,0 +1,83 @@
+# Throwaway M8 spike infra: Hatchet (Postgres-backed durable task queue).
+#
+# Mirrors the reference's proven local setup (effect-api-layout/docker-compose.yml):
+# the all-in-one `hatchet-lite` image on its OWN Postgres, plus a one-shot
+# `hatchet-setup` that mints an API token into a host-readable file.
+#
+# Ports are remapped off the defaults (gRPC 7079, API 8899) because this host
+# already runs a separate, persistent Hatchet on 7077/8888. The minted token
+# embeds the gRPC BROADCAST address, so SERVER_GRPC_BROADCAST_ADDRESS must match
+# the host port we actually expose (localhost:7079) — otherwise the SDK would
+# dial the OTHER Hatchet. The in-container internal client still uses 7077.
+#
+# The durable WORK projects into the SAME app Postgres the rest of the spike
+# uses (infra/docker-compose.yml on :5499) — this stack only runs Hatchet.
+name: pawrrtal-spike-m8
+
+services:
+  hatchet-postgres:
+    image: postgres:17-alpine
+    container_name: spike-m8-hatchet-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: hatchet
+    ports:
+      - "127.0.0.1:5502:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d hatchet"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  hatchet:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
+    container_name: spike-m8-hatchet
+    depends_on:
+      hatchet-postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8899:8888"
+      - "127.0.0.1:7079:7077"
+    environment:
+      DATABASE_URL: "postgresql://postgres:postgres@hatchet-postgres:5432/hatchet?sslmode=disable"
+      SERVER_AUTH_COOKIE_DOMAIN: "localhost"
+      SERVER_AUTH_COOKIE_INSECURE: "t"
+      SERVER_AUTH_SET_EMAIL_VERIFIED: "t"
+      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
+      SERVER_GRPC_INSECURE: "t"
+      SERVER_GRPC_PORT: "7077"
+      SERVER_GRPC_BROADCAST_ADDRESS: "localhost:7079"
+      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: "localhost:7077"
+      SERVER_URL: "http://localhost:8899"
+      SERVER_MSGQUEUE_KIND: "postgres"
+      SERVER_DEFAULT_ENGINE_VERSION: "V1"
+    volumes:
+      - hatchet_config:/config
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8888 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
+
+  hatchet-setup:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
+    container_name: spike-m8-hatchet-setup
+    depends_on:
+      hatchet:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgresql://postgres:postgres@hatchet-postgres:5432/hatchet?sslmode=disable"
+    volumes:
+      - hatchet_config:/config
+      - ./hatchet-creds:/output
+    entrypoint: >
+      /bin/sh -c "
+        echo 'Generating Hatchet API token...';
+        /hatchet-admin token create --config /config --tenant-id 707d0855-80ab-4e1f-a156-f1c4546cbf52 --name spike-m8 2>/dev/null > /output/api-token;
+        echo 'Done.';
+      "
+
+volumes:
+  hatchet_config:

--- a/spikes/rivet-pi-electric/package.json
+++ b/spikes/rivet-pi-electric/package.json
@@ -17,6 +17,7 @@
     "m6": "bun run src/m6.ts",
     "m7": "bun run src/m7.ts",
     "m8": "bun run src/m8.ts",
+    "m9": "bun run src/m9.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/spikes/rivet-pi-electric/package.json
+++ b/spikes/rivet-pi-electric/package.json
@@ -8,15 +8,22 @@
     "m1": "bun run src/m1.ts",
     "m2:seed": "bun run src/m2.ts seed",
     "m2:verify": "bun run src/m2.ts verify",
+    "m3a": "bun run src/m3.ts m3a",
+    "m3b": "bun run src/m3.ts m3b",
+    "m3c:seed": "bun run src/m3.ts seed",
+    "m3c:verify": "bun run src/m3.ts verify",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.80.2",
     "@earendil-works/pi-ai": "0.80.2",
+    "@electric-sql/client": "1.5.13",
+    "pg": "^8.13.0",
     "rivetkit": "^2.2.2-rc.1"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "@types/pg": "^8.11.10",
     "typescript": "^5.9.3"
   }
 }

--- a/spikes/rivet-pi-electric/package.json
+++ b/spikes/rivet-pi-electric/package.json
@@ -12,6 +12,7 @@
     "m3b": "bun run src/m3.ts m3b",
     "m3c:seed": "bun run src/m3.ts seed",
     "m3c:verify": "bun run src/m3.ts verify",
+    "m4": "bun run src/m4.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/spikes/rivet-pi-electric/package.json
+++ b/spikes/rivet-pi-electric/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "spike-rivet-pi-electric",
+  "private": true,
+  "type": "module",
+  "workspaces": [],
+  "description": "Throwaway spike: one conversation = one Rivet actor running the unforked Pi agent loop, streaming tokens out over the actor WebSocket. Validates the 003 substrate ADR (Rivet + Postgres + Electric + Hatchet) before rewriting the plan. NOT the final package layout.",
+  "scripts": {
+    "m1": "bun run src/m1.ts",
+    "m2:seed": "bun run src/m2.ts seed",
+    "m2:verify": "bun run src/m2.ts verify",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "0.80.2",
+    "@earendil-works/pi-ai": "0.80.2",
+    "rivetkit": "^2.2.2-rc.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/spikes/rivet-pi-electric/package.json
+++ b/spikes/rivet-pi-electric/package.json
@@ -13,12 +13,18 @@
     "m3c:seed": "bun run src/m3.ts seed",
     "m3c:verify": "bun run src/m3.ts verify",
     "m4": "bun run src/m4.ts",
+    "m5": "bun run src/m5.ts",
+    "m6": "bun run src/m6.ts",
+    "m7": "bun run src/m7.ts",
+    "m8": "bun run src/m8.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.80.2",
     "@earendil-works/pi-ai": "0.80.2",
     "@electric-sql/client": "1.5.13",
+    "@hatchet-dev/typescript-sdk": "^1.22.0",
+    "effect": "4.0.0-beta.74",
     "pg": "^8.13.0",
     "rivetkit": "^2.2.2-rc.1"
   },

--- a/spikes/rivet-pi-electric/src/api.ts
+++ b/spikes/rivet-pi-electric/src/api.ts
@@ -1,0 +1,41 @@
+/**
+ * The API seam — the single writer of Postgres.
+ *
+ * In the real system this is `apps/api` reached over RPC; in the spike it is an
+ * in-process function. Either way it is the ONLY path that writes the
+ * `conversations` record. The Rivet actor calls `upsertConversationSummary`; it
+ * never opens its own PG connection. That is the "single writer per store"
+ * invariant from the 003 substrate ADR, made structural.
+ */
+import { ensureSchema, query } from './db.ts';
+
+export interface ConversationSummary {
+  readonly id: string;
+  readonly owner: string;
+  readonly title: string;
+  readonly lastMessage: string;
+  readonly turnCount: number;
+}
+
+/** Make sure the store is ready (delegates to the storage layer). */
+export async function ensureReady(): Promise<void> {
+  await ensureSchema();
+}
+
+/**
+ * Upsert a conversation's summary row. Insert on first write, update its
+ * `last_message` / `turn_count` / `updated_at` thereafter.
+ */
+export async function upsertConversationSummary(summary: ConversationSummary): Promise<void> {
+  await query(
+    `
+    INSERT INTO conversations (id, owner, title, last_message, turn_count, updated_at)
+    VALUES ($1, $2, $3, $4, $5, now())
+    ON CONFLICT (id) DO UPDATE SET
+      last_message = EXCLUDED.last_message,
+      turn_count   = EXCLUDED.turn_count,
+      updated_at   = now();
+    `,
+    [summary.id, summary.owner, summary.title, summary.lastMessage, summary.turnCount]
+  );
+}

--- a/spikes/rivet-pi-electric/src/config.ts
+++ b/spikes/rivet-pi-electric/src/config.ts
@@ -1,0 +1,11 @@
+/**
+ * M3 spike endpoints. These point at the throwaway docker-compose stack in
+ * `infra/docker-compose.yml` (isolated, loopback-only ports so they don't
+ * collide with the host's other Postgres instances).
+ */
+
+/** Postgres the API writes to (the single-writer store). */
+export const PG_URL = process.env.SPIKE_PG_URL ?? 'postgresql://postgres:postgres@127.0.0.1:5499/app';
+
+/** Electric sync service the read-path clients subscribe to. */
+export const ELECTRIC_URL = process.env.SPIKE_ELECTRIC_URL ?? 'http://127.0.0.1:5599';

--- a/spikes/rivet-pi-electric/src/config.ts
+++ b/spikes/rivet-pi-electric/src/config.ts
@@ -9,3 +9,7 @@ export const PG_URL = process.env.SPIKE_PG_URL ?? 'postgresql://postgres:postgre
 
 /** Electric sync service the read-path clients subscribe to. */
 export const ELECTRIC_URL = process.env.SPIKE_ELECTRIC_URL ?? 'http://127.0.0.1:5599';
+
+/** Identity-scoped gatekeeper proxy that sits in front of Electric (M4). */
+export const PROXY_PORT = Number(process.env.SPIKE_PROXY_PORT ?? 5699);
+export const PROXY_URL = process.env.SPIKE_PROXY_URL ?? `http://127.0.0.1:${PROXY_PORT}`;

--- a/spikes/rivet-pi-electric/src/conversation-actor.ts
+++ b/spikes/rivet-pi-electric/src/conversation-actor.ts
@@ -24,6 +24,10 @@ interface ConversationState {
   owner: string;
   messages: AgentMessage[];
   turnCount: number;
+  /** Times the actor's own scheduler fired a per-session wake (M9 durability). */
+  wakeCount: number;
+  /** Label of the most recent fired wake; proves the right schedule ran. */
+  lastWakeLabel: string | null;
 }
 
 /** Extract the concatenated assistant text from a finished turn's new messages. */
@@ -57,6 +61,8 @@ export const conversation = actor({
     owner: 'spike-user',
     messages: [],
     turnCount: 0,
+    wakeCount: 0,
+    lastWakeLabel: null,
   }),
 
   actions: {
@@ -129,6 +135,29 @@ export const conversation = actor({
       turnCount: c.state.turnCount,
       messageCount: c.state.messages.length,
       messages: c.state.messages,
+    }),
+
+    /**
+     * Register a per-session wake `delayMs` from now via the actor's OWN
+     * scheduler. The wake invokes `fireWake` even if the actor hibernates or the
+     * engine restarts in the meantime — this is the session-scoped durable timer
+     * the ADR puts on the actor (not Hatchet). Returns when the wake will fire.
+     */
+    scheduleWake: async (c, args: { delayMs: number; label: string }) => {
+      await c.schedule.after(args.delayMs, 'fireWake', args.label);
+      return { scheduledFor: Date.now() + args.delayMs, label: args.label };
+    },
+
+    /** Scheduler-invoked callback (never called by clients). Mutates state. */
+    fireWake: (c, label: string) => {
+      c.state.wakeCount += 1;
+      c.state.lastWakeLabel = label;
+    },
+
+    /** Read the wake counters (used to prove the schedule fired post-restart). */
+    getWakes: (c) => ({
+      wakeCount: c.state.wakeCount,
+      lastWakeLabel: c.state.lastWakeLabel,
     }),
   },
 });

--- a/spikes/rivet-pi-electric/src/conversation-actor.ts
+++ b/spikes/rivet-pi-electric/src/conversation-actor.ts
@@ -1,0 +1,85 @@
+/**
+ * One conversation = one Rivet actor.
+ *
+ * The actor owns the live session state (transcript + turn counter) and is the
+ * single writer for it. `sendMessage` runs an unforked Pi turn and broadcasts
+ * each text delta over the actor's WebSocket so connected clients stream live.
+ * This is the M1/M2 substrate probe for the 003 overhaul ADR.
+ */
+
+import type { AgentEvent, AgentMessage } from '@earendil-works/pi-agent-core';
+import { actor } from 'rivetkit';
+import { runPiTurn, userMessage } from './pi-turn.ts';
+
+const SYSTEM_PROMPT = 'You are Pawrrtal, running inside a Rivet actor.';
+
+interface ConversationState {
+  systemPrompt: string;
+  messages: AgentMessage[];
+  turnCount: number;
+}
+
+/** Extract the concatenated assistant text from a finished turn's new messages. */
+function assistantText(messages: AgentMessage[]): string {
+  const assistant = [...messages].reverse().find((m) => m.role === 'assistant');
+  if (!assistant || assistant.role !== 'assistant') {
+    return '';
+  }
+  return assistant.content.map((block) => (block.type === 'text' ? block.text : '')).join('');
+}
+
+export const conversation = actor({
+  createState: (): ConversationState => ({
+    systemPrompt: SYSTEM_PROMPT,
+    messages: [],
+    turnCount: 0,
+  }),
+
+  actions: {
+    /** Run one Pi turn for `text`, streaming deltas out as broadcasts. */
+    sendMessage: async (c, text: string) => {
+      const priorHistory = c.state.messages;
+      const prompt = userMessage(text);
+
+      const onEvent = (event: AgentEvent): void => {
+        if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
+          c.broadcast('delta', { text: event.assistantMessageEvent.delta });
+          return;
+        }
+        if (event.type === 'turn_end') {
+          c.broadcast('turn_done', {
+            stopReason: event.message.role === 'assistant' ? event.message.stopReason : 'stop',
+          });
+        }
+      };
+
+      const newMessages = await runPiTurn({
+        context: {
+          systemPrompt: c.state.systemPrompt,
+          messages: priorHistory,
+          tools: [],
+        },
+        prompts: [prompt],
+        onEvent,
+        signal: c.abortSignal,
+      });
+
+      c.state.messages = [...priorHistory, ...newMessages];
+      c.state.turnCount += 1;
+
+      return {
+        ok: true as const,
+        turnCount: c.state.turnCount,
+        assistantText: assistantText(newMessages),
+        transcriptLength: c.state.messages.length,
+      };
+    },
+
+    /** Read the persisted transcript (used to prove durability across restart). */
+    getTranscript: (c) => ({
+      turnCount: c.state.turnCount,
+      messageCount: c.state.messages.length,
+      messages: c.state.messages,
+    }),
+  },
+});

--- a/spikes/rivet-pi-electric/src/conversation-actor.ts
+++ b/spikes/rivet-pi-electric/src/conversation-actor.ts
@@ -3,18 +3,25 @@
  *
  * The actor owns the live session state (transcript + turn counter) and is the
  * single writer for it. `sendMessage` runs an unforked Pi turn and broadcasts
- * each text delta over the actor's WebSocket so connected clients stream live.
- * This is the M1/M2 substrate probe for the 003 overhaul ADR.
+ * each text delta over the actor's WebSocket so connected clients stream live
+ * (M1/M2). When an identity is bound via `setIdentity`, each finished turn also
+ * projects a conversation-summary row to Postgres through the API seam — the
+ * actor never touches PG directly (M3 single-writer path).
  */
 
 import type { AgentEvent, AgentMessage } from '@earendil-works/pi-agent-core';
 import { actor } from 'rivetkit';
+import { upsertConversationSummary } from './api.ts';
 import { runPiTurn, userMessage } from './pi-turn.ts';
 
 const SYSTEM_PROMPT = 'You are Pawrrtal, running inside a Rivet actor.';
+const TITLE_MAX_LENGTH = 60;
 
 interface ConversationState {
   systemPrompt: string;
+  /** Postgres conversation id; null until `setIdentity` binds one (no projection). */
+  id: string | null;
+  owner: string;
   messages: AgentMessage[];
   turnCount: number;
 }
@@ -28,14 +35,44 @@ function assistantText(messages: AgentMessage[]): string {
   return assistant.content.map((block) => (block.type === 'text' ? block.text : '')).join('');
 }
 
+/** Derive a conversation title from the first user message. */
+function conversationTitle(messages: AgentMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user');
+  let text = '';
+  if (firstUser?.role === 'user') {
+    const { content } = firstUser;
+    text =
+      typeof content === 'string'
+        ? content
+        : content.map((block) => (block.type === 'text' ? block.text : '')).join('');
+  }
+  const title = text.trim().length > 0 ? text.trim() : 'New conversation';
+  return title.length > TITLE_MAX_LENGTH ? `${title.slice(0, TITLE_MAX_LENGTH - 1)}…` : title;
+}
+
 export const conversation = actor({
   createState: (): ConversationState => ({
     systemPrompt: SYSTEM_PROMPT,
+    id: null,
+    owner: 'spike-user',
     messages: [],
     turnCount: 0,
   }),
 
   actions: {
+    /**
+     * Bind this actor to a Postgres conversation id (and owner) so finished
+     * turns project a summary row through the API. Without it, the actor stays
+     * PG-free (M1/M2 behavior).
+     */
+    setIdentity: (c, identity: { id: string; owner?: string }) => {
+      c.state.id = identity.id;
+      if (identity.owner) {
+        c.state.owner = identity.owner;
+      }
+      return { id: c.state.id, owner: c.state.owner };
+    },
+
     /** Run one Pi turn for `text`, streaming deltas out as broadcasts. */
     sendMessage: async (c, text: string) => {
       const priorHistory = c.state.messages;
@@ -66,11 +103,23 @@ export const conversation = actor({
 
       c.state.messages = [...priorHistory, ...newMessages];
       c.state.turnCount += 1;
+      const reply = assistantText(newMessages);
+
+      // Single-writer projection: the actor reaches Postgres only via the API.
+      if (c.state.id) {
+        await upsertConversationSummary({
+          id: c.state.id,
+          owner: c.state.owner,
+          title: conversationTitle(c.state.messages),
+          lastMessage: reply,
+          turnCount: c.state.turnCount,
+        });
+      }
 
       return {
         ok: true as const,
         turnCount: c.state.turnCount,
-        assistantText: assistantText(newMessages),
+        assistantText: reply,
         transcriptLength: c.state.messages.length,
       };
     },

--- a/spikes/rivet-pi-electric/src/db.ts
+++ b/spikes/rivet-pi-electric/src/db.ts
@@ -1,0 +1,54 @@
+/**
+ * The Postgres connection — the ONLY module in the spike that talks to PG.
+ *
+ * Keeping every `pg` call behind this module (and exposing writes solely
+ * through `api.ts`) is what makes the "single writer per store" invariant
+ * visible: the Rivet actor never imports `db.ts`, only `api.ts`.
+ *
+ * The pool is created lazily on first use so that importing this module (which
+ * the actor's projection path pulls in transitively) does NOT open a PG
+ * connection. M1/M2, which never project, therefore never touch Postgres.
+ */
+import { Pool } from 'pg';
+import { PG_URL } from './config.ts';
+
+let pool: Pool | undefined;
+
+/** Lazily-created shared pool. */
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: PG_URL, max: 4 });
+  }
+  return pool;
+}
+
+/** Create the one table the spike projects into. Idempotent. */
+export async function ensureSchema(): Promise<void> {
+  await getPool().query(`
+    CREATE TABLE IF NOT EXISTS conversations (
+      id           TEXT PRIMARY KEY,
+      owner        TEXT NOT NULL,
+      title        TEXT NOT NULL,
+      last_message TEXT NOT NULL,
+      turn_count   INTEGER NOT NULL,
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+}
+
+/** Run a parameterized query. Internal to the storage layer. */
+export async function query<R extends Record<string, unknown>>(
+  text: string,
+  params: ReadonlyArray<unknown>
+): Promise<R[]> {
+  const result = await getPool().query(text, params as unknown[]);
+  return result.rows as R[];
+}
+
+/** Close the pool (spike cleanup). */
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+}

--- a/spikes/rivet-pi-electric/src/effect/Conversations.ts
+++ b/spikes/rivet-pi-electric/src/effect/Conversations.ts
@@ -1,0 +1,45 @@
+/**
+ * The single-writer API seam wrapped as an Effect v4 service (M7).
+ *
+ * Mirrors `api.ts`'s `upsertConversationSummary`, but as a `Conversations`
+ * service that depends on {@link Pg}. `ConversationsLive` provides its own `Pg`,
+ * so consumers get a self-contained layer — the same composition shape as
+ * backend-ts `ProjectsRepoLive` (a `Layer.effect` body wired to its DB layer).
+ */
+import { Context, Effect, Layer } from 'effect';
+import type { ConversationSummary } from '../api.ts';
+import { Pg, PgLive } from './Pg.ts';
+
+const UPSERT_SQL = `
+  INSERT INTO conversations (id, owner, title, last_message, turn_count, updated_at)
+  VALUES ($1, $2, $3, $4, $5, now())
+  ON CONFLICT (id) DO UPDATE SET
+    last_message = EXCLUDED.last_message,
+    turn_count   = EXCLUDED.turn_count,
+    updated_at   = now();
+`;
+
+export class Conversations extends Context.Service<
+  Conversations,
+  {
+    readonly upsertSummary: (summary: ConversationSummary) => Effect.Effect<void>;
+  }
+>()('@spike/effect/Conversations') {}
+
+/** `Conversations` requiring a `Pg`; wire with {@link ConversationsLive}. */
+export const ConversationsBody: Layer.Layer<Conversations, never, Pg> = Layer.effect(
+  Conversations,
+  Effect.gen(function* () {
+    const pg = yield* Pg;
+
+    const upsertSummary = (summary: ConversationSummary): Effect.Effect<void> =>
+      pg
+        .query(UPSERT_SQL, [summary.id, summary.owner, summary.title, summary.lastMessage, summary.turnCount])
+        .pipe(Effect.asVoid);
+
+    return { upsertSummary } as const;
+  })
+);
+
+/** Self-contained `Conversations` backed by its own PG pool. */
+export const ConversationsLive: Layer.Layer<Conversations> = ConversationsBody.pipe(Layer.provide(PgLive));

--- a/spikes/rivet-pi-electric/src/effect/Electric.ts
+++ b/spikes/rivet-pi-electric/src/effect/Electric.ts
@@ -1,0 +1,40 @@
+/**
+ * The Electric read-path client wrapped as an Effect v4 service (M7).
+ *
+ * The raw client is `openConversationShape` (an `@electric-sql/client`
+ * ShapeStream). `awaitRow` exposes it as an effect that opens a shape, resolves
+ * once the row materializes, and ALWAYS closes the stream via
+ * `Effect.acquireUseRelease` — so a subscription can't leak even on timeout.
+ */
+import { Context, Effect, Layer } from 'effect';
+import { type ConversationRow, openConversationShape } from '../shape-client.ts';
+
+const DEFAULT_TIMEOUT_MS = 20000;
+
+export class Electric extends Context.Service<
+  Electric,
+  {
+    readonly awaitRow: (id: string, opts?: { where?: string; timeoutMs?: number }) => Effect.Effect<ConversationRow>;
+  }
+>()('@spike/effect/Electric') {}
+
+/** A `Electric` that subscribes directly to the Electric sync service. */
+export const ElectricLive: Layer.Layer<Electric> = Layer.succeed(Electric, {
+  awaitRow: (id, opts = {}) =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => openConversationShape(opts.where ? { where: opts.where } : {})),
+      (shape) =>
+        Effect.tryPromise(() =>
+          shape
+            .waitFor((rows) => rows.has(id), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+            .then(() => {
+              const row = shape.rows.get(id);
+              if (!row) {
+                throw new Error(`row ${id} missing after waitFor`);
+              }
+              return row;
+            })
+        ).pipe(Effect.orDie),
+      (shape) => Effect.sync(() => shape.close())
+    ),
+});

--- a/spikes/rivet-pi-electric/src/effect/Pg.ts
+++ b/spikes/rivet-pi-electric/src/effect/Pg.ts
@@ -1,0 +1,41 @@
+/**
+ * The Postgres pool wrapped as an Effect v4 service (M7).
+ *
+ * The raw client is node-postgres' `Pool` (the same one `db.ts` uses). Here it
+ * is acquired/released inside the layer via `Effect.acquireRelease`, and
+ * `Layer.effect` discharges the resulting `Scope` so the pool closes when the
+ * owning runtime scope ends. APIs follow effect-smol v4 (no `Layer.scoped`;
+ * `Layer.effect` of a scoped effect).
+ */
+import { Context, Effect, Layer } from 'effect';
+import { Pool, type QueryResultRow } from 'pg';
+import { PG_URL } from '../config.ts';
+
+export class Pg extends Context.Service<
+  Pg,
+  {
+    readonly query: <T extends QueryResultRow = QueryResultRow>(
+      text: string,
+      params?: ReadonlyArray<unknown>
+    ) => Effect.Effect<ReadonlyArray<T>>;
+  }
+>()('@spike/effect/Pg') {}
+
+/** A `Pg` backed by a node-postgres pool whose lifetime is the layer's scope. */
+export const PgLive: Layer.Layer<Pg> = Layer.effect(
+  Pg,
+  Effect.gen(function* () {
+    const pool = yield* Effect.acquireRelease(
+      Effect.sync(() => new Pool({ connectionString: PG_URL, max: 4 })),
+      (acquired) => Effect.promise(() => acquired.end())
+    );
+
+    const query = <T extends QueryResultRow = QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<unknown> = []
+    ): Effect.Effect<ReadonlyArray<T>> =>
+      Effect.promise(() => pool.query<T>(text, params as unknown[]).then((result) => result.rows));
+
+    return { query } as const;
+  })
+);

--- a/spikes/rivet-pi-electric/src/effect/Rivet.ts
+++ b/spikes/rivet-pi-electric/src/effect/Rivet.ts
@@ -1,0 +1,59 @@
+/**
+ * The Rivet actor client wrapped as an Effect v4 service (M7).
+ *
+ * The raw client is rivetkit's `createClient` against the standalone server.
+ * `sendMessage` / `transcript` open a connection, run the action, and always
+ * dispose it. The layer is endpoint-parameterized (`makeRivetLive`) so tests
+ * point it at whatever server they booted.
+ */
+import { Context, Effect, Layer } from 'effect';
+import { createClient } from 'rivetkit/client';
+import type { Registry } from '../registry.ts';
+
+export interface RivetTurn {
+  readonly turnCount: number;
+  readonly transcriptLength: number;
+}
+
+export interface RivetTranscript {
+  readonly turnCount: number;
+  readonly messageCount: number;
+}
+
+export class Rivet extends Context.Service<
+  Rivet,
+  {
+    readonly sendMessage: (key: ReadonlyArray<string>, text: string) => Effect.Effect<RivetTurn>;
+    readonly transcript: (key: ReadonlyArray<string>) => Effect.Effect<RivetTranscript>;
+  }
+>()('@spike/effect/Rivet') {}
+
+/** A `Rivet` that connects to the actor server at `endpoint`. */
+export const makeRivetLive = (endpoint: string): Layer.Layer<Rivet> =>
+  Layer.succeed(Rivet, {
+    sendMessage: (key, text) =>
+      Effect.tryPromise(async () => {
+        const conn = createClient<Registry>(endpoint)
+          .conversation.getOrCreate([...key])
+          .connect();
+        try {
+          const result = await conn.sendMessage(text);
+          return { turnCount: result.turnCount, transcriptLength: result.transcriptLength };
+        } finally {
+          await conn.dispose();
+        }
+      }).pipe(Effect.orDie),
+
+    transcript: (key) =>
+      Effect.tryPromise(async () => {
+        const conn = createClient<Registry>(endpoint)
+          .conversation.getOrCreate([...key])
+          .connect();
+        try {
+          const result = await conn.getTranscript();
+          return { turnCount: result.turnCount, messageCount: result.messageCount };
+        } finally {
+          await conn.dispose();
+        }
+      }).pipe(Effect.orDie),
+  });

--- a/spikes/rivet-pi-electric/src/effect/index.ts
+++ b/spikes/rivet-pi-electric/src/effect/index.ts
@@ -1,0 +1,5 @@
+/** Public surface of the M7 Effect-wrapped substrate clients. */
+export { Conversations, ConversationsBody, ConversationsLive } from './Conversations.ts';
+export { Electric, ElectricLive } from './Electric.ts';
+export { Pg, PgLive } from './Pg.ts';
+export { makeRivetLive, Rivet, type RivetTranscript, type RivetTurn } from './Rivet.ts';

--- a/spikes/rivet-pi-electric/src/harness.ts
+++ b/spikes/rivet-pi-electric/src/harness.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared in-process boot helper for the spike.
+ *
+ * rivetkit's `setupTest` spawns the native engine and waits for its `/metadata`
+ * endpoint, but NOT for the in-process runner pool to finish registering. The
+ * first actor call therefore races runner registration and intermittently fails
+ * with `no_runner_config_configured`. `bootConversation` papers over that race
+ * by retrying the first (idempotent) actor call until the runner is ready, then
+ * hands back a live connection. This is a spike-harness concern, not a Pawrrtal
+ * runtime concern.
+ */
+import { setupTest } from 'rivetkit/test';
+import { registry } from './registry.ts';
+
+type Finalizer = () => void | Promise<void>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRunnerNotReady(error: unknown): boolean {
+  return String(error).includes('no_runner_config_configured');
+}
+
+/** Boot the runtime + client and return a connection once the runner is ready. */
+export async function bootConversation(key: string[]): Promise<{
+  // biome-ignore lint/suspicious/noExplicitAny: rivetkit conn type is deeply generic; spike-local
+  conn: any;
+  cleanup: () => Promise<void>;
+}> {
+  const finalizers: Finalizer[] = [];
+  const testCtx = { onTestFinished: (fn: Finalizer) => finalizers.push(fn) };
+  // biome-ignore lint/suspicious/noExplicitAny: stub vitest TestContext for the harness
+  const { client } = await setupTest(testCtx as any, registry);
+
+  const attempts = 40;
+  const delayMs = 250;
+  let lastError: unknown;
+  // biome-ignore lint/suspicious/noExplicitAny: spike-local conn handle
+  let ready: any;
+  for (let i = 0; i < attempts; i++) {
+    const conn = client.conversation.getOrCreate(key).connect();
+    try {
+      await conn.getTranscript();
+      ready = conn;
+      break;
+    } catch (error) {
+      lastError = error;
+      try {
+        await conn.dispose();
+      } catch {
+        // ignore dispose failures on a connection that never opened
+      }
+      if (!isRunnerNotReady(error)) {
+        throw error;
+      }
+      await sleep(delayMs);
+    }
+  }
+  if (!ready) {
+    throw lastError;
+  }
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      await ready.dispose();
+    } catch {
+      // ignore
+    }
+    for (const fn of finalizers) {
+      try {
+        await fn();
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      await registry.shutdown();
+    } catch {
+      // ignore
+    }
+  };
+
+  return { conn: ready, cleanup };
+}

--- a/spikes/rivet-pi-electric/src/hatchet/worker.ts
+++ b/spikes/rivet-pi-electric/src/hatchet/worker.ts
@@ -1,0 +1,21 @@
+/**
+ * Standalone Hatchet worker (M8).
+ *
+ * Run as a child process so the M8 runner can SIGKILL it mid-flight and prove a
+ * task enqueued while it was down still runs after it restarts. It registers the
+ * one projection task and blocks in `worker.start()`.
+ */
+import { defineProjectSummary, makeHatchet } from './workflow.ts';
+
+async function main(): Promise<void> {
+  const hatchet = makeHatchet();
+  const task = defineProjectSummary(hatchet);
+  const worker = await hatchet.worker('spike-m8-worker', { workflows: [task] });
+  process.stdout.write('[worker] starting\n');
+  await worker.start();
+}
+
+main().catch((error) => {
+  process.stderr.write(`[worker] crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/hatchet/workflow.ts
+++ b/spikes/rivet-pi-electric/src/hatchet/workflow.ts
@@ -1,0 +1,61 @@
+/**
+ * The Hatchet client + the one durable task the spike registers (M8).
+ *
+ * The task projects a conversation summary into the app Postgres through the
+ * SAME single-writer seam the actor uses (`upsertConversationSummary`). It is
+ * shared by the worker (which executes it) and m8 (which triggers it), so both
+ * sides agree on the task name and input shape.
+ */
+import { HatchetClient } from '@hatchet-dev/typescript-sdk/v1';
+import { upsertConversationSummary } from '../api.ts';
+
+export const TASK_NAME = 'project-conversation-summary';
+
+// `type` (not `interface`) so these satisfy Hatchet's `JsonObject` constraint:
+// object-literal type aliases get an implicit string index signature, interfaces don't.
+export type ProjectSummaryInput = {
+  readonly id: string;
+  readonly owner: string;
+  readonly title: string;
+  readonly lastMessage: string;
+  readonly turnCount: number;
+};
+
+export type ProjectSummaryOutput = {
+  readonly projected: boolean;
+  readonly id: string;
+};
+
+// 7079, not the default 7077: this host already runs a separate persistent
+// Hatchet on 7077. Must match the compose SERVER_GRPC_BROADCAST_ADDRESS.
+const HOST_PORT = process.env.HATCHET_HOST_PORT ?? '127.0.0.1:7079';
+
+/** Build a Hatchet client from the env token (insecure local gRPC). */
+export function makeHatchet(): HatchetClient {
+  const token = process.env.HATCHET_CLIENT_TOKEN;
+  if (!token) {
+    throw new Error('HATCHET_CLIENT_TOKEN is required (see infra/hatchet-creds/api-token)');
+  }
+  return HatchetClient.init({
+    token,
+    host_port: HOST_PORT,
+    tls_config: { tls_strategy: 'none' },
+  });
+}
+
+/** Define the durable projection task; pass to a worker to register + execute it. */
+export function defineProjectSummary(hatchet: HatchetClient) {
+  return hatchet.task({
+    name: TASK_NAME,
+    fn: async (input: ProjectSummaryInput): Promise<ProjectSummaryOutput> => {
+      await upsertConversationSummary({
+        id: input.id,
+        owner: input.owner,
+        title: input.title,
+        lastMessage: input.lastMessage,
+        turnCount: input.turnCount,
+      });
+      return { projected: true, id: input.id };
+    },
+  });
+}

--- a/spikes/rivet-pi-electric/src/m1.ts
+++ b/spikes/rivet-pi-electric/src/m1.ts
@@ -1,0 +1,57 @@
+/**
+ * M1 — Pi-in-actor streaming.
+ *
+ * Boots the Rivet registry in-process (rivetkit's `setupTest` harness, driven
+ * from a plain script via a stub test context), connects a client to the
+ * conversation actor, sends a message, and prints every `text_delta` the actor
+ * broadcasts while the unforked Pi loop runs. Success = tokens appear live and
+ * the returned transcript is non-empty.
+ *
+ * Run: `bun run src/m1.ts`
+ */
+import { bootConversation } from './harness.ts';
+
+/** Write a line to stdout (this is a CLI runner; stdout is the product). */
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+async function main(): Promise<void> {
+  const { conn, cleanup } = await bootConversation(['spike-conversation']);
+
+  let streamed = '';
+  let deltaCount = 0;
+  conn.on('delta', (payload: { text: string }) => {
+    streamed += payload.text;
+    deltaCount += 1;
+    process.stdout.write(payload.text);
+  });
+  conn.on('turn_done', (payload: { stopReason: string }) => {
+    process.stdout.write(`\n[turn_done stopReason=${payload.stopReason}]\n`);
+  });
+
+  out('--- sending message, streaming live tokens below ---\n');
+  const result = await conn.sendMessage('Tell me what you are and where you run.');
+
+  // Give any trailing broadcasts a moment to drain to this connection.
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const transcript = await conn.getTranscript();
+
+  out('\n--- result ---');
+  out(JSON.stringify(result, null, 2));
+  out(`deltas received: ${deltaCount}`);
+  out(`streamed length: ${streamed.length}`);
+  out(`transcript messageCount: ${transcript.messageCount}`);
+
+  const ok = deltaCount > 0 && streamed.length > 0 && result.assistantText === streamed && transcript.messageCount >= 2;
+  out(ok ? '\nM1 PASS' : '\nM1 FAIL');
+
+  await cleanup();
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M1 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m2.ts
+++ b/spikes/rivet-pi-electric/src/m2.ts
@@ -1,0 +1,72 @@
+/**
+ * M2 — durability across a real restart.
+ *
+ * Two separate process invocations share one on-disk Rivet engine DB (via a
+ * stable `$HOME/.rivetkit`):
+ *
+ *   1. `bun run src/m2.ts seed`   — send one turn to the "conv-durable" actor,
+ *                                    then shut the runtime down.
+ *   2. `bun run src/m2.ts verify` — boot a fresh process, read the transcript
+ *                                    (must replay the seeded turn from disk),
+ *                                    then send another turn and confirm the
+ *                                    turn counter continued from the persisted
+ *                                    value rather than resetting.
+ *
+ * Success = the seeded transcript survives the restart AND the follow-up turn
+ * builds on it (turnCount 1 -> 2, messages 2 -> 4).
+ */
+import { bootConversation } from './harness.ts';
+
+/** Write a line to stdout (this is a CLI runner; stdout is the product). */
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+const ACTOR_KEY = ['conv-durable'];
+
+async function seed(): Promise<void> {
+  const { conn, cleanup } = await bootConversation(ACTOR_KEY);
+  const result = await conn.sendMessage('First message, before the restart.');
+  out(`[seed] turnCount: ${result.turnCount}`);
+  out(`[seed] transcriptLength: ${result.transcriptLength}`);
+  await cleanup();
+  out('[seed] runtime shut down; state should be on disk');
+  process.exit(0);
+}
+
+async function verify(): Promise<void> {
+  const { conn, cleanup } = await bootConversation(ACTOR_KEY);
+
+  const replayed = await conn.getTranscript();
+  out(`[verify] replayed turnCount: ${replayed.turnCount}`);
+  out(`[verify] replayed messageCount: ${replayed.messageCount}`);
+
+  const replayOk = replayed.turnCount === 1 && replayed.messageCount === 2;
+
+  const result = await conn.sendMessage('Second message, after the restart.');
+  out(`[verify] continued turnCount: ${result.turnCount}`);
+  out(`[verify] continued transcriptLength: ${result.transcriptLength}`);
+
+  const continueOk = result.turnCount === 2 && result.transcriptLength === 4;
+
+  await cleanup();
+
+  const ok = replayOk && continueOk;
+  out(
+    ok
+      ? '\nM2 PASS — state replayed from disk and the next turn continued it'
+      : `\nM2 FAIL — replayOk=${replayOk} continueOk=${continueOk}`
+  );
+  process.exit(ok ? 0 : 1);
+}
+
+const phase = process.argv[2];
+const run = phase === 'seed' ? seed : phase === 'verify' ? verify : undefined;
+if (!run) {
+  process.stderr.write('usage: bun run src/m2.ts <seed|verify>\n');
+  process.exit(2);
+}
+run().catch((error) => {
+  process.stderr.write(`M2 ${phase} crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m3.ts
+++ b/spikes/rivet-pi-electric/src/m3.ts
@@ -1,0 +1,174 @@
+/**
+ * M3 — Postgres single-writer projection + Electric read-path sync.
+ *
+ * Builds on M1/M2 (Pi-in-actor streaming + restart durability) and validates
+ * the half the earlier gate skipped:
+ *
+ *   - the actor reaches Postgres ONLY through the API seam (single writer), and
+ *   - a second client sees that row live via Electric (the read path that
+ *     files-first never had).
+ *
+ * Phases:
+ *   m3a    — raw sync: API writes a row → Electric pushes insert+update to a client.
+ *   m3b    — actor projection: a Pi turn streams to client A (actor WS) AND the
+ *            summary row appears in client B (Electric), single-writer.
+ *   seed   — durability: one projected turn, then shut the runtime down.
+ *   verify — after a cold restart (engine killed; PG+Electric kept running):
+ *            the PG row replays via Electric, the actor replays its transcript
+ *            from RocksDB, and a follow-up turn re-projects (turn_count 1 -> 2).
+ *
+ * Run (PG+Electric must be up via infra/docker-compose.yml):
+ *   RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3a
+ *   RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3b
+ *   rm -rf .rivethome && mkdir -p .rivethome
+ *   RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:seed
+ *   pkill -f 'rivet-engine start'; sleep 5
+ *   RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:verify
+ */
+import { ensureReady, upsertConversationSummary } from './api.ts';
+import { closePool } from './db.ts';
+import { bootConversation } from './harness.ts';
+import { type ConversationRow, openConversationShape } from './shape-client.ts';
+
+const WAIT_MS = 20000;
+const DURABLE_KEY = ['conv-m3-durable'];
+const DURABLE_ID = 'conv-m3-durable';
+const DURABLE_OWNER = 'carol';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+/** Electric parses ints, but coerce defensively for assertions. */
+function turnCountOf(row: ConversationRow | undefined): number {
+  return row ? Number(row.turn_count) : Number.NaN;
+}
+
+/** M3a — raw single-writer write → Electric read-path sync. */
+async function m3a(): Promise<void> {
+  await ensureReady();
+  const id = `m3a-${Date.now()}`;
+  const shape = openConversationShape();
+
+  await upsertConversationSummary({
+    id,
+    owner: 'alice',
+    title: 'Raw sync test',
+    lastMessage: 'first write',
+    turnCount: 1,
+  });
+  await shape.waitFor((rows) => turnCountOf(rows.get(id)) === 1, WAIT_MS);
+  out(`[m3a] client B saw INSERT id=${id} turn_count=1`);
+
+  await upsertConversationSummary({
+    id,
+    owner: 'alice',
+    title: 'Raw sync test',
+    lastMessage: 'second write',
+    turnCount: 2,
+  });
+  await shape.waitFor(
+    (rows) => turnCountOf(rows.get(id)) === 2 && rows.get(id)?.last_message === 'second write',
+    WAIT_MS
+  );
+  out(`[m3a] client B saw UPDATE id=${id} turn_count=2`);
+
+  shape.close();
+  await closePool();
+  out('\nM3a PASS — API write reached a second client live via Electric');
+  process.exit(0);
+}
+
+/** M3b — actor projects through the API; client A streams, client B syncs. */
+async function m3b(): Promise<void> {
+  await ensureReady();
+  const id = `m3b-${Date.now()}`;
+  const owner = 'bob';
+  const shape = openConversationShape();
+  const { conn, cleanup } = await bootConversation([`spike-${id}`]);
+  await conn.setIdentity({ id, owner });
+
+  let streamed = '';
+  let deltaCount = 0;
+  conn.on('delta', (payload: { text: string }) => {
+    streamed += payload.text;
+    deltaCount += 1;
+  });
+
+  const result = await conn.sendMessage('What are you and where do you run?');
+  await shape.waitFor((rows) => turnCountOf(rows.get(id)) === 1, WAIT_MS);
+  const row = shape.rows.get(id);
+
+  out(`[m3b] client A streamed ${deltaCount} deltas (${streamed.length} chars)`);
+  out(`[m3b] client B row: id=${row?.id} owner=${row?.owner} turn_count=${row?.turn_count}`);
+  out(`[m3b] title="${row?.title}"`);
+
+  const ok = deltaCount > 0 && result.assistantText === streamed && turnCountOf(row) === 1 && row?.owner === owner;
+
+  shape.close();
+  await cleanup();
+  await closePool();
+  out(ok ? '\nM3b PASS — token live in A AND summary row live in B' : '\nM3b FAIL');
+  process.exit(ok ? 0 : 1);
+}
+
+/** M3c seed — one projected turn, then shut the runtime down. */
+async function seed(): Promise<void> {
+  await ensureReady();
+  const { conn, cleanup } = await bootConversation(DURABLE_KEY);
+  await conn.setIdentity({ id: DURABLE_ID, owner: DURABLE_OWNER });
+  const result = await conn.sendMessage('First message, before the restart.');
+  out(`[seed] turnCount=${result.turnCount} transcriptLength=${result.transcriptLength}`);
+  await cleanup();
+  await closePool();
+  out('[seed] runtime shut down; PG row + actor state should be on disk');
+  process.exit(0);
+}
+
+/** M3c verify — PG row replays via Electric, actor replays, follow-up re-projects. */
+async function verify(): Promise<void> {
+  await ensureReady();
+
+  const shape = openConversationShape();
+  await shape.waitFor((rows) => rows.has(DURABLE_ID), WAIT_MS);
+  const seeded = shape.rows.get(DURABLE_ID);
+  const replayRowOk = turnCountOf(seeded) === 1;
+  out(`[verify] Electric replayed PG row turn_count=${seeded?.turn_count} (persisted across restart)`);
+
+  const { conn, cleanup } = await bootConversation(DURABLE_KEY);
+  const transcript = await conn.getTranscript();
+  const replayActorOk = transcript.turnCount === 1 && transcript.messageCount === 2;
+  out(`[verify] actor replayed turnCount=${transcript.turnCount} messageCount=${transcript.messageCount}`);
+
+  await conn.setIdentity({ id: DURABLE_ID, owner: DURABLE_OWNER });
+  const result = await conn.sendMessage('Second message, after the restart.');
+  const continueActorOk = result.turnCount === 2 && result.transcriptLength === 4;
+  out(`[verify] continued turnCount=${result.turnCount} transcriptLength=${result.transcriptLength}`);
+
+  await shape.waitFor((rows) => turnCountOf(rows.get(DURABLE_ID)) === 2, WAIT_MS);
+  out('[verify] Electric synced post-restart UPDATE turn_count=2');
+
+  shape.close();
+  await cleanup();
+  await closePool();
+
+  const ok = replayRowOk && replayActorOk && continueActorOk;
+  out(
+    ok
+      ? '\nM3c PASS — PG row + actor state survived the cold restart and continued in sync'
+      : `\nM3c FAIL — replayRowOk=${replayRowOk} replayActorOk=${replayActorOk} continueActorOk=${continueActorOk}`
+  );
+  process.exit(ok ? 0 : 1);
+}
+
+const phase = process.argv[2];
+const phases: Record<string, () => Promise<void>> = { m3a, m3b, seed, verify };
+const run = phase ? phases[phase] : undefined;
+if (!run) {
+  process.stderr.write('usage: bun run src/m3.ts <m3a|m3b|seed|verify>\n');
+  process.exit(2);
+}
+run().catch((error) => {
+  process.stderr.write(`M3 ${phase} crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m4.ts
+++ b/spikes/rivet-pi-electric/src/m4.ts
@@ -1,0 +1,138 @@
+/**
+ * M4 — identity-scoped Electric gatekeeper.
+ *
+ * M3 proved the write path (actor → API → Postgres → Electric → client). M4
+ * proves the read path is SAFE for a public, multi-tenant audience: a client
+ * may only ever sync its own rows, and that scope is enforced by the server,
+ * not trusted from the client.
+ *
+ * No Rivet engine here — this is purely the read path (rows written directly
+ * through the single-writer API seam, then read back through the proxy).
+ *
+ * Phases (all in one process):
+ *   scope   — alice and bob each own a row. A client authenticating as alice
+ *             (via the proxy) sees ONLY alice's row, never bob's.
+ *   sneak   — a client authenticating as alice but asking for `where owner=bob`
+ *             STILL sees only alice's row (the proxy drops the client where and
+ *             forces `owner = $1`).
+ *   reject  — a request with no identity → 401; a request for a non-allowlisted
+ *             table → 403.
+ *
+ * Run (PG + Electric must be up via infra/docker-compose.yml):
+ *   bun run m4
+ */
+import { ensureReady, upsertConversationSummary } from './api.ts';
+import { PROXY_PORT, PROXY_URL } from './config.ts';
+import { closePool } from './db.ts';
+import { startProxy } from './proxy.ts';
+import { openConversationShape } from './shape-client.ts';
+
+const WAIT_MS = 20000;
+/** After a client's own row arrives, wait this long to prove the other owner's never does. */
+const GRACE_MS = 4000;
+const SHAPE_ENDPOINT = `${PROXY_URL}/v1/shape`;
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  await ensureReady();
+
+  const stamp = Date.now();
+  const alice = `alice-${stamp}@example.com`;
+  const bob = `bob-${stamp}@example.com`;
+  const aliceConv = `m4-alice-${stamp}`;
+  const bobConv = `m4-bob-${stamp}`;
+
+  // Seed one row per owner via the single-writer API seam.
+  await upsertConversationSummary({
+    id: aliceConv,
+    owner: alice,
+    title: 'Alice chat',
+    lastMessage: 'hi from alice',
+    turnCount: 1,
+  });
+  await upsertConversationSummary({
+    id: bobConv,
+    owner: bob,
+    title: 'Bob chat',
+    lastMessage: 'hi from bob',
+    turnCount: 1,
+  });
+
+  const server = startProxy(PROXY_PORT);
+  out(`[m4] gatekeeper proxy listening on ${PROXY_URL}`);
+
+  let pass = true;
+
+  // --- scope: alice sees only her own row ---
+  const aliceShape = openConversationShape({
+    url: SHAPE_ENDPOINT,
+    headers: { 'x-spike-user': alice },
+  });
+  await aliceShape.waitFor((rows) => rows.has(aliceConv), WAIT_MS);
+  await delay(GRACE_MS);
+  const aliceSeesOwn = aliceShape.rows.has(aliceConv);
+  const aliceSeesBob = aliceShape.rows.has(bobConv);
+  const aliceOnlyOwnOwner = [...aliceShape.rows.values()].every((row) => row.owner === alice);
+  out(
+    `[m4] scope: alice ownRow=${aliceSeesOwn} bobRow=${aliceSeesBob} onlyOwnOwner=${aliceOnlyOwnOwner} rows=${aliceShape.rows.size}`
+  );
+  if (!aliceSeesOwn || aliceSeesBob || !aliceOnlyOwnOwner) {
+    pass = false;
+  }
+  aliceShape.close();
+
+  // --- sneak: alice asks for bob's rows; proxy ignores the client where ---
+  const sneaky = openConversationShape({
+    url: SHAPE_ENDPOINT,
+    headers: { 'x-spike-user': alice },
+    where: `owner = '${bob}'`,
+  });
+  await sneaky.waitFor((rows) => rows.has(aliceConv), WAIT_MS).catch(() => undefined);
+  await delay(GRACE_MS);
+  const sneakSeesBob = sneaky.rows.has(bobConv);
+  out(`[m4] sneak: alice-asking-for-bob bobRow=${sneakSeesBob} (must be false)`);
+  if (sneakSeesBob) {
+    pass = false;
+  }
+  sneaky.close();
+
+  // --- reject: missing identity → 401 ---
+  const noIdentity = await fetch(`${SHAPE_ENDPOINT}?table=conversations&offset=-1`);
+  await noIdentity.body?.cancel();
+  out(`[m4] reject: no-identity status=${noIdentity.status} (expect 401)`);
+  if (noIdentity.status !== 401) {
+    pass = false;
+  }
+
+  // --- reject: non-allowlisted table → 403 ---
+  const badTable = await fetch(`${SHAPE_ENDPOINT}?table=secrets&offset=-1`, {
+    headers: { 'x-spike-user': alice },
+  });
+  await badTable.body?.cancel();
+  out(`[m4] reject: bad-table status=${badTable.status} (expect 403)`);
+  if (badTable.status !== 403) {
+    pass = false;
+  }
+
+  server.close();
+  await closePool();
+
+  out(
+    pass
+      ? '\nM4 PASS — gatekeeper enforces owner scope + table allowlist server-side; clients cannot widen their view'
+      : '\nM4 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M4 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m5.ts
+++ b/spikes/rivet-pi-electric/src/m5.ts
@@ -1,0 +1,151 @@
+/**
+ * M5 — real session identity behind the gatekeeper.
+ *
+ * M4 proved the proxy scopes reads per owner, but it trusted an `x-spike-user`
+ * header — i.e. the client asserted its own identity. That is unsafe for a
+ * public audience. M5 closes the gap: identity is resolved through a trusted
+ * authority (the {@link createSessionStore} stand-in for `/users/me`), and a
+ * client-asserted value carries no weight.
+ *
+ * No new infra — reuses M4's Postgres + Electric.
+ *
+ * Phases (one process):
+ *   session-scope     — a validated session for alice syncs only alice's rows.
+ *   header-not-trusted — alice's session + `x-spike-user: bob` still yields only
+ *                        alice's rows (the asserted header is ignored).
+ *   reject             — forged session → 401, no credential → 401, revoked
+ *                        session → 401.
+ *
+ * Run (PG + Electric must be up via infra/docker-compose.yml):
+ *   bun run m5
+ */
+import { ensureReady, upsertConversationSummary } from './api.ts';
+import { PROXY_PORT, PROXY_URL } from './config.ts';
+import { closePool } from './db.ts';
+import { sessionAuth, startProxy } from './proxy.ts';
+import { createSessionStore } from './session-store.ts';
+import { openConversationShape } from './shape-client.ts';
+
+const WAIT_MS = 20000;
+const GRACE_MS = 4000;
+const SHAPE_ENDPOINT = `${PROXY_URL}/v1/shape`;
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  await ensureReady();
+
+  const stamp = Date.now();
+  const alice = `alice-${stamp}@example.com`;
+  const bob = `bob-${stamp}@example.com`;
+  const aliceConv = `m5-alice-${stamp}`;
+  const bobConv = `m5-bob-${stamp}`;
+
+  await upsertConversationSummary({
+    id: aliceConv,
+    owner: alice,
+    title: 'Alice chat',
+    lastMessage: 'hi from alice',
+    turnCount: 1,
+  });
+  await upsertConversationSummary({
+    id: bobConv,
+    owner: bob,
+    title: 'Bob chat',
+    lastMessage: 'hi from bob',
+    turnCount: 1,
+  });
+
+  // The trusted authority mints sessions; the proxy resolves identity via it.
+  const store = createSessionStore();
+  const aliceSession = store.create(alice);
+  const bobSession = store.create(bob);
+
+  const server = startProxy(PROXY_PORT, sessionAuth(store));
+  out(`[m5] gatekeeper (session identity) listening on ${PROXY_URL}`);
+
+  let pass = true;
+
+  // --- a validated session scopes to its owner ---
+  const aliceShape = openConversationShape({
+    url: SHAPE_ENDPOINT,
+    headers: { Authorization: `Bearer ${aliceSession}` },
+  });
+  await aliceShape.waitFor((rows) => rows.has(aliceConv), WAIT_MS);
+  await delay(GRACE_MS);
+  const aliceOk =
+    aliceShape.rows.has(aliceConv) &&
+    !aliceShape.rows.has(bobConv) &&
+    [...aliceShape.rows.values()].every((row) => row.owner === alice);
+  out(
+    `[m5] session-scope: alice ownRow=${aliceShape.rows.has(aliceConv)} bobRow=${aliceShape.rows.has(bobConv)} rows=${aliceShape.rows.size}`
+  );
+  if (!aliceOk) {
+    pass = false;
+  }
+  aliceShape.close();
+
+  // --- a client-asserted header is NOT trusted ---
+  const spoof = openConversationShape({
+    url: SHAPE_ENDPOINT,
+    headers: { Authorization: `Bearer ${aliceSession}`, 'x-spike-user': bob },
+  });
+  await spoof.waitFor((rows) => rows.has(aliceConv), WAIT_MS).catch(() => undefined);
+  await delay(GRACE_MS);
+  const spoofSawBob = spoof.rows.has(bobConv);
+  out(`[m5] header-not-trusted: alice-session + x-spike-user=bob -> bobRow=${spoofSawBob} (must be false)`);
+  if (spoofSawBob) {
+    pass = false;
+  }
+  spoof.close();
+
+  // --- forged session -> 401 ---
+  const forged = await fetch(`${SHAPE_ENDPOINT}?table=conversations&offset=-1`, {
+    headers: { Authorization: 'Bearer forged-not-a-real-session' },
+  });
+  await forged.body?.cancel();
+  out(`[m5] reject: forged-session status=${forged.status} (expect 401)`);
+  if (forged.status !== 401) {
+    pass = false;
+  }
+
+  // --- no credential -> 401 ---
+  const anon = await fetch(`${SHAPE_ENDPOINT}?table=conversations&offset=-1`);
+  await anon.body?.cancel();
+  out(`[m5] reject: no-credential status=${anon.status} (expect 401)`);
+  if (anon.status !== 401) {
+    pass = false;
+  }
+
+  // --- revoked session -> 401 ---
+  store.revoke(bobSession);
+  const revoked = await fetch(`${SHAPE_ENDPOINT}?table=conversations&offset=-1`, {
+    headers: { Authorization: `Bearer ${bobSession}` },
+  });
+  await revoked.body?.cancel();
+  out(`[m5] reject: revoked-session status=${revoked.status} (expect 401)`);
+  if (revoked.status !== 401) {
+    pass = false;
+  }
+
+  server.close();
+  await closePool();
+
+  out(
+    pass
+      ? '\nM5 PASS — identity comes from the validated session; forged/missing/revoked rejected; client-asserted header ignored'
+      : '\nM5 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M5 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m6.ts
+++ b/spikes/rivet-pi-electric/src/m6.ts
@@ -1,0 +1,97 @@
+/**
+ * M6 — engine lifecycle off the test harness, durable across a cold restart.
+ *
+ * M1–M5 booted via `rivetkit/test`'s `setupTest`. M6 runs the actor under the
+ * production standalone shape (`src/server.ts`: `startEngine` + pinned
+ * `engineVersion`/`envoy.version` + `registry.start()`), connects with an
+ * external `createClient`, and proves state survives a REAL cold restart that
+ * this runner performs itself.
+ *
+ * No Postgres/Electric — this isolates the engine/runner durability (the PG
+ * projection path was already proven in M3c). The actor's RocksDB state lives
+ * under `.rivethome-m6`; the same dir is reused across the restart so state
+ * replays, and the engine version is pinned so the runner re-registers.
+ *
+ * Phases (one process):
+ *   seed     — boot server, send turn 1 (transcript = 2 messages).
+ *   restart  — kill the server AND the engine, wait for :6420 to free.
+ *   replay   — boot server again, read transcript: turn 1 still there.
+ *   continue — send turn 2 on the replayed state (transcript = 4 messages).
+ *
+ * Run (no infra needed):
+ *   bun run m6
+ */
+import { mkdirSync, rmSync } from 'node:fs';
+import { createClient } from 'rivetkit/client';
+import type { Registry } from './registry.ts';
+import { type ServerOptions, spawnServer, stopServer, waitForReady, waitPortFree } from './server-control.ts';
+
+const ENGINE_PORT = 6420;
+const ENDPOINT = `http://127.0.0.1:${ENGINE_PORT}`;
+const HOME_DIR = `${process.cwd()}/.rivethome-m6`;
+const SERVER: ServerOptions = { enginePort: ENGINE_PORT, engineVersion: '1', homeDir: HOME_DIR };
+const DURABLE_KEY = ['conv-m6-durable'];
+// The actor persists its state to the engine over the wire; the turn resolving
+// only means the in-memory state changed, not that the engine flushed it to
+// RocksDB. Settle before the cold kill so we test DURABILITY of committed state,
+// not a torn write (mirrors M2/M3c's pre-kill pause).
+const SETTLE_MS = 3000;
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  // Deterministic reruns: start each run from empty engine state.
+  rmSync(HOME_DIR, { recursive: true, force: true });
+  mkdirSync(HOME_DIR, { recursive: true });
+
+  // --- seed ---
+  let server = spawnServer(SERVER);
+  await waitForReady(ENDPOINT);
+  const conn1 = createClient<Registry>(ENDPOINT).conversation.getOrCreate(DURABLE_KEY).connect();
+  const seed = await conn1.sendMessage('first message before restart');
+  out(`[m6] seed: turnCount=${seed.turnCount} transcriptLength=${seed.transcriptLength}`);
+  await conn1.dispose();
+  await delay(SETTLE_MS);
+
+  // --- cold restart: kill the server AND the engine ---
+  await stopServer(server);
+  await waitPortFree(ENGINE_PORT);
+  out('[m6] cold restart: server + engine down, :6420 free');
+
+  // --- replay + continue ---
+  server = spawnServer(SERVER);
+  await waitForReady(ENDPOINT);
+  const conn2 = createClient<Registry>(ENDPOINT).conversation.getOrCreate(DURABLE_KEY).connect();
+  const replay = await conn2.getTranscript();
+  out(`[m6] replay: turnCount=${replay.turnCount} messageCount=${replay.messageCount}`);
+  const post = await conn2.sendMessage('second message after restart');
+  out(`[m6] continue: turnCount=${post.turnCount} transcriptLength=${post.transcriptLength}`);
+  await conn2.dispose();
+  await stopServer(server);
+
+  const pass =
+    seed.turnCount === 1 &&
+    seed.transcriptLength === 2 &&
+    replay.turnCount === 1 &&
+    replay.messageCount === 2 &&
+    post.turnCount === 2 &&
+    post.transcriptLength === 4;
+
+  out(
+    pass
+      ? '\nM6 PASS — actor state durable across a real cold restart under the production engine config (startEngine + pinned engineVersion/envoy.version), off the setupTest harness'
+      : '\nM6 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M6 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m7.ts
+++ b/spikes/rivet-pi-electric/src/m7.ts
@@ -1,0 +1,96 @@
+/**
+ * M7 — the substrate clients wrapped as Effect v4 layers.
+ *
+ * M1–M6 used the raw clients directly (node-postgres `Pool`,
+ * `@electric-sql/client` ShapeStream, rivetkit `createClient`). M7 proves the
+ * 003 wrapping pattern: each raw client becomes an Effect `Service` with a
+ * `Layer` (PG as a scoped pool via `Layer.effect` + `acquireRelease`; Electric
+ * and Rivet as `Layer.succeed`), composed with `Layer.mergeAll` and run once via
+ * `Effect.runPromise`. The idiom follows effect-smol v4 (`Context.Service` /
+ * `Layer` / `Effect.gen`), matching backend-ts `apps/api`.
+ *
+ * Runtime proof (reuses M3/M5 PG+Electric infra + a brief standalone server):
+ *   pg+electric — write a summary through the wrapped Conversations seam (over
+ *                 the scoped PG pool), then read it back through the wrapped
+ *                 Electric shape.
+ *   rivet       — run a turn and read the transcript through the wrapped Rivet
+ *                 client against the standalone actor server.
+ *
+ * Run (PG + Electric up via infra/docker-compose.yml):
+ *   bun run m7
+ */
+import { mkdirSync, rmSync } from 'node:fs';
+import { Effect, Layer } from 'effect';
+import { ensureReady } from './api.ts';
+import { Conversations, ConversationsLive, Electric, ElectricLive, makeRivetLive, Rivet } from './effect/index.ts';
+import { type ServerOptions, spawnServer, stopServer, waitForReady } from './server-control.ts';
+
+const ENGINE_PORT = 6420;
+const ENDPOINT = `http://127.0.0.1:${ENGINE_PORT}`;
+const HOME_DIR = `${process.cwd()}/.rivethome-m7`;
+const SERVER: ServerOptions = { enginePort: ENGINE_PORT, engineVersion: '1', homeDir: HOME_DIR };
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+async function main(): Promise<void> {
+  await ensureReady();
+  rmSync(HOME_DIR, { recursive: true, force: true });
+  mkdirSync(HOME_DIR, { recursive: true });
+
+  const server = spawnServer(SERVER);
+  await waitForReady(ENDPOINT);
+
+  const stamp = Date.now();
+  const id = `m7-${stamp}`;
+  const owner = `m7-${stamp}@example.com`;
+
+  const layer = Layer.mergeAll(ConversationsLive, ElectricLive, makeRivetLive(ENDPOINT));
+
+  const program = Effect.gen(function* () {
+    const conversations = yield* Conversations;
+    const electric = yield* Electric;
+    const rivet = yield* Rivet;
+
+    // pg + electric: write through the wrapped seam, read through the wrapped shape.
+    yield* conversations.upsertSummary({
+      id,
+      owner,
+      title: 'M7 wrapped',
+      lastMessage: 'written via Effect',
+      turnCount: 1,
+    });
+    const row = yield* electric.awaitRow(id, { timeoutMs: 20000 });
+
+    // rivet: run a turn and read the transcript through the wrapped client.
+    const turn = yield* rivet.sendMessage(['m7-conv'], 'hello through the wrapped client');
+    const transcript = yield* rivet.transcript(['m7-conv']);
+
+    return { row, turn, transcript };
+  });
+
+  const { row, turn, transcript } = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+
+  await stopServer(server);
+
+  const pgElectricOk = row.id === id && row.owner === owner && row.turn_count === 1;
+  const rivetOk = turn.turnCount === 1 && transcript.turnCount === 1 && transcript.messageCount === 2;
+  out(`[m7] pg+electric: row.owner=${row.owner} turn_count=${row.turn_count} ok=${pgElectricOk}`);
+  out(
+    `[m7] rivet: turn=${turn.turnCount} transcript.turnCount=${transcript.turnCount} messageCount=${transcript.messageCount} ok=${rivetOk}`
+  );
+
+  const pass = pgElectricOk && rivetOk;
+  out(
+    pass
+      ? '\nM7 PASS — PG, Electric, and Rivet wrapped as Effect v4 layers and exercised through one composed runtime'
+      : '\nM7 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M7 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m8.ts
+++ b/spikes/rivet-pi-electric/src/m8.ts
@@ -1,0 +1,118 @@
+/**
+ * M8 — Hatchet durable background workflow, surviving a worker restart.
+ *
+ * Proves the last 003 substrate piece: durable system work runs on Hatchet
+ * (Postgres-backed queue), survives the worker dying, and projects into the app
+ * Postgres through the SAME single-writer seam the actor uses.
+ *
+ * Phases (one process; Hatchet via infra/hatchet-compose.yml, app PG via
+ * infra/docker-compose.yml):
+ *   baseline — start the worker, run task A end-to-end → row A in PG.
+ *   down     — SIGKILL the worker, then enqueue task B while nothing serves it;
+ *              B must NOT be projected yet (it sits in Hatchet's PG queue).
+ *   restart  — restart the worker → it picks B off the queue → row B in PG.
+ *
+ * Run:
+ *   bun run m8
+ */
+import { type ChildProcess, spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { ensureReady } from './api.ts';
+import { closePool, query } from './db.ts';
+import { defineProjectSummary, makeHatchet, type ProjectSummaryInput } from './hatchet/workflow.ts';
+
+const TOKEN_FILE = `${process.cwd()}/infra/hatchet-creds/api-token`;
+const B_TIMEOUT_MS = 90000;
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function spawnWorker(token: string): ChildProcess {
+  return spawn('bun', ['run', 'src/hatchet/worker.ts'], {
+    env: { ...process.env, HATCHET_CLIENT_TOKEN: token, HATCHET_CLIENT_TLS_STRATEGY: 'none' },
+    stdio: 'inherit',
+  });
+}
+
+/** True once the projection row for `id` exists in the app Postgres. */
+async function rowExists(id: string): Promise<boolean> {
+  const rows = await query('SELECT id FROM conversations WHERE id = $1', [id]);
+  return rows.length > 0;
+}
+
+async function waitRowExists(id: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await rowExists(id)) {
+      return true;
+    }
+    await delay(1000);
+  }
+  return false;
+}
+
+async function main(): Promise<void> {
+  await ensureReady();
+
+  const token = readFileSync(TOKEN_FILE, 'utf8').trim();
+  process.env.HATCHET_CLIENT_TOKEN = token;
+
+  const hatchet = makeHatchet();
+  const task = defineProjectSummary(hatchet);
+
+  const stamp = Date.now();
+  const owner = `m8-${stamp}@example.com`;
+  const idA = `m8a-${stamp}`;
+  const idB = `m8b-${stamp}`;
+  const inputA: ProjectSummaryInput = { id: idA, owner, title: 'A', lastMessage: 'task A', turnCount: 1 };
+  const inputB: ProjectSummaryInput = {
+    id: idB,
+    owner,
+    title: 'B',
+    lastMessage: 'task B enqueued while worker down',
+    turnCount: 1,
+  };
+
+  // --- baseline: worker up, run task A end-to-end (also registers the workflow) ---
+  let worker = spawnWorker(token);
+  await delay(6000);
+  await task.run(inputA);
+  const aProjected = await rowExists(idA);
+  out(`[m8] baseline: task A ran; row A in PG=${aProjected}`);
+
+  // --- down: kill the worker, enqueue B while nothing serves it ---
+  worker.kill('SIGKILL');
+  await delay(2000);
+  const ref = await task.runNoWait(inputB);
+  const runId = await ref.getWorkflowRunId();
+  await delay(3000);
+  const bBeforeRestart = await rowExists(idB);
+  out(`[m8] down: enqueued B (runId=${runId}); B projected before restart=${bBeforeRestart} (expect false)`);
+
+  // --- restart: bring the worker back; B must be picked off the durable queue ---
+  worker = spawnWorker(token);
+  const bAfterRestart = await waitRowExists(idB, B_TIMEOUT_MS);
+  out(`[m8] restart: B projected after restart=${bAfterRestart} (expect true)`);
+
+  worker.kill('SIGKILL');
+  await delay(500);
+  await closePool();
+
+  const pass = aProjected && !bBeforeRestart && bAfterRestart;
+  out(
+    pass
+      ? '\nM8 PASS — Hatchet durably queued the task across a worker restart and projected it through the API seam'
+      : '\nM8 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M8 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/m9.ts
+++ b/spikes/rivet-pi-electric/src/m9.ts
@@ -1,0 +1,124 @@
+/**
+ * M9 — actor scheduler/alarm durability across a cold restart.
+ *
+ * The ADR names BOTH "alarm" and "state" durability as the first RC risks to
+ * validate; M2/M3c/M6 proved state durability, but the actor's OWN scheduler
+ * (`c.schedule.after(...)` → a named action) — the session-scoped timer the ADR
+ * puts on the actor rather than Hatchet — was never exercised. M9 closes that:
+ * a wake registered before a real cold restart must still fire (and mutate
+ * state) after the actor rehydrates on a fresh engine, with no client invoking
+ * the callback.
+ *
+ * No Postgres/Electric — this isolates the scheduler (same standalone engine
+ * shape as M6). State lives under `.rivethome-m9`, reused across the restart.
+ *
+ * Phases (one process):
+ *   schedule — boot server, register a wake WAKE_DELAY_MS out, settle so it
+ *              persists, confirm it has NOT fired yet.
+ *   restart  — kill the server AND the engine while the wake is still pending,
+ *              wait for :6420 to free, boot again.
+ *   fire     — after reboot the scheduler fires the wake on its own (either it
+ *              was still pending, or its time elapsed during downtime and it
+ *              catches up on rehydration) → wakeCount=1, label matches. It was
+ *              0 before the restart, so the increment is the durable schedule.
+ *
+ * Run (no infra needed; ensure :6420 is free first):
+ *   bun run m9
+ */
+import { mkdirSync, rmSync } from 'node:fs';
+import { createClient } from 'rivetkit/client';
+import type { Registry } from './registry.ts';
+import { type ServerOptions, spawnServer, stopServer, waitForReady, waitPortFree } from './server-control.ts';
+
+const ENGINE_PORT = 6420;
+const ENDPOINT = `http://127.0.0.1:${ENGINE_PORT}`;
+const HOME_DIR = `${process.cwd()}/.rivethome-m9`;
+const SERVER: ServerOptions = { enginePort: ENGINE_PORT, engineVersion: '1', homeDir: HOME_DIR };
+const DURABLE_KEY = ['conv-m9-wake'];
+// Long enough that the wake cannot fire before the cold kill (kill lands ~5s
+// in), but the engine reboot (boot + runner registration) can itself take
+// ~20-30s — so the wake may be pending at reboot OR already overdue and caught
+// up on rehydration. Both prove durability. Persisting the schedule is async
+// w.r.t. the call returning (see FINDINGS #12), so settle before the cold kill.
+const WAKE_DELAY_MS = 20000;
+const SETTLE_MS = 3000;
+const FIRE_TIMEOUT_MS = 45000;
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function client() {
+  return createClient<Registry>(ENDPOINT).conversation.getOrCreate(DURABLE_KEY).connect();
+}
+
+async function readWakes(): Promise<{ wakeCount: number; lastWakeLabel: string | null }> {
+  const conn = client();
+  try {
+    return await conn.getWakes();
+  } finally {
+    await conn.dispose();
+  }
+}
+
+async function main(): Promise<void> {
+  rmSync(HOME_DIR, { recursive: true, force: true });
+  mkdirSync(HOME_DIR, { recursive: true });
+
+  const label = `wake-${Date.now()}`;
+
+  // --- schedule ---
+  let server = spawnServer(SERVER);
+  await waitForReady(ENDPOINT);
+  const conn1 = client();
+  await conn1.scheduleWake({ delayMs: WAKE_DELAY_MS, label });
+  await conn1.dispose();
+  await delay(SETTLE_MS);
+  const beforeRestart = await readWakes();
+  out(`[m9] schedule: wake '${label}' set for +${WAKE_DELAY_MS}ms; wakeCount=${beforeRestart.wakeCount} (expect 0)`);
+
+  // --- cold restart while the wake is still pending ---
+  await stopServer(server);
+  await waitPortFree(ENGINE_PORT);
+  out('[m9] cold restart: server + engine down, :6420 free');
+  server = spawnServer(SERVER);
+  await waitForReady(ENDPOINT);
+
+  // --- fire: the scheduler fires the pending/overdue wake after rehydration ---
+  const atReboot = await readWakes();
+  out(
+    `[m9] reboot: wakeCount=${atReboot.wakeCount} (${atReboot.wakeCount === 0 ? 'still pending' : 'caught up on rehydration'})`
+  );
+
+  const deadline = Date.now() + FIRE_TIMEOUT_MS;
+  let fired = atReboot;
+  while (Date.now() < deadline && fired.wakeCount === 0) {
+    await delay(1000);
+    fired = await readWakes();
+  }
+  out(`[m9] fire: wakeCount=${fired.wakeCount} lastWakeLabel=${fired.lastWakeLabel} (expect 1 / '${label}')`);
+
+  await stopServer(server);
+
+  // The wake did NOT fire before the cold restart (0 at settle, long before its
+  // fire time), and DID fire afterward with the right payload — whether still
+  // pending at reboot or caught up on rehydration. fireWake is only ever invoked
+  // by the scheduler, so the post-restart increment is the durable schedule.
+  const pass = beforeRestart.wakeCount === 0 && fired.wakeCount === 1 && fired.lastWakeLabel === label;
+
+  out(
+    pass
+      ? '\nM9 PASS — a per-session scheduled wake survived a real cold restart and fired (mutating state) after the actor rehydrated, with no client invoking it'
+      : '\nM9 FAIL'
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(`M9 crashed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/spikes/rivet-pi-electric/src/pi-turn.ts
+++ b/spikes/rivet-pi-electric/src/pi-turn.ts
@@ -1,0 +1,90 @@
+/**
+ * The unforked-Pi seam.
+ *
+ * `runPiTurn` drives the real `@earendil-works/pi-agent-core` loop with a keyless
+ * faux provider so the spike can prove "Pi runs inside a Rivet actor" without any
+ * API keys or network. Nothing here patches Pi; it only wires Pi's public
+ * `runAgentLoop` + `createFauxCore` together and forwards events to a sink.
+ */
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from '@earendil-works/pi-agent-core';
+import { runAgentLoop } from '@earendil-works/pi-agent-core';
+import type { Message } from '@earendil-works/pi-ai';
+import { createFauxCore, fauxAssistantMessage } from '@earendil-works/pi-ai/providers/faux';
+
+/** A plain text user message in Pi's `AgentMessage` shape. */
+export function userMessage(text: string): AgentMessage {
+  return {
+    role: 'user',
+    content: [{ type: 'text', text }],
+    timestamp: Date.now(),
+  };
+}
+
+/** Pull the most recent user text out of a prompt list, for the canned reply. */
+function lastUserText(prompts: AgentMessage[]): string {
+  for (let i = prompts.length - 1; i >= 0; i--) {
+    const message = prompts[i];
+    if (message.role !== 'user') {
+      continue;
+    }
+    const { content } = message;
+    if (typeof content === 'string') {
+      return content;
+    }
+    return content.map((block) => (block.type === 'text' ? block.text : '')).join('');
+  }
+  return '';
+}
+
+/** Scripted reply the faux provider streams back, so deltas are visibly chunked. */
+function defaultReply(prompts: AgentMessage[]): string {
+  const said = lastUserText(prompts).trim();
+  return [
+    "I'm the Pi agent loop, running unmodified inside a Rivet actor.",
+    said ? `You said: "${said}".` : '',
+    'Every token in this sentence is a faux-provider delta the actor is',
+    'broadcasting over its WebSocket to prove the substrate streams end to end.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export interface RunPiTurnArgs {
+  /** Prior transcript visible to the model (does not include the new prompt). */
+  readonly context: AgentContext;
+  /** New prompt messages to start this turn. */
+  readonly prompts: AgentMessage[];
+  /** Sink for every Pi agent event (used to broadcast deltas from the actor). */
+  readonly onEvent: (event: AgentEvent) => void | Promise<void>;
+  /** Optional override for the streamed reply text. */
+  readonly reply?: string;
+  /** Tokens-per-second pacing for the faux stream. */
+  readonly tokensPerSecond?: number;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Run one Pi turn against a keyless faux provider and return the new messages
+ * (prompt + assistant response) the loop produced.
+ */
+export async function runPiTurn(args: RunPiTurnArgs): Promise<AgentMessage[]> {
+  const faux = createFauxCore({
+    tokensPerSecond: args.tokensPerSecond ?? 40,
+    tokenSize: { min: 2, max: 4 },
+  });
+  faux.setResponses([fauxAssistantMessage(args.reply ?? defaultReply(args.prompts))]);
+
+  const config: AgentLoopConfig = {
+    model: faux.getModel(),
+    convertToLlm: (messages: AgentMessage[]): Message[] => messages as Message[],
+  };
+
+  return runAgentLoop(
+    args.prompts,
+    args.context,
+    config,
+    (event) => args.onEvent(event),
+    args.signal,
+    faux.stream as unknown as StreamFn
+  );
+}

--- a/spikes/rivet-pi-electric/src/proxy.ts
+++ b/spikes/rivet-pi-electric/src/proxy.ts
@@ -16,6 +16,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client';
 import { ELECTRIC_URL } from './config.ts';
+import type { SessionStore } from './session-store.ts';
 
 /** Per-table column allowlist; the client's requested columns are ignored. */
 const ALLOWED_COLUMNS: Record<string, readonly string[]> = {
@@ -25,10 +26,62 @@ const ALLOWED_COLUMNS: Record<string, readonly string[]> = {
 const PROTOCOL_PARAMS = new Set<string>(ELECTRIC_PROTOCOL_QUERY_PARAMS);
 const HOP_BY_HOP = ['content-encoding', 'content-length', 'transfer-encoding', 'connection'];
 
+/**
+ * Resolves the authenticated owner for a request, or `null` to reject (401).
+ * This is the seam where real identity plugs in: it must derive the owner from
+ * something the server trusts, never from a client-asserted value.
+ */
+export type ProxyAuth = (req: IncomingMessage) => string | null;
+
+/**
+ * M4 authenticator: trust an `x-spike-user` header. Fine for proving the scope
+ * mechanism, but NOT safe for real clients — the caller asserts its own
+ * identity. Superseded by `sessionAuth` (M5).
+ */
+export const headerAuth: ProxyAuth = (req) => {
+  const header = req.headers['x-spike-user'];
+  return (Array.isArray(header) ? header[0] : header) ?? null;
+};
+
+/** Pull a session id from `Authorization: Bearer <id>` or `Cookie: session=<id>`. */
+function extractSessionId(req: IncomingMessage): string | null {
+  const authHeader = req.headers.authorization;
+  const auth = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (auth?.startsWith('Bearer ')) {
+    return auth.slice('Bearer '.length).trim() || null;
+  }
+  const cookieHeader = req.headers.cookie;
+  const cookie = Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader;
+  if (cookie) {
+    for (const part of cookie.split(';')) {
+      const [name, ...rest] = part.trim().split('=');
+      if (name === 'session') {
+        return rest.join('=') || null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * M5 authenticator: resolve identity through the trusted {@link SessionStore}.
+ * A client-asserted header is ignored entirely — only a validated session id
+ * (from `Authorization`/`Cookie`) yields an owner; unknown/forged → reject.
+ */
+export function sessionAuth(store: SessionStore): ProxyAuth {
+  return (req) => {
+    const sessionId = extractSessionId(req);
+    if (!sessionId) {
+      return null;
+    }
+    return store.lookup(sessionId);
+  };
+}
+
 /** Start the gatekeeper proxy on `port` (loopback only). */
-export function startProxy(port: number): Server {
+export function startProxy(port: number, authenticate: ProxyAuth = headerAuth): Server {
   const server = createServer((req, res) => {
-    handle(req, res, port).catch((error) => {
+    handle(req, res, port, authenticate).catch((error) => {
       if (!res.headersSent) {
         res.writeHead(500, { 'content-type': 'application/json' });
       }
@@ -51,7 +104,7 @@ function abortSignalFor(req: IncomingMessage): AbortSignal {
   return controller.signal;
 }
 
-async function handle(req: IncomingMessage, res: ServerResponse, port: number): Promise<void> {
+async function handle(req: IncomingMessage, res: ServerResponse, port: number, authenticate: ProxyAuth): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
   if (url.pathname !== '/v1/shape') {
     return deny(res, 404, { error: 'not_found' });
@@ -60,11 +113,11 @@ async function handle(req: IncomingMessage, res: ServerResponse, port: number): 
     return deny(res, 405, { error: 'method_not_allowed' });
   }
 
-  // 1. Identity — stand-in for the session cookie a real deployment validates.
-  const header = req.headers['x-spike-user'];
-  const owner = Array.isArray(header) ? header[0] : header;
+  // 1. Identity — resolved by the configured authenticator (a validated session
+  //    in production), never trusted from a client-asserted value.
+  const owner = authenticate(req);
   if (!owner) {
-    return deny(res, 401, { error: 'missing identity' });
+    return deny(res, 401, { error: 'missing or invalid identity' });
   }
 
   // 2. Table allowlist (also drives the column allowlist).

--- a/spikes/rivet-pi-electric/src/proxy.ts
+++ b/spikes/rivet-pi-electric/src/proxy.ts
@@ -1,0 +1,120 @@
+/**
+ * The identity-scoped Electric gatekeeper (M4).
+ *
+ * Mirrors `backend/vendor/effect-api-layout/apps/electric-proxy` (trimmed to
+ * plain TS): authenticate → validate the table → forward ONLY recognized
+ * Electric protocol params (offset/handle/live/cursor/…) → server-force the
+ * `table`, a `columns` allowlist, and an owner-scoped parameterized `where`
+ * → stream the upstream response back.
+ *
+ * The security property: a client can NOT widen its view. Any client-supplied
+ * `where`/`table`/`columns` are dropped (they aren't protocol params), and the
+ * only filter that reaches Electric is the proxy's `owner = $1` bound to the
+ * authenticated identity. This is the read-path half of "single writer +
+ * per-identity scoped sync" that files-first could never enforce centrally.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { ELECTRIC_PROTOCOL_QUERY_PARAMS } from '@electric-sql/client';
+import { ELECTRIC_URL } from './config.ts';
+
+/** Per-table column allowlist; the client's requested columns are ignored. */
+const ALLOWED_COLUMNS: Record<string, readonly string[]> = {
+  conversations: ['id', 'owner', 'title', 'last_message', 'turn_count', 'updated_at'],
+};
+
+const PROTOCOL_PARAMS = new Set<string>(ELECTRIC_PROTOCOL_QUERY_PARAMS);
+const HOP_BY_HOP = ['content-encoding', 'content-length', 'transfer-encoding', 'connection'];
+
+/** Start the gatekeeper proxy on `port` (loopback only). */
+export function startProxy(port: number): Server {
+  const server = createServer((req, res) => {
+    handle(req, res, port).catch((error) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'content-type': 'application/json' });
+      }
+      res.end(JSON.stringify({ error: 'proxy_internal', detail: String(error) }));
+    });
+  });
+  server.listen(port, '127.0.0.1');
+  return server;
+}
+
+function deny(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/** Abort the upstream fetch when the downstream client disconnects. */
+function abortSignalFor(req: IncomingMessage): AbortSignal {
+  const controller = new AbortController();
+  req.on('close', () => controller.abort());
+  return controller.signal;
+}
+
+async function handle(req: IncomingMessage, res: ServerResponse, port: number): Promise<void> {
+  const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
+  if (url.pathname !== '/v1/shape') {
+    return deny(res, 404, { error: 'not_found' });
+  }
+  if (req.method !== 'GET' && req.method !== 'DELETE') {
+    return deny(res, 405, { error: 'method_not_allowed' });
+  }
+
+  // 1. Identity — stand-in for the session cookie a real deployment validates.
+  const header = req.headers['x-spike-user'];
+  const owner = Array.isArray(header) ? header[0] : header;
+  if (!owner) {
+    return deny(res, 401, { error: 'missing identity' });
+  }
+
+  // 2. Table allowlist (also drives the column allowlist).
+  const table = url.searchParams.get('table');
+  if (!table) {
+    return deny(res, 400, { error: 'missing table' });
+  }
+  const columns = ALLOWED_COLUMNS[table];
+  if (!columns) {
+    return deny(res, 403, { error: `table "${table}" is not allowed for sync` });
+  }
+
+  // 3. Forward ONLY recognized Electric protocol params from the client.
+  const upstream = new URL(`${ELECTRIC_URL}/v1/shape`);
+  for (const [key, value] of url.searchParams.entries()) {
+    if (PROTOCOL_PARAMS.has(key)) {
+      upstream.searchParams.set(key, value);
+    }
+  }
+
+  // 4. Server forces table + columns + owner-scoped where (client can't override).
+  upstream.searchParams.set('table', table);
+  upstream.searchParams.set('columns', columns.join(','));
+  upstream.searchParams.set('where', 'owner = $1');
+  const upstreamUrl = `${upstream.toString()}&params[1]=${encodeURIComponent(owner)}`;
+
+  // 5. Forward and stream the response back.
+  const upstreamRes = await fetch(upstreamUrl, { signal: abortSignalFor(req) });
+  const headers: Record<string, string> = {};
+  upstreamRes.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.includes(key.toLowerCase())) {
+      headers[key] = value;
+    }
+  });
+  headers['cache-control'] = 'private, no-store';
+  res.writeHead(upstreamRes.status, headers);
+
+  if (!upstreamRes.body) {
+    res.end();
+    return;
+  }
+  const reader = upstreamRes.body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      res.write(value);
+    }
+  }
+  res.end();
+}

--- a/spikes/rivet-pi-electric/src/registry.ts
+++ b/spikes/rivet-pi-electric/src/registry.ts
@@ -1,0 +1,9 @@
+/** Rivet registry: the one actor the spike exposes. */
+import { setup } from 'rivetkit';
+import { conversation } from './conversation-actor.ts';
+
+export const registry = setup({
+  use: { conversation },
+});
+
+export type Registry = typeof registry;

--- a/spikes/rivet-pi-electric/src/server-control.ts
+++ b/spikes/rivet-pi-electric/src/server-control.ts
@@ -1,0 +1,95 @@
+/**
+ * OS-level lifecycle for the standalone actor server (`src/server.ts`).
+ *
+ * Shared by M6 (cold-restart durability) and M7 (exercising the wrapped Rivet
+ * client). A "cold restart" requires killing BOTH the server process and the
+ * engine it spawned — when the engine dies the rivetkit envoy retries forever
+ * and never respawns it (observed in M6), so we kill the engine by name too.
+ */
+import { type ChildProcess, spawn } from 'node:child_process';
+import { connect as netConnect } from 'node:net';
+import { createClient } from 'rivetkit/client';
+import type { Registry } from './registry.ts';
+
+export interface ServerOptions {
+  readonly enginePort: number;
+  readonly engineVersion: string;
+  readonly homeDir: string;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Spawn the standalone actor server as a child (so it can be truly killed). */
+export function spawnServer(opts: ServerOptions): ChildProcess {
+  return spawn('bun', ['run', 'src/server.ts'], {
+    env: {
+      ...process.env,
+      HOME: opts.homeDir,
+      SPIKE_ENGINE_PORT: String(opts.enginePort),
+      SPIKE_ENGINE_VERSION: opts.engineVersion,
+    },
+    stdio: 'inherit',
+  });
+}
+
+/** Kill any local engine by exact process name (the server never respawns it). */
+export function killEngine(): Promise<void> {
+  return new Promise((resolve) => {
+    const proc = spawn('pkill', ['-x', 'rivet-engine']);
+    proc.on('exit', () => resolve());
+    proc.on('error', () => resolve());
+  });
+}
+
+/** Kill the server child and the engine it spawned; both must die for a cold restart. */
+export async function stopServer(server: ChildProcess): Promise<void> {
+  server.kill('SIGKILL');
+  await killEngine();
+  await delay(1500);
+}
+
+/** True once nothing is listening on `port`. */
+export function portFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = netConnect({ host: '127.0.0.1', port });
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('error', () => resolve(true));
+    socket.setTimeout(1000, () => {
+      socket.destroy();
+      resolve(true);
+    });
+  });
+}
+
+export async function waitPortFree(port: number): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    if (await portFree(port)) {
+      return;
+    }
+    await delay(500);
+  }
+  throw new Error(`port ${port} never freed`);
+}
+
+/** Poll an actor action until the freshly-booted server can serve it. */
+export async function waitForReady(endpoint: string, timeoutMs = 30000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const conn = createClient<Registry>(endpoint).conversation.getOrCreate(['ready-probe']).connect();
+      await conn.getTranscript();
+      await conn.dispose();
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(500);
+    }
+  }
+  throw new Error(`server not ready: ${String(lastError)}`);
+}

--- a/spikes/rivet-pi-electric/src/server.ts
+++ b/spikes/rivet-pi-electric/src/server.ts
@@ -1,0 +1,35 @@
+/**
+ * M6 — the actor server in the production "standalone" shape.
+ *
+ * M1–M5 booted the runtime via `rivetkit/test`'s `setupTest`, which spawns the
+ * engine implicitly and needs a runner-readiness retry. This module owns the
+ * engine lifecycle explicitly the way a deployed pod would:
+ *   - `startEngine: true` spawns the engine,
+ *   - `engineVersion` + `envoy.version` pin a STABLE runner version (the M2
+ *     durability knob, here as config instead of the `RIVET_ENVOY_VERSION` env
+ *     hack), and
+ *   - `registry.start()` runs the actor envoy and keeps the process alive.
+ *
+ * Killing this process (and the engine it spawned) is a real cold restart.
+ *
+ * NB (rivetkit 2.3.2): the reference's `serverless.{spawnEngine,
+ * configureRunnerPool}` is superseded by top-level `startEngine` +
+ * `engine*`/`envoy`. `configurePool` is only for the serverless HTTP-callback
+ * pool (Mode B); the in-process envoy here needs no callback URL.
+ */
+import { setup } from 'rivetkit';
+import { conversation } from './conversation-actor.ts';
+
+const ENGINE_PORT = Number(process.env.SPIKE_ENGINE_PORT ?? 6420);
+const ENGINE_VERSION = process.env.SPIKE_ENGINE_VERSION ?? '1';
+
+const registry = setup({
+  use: { conversation },
+  startEngine: true,
+  enginePort: ENGINE_PORT,
+  engineVersion: ENGINE_VERSION,
+  envoy: { version: Number(ENGINE_VERSION), totalSlots: 16 },
+});
+
+registry.start();
+process.stdout.write(`[server] envoy started; engine :${ENGINE_PORT} version=${ENGINE_VERSION}\n`);

--- a/spikes/rivet-pi-electric/src/session-store.ts
+++ b/spikes/rivet-pi-electric/src/session-store.ts
@@ -1,0 +1,41 @@
+/**
+ * The trusted identity authority (M5).
+ *
+ * Stands in for what the reference does over RPC: the electric-proxy forwards
+ * the caller's credential headers to the main API, which validates them and
+ * returns the identity (`backend/vendor/effect-api-layout/apps/electric-proxy/
+ * src/Modules/Authentication/Services/Auth.ts`). In production this is the
+ * Python `GET :8000/users/me` / Session-in-Effect lookup.
+ *
+ * Here it is an in-memory map: a session id resolves to an owner, or to nothing
+ * (unknown/forged/expired). The point of M5 is that the proxy derives identity
+ * from THIS authority, never from a client-asserted value.
+ */
+import { randomUUID } from 'node:crypto';
+
+export interface SessionStore {
+  /** Mint a session for `owner`; returns the opaque session id. */
+  create(owner: string): string;
+  /** Resolve a session id to its owner, or `null` if unknown/revoked. */
+  lookup(sessionId: string): string | null;
+  /** Invalidate a session (e.g. logout); subsequent lookups return `null`. */
+  revoke(sessionId: string): void;
+}
+
+/** Build an in-memory session store. */
+export function createSessionStore(): SessionStore {
+  const sessions = new Map<string, string>();
+  return {
+    create(owner: string): string {
+      const sessionId = randomUUID();
+      sessions.set(sessionId, owner);
+      return sessionId;
+    },
+    lookup(sessionId: string): string | null {
+      return sessions.get(sessionId) ?? null;
+    },
+    revoke(sessionId: string): void {
+      sessions.delete(sessionId);
+    },
+  };
+}

--- a/spikes/rivet-pi-electric/src/shape-client.ts
+++ b/spikes/rivet-pi-electric/src/shape-client.ts
@@ -27,18 +27,29 @@ export interface ConversationShape {
   close(): void;
 }
 
+export interface ShapeOptions {
+  /** Scope the shape (e.g. `owner = 'alice'`). Ignored when going via the gatekeeper. */
+  where?: string;
+  /** Shape endpoint; defaults to Electric directly. Point at the proxy for M4. */
+  url?: string;
+  /** Extra request headers (e.g. the identity the proxy authenticates on). */
+  headers?: Record<string, string>;
+}
+
 /**
- * Open a live subscription to the `conversations` shape. Pass `where` to scope
- * it (e.g. `owner = 'alice'`); omit for the whole table.
+ * Open a live subscription to the `conversations` shape. By default it hits
+ * Electric directly (M3); pass `url`/`headers` to route through the gatekeeper
+ * proxy (M4), which enforces the owner scope server-side regardless of `where`.
  */
-export function openConversationShape(where?: string): ConversationShape {
+export function openConversationShape(opts: ShapeOptions = {}): ConversationShape {
   const controller = new AbortController();
   const rows = new Map<string, ConversationRow>();
   const listeners = new Set<() => void>();
 
   const stream = new ShapeStream<ConversationRow>({
-    url: `${ELECTRIC_URL}/v1/shape`,
-    params: { table: 'conversations', ...(where ? { where } : {}) },
+    url: opts.url ?? `${ELECTRIC_URL}/v1/shape`,
+    params: { table: 'conversations', ...(opts.where ? { where: opts.where } : {}) },
+    ...(opts.headers ? { headers: opts.headers } : {}),
     signal: controller.signal,
     // Tolerate the startup race where the shape is requested before Electric has
     // finished publishing the table; returning {} retries with the same params.

--- a/spikes/rivet-pi-electric/src/shape-client.ts
+++ b/spikes/rivet-pi-electric/src/shape-client.ts
@@ -1,0 +1,114 @@
+/**
+ * The read-path client (client B).
+ *
+ * Subscribes to the `conversations` shape via `@electric-sql/client` and
+ * materializes a live `Map<id, row>`. This is the half files-first could never
+ * do: a second client sees Postgres rows appear/update live, pushed by Electric
+ * over the shape log — no polling, no manual refresh.
+ */
+import { type ChangeMessage, isChangeMessage, type Row, ShapeStream } from '@electric-sql/client';
+import { ELECTRIC_URL } from './config.ts';
+
+export interface ConversationRow extends Row {
+  id: string;
+  owner: string;
+  title: string;
+  last_message: string;
+  turn_count: number;
+  updated_at: string;
+}
+
+export interface ConversationShape {
+  /** Live materialized rows keyed by primary key. */
+  readonly rows: Map<string, ConversationRow>;
+  /** Resolve once `predicate` holds, else reject after `timeoutMs`. */
+  waitFor(predicate: (rows: Map<string, ConversationRow>) => boolean, timeoutMs: number): Promise<void>;
+  /** Stop the stream. */
+  close(): void;
+}
+
+/**
+ * Open a live subscription to the `conversations` shape. Pass `where` to scope
+ * it (e.g. `owner = 'alice'`); omit for the whole table.
+ */
+export function openConversationShape(where?: string): ConversationShape {
+  const controller = new AbortController();
+  const rows = new Map<string, ConversationRow>();
+  const listeners = new Set<() => void>();
+
+  const stream = new ShapeStream<ConversationRow>({
+    url: `${ELECTRIC_URL}/v1/shape`,
+    params: { table: 'conversations', ...(where ? { where } : {}) },
+    signal: controller.signal,
+    // Tolerate the startup race where the shape is requested before Electric has
+    // finished publishing the table; returning {} retries with the same params.
+    onError: (error) => {
+      process.stderr.write(`[shape] stream error (retrying): ${String(error)}\n`);
+      return {};
+    },
+  });
+
+  stream.subscribe((messages) => {
+    let changed = false;
+    for (const message of messages) {
+      if (!isChangeMessage(message)) {
+        continue;
+      }
+      changed = true;
+      applyChange(rows, message);
+    }
+    if (changed) {
+      for (const listener of listeners) {
+        listener();
+      }
+    }
+  });
+
+  const waitFor = (predicate: (rows: Map<string, ConversationRow>) => boolean, timeoutMs: number): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const check = (): boolean => {
+        if (predicate(rows)) {
+          cleanup();
+          resolve();
+          return true;
+        }
+        return false;
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(`shape predicate not satisfied within ${timeoutMs}ms`));
+      }, timeoutMs);
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        listeners.delete(check);
+      };
+      if (check()) {
+        return;
+      }
+      listeners.add(check);
+    });
+
+  return {
+    rows,
+    waitFor,
+    close: () => controller.abort(),
+  };
+}
+
+/**
+ * Fold one change message into the materialized row map.
+ *
+ * Keyed by the row's own `id` (the PK, always present in the change value),
+ * NOT by Electric's structured `message.key` (e.g. `"public"."conversations"/"x"`)
+ * — so callers can look up by the id they wrote. With the default replica an
+ * update carries the PK plus only the changed columns, hence the merge.
+ */
+function applyChange(rows: Map<string, ConversationRow>, message: ChangeMessage<ConversationRow>): void {
+  const id = String(message.value.id);
+  if (message.headers.operation === 'delete') {
+    rows.delete(id);
+    return;
+  }
+  const existing = rows.get(id);
+  rows.set(id, { ...(existing ?? {}), ...message.value } as ConversationRow);
+}

--- a/spikes/rivet-pi-electric/tsconfig.json
+++ b/spikes/rivet-pi-electric/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["node", "bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Throwaway, isolated spike validating the riskiest assumptions of the **003 substrate ADR** (`2026-06-27-rivet-postgres-electric-hatchet-substrate`) *before* rewriting the 003 plan. It now covers the full read/write vertical slice **plus the read-path security boundary**: **one conversation = one Rivet actor running the unforked Pi agent loop**, streaming tokens out (M1), surviving a real cold restart (M2), projecting to **Postgres through the API (single writer)** with **Electric** syncing the row to a second client live (M3), and an **identity-scoped gatekeeper** in front of Electric that enforces per-owner scope server-side (M4).

Lives under `spikes/rivet-pi-electric/` with its own isolated `node_modules` (empty `workspaces` array) so it does not touch the `backend-ts` / frontend monorepo graphs. Pi is consumed as a **published npm dep** (`@earendil-works/pi-agent-core@0.80.2`), not the vendored copy — nothing patches it.

## What it proves

- **M1 — PASS.** Pi's `runAgentLoop` (keyless faux provider via `createFauxCore`) runs *inside* a `rivetkit` actor; `text_delta` events were broadcast live over the actor WebSocket to a connected client, the returned `assistantText` equalled the concatenated stream, and the transcript persisted (user + assistant).
- **M2 — PASS.** Actor transcript + turn counter survived a **true cold restart** (both the JS process *and* the native engine were killed) via the on-disk RocksDB: `verify` replayed `turnCount=1, messageCount=2` from disk, then continued to `turnCount=2, messageCount=4`.
- **M3 — PASS (added in `db608d16`).** The actor projects a conversation summary to Postgres **only through the API seam** (it imports `api.ts`, never `db.ts` — single writer), and a second client sees that row live via **Electric**:
  - *M3a* — an API write reached a `@electric-sql/client` `ShapeStream` client as a live insert then update.
  - *M3b* — one Pi turn streamed 23 deltas to client A (actor WS) **and** the summary row (`owner`, `turn_count`, title) appeared in client B (Electric) — the ADR's combined acceptance criterion.
  - *M3c* — cold restart with **PG + Electric left running, only the Rivet engine killed** (verified `6420 FREE before verify`): Electric replayed the persisted PG row, the actor replayed its transcript from RocksDB, and a follow-up turn re-projected (`turn_count` 1 → 2) with Electric syncing the update.
- **M4 — PASS (added in `6724584c`).** A `node:http` gatekeeper (trimmed from `backend/vendor/effect-api-layout/apps/electric-proxy`) sits in front of Electric, authenticates an identity, validates the table, forwards **only** recognized Electric protocol params, and **server-forces** the table + a column allowlist + `where owner = $1`:
  - *scope* — a client authenticating as `alice` synced **only** alice's row (`bobRow=false, onlyOwnOwner=true, rows=1`); bob's row never arrived.
  - *sneak* — a client authenticating as alice but requesting `where owner='bob'` **still** saw nothing of bob's: the proxy drops the client `where` and forces the owner scope.
  - *reject* — no identity → **401**; a non-allowlisted table (`secrets`) → **403**. No actor/engine needed — this is purely the read path.

## Key operational findings (see `FINDINGS.md`)

These feed the production wiring decisions, not just the spike:

1. `rivetkit` dev/test is **not** pure in-process — even `setupTest` spawns the native engine binary, binds a local port, and persists state to an on-disk RocksDB under `$HOME/.rivetkit`.
2. The engine child is **orphaned on shutdown** (`registry.shutdown()` does not reap it); it holds the RocksDB `LOCK`. Production must own engine lifecycle.
3. First actor call **races runner registration** (`no_runner_config_configured`) — worked around with a readiness retry in `harness.ts`.
4. Cross-restart durability **requires a stable `RIVET_ENVOY_VERSION`** (else `actor_ready_timeout`). The reference project's `configureRunnerPool` + versioning is the real durable path.
5. **Postgres durability is independent of the Rivet engine** — the queryable row survives an engine restart for free and Electric re-syncs it on reconnect. That's exactly why the record lives in PG, not the actor.
6. **Electric's `message.key` is structured, not the PK** (`"public"."conversations"/"<id>"`); materialize by `message.value.id` and merge partial update values (default `replica`).
7. **`pgrep -f '...rivet-engine start'` self-matches the shell** running it — exclude it (`pgrep -x rivet-engine` by process name is safe) or you'll kill your own shell.
8. **The gatekeeper's safety is an allowlist, not a denylist** — it forwards only `ELECTRIC_PROTOCOL_QUERY_PARAMS` and sets `table`/`columns`/`where`/`params` itself, so any client-supplied `where`/`table`/`columns` are silently dropped. Forward the protocol param list shipped by `@electric-sql/client`; don't hand-maintain it.
9. **Forward the client's disconnect to the upstream** — Electric long-polls on `live=true`; wire the request `close` into an `AbortController` on the upstream `fetch`, or each client reconnect leaks a dangling long-poll.

## Resolved versions

| Package / image | Pinned | Resolved |
|---|---|---|
| `rivetkit` | `^2.2.2-rc.1` | **2.3.2** |
| `@earendil-works/pi-agent-core` / `pi-ai` | `0.80.2` | 0.80.2 |
| `@electric-sql/client` | `1.5.13` | 1.5.13 |
| `pg` | `^8.13.0` | 8.22.0 |
| `electricsql/electric` (image) | `1.5.1` | 1.5.1 |
| `postgres` (image) | `17-alpine` | 17 |

## Test plan

```bash
cd spikes/rivet-pi-electric
bun install

# M1 — Pi-in-actor streaming
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m1

# M2 — durability across a real cold restart
rm -rf .rivethome && mkdir -p .rivethome
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:seed
pgrep -x rivet-engine | xargs -r kill; sleep 5      # kill ONLY the engine (by name, not -f)
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m2:verify

# M3 — Postgres single-writer + Electric read-path sync (needs the infra)
docker compose -f infra/docker-compose.yml up -d    # PG17 logical + electric 1.5.1 (ports 5499/5599)
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3a
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3b
rm -rf .rivethome && mkdir -p .rivethome
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:seed
pgrep -x rivet-engine | xargs -r kill; sleep 5      # PG + Electric keep running; only the engine restarts
RIVET_ENVOY_VERSION=1 HOME="$PWD/.rivethome" bun run m3c:verify

# M4 — identity-scoped gatekeeper (PG + Electric only; no actor/engine)
bun run m4

docker compose -f infra/docker-compose.yml down -v
```

`bun run typecheck` is green. This is **not** the final package layout — it's a de-risking probe. Deliberately deferred: engine lifecycle off the `setupTest` harness, real session-cookie identity behind the gatekeeper (the spike trusts an `x-spike-user` header), Effect v4 wrapping, and Hatchet. The 003 plan rewrite follows once the substrate is accepted.

Made with [Cursor](https://cursor.com)
